### PR TITLE
Fix backtrace cleaner usage for Rails 4

### DIFF
--- a/lib/appsignal/exception_notification.rb
+++ b/lib/appsignal/exception_notification.rb
@@ -5,13 +5,16 @@ module Appsignal
   end
 
   class ExceptionNotification
-    attr_reader :env, :exception, :kontroller, :request, :backtrace
+    attr_reader :env, :exception, :backtrace
 
-    def initialize(env, exception, rails_cleaner=true)
+    def initialize(env, exception, run_rails_cleaner=true)
+      @env = env
       @exception = exception
-      @backtrace = rails_cleaner && Rails.respond_to?(:backtrace_cleaner) ?
-        Rails.backtrace_cleaner.send(:filter, exception.backtrace) :
-        exception.backtrace
+      if run_rails_cleaner && Rails.respond_to?(:backtrace_cleaner)
+        @backtrace = Rails.backtrace_cleaner.clean(@exception.backtrace, nil)
+      else
+        @backtrace = @exception.backtrace
+      end
     end
 
     def name

--- a/spec/appsignal/exception_notification_spec.rb
+++ b/spec/appsignal/exception_notification_spec.rb
@@ -2,11 +2,37 @@ require 'spec_helper'
 
 describe Appsignal::ExceptionNotification do
   let(:error) { StandardError.new('moo') }
-  let(:notification) { Appsignal::ExceptionNotification.new({}, error) }
+  let(:notification) { Appsignal::ExceptionNotification.new({}, error, false) }
   subject { notification }
-  before { Rails.stub(:respond_to? => false) }
+  before do
+    Rails.stub(:root => '/home/app/current')
+  end
 
+  its(:env) { should == {} }
   its(:exception) { should == error }
   its(:name) { should == 'StandardError' }
   its(:message) { should == 'moo' }
+
+  context "backtrace" do
+    let(:backtrace) do
+      [
+        '/home/app/current/app/controllers/somethings_controller.rb:10',
+        '/user/local/ruby/path.rb:8'
+      ]
+    end
+    before { error.stub(:backtrace => backtrace) }
+
+    subject { notification.backtrace }
+
+    it { should == backtrace }
+
+    context "when running the backtrace cleaner" do
+      let(:notification) { Appsignal::ExceptionNotification.new({}, error) }
+
+      it { should == [
+        'app/controllers/somethings_controller.rb:10',
+        '/user/local/ruby/path.rb:8'
+      ] }
+    end
+  end
 end


### PR DESCRIPTION
In our previous implementation we called filter on the backtrace
cleaner, which strips more backtrace lines than we want since Rails 4.

We now call clean with a second nil argument to do this the proper way.
