### PR TITLE
Fix notifications if env is a symbol

### DIFF
--- a/lib/appsignal/integrations/capistrano.rb
+++ b/lib/appsignal/integrations/capistrano.rb
@@ -15,7 +15,7 @@ module Appsignal
 
               appsignal_config = Appsignal::Config.new(
                 ENV['PWD'],
-                env,
+                env.to_s,
                 logger
               )
 

--- a/spec/lib/appsignal/integrations/capistrano_spec.rb
+++ b/spec/lib/appsignal/integrations/capistrano_spec.rb
@@ -51,6 +51,20 @@ describe Appsignal::Integrations::Capistrano do
         end
       end
 
+      context "when env is a symbol instead of a string" do
+        before do
+          @capistrano_config.set(:rails_env, :production)
+        end
+
+        it "should be instantiated with the right params" do
+          Appsignal::Config.should_receive(:new).with(
+            ENV['PWD'],
+            'production',
+            kind_of(Capistrano::Logger)
+          )
+        end
+      end
+
       after { @capistrano_config.find_and_execute_task('appsignal:deploy') }
     end
 


### PR DESCRIPTION
I'm not quite sure why and since when but our deploy notifications weren't working anymore. I tracked it down to the `env` that's passed in from Capistrano being a symbol instead of a string so `load_config_from_disk` couldn't find the correct configuration.

We use `capistrano/ext/multistage` other than that it's just vanilla Capistrano usage. The weird thing is that this used to work without problems and we haven't changed anything. I couldn't really find any relevant commits in Appsignal either. 
