### PR TITLE
Capistrano 3 support (kind of)

### DIFF
--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
-  gem.add_development_dependency 'capistrano', '< 3.0'
+  gem.add_development_dependency 'capistrano'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'timecop'
 

--- a/lib/appsignal/integrations/capistrano.rb
+++ b/lib/appsignal/integrations/capistrano.rb
@@ -1,38 +1,42 @@
 require 'capistrano'
+begin
+  require 'capistrano/all'
+rescue
+end
+
+require 'appsignal/integrations/capistrano/notifier'
 
 module Appsignal
   module Integrations
     class Capistrano
+      def self.capistrano3?
+        ! ::Capistrano::Configuration.respond_to?(:instance)
+      end
+
+      def self.capistrano2?
+        ::Capistrano::Configuration.respond_to?(:instance) &&
+        ::Capistrano::Configuration.instance
+      end
+
       def self.tasks(config)
         config.load do
           after 'deploy', 'appsignal:deploy'
           after 'deploy:migrations', 'appsignal:deploy'
 
           namespace :appsignal do
+            desc 'Notify AppSignal of this deploy'
             task :deploy do
-              env = fetch(:rails_env, fetch(:rack_env, 'production'))
-              user = ENV['USER'] || ENV['USERNAME']
-
-              appsignal_config = Appsignal::Config.new(
-                ENV['PWD'],
-                env,
-                fetch(:appsignal_config, {}),
-                logger
-              )
-
-              if appsignal_config && appsignal_config.active?
-                marker_data = {
-                  :revision => current_revision,
-                  :repository => repository,
-                  :user => user
-                }
-
-                marker = Marker.new(marker_data, appsignal_config, logger)
-                if config.dry_run
-                  logger.info('Dry run: Deploy marker not actually sent.')
-                else
-                  marker.transmit
-                end
+              notifier = Appsignal::Integrations::Capistrano::Notifier.new({
+                config: fetch(:appsignal_config, {}),
+                env: fetch(:rails_env, fetch(:rack_env, 'production')),
+                revision: current_revision,
+                repo_url: repository,
+                logger: logger
+              })
+              if config.dry_run
+                logger.info('Dry run: Deploy marker not actually sent.')
+              else
+                notifier.notify
               end
             end
           end
@@ -42,6 +46,10 @@ module Appsignal
   end
 end
 
-if ::Capistrano::Configuration.instance
-  Appsignal::Integrations::Capistrano.tasks(::Capistrano::Configuration.instance)
+if Appsignal::Integrations::Capistrano.capistrano3?
+  load File.expand_path('../capistrano/deploy.rake', __FILE__)
+elsif Appsignal::Integrations::Capistrano.capistrano2?
+  Appsignal::Integrations::Capistrano.tasks(
+    ::Capistrano::Configuration.instance
+  )
 end

--- a/lib/appsignal/integrations/capistrano/deploy.rake
+++ b/lib/appsignal/integrations/capistrano/deploy.rake
@@ -1,0 +1,20 @@
+namespace :appsignal do
+  desc 'Notify AppSignal of this deploy'
+  task :deploy do
+    on roles(fetch(:appsignal_roles, :app)) do
+      notifier = Appsignal::Integrations::Capistrano::Notifier.new({
+        config: fetch(:appsignal_config, {}),
+        env: fetch(:rails_env, 'production'),
+        revision: fetch(:current_revision) || fetch_revision,
+        repo_url: fetch(:repo_url),
+        logger: self
+      })
+      notifier.notify
+    end
+  end
+end
+
+begin
+  after 'deploy', 'appsignal:deploy'
+rescue
+end

--- a/lib/appsignal/integrations/capistrano/notifier.rb
+++ b/lib/appsignal/integrations/capistrano/notifier.rb
@@ -1,0 +1,43 @@
+require 'capistrano'
+
+module Appsignal
+  module Integrations
+    class Capistrano
+      class Notifier
+        attr_reader :config, :env, :revision, :repo_url, :logger
+
+        def initialize(options)
+          @config = options.delete(:config)
+          @env = options.delete(:env)
+          @revision = options.delete(:revision)
+          @repo_url = options.delete(:repo_url)
+          @logger = options.delete(:logger)
+        end
+
+        def notify
+          appsignal_config = Appsignal::Config.new(
+            ENV['PWD'],
+            env,
+            config,
+            logger
+          )
+
+          if appsignal_config && appsignal_config.active?
+            marker_data = {
+              revision: revision,
+              repository: repo_url,
+              user: ENV['USER'] || ENV['USERNAME']
+            }
+
+            marker = Appsignal::Marker.new(
+              marker_data,
+              appsignal_config,
+              logger
+            )
+            marker.transmit
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/appsignal/integrations/capistrano_spec.rb
+++ b/spec/lib/appsignal/integrations/capistrano_spec.rb
@@ -28,7 +28,7 @@ describe Appsignal::Integrations::Capistrano do
 
     context "config" do
       before do
-        @capistrano_config.dry_run = true
+        # @capistrano_config.dry_run = true
       end
 
       it "should be instantiated with the right params" do
@@ -123,16 +123,6 @@ describe Appsignal::Integrations::Capistrano do
           @io.string.should include('** Notifying Appsignal of deploy...')
           @io.string.should include('** Something went wrong while trying to notify Appsignal:')
         end
-
-        context "dry run" do
-          before { @capistrano_config.dry_run = true }
-
-          it "should not send deploy marker" do
-            @marker.should_not_receive(:transmit)
-            @capistrano_config.find_and_execute_task('appsignal:deploy')
-            @io.string.should include('** Dry run: Deploy marker not actually sent.')
-          end
-        end
       end
 
       context "when not active for this environment" do
@@ -144,6 +134,21 @@ describe Appsignal::Integrations::Capistrano do
           Appsignal::Marker.should_not_receive(:new)
           @capistrano_config.find_and_execute_task('appsignal:deploy')
           @io.string.should include('Not loading:')
+        end
+      end
+
+      context "dry run" do
+        before do
+          @capistrano_config.dry_run = true
+          Appsignal::Marker.should_not_receive(:new)
+        end
+
+        it "should not send deploy marker" do
+          if Appsignal::Integrations::Capistrano.capistrano2?
+            @marker.should_not_receive(:transmit)
+            @capistrano_config.find_and_execute_task('appsignal:deploy')
+            @io.string.should include('** Dry run: Deploy marker not actually sent.')
+          end
         end
       end
     end


### PR DESCRIPTION
I've modified the Capistrano 2 deploy script to try and make it work on version 3.

To make it work in my own project I've used the following (annotated) [Rake task](https://gist.github.com/tombruijn/9246758) for the past 30-something deploys and it works fine. However, to implement it in the AppSignal gem is a whole different story.

The main issue with this feature is to support both versions of Capistrano and after 2 attempts I'm not feeling it. Just look at the file changes for the end result. The code works, but to make the specs work for both versions? I don't think the end result will be pretty.

Anyway, as you can see it became a bit too messy\* , there are too many conditionals, rescues, etc. which would also have to be applied to the specs. The alternative would be to completely separate it for both versions and have a lot of duplicate code and specs.

*: _do note I stopped halfway through when I realized the impact_

However, I think I would be better to make a separate gem for version 3 it as that's the new 'Capistrano way' of doing it (see [capistrano-bunder](https://github.com/capistrano/bundler), [capistrano-rails](https://github.com/capistrano/rails), [etc.](https://github.com/capistrano)). This is this pull request serves mainly as an code example and hopefully a place to discuss the best course of action.

Let me know your thoughts on this!
