### PR TITLE
Only ever remove the global transaction if you are the global transactio...

### DIFF
--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -116,7 +116,7 @@
 
     def complete!
       Appsignal.logger.debug("Completing transaction: #{@request_id}")
-      Thread.current[:appsignal_transaction_id] = nil
+      Thread.current[:appsignal_transaction_id] = nil if @request_id == Thread.current[:appsignal_transaction_id]
       current_transaction = Appsignal.transactions.delete(@request_id)
       if process_action_event || exception?
         if Appsignal::Pipe.current


### PR DESCRIPTION
...n

This isn't the neatest way to do this probably. I think we want a global method like create to destroy as well, like 'complete_current!'
