### PR TITLE
Allow a custom request_class and params_method on Rack::Instrumentation

### DIFF
--- a/lib/appsignal/rack/instrumentation.rb
+++ b/lib/appsignal/rack/instrumentation.rb
@@ -16,10 +16,11 @@ module Appsignal
       end
 
       def raw_payload(env)
-        request = ::Rack::Request.new(env)
+        request = @options.fetch(:request_class, ::Rack::Request).new(env)
+        params = request.public_send(@options.fetch(:params_method, :params))
         {
           :action => "#{request.request_method}:#{request.path}",
-          :params => request.params,
+          :params => params,
           :method => request.request_method,
           :path   => request.path
         }

--- a/spec/lib/appsignal/rack/instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/instrumentation_spec.rb
@@ -46,4 +46,28 @@ describe Appsignal::Rack::Instrumentation do
       :path => '/homepage'
     } }
   end
+
+  describe "use a custom request class and parameters method" do
+    let(:request_class) do
+      double(
+        new: double(
+          request_method: 'POST',
+          path: '/somewhere',
+          filtered_params: {'param' => 'changed_something'}
+        )
+      )
+    end
+    let(:options) do
+      { request_class: request_class, params_method: :filtered_params }
+    end
+    let(:middleware) { Appsignal::Rack::Instrumentation.new(app, options) }
+    subject { middleware.raw_payload(env) }
+
+    it { should == {
+      :action => 'POST:/somewhere',
+      :params => {'param' => 'changed_something'},
+      :method => 'POST',
+      :path => '/somewhere'
+    } }
+  end
 end


### PR DESCRIPTION
The reasoning for this is to filter params before sending to Appsignal.
F.E.

``` ruby
use Appsignal::Rack::Instrumentation,
  request_class: ActionDispatch::Request,
  params_method: :filtered_parameters
```
