### PR TITLE
Add Que integration

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -20,6 +20,7 @@ module Appsignal
       require 'appsignal/integrations/sidekiq'
       require 'appsignal/integrations/resque'
       require 'appsignal/integrations/sequel'
+      require 'appsignal/integrations/que'
     end
 
     def load_instrumentations

--- a/lib/appsignal/integrations/que.rb
+++ b/lib/appsignal/integrations/que.rb
@@ -1,0 +1,29 @@
+if defined?(::Que)
+  Appsignal.logger.info('Loading Que integration')
+
+  module Appsignal
+    module Integrations
+      module QuePlugin
+        def _run
+          Appsignal.monitor_transaction(
+            'perform_job.que',
+            :class    => attrs[:job_class],
+            :method   => 'run',
+            :metadata => {
+              :id        => attrs[:job_id],
+              :queue     => attrs[:queue],
+              :run_at    => attrs[:run_at].to_s,
+              :priority  => attrs[:priority],
+              :attempts  => attrs[:error_count].to_i
+            },
+            :params   => attrs[:args]
+          ) { super }
+        end
+      end
+    end
+  end
+
+  class Que::Job
+    prepend Appsignal::Integrations::QuePlugin
+  end
+end

--- a/lib/appsignal/integrations/que.rb
+++ b/lib/appsignal/integrations/que.rb
@@ -8,9 +8,11 @@ if defined?(::Que)
           base.class_eval do
 
             def _run_with_appsignal
+              cls = attrs[:job_class]
+              cls = attrs[:args].last['job_class'] if cls == "ActiveJob::QueueAdapters::QueAdapter::JobWrapper"
               Appsignal.monitor_transaction(
                 'perform_job.que',
-                :class    => attrs[:job_class],
+                :class    => cls,
                 :method   => 'run',
                 :metadata => {
                   :id        => attrs[:job_id],

--- a/lib/appsignal/integrations/que.rb
+++ b/lib/appsignal/integrations/que.rb
@@ -4,26 +4,36 @@ if defined?(::Que)
   module Appsignal
     module Integrations
       module QuePlugin
-        def _run
-          Appsignal.monitor_transaction(
-            'perform_job.que',
-            :class    => attrs[:job_class],
-            :method   => 'run',
-            :metadata => {
-              :id        => attrs[:job_id],
-              :queue     => attrs[:queue],
-              :run_at    => attrs[:run_at].to_s,
-              :priority  => attrs[:priority],
-              :attempts  => attrs[:error_count].to_i
-            },
-            :params   => attrs[:args]
-          ) { super }
+        def self.included(base)
+          base.class_eval do
+
+            def _run_with_appsignal
+              Appsignal.monitor_transaction(
+                'perform_job.que',
+                :class    => attrs[:job_class],
+                :method   => 'run',
+                :metadata => {
+                  :id        => attrs[:job_id],
+                  :queue     => attrs[:queue],
+                  :run_at    => attrs[:run_at].to_s,
+                  :priority  => attrs[:priority],
+                  :attempts  => attrs[:error_count].to_i
+                },
+                :params => attrs[:args]
+              ) { _run_without_appsignal }
+            end
+
+            alias_method :_run_without_appsignal, :_run
+            alias_method :_run, :_run_with_appsignal
+
+          end
         end
       end
     end
   end
 
   class Que::Job
-    prepend Appsignal::Integrations::QuePlugin
+    # For Ruby 2+ prepend would be more beautiful, but we support 1.9.3 too.
+    include Appsignal::Integrations::QuePlugin
   end
 end

--- a/spec/lib/appsignal/integrations/que_spec.rb
+++ b/spec/lib/appsignal/integrations/que_spec.rb
@@ -1,0 +1,105 @@
+require 'spec_helper'
+
+describe "Que integration" do
+  let(:file) { File.expand_path('lib/appsignal/integrations/que.rb') }
+
+  context "with que" do
+    before do
+      module Que
+        class Job
+          def _run
+            run
+          end
+
+          def attrs
+            {
+              job_id: 123,
+              queue: 'dfl',
+              job_class: self.class.name,
+              priority: 100,
+              args: ['the floor'],
+              run_at: '1-1-1'
+            }
+          end
+        end
+      end
+
+      class SuccessJob < Que::Job
+        def run
+        end
+      end
+
+      class FailureJob < Que::Job
+        def run
+          raise TestError.new('the roof')
+        end
+
+        class TestError < StandardError
+        end
+      end
+
+      load file
+      start_agent
+    end
+
+    describe :around_perform_resque_plugin do
+      let(:transaction) { Appsignal::Transaction.new(1, {}) }
+      let(:job) { SuccessJob.new }
+      let(:invoked_job) { nil }
+      before do
+        transaction.stub(:complete! => true)
+        Appsignal::Transaction.stub(:current => transaction)
+      end
+
+      context "without exception" do
+        it "should create a new transaction" do
+          Appsignal::Transaction.should_receive(:create).and_return(transaction)
+        end
+
+        it "should wrap in a transaction with the correct params" do
+          Appsignal.should_receive(:monitor_transaction).with(
+            'perform_job.que',
+            class:  'SuccessJob',
+            method: 'run',
+            metadata: {
+              id: 123,
+              queue: 'dfl',
+              priority: 100,
+              run_at: '1-1-1',
+              attempts: 0
+            },
+            params: ['the floor']
+          )
+        end
+
+        it "should close the transaction" do
+          transaction.should_receive(:complete!)
+        end
+
+        after { job._run }
+      end
+
+      context "with exception" do
+        let(:job) { FailureJob.new }
+        it "should set the exception" do
+          transaction.should_receive(:add_exception)
+        end
+
+        after do
+          begin
+            job._run
+          rescue FailureJob::TestError
+            # Do nothing
+          end
+        end
+      end
+    end
+  end
+
+  context "without que" do
+    before(:all) { Object.send(:remove_const, :Que) }
+
+    specify { expect { ::Que }.to raise_error(NameError) }
+    specify { expect { load file }.to_not raise_error }
+  end
+end


### PR DESCRIPTION
Adds support for the [Que](https://github.com/chanks/que) jobs backend. I haven't this tested yet as much as to be ready for merging, but opening a PR allows us to discuss already.

See also https://github.com/chanks/que/issues/119.

- [x] Report ActiveJob jobs by their original name (#25)
- [x] Make it work on Ruby 1.9.3, using `alias_method` instead of `Module#prepend`.
- [x] Test in production