### PR TITLE
Add Elasticsearch Event Formatter

### DIFF
--- a/lib/appsignal/event_formatter/elastic_search/search_formatter.rb
+++ b/lib/appsignal/event_formatter/elastic_search/search_formatter.rb
@@ -1,0 +1,29 @@
+module Appsignal
+  class EventFormatter
+    module ElasticSearch
+      class SearchFormatter < Appsignal::EventFormatter
+        register 'search.elasticsearch'
+
+        def format(payload)
+          [
+            "#{payload[:name]}: #{payload[:klass]}",
+            sanitized_search(payload[:search]).inspect
+          ]
+        end
+
+        def sanitized_search(search)
+          return nil unless search.is_a?(Hash)
+          {}.tap do |hsh|
+            search.each do |key, val|
+              if [:index, :type].include?(key)
+                hsh[key] = val
+              else
+                hsh[key] = Appsignal::Utils.sanitize(val)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/appsignal/event_formatter/elastic_search/search_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/elastic_search/search_formatter_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe Appsignal::EventFormatter::ElasticSearch::SearchFormatter do
+  let(:klass)     { Appsignal::EventFormatter::ElasticSearch::SearchFormatter }
+  let(:formatter) { klass.new }
+
+  it "should register query.moped" do
+    expect(
+      Appsignal::EventFormatter.registered?('search.elasticsearch', klass)
+    ).to be_true
+  end
+
+  describe "#format" do
+    let(:payload) do
+      {
+        :name   => 'Search',
+        :klass  => 'User',
+        :search => {:index => 'users', :type => 'user', :q => 'John Doe'}
+      }
+    end
+
+    it "should return a payload with name and sanitized body" do
+      expect( formatter.format(payload) ).to eql([
+        "Search: User",
+        "{:index=>\"users\", :type=>\"user\", :q=>\"?\"}"
+      ])
+    end
+  end
+
+  describe "#sanitized_search" do
+    let(:search) do
+      {
+        :index => 'users',
+        :type  => 'user',
+        :q     => 'John Doe',
+        :other => 'Other'
+      }
+    end
+
+    it "should sanitize non-whitelisted params" do
+      expect(
+        formatter.sanitized_search(search)
+      ).to eql({:index => 'users', :type => 'user', :q => '?', :other => '?'})
+    end
+
+    it "should return nil string when search is nil" do
+      expect( formatter.sanitized_search(nil) ).to be_nil
+    end
+
+    it "should return nil string when search is not a hash" do
+      expect( formatter.sanitized_search([]) ).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Based on the Elasticsearch-rails instrumentation (https://github.com/elastic/elasticsearch-rails/blob/master/elasticsearch-rails/lib/elasticsearch/rails/instrumentation/publishers.rb and https://github.com/elastic/elasticsearch-rails/tree/master/elasticsearch-rails#activesupport-instrumentation)
