### PR TITLE
Faraday instrumentation formatter

### DIFF
--- a/lib/appsignal/event_formatter/faraday/request_formatter.rb
+++ b/lib/appsignal/event_formatter/faraday/request_formatter.rb
@@ -1,0 +1,13 @@
+module Appsignal
+  class EventFormatter
+    module Faraday
+      class RequestFormatter < Appsignal::EventFormatter
+        register 'request.faraday'
+
+        def format(payload)
+          ["#{payload[:method].to_s.upcase} #{payload[:url]}", nil]
+        end
+      end
+    end
+  end
+end

--- a/lib/appsignal/event_formatter/faraday/request_formatter.rb
+++ b/lib/appsignal/event_formatter/faraday/request_formatter.rb
@@ -5,7 +5,12 @@ module Appsignal
         register 'request.faraday'
 
         def format(payload)
-          ["#{payload[:method].to_s.upcase} #{payload[:url]}", nil]
+          http_method = payload[:method].to_s.upcase
+          uri = payload[:url]
+          [
+            "#{http_method} #{uri.scheme}://#{uri.host}",
+            "#{http_method} #{uri.scheme}://#{uri.host}#{uri.path}"
+          ]
         end
       end
     end

--- a/spec/lib/appsignal/event_formatter/faraday/request_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/faraday/request_formatter_spec.rb
@@ -12,12 +12,12 @@ describe Appsignal::EventFormatter::Faraday::RequestFormatter do
     let(:payload) do
       {
         method: :get,
-        url: URI.parse("http://example.org/hello/world")
+        url: URI.parse("http://example.org/hello/world?some=param")
       }
     end
 
     subject { formatter.format(payload) }
 
-    it { should == ['GET http://example.org/hello/world', nil] }
+    it { should == ['GET http://example.org', 'GET http://example.org/hello/world'] }
   end
 end

--- a/spec/lib/appsignal/event_formatter/faraday/request_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/faraday/request_formatter_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Appsignal::EventFormatter::Faraday::RequestFormatter do
+  let(:klass)     { Appsignal::EventFormatter::Faraday::RequestFormatter }
+  let(:formatter) { klass.new }
+
+  it "should register request.faraday" do
+    Appsignal::EventFormatter.registered?('request.faraday', klass).should be_true
+  end
+
+  describe "#format" do
+    let(:payload) do
+      {
+        method: :get,
+        url: URI.parse("http://example.org/hello/world")
+      }
+    end
+
+    subject { formatter.format(payload) }
+
+    it { should == ['GET http://example.org/hello/world', nil] }
+  end
+end


### PR DESCRIPTION
This adds a Formatter for the `request.faraday` event.

`FaradayMiddleware::Instrumentation` is in the `faraday_middleware` gem and is widely used. This is a first iteration, adding basic info as the title of the event in appsignal.

I'd like to add more information about the request in the body soon enough, but this is a nice minimal start I think.

What are the accepted values for body_format? I see SQL is set to `1`, but I'm not sure what that entails.