### PR TITLE
ensure current transaction is nil on completion

### DIFF
--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -37,8 +37,13 @@ module Appsignal
       end
 
       def complete_current!
-        current.complete
-        Thread.current[:appsignal_transaction] = nil
+        begin
+          current.complete
+        rescue Exception => e
+          Appsignal.logger.error("Failed to complete transaction ##{current.transaction_id}. #{e.message}")
+        ensure
+          Thread.current[:appsignal_transaction] = nil
+        end
       end
     end
 


### PR DESCRIPTION
If current transaction is not set to nil for any reason, all later requests try to send it and fail. This would render the server's worker unusable which is unacceptable.