### PR TITLE
Require `json` before defining `JSON_EXCEPTIONS`

### DIFF
--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module Appsignal
   class Transaction
     HTTP_REQUEST   = 'http_request'.freeze


### PR DESCRIPTION
Requiring `json` is now a dependency of requising `appsignal`, since the
`Transaction` class definition make references to the `JSON` constant.

This was spotted by trying to run the `cap` executable inside an application that notifies AppSignal of new deployments:

```
bin/cap production deploy
(Backtrace restricted to imported tasks)
cap aborted!
NameError: uninitialized constant Appsignal::Transaction::JSON

Tasks: TOP => production
(See full trace by running task with --trace)
```