### PR TITLE
Add `queue_time` key to Sidekiq instrumentation

### DIFF
--- a/lib/appsignal/hooks/sidekiq.rb
+++ b/lib/appsignal/hooks/sidekiq.rb
@@ -25,7 +25,8 @@ module Appsignal
           :method      => 'perform',
           :metadata    => formatted_metadata(item),
           :params      => params,
-          :queue_start => item['enqueued_at']
+          :queue_start => item['enqueued_at'],
+          :queue_time  => (Time.now.to_f - item['enqueued_at'].to_f) * 1000
         ) do
           yield
         end

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -32,7 +32,8 @@ describe Appsignal::Hooks::SidekiqPlugin do
           'extra'       => 'data'
         },
         :params      => ['Model', "1"],
-        :queue_start => Time.parse('01-01-2001 10:00:00UTC')
+        :queue_start => Time.parse('01-01-2001 10:00:00UTC'),
+        :queue_time  => 60000.to_f
       )
     end
 
@@ -62,7 +63,8 @@ describe Appsignal::Hooks::SidekiqPlugin do
             'queue' => 'default'
           },
           :params      => ['Model', "1"],
-          :queue_start => Time.parse('01-01-2001 10:00:00UTC').to_f
+          :queue_start => Time.parse('01-01-2001 10:00:00UTC').to_f,
+          :queue_time  => 60000.to_f
         )
       end
     end


### PR DESCRIPTION
I noticed that there is a queue time graph for background hosts on the AppSignal UI and the examples of custom instrumentation mentions the `queue_time` (http://docs.appsignal.com/background-monitoring/custom.html) parameter, but that metric isn't collected by default anywhere, so I added it to the Sidekiq hook to collect it by default for all jobs. 