### PR TITLE
Allow usage of APPSIGNAL_APP_ENV in padrino

### DIFF
--- a/lib/appsignal/integrations/padrino.rb
+++ b/lib/appsignal/integrations/padrino.rb
@@ -8,7 +8,7 @@ module Appsignal::Integrations
       root             = Padrino.mounted_root
       Appsignal.config = Appsignal::Config.new(
         root,
-        Padrino.env,
+        ENV.fetch('APPSIGNAL_APP_ENV'.freeze, Padrino.env.to_s),
         :log_path => File.join(root, 'log')
       )
 

--- a/spec/lib/appsignal/integrations/padrino_spec.rb
+++ b/spec/lib/appsignal/integrations/padrino_spec.rb
@@ -38,6 +38,28 @@ if padrino_present?
         end
       end
 
+      context "when APPSIGNAL_APP_ENV ENV var is provided" do
+        it 'should use this as the environment' do
+          ENV['APPSIGNAL_APP_ENV'] = 'custom'
+
+          # Reset the plugin to pull down the latest data
+          Appsignal::Integrations::PadrinoPlugin.init
+
+          expect(Appsignal.config.env).to eq 'custom'
+        end
+      end
+
+      context "when APPSIGNAL_APP_ENV ENV var is not provided" do
+        it 'should use the Padrino environment' do
+          ENV['APPSIGNAL_APP_ENV'] = nil
+
+          # Reset the plugin to pull down the latest data
+          Appsignal::Integrations::PadrinoPlugin.init
+
+          expect(Appsignal.config.env).to eq Padrino.env.to_s
+        end
+      end
+
       after { Appsignal::Integrations::PadrinoPlugin.init }
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 ENV['RAILS_ENV'] ||= 'test'
+ENV['PADRINO_ENV'] ||= 'test'
+
 require 'rack'
 require 'rspec'
 require 'pry'
@@ -143,6 +145,7 @@ RSpec.configure do |config|
 
   config.before do
     ENV['RAILS_ENV'] = 'test'
+    ENV['PADRINO_ENV'] = 'test'
 
     # Clean environment
     ENV.keys.select { |key| key.start_with?('APPSIGNAL_') }.each do |key|


### PR DESCRIPTION
Currently the only integration which allows overriding the environment of AppSignal is Rails via the Railties integration.

We'd like to use the same override in Padrino too! It's currently ignored in Padrino and defaults to `production`.

`PADRINO_ENV` is seeding during test setup/reset so that we don't default to the `development` env variable during testing.

Based on Master as it seems more like a bugfix than a new feature, but it's a thin line.