### PR TITLE
Remove 1.9.3 from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: ruby
 
 rvm:
-  - "1.9.3"
   - "2.0.0"
   - "2.1.8"
   - "2.2.4"
@@ -28,8 +27,6 @@ gemfile:
 
 matrix:
   exclude:
-    - rvm: "1.9.3"
-      gemfile: "gemfiles/rails-5.0.gemfile"
     - rvm: "2.0.0"
       gemfile: "gemfiles/rails-5.0.gemfile"
     - rvm: "2.1.8"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ AppSignal agent
 This gem collects error and performance data from your Rails
 applications and sends it to [AppSignal](https://appsignal.com)
 
-[![Build Status](https://travis-ci.org/appsignal/appsignal.png?branch=master)](https://travis-ci.org/appsignal/appsignal-ruby)
+[![Build Status](https://travis-ci.org/appsignal/appsignal-ruby.png?branch=master)](https://travis-ci.org/appsignal/appsignal-ruby)
 [![Gem Version](https://badge.fury.io/rb/appsignal.svg)](http://badge.fury.io/rb/appsignal)
 [![Code Climate](https://codeclimate.com/github/appsignal/appsignal.png)](https://codeclimate.com/github/appsignal/appsignal)
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@ require 'rspec/core/rake_task'
 GEMFILES = %w(
   capistrano2
   capistrano3
+  grape
   no_dependencies
   padrino
   rails-3.2
@@ -13,11 +14,9 @@ GEMFILES = %w(
   sequel
   sequel-435
   sinatra
-  grape
 )
 
 RUBY_VERSIONS = %w(
-  1.9.3-p551
   2.0.0-p648
   2.1.8
   2.2.4
@@ -25,7 +24,7 @@ RUBY_VERSIONS = %w(
 )
 
 EXCLUSIONS = {
-  'rails-5.0' => %w( 1.9.3 2.0.0 2.1.8)
+  'rails-5.0' => %w(2.0.0 2.1.8)
 }
 
 VERSION_MANAGERS = {

--- a/gemfiles/capistrano2.gemfile
+++ b/gemfiles/capistrano2.gemfile
@@ -2,6 +2,6 @@ source 'https://rubygems.org'
 
 gem 'capistrano', '< 3.0'
 gem 'net-ssh', '2.9.2'
-gem 'rack', '~> 1.6.4'
+gem 'rack', '~> 1.6'
 
 gemspec :path => '../'

--- a/gemfiles/capistrano3.gemfile
+++ b/gemfiles/capistrano3.gemfile
@@ -2,6 +2,6 @@ source 'https://rubygems.org'
 
 gem 'capistrano', '3.4.0'
 gem 'net-ssh', '2.9.2'
-gem 'rack', '~> 1.6.4'
+gem 'rack', '~> 1.6'
 
 gemspec :path => '../'

--- a/gemfiles/grape.gemfile
+++ b/gemfiles/grape.gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'grape', '0.14.0'
-gem 'rack', '~> 1.6.4'
+gem 'rack', '~> 1.6'
+gem 'activesupport', '~> 4.2'
 
 gemspec :path => '../'

--- a/gemfiles/no_dependencies.gemfile
+++ b/gemfiles/no_dependencies.gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'rack', '~> 1.6.4'
+gem 'rack', '~> 1.6'
 
 gemspec :path => '../'

--- a/gemfiles/padrino.gemfile
+++ b/gemfiles/padrino.gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'padrino', '~> 0.12.0'
-gem 'rack', '~> 1.6.4'
+gem 'rack', '~> 1.6'
+gem 'activesupport', '~> 4.2'
 
 gemspec :path => '../'

--- a/gemfiles/rails-3.2.gemfile
+++ b/gemfiles/rails-3.2.gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 3.2.14'
-gem 'rack', '~> 1.6.4'
 gem 'test-unit'
 
 gemspec :path => '../'

--- a/gemfiles/rails-4.0.gemfile
+++ b/gemfiles/rails-4.0.gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 4.0.0'
-gem 'rack', '~> 1.6.4'
 gem 'mime-types', '~> 2.6'
 
 gemspec :path => '../'

--- a/gemfiles/rails-4.1.gemfile
+++ b/gemfiles/rails-4.1.gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 4.1.0'
-gem 'rack', '~> 1.6.4'
 gem 'mime-types', '~> 2.6'
 
 gemspec :path => '../'

--- a/gemfiles/rails-4.2.gemfile
+++ b/gemfiles/rails-4.2.gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 4.2.0'
-gem 'rack', '~> 1.6.4'
 gem 'mime-types', '~> 2.6'
 
 gemspec :path => '../'

--- a/gemfiles/resque.gemfile
+++ b/gemfiles/resque.gemfile
@@ -3,6 +3,5 @@ source 'https://rubygems.org'
 gem 'resque'
 gem 'rails', '~> 4.2.0'
 gem 'mime-types', '~> 2.6'
-gem 'rack', '~> 1.6.4'
 
 gemspec :path => '../'

--- a/gemfiles/sequel-435.gemfile
+++ b/gemfiles/sequel-435.gemfile
@@ -2,6 +2,6 @@ source 'https://rubygems.org'
 
 gem 'sequel', '~> 4.35'
 gem 'sqlite3'
-gem 'rack', '~> 1.6.4'
+gem 'rack', '~> 1.6'
 
 gemspec :path => '../'

--- a/gemfiles/sequel.gemfile
+++ b/gemfiles/sequel.gemfile
@@ -2,6 +2,6 @@ source 'https://rubygems.org'
 
 gem 'sequel', '< 4.35'
 gem 'sqlite3'
-gem 'rack', '~> 1.6.4'
+gem 'rack', '~> 1.6'
 
 gemspec :path => '../'

--- a/gemfiles/sinatra.gemfile
+++ b/gemfiles/sinatra.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'sinatra'
-gem 'rack', '~> 1.6.4'
+gem 'rack', '~> 1.6'
 
 gemspec :path => '../'


### PR DESCRIPTION
Since the Rails 5 release the current versions of a number of gems do not work on 1.9.3. This seems to be a good moment to not run our tests on 1.9.3 anymore.