### PR TITLE
Sinatra middleware improvements

### DIFF
--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -28,6 +28,11 @@ module Appsignal
 
     class << self
       def create(id, namespace, request, options={})
+        # Allow middleware to force a new transaction
+        if options.include?(:force) && options[:force]
+          Thread.current[:appsignal_transaction] = nil
+        end
+
         # Check if we already have a running transaction
         if Thread.current[:appsignal_transaction] != nil
           # Log the issue and return the current transaction

--- a/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
@@ -51,7 +51,8 @@ if defined?(::Sinatra)
         Appsignal::Transaction.should_receive(:create).with(
           kind_of(String),
           Appsignal::Transaction::HTTP_REQUEST,
-          kind_of(Sinatra::Request)
+          kind_of(Sinatra::Request),
+          kind_of(Hash)
         ).and_return(double(:set_action => nil, :set_http_or_background_queue_start => nil, :set_metadata => nil))
       end
 
@@ -119,6 +120,13 @@ if defined?(::Sinatra)
                           with(env.merge(:params_method => :filtered_params)).
                           at_least(:once).
                           and_return(request)
+        end
+      end
+
+      context "with option to set path prefix" do
+        let(:options) {{ :mounted_at  => "/api/v2" }}
+        it "should call set_action with a prefix path" do
+          Appsignal::Transaction.any_instance.should_receive(:set_action).with("GET /api/v2/")
         end
       end
 

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -57,6 +57,16 @@ describe Appsignal::Transaction do
 
           Appsignal::Transaction.create('1', namespace, request, options)
         end
+
+        context "with option to force a new transaction" do
+          let(:options) { {:force => true} }
+          it "should not create a new transaction" do
+            expect(
+              Appsignal::Transaction.create('1', namespace, request, options)
+            ).to_not eq(running_transaction)
+          end
+        end
+
       end
     end
 


### PR DESCRIPTION
@thijsc As discussed last friday. This PR adds two new features:

1. Allowing instrumentation middleware to *force* a new transaction.
The use case for this is a sinatra app mounted in a rails app. This option allows us to start a new transaction. Used like this:

```
use Appsignal::Rack::SinatraInstrumentation, force: true
```

2. Set mounted_at for actions
Same use case as for number 1. Allows to set a prefix for an action to improve readability of Appsignal reports

```
use Appsignal::Rack::SinatraInstrumentation, mounted_at: "/api/v2"
```