### PR TITLE
Listen to appsignal_env in Capistrano3

### DIFF
--- a/lib/appsignal/integrations/capistrano/appsignal.cap
+++ b/lib/appsignal/integrations/capistrano/appsignal.cap
@@ -1,6 +1,6 @@
 namespace :appsignal do
   task :deploy do
-    env = fetch(:stage, fetch(:rails_env, fetch(:rack_env, 'production')))
+    env = fetch(:appsignal_env, fetch(:stage, fetch(:rails_env, fetch(:rack_env, 'production'))))
     user = ENV['USER'] || ENV['USERNAME']
     revision = fetch(:appsignal_revision, fetch(:current_revision))
 


### PR DESCRIPTION
Allow Capistrano3 users to set an AppSignal environment regardless of their Capistrano stage, Rails env or Rack env.

Not always do environment names match the stage names.

## Example

```ruby
# config/deploy/staging.rb
# Normal staging stage and environment
set :stage, :staging
set :rails_env, :staging
# AppSignal env is `:staging`
```

```ruby
# config/deploy/beta.rb
# Beta stage with staging environment
set :stage, :beta
set :rails_env, :staging
set :appsignal_env, :staging
```

## Notes

Updated spec names to better reflect what's being tested.

## Related issues

Closes #118