### PR TITLE
rake install with `Bundler.with_clean_env`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,6 @@
+require 'bundler'
 require 'rspec/core/rake_task'
+
 GEMFILES = %w(
   capistrano2
   capistrano3
@@ -106,8 +108,10 @@ end
 
 task :install do
   system 'cd ext && rm -f libappsignal.a appsignal-agent appsignal_extension.h Makefile appsignal_extension.bundle && ruby extconf.rb && make && cd ..'
-  GEMFILES.each do |gemfile|
-    system "bundle --gemfile gemfiles/#{gemfile}.gemfile"
+  Bundler.with_clean_env do
+    GEMFILES.each do |gemfile|
+      system "bundle --gemfile gemfiles/#{gemfile}.gemfile"
+    end
   end
 end
 


### PR DESCRIPTION
This allows you to install the extension when running with bundler.

This is especially useful if people use shell frameworks or have aliases
prefixing bundle exec for every rake command.

https://github.com/bundler/bundler/blob/dfdeb0f89e7e88fcdfd001da089f09af3a77d2b4/man/bundle-exec.ronn#L66

https://app.intercom.io/a/apps/yzor8gyw/inbox/conversation/5753442547