### PR TITLE
Fix DataMapper error

### DIFF
--- a/lib/appsignal/integrations/data_mapper.rb
+++ b/lib/appsignal/integrations/data_mapper.rb
@@ -1,13 +1,16 @@
 module Appsignal
   class Hooks
     module DataMapperLogListener
+      SQL_CLASSES = [
+        "DataObjects::SqlServer::Connection",
+        "DataObjects::Sqlite3::Connection",
+        "DataObjects::Mysql::Connection",
+        "DataObjects::Postgres::Connection"
+      ]
 
       def log(message)
-        # Attempt to find the scheme used for this message
-        scheme = instance_variable_get(:@uri).scheme
-
         # If scheme is SQL-like, try to sanitize it, otherwise clear the body
-        if %w(sqlite sqlite3 mysql postgres).include?(scheme)
+        if SQL_CLASSES.include?(self.class.to_s)
           body_content = message.query
           body_format = Appsignal::EventFormatter::SQL_BODY_FORMAT
         else

--- a/spec/lib/appsignal/integrations/data_mapper_spec.rb
+++ b/spec/lib/appsignal/integrations/data_mapper_spec.rb
@@ -8,29 +8,26 @@ describe Appsignal::Hooks::DataMapperLogListener do
     end
   end
 
-  class DataMapperTestClass
-    include DataMapperLog
-    include Appsignal::Hooks::DataMapperLogListener
-
-    def initialize(uri)
-      @uri = uri
-    end
-  end
-
   describe "#log" do
-    let!(:data_mapper_class) { DataMapperTestClass.new(uri) }
-    let(:uri)                { double(:scheme => 'mysql') }
-    let(:transaction)        { double }
+    let(:transaction) { double }
     let(:message) do
       double(
         :query    => "SELECT * from users",
         :duration => 100
       )
     end
-
-    before do
-      Appsignal::Transaction.stub(:current) { transaction }
+    let(:connection_class) do
+      module DataObjects
+        module Sqlite3
+          class Connection
+            include DataMapperLog
+            include Appsignal::Hooks::DataMapperLogListener
+          end
+        end
+      end
     end
+
+    before { Appsignal::Transaction.stub(:current) { transaction } }
 
     it "should record the log entry in an event" do
       expect( transaction ).to receive(:record_event).with(
@@ -43,7 +40,16 @@ describe Appsignal::Hooks::DataMapperLogListener do
     end
 
     context "when scheme is not sql-like" do
-      let(:uri) { double(:scheme => 'mongodb') }
+      let(:connection_class) do
+        module DataObjects
+          module MongoDB
+            class Connection
+              include DataMapperLog
+              include Appsignal::Hooks::DataMapperLogListener
+            end
+          end
+        end
+      end
 
       it "should record the log entry in an event without body" do
         expect( transaction ).to receive(:record_event).with(
@@ -56,6 +62,6 @@ describe Appsignal::Hooks::DataMapperLogListener do
       end
     end
 
-    after { data_mapper_class.log(message) }
+    after { connection_class.new.log(message) }
   end
 end


### PR DESCRIPTION
DataObjects adapter sometimes don't expose an @uri instance variable.

This new way checks the class name of the DataObjects::xx::Connection class (where xx is the database driver) instead of relying on an instance variable.

Conflicts:
	lib/appsignal/integrations/data_mapper.rb