### PR TITLE
Update setup instructions and fix various Ruby warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,26 +10,41 @@ applications and sends it to [AppSignal](https://appsignal.com)
 
 ## Development
 
-Run `rake install`, then run the spec suite with a specific Gemfile:
+Make sure you have Bundler installed and then use the Rake install task to
+install all other dependencies.
+
+```
+gem install bundler
+rake install
+```
+
+AppSignal runs in many different configurations. To replicate these
+configurations you need to run the spec suite with a specific Gemfile.
 
 ```
 BUNDLE_GEMFILE=gemfiles/capistrano2.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/capistrano3.gemfile bundle exec rspec
+BUNDLE_GEMFILE=gemfiles/grape.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/no_dependencies.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/padrino.gemfile bundle exec rspec
-BUNDLE_GEMFILE=gemfiles/rails-3.0.gemfile bundle exec rspec
-BUNDLE_GEMFILE=gemfiles/rails-3.1.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/rails-3.2.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/rails-4.0.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/rails-4.1.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/rails-4.2.gemfile bundle exec rspec
+BUNDLE_GEMFILE=gemfiles/rails-5.0.gemfile bundle exec rspec
+BUNDLE_GEMFILE=gemfiles/resque.gemfile bundle exec rspec
+BUNDLE_GEMFILE=gemfiles/sequel-435.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/sequel.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/sinatra.gemfile bundle exec rspec
+BUNDLE_GEMFILE=gemfiles/webmachine.gemfile bundle exec rspec
 ```
 
-Or run `rake generate_bundle_and_spec_all` to generate a script that runs specs for all
-Ruby versions and gem combinations we support.
-You need Rvm or Rbenv to do this. Travis will run specs for these combinations as well.
+If you have either Rvm or Rbenv installed you can also use
+`rake generate_bundle_and_spec_all` to generate a script that runs specs for
+all Ruby versions and gem combinations we support.
+
+On Travis we run the suite against all of the Gemfiles mentioned above and on
+a number of different Ruby versions.
 
 ## Branches and versions
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,4 @@
 require 'bundler'
-require 'rspec/core/rake_task'
 
 GEMFILES = %w(
   capistrano2
@@ -176,8 +175,13 @@ task :install_extension do
   `cd ext && rm -f libappsignal.a && ruby extconf.rb && make clean && make`
 end
 
-RSpec::Core::RakeTask.new(:rspec) do |t|
-  t.pattern = Dir.glob('spec/**/*_spec.rb')
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:rspec) do |t|
+    t.pattern = Dir.glob('spec/**/*_spec.rb')
+  end
+rescue LoadError
+  # When running rake install, there is no RSpec yet.
 end
 
 task :travis => [:install_extension, :rspec]

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -47,9 +47,9 @@ def install
 
   arch_config = AGENT_CONFIG['triples'][ARCH]
 
-  unless File.exists?(ext_path('appsignal-agent')) &&
-           File.exists?(ext_path('libappsignal.a')) &&
-           File.exists?(ext_path('appsignal_extension.h'))
+  unless File.exist?(ext_path('appsignal-agent')) &&
+           File.exist?(ext_path('libappsignal.a')) &&
+           File.exist?(ext_path('appsignal_extension.h'))
     logger.info "Downloading agent release from #{arch_config['download_url']}"
 
     archive = open(arch_config['download_url'], :ssl_ca_cert => CA_CERT_PATH)

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -15,7 +15,8 @@ end
 
 module Appsignal
   class << self
-    attr_accessor :config, :subscriber, :logger, :agent, :in_memory_log, :extension_loaded
+    attr_accessor :config, :subscriber, :agent, :in_memory_log, :extension_loaded
+    attr_writer :logger
 
     def extensions
       @extensions ||= []

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -15,8 +15,8 @@ end
 
 module Appsignal
   class << self
-    attr_accessor :config, :subscriber, :agent, :in_memory_log, :extension_loaded
-    attr_writer :logger
+    attr_accessor :config, :subscriber, :agent, :extension_loaded
+    attr_writer :logger, :in_memory_log
 
     def extensions
       @extensions ||= []
@@ -66,6 +66,14 @@ module Appsignal
         end
       else
         logger.error('Not starting, no valid config for this environment')
+      end
+    end
+
+    def in_memory_log
+      if defined?(@in_memory_log) && @in_memory_log
+        @in_memory_log
+      else
+        @in_memory_log = StringIO.new
       end
     end
 
@@ -209,8 +217,7 @@ module Appsignal
     end
 
     def logger
-      @in_memory_log = StringIO.new unless @in_memory_log
-      @logger ||= Logger.new(@in_memory_log).tap do |l|
+      @logger ||= Logger.new(in_memory_log).tap do |l|
         l.level = Logger::INFO
         l.formatter = log_formatter
       end
@@ -238,7 +245,10 @@ module Appsignal
       else
         @logger.level = Logger::INFO
       end
-      @logger << @in_memory_log.string if @in_memory_log
+
+      if in_memory_log
+        @logger << in_memory_log.string
+      end
 
       if path_arg
         @logger.info('Setting the path in start_logger has no effect anymore, set it in the config instead')

--- a/lib/appsignal/cli.rb
+++ b/lib/appsignal/cli.rb
@@ -11,7 +11,8 @@ module Appsignal
     AVAILABLE_COMMANDS = %w(diagnose install notify_of_deploy).freeze
 
     class << self
-      attr_accessor :options, :config, :initial_config
+      attr_accessor :options, :initial_config
+      attr_writer :config
 
       def run(argv=ARGV)
         @options = {}

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -49,7 +49,7 @@ module Appsignal
         def check_api_key
           start_appsignal
           auth_check = ::Appsignal::AuthCheck.new(Appsignal.config, Appsignal.logger)
-          status, result = auth_check.perform_with_result
+          status, _ = auth_check.perform_with_result
           if status == '200'
             puts "Checking API key: Ok"
           else

--- a/lib/appsignal/cli/install.rb
+++ b/lib/appsignal/cli/install.rb
@@ -188,7 +188,7 @@ module Appsignal
 
         def configure(config, environments, name_overwritten)
           deploy_rb_file = File.join(Dir.pwd, 'config/deploy.rb')
-          if File.exists?(deploy_rb_file) && (File.read(deploy_rb_file) =~ /require (\'|\").\/appsignal\/capistrano/).nil?
+          if File.exist?(deploy_rb_file) && (File.read(deploy_rb_file) =~ /require (\'|\").\/appsignal\/capistrano/).nil?
             print 'Adding AppSignal integration to deploy.rb'
             File.open(deploy_rb_file, 'a') do |f|
               f.write "\nrequire 'appsignal/capistrano'\n"

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -62,7 +62,7 @@ module Appsignal
       load_from_environment
 
       # Load the config file if it exists
-      if config_file && File.exists?(config_file)
+      if config_file && File.exist?(config_file)
         load_from_disk
       end
 

--- a/lib/appsignal/hooks.rb
+++ b/lib/appsignal/hooks.rb
@@ -21,6 +21,10 @@ module Appsignal
         Appsignal::Hooks.register(name, hook.new)
       end
 
+      def initialize
+        @installed = false
+      end
+
       def try_to_install(name)
         if dependencies_present? && !installed?
           Appsignal.logger.info("Installing #{name} hook")
@@ -34,7 +38,7 @@ module Appsignal
       end
 
       def installed?
-        !! @installed
+        @installed
       end
 
       def dependencies_present?

--- a/spec/lib/appsignal/transmitter_spec.rb
+++ b/spec/lib/appsignal/transmitter_spec.rb
@@ -59,7 +59,7 @@ describe Appsignal::Transmitter do
     subject { Appsignal::Transmitter::CA_FILE_PATH }
 
     it { should include('resources/cacert.pem') }
-    it("should exist") { File.exists?(subject).should be_true }
+    it("should exist") { File.exist?(subject).should be_true }
   end
 
   describe "#http_client" do

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -523,7 +523,7 @@ describe Appsignal do
           Appsignal.start_logger
           Appsignal.logger.level.should == Logger::INFO
           Appsignal.logger.error('Log to file')
-          File.exists?(log_file).should be_true
+          File.exist?(log_file).should be_true
           File.open(log_file).read.should include 'Log to file'
           File.open(log_file).read.should include 'Log something'
         end


### PR DESCRIPTION
We usually run our test suites with warnings so I noticed some warnings coming from AppSignal. These changes address those issues.

I haven't touched warnings coming from the spec suite itself, frankly because I don't have to look at that every day 😀.