### PR TITLE
Enable TravisCI bundler cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 
 language: ruby
+cache: bundler
 
 rvm:
   - "2.0.0"


### PR DESCRIPTION
Activate bundler cache on travisci to speed up the test suite there. Benefits gemspecs with a lot of dependencies like Rails.

- Build without cache:
  https://travis-ci.org/appsignal/appsignal-ruby/builds/155574914
- Build with cache:
  https://travis-ci.org/appsignal/appsignal-ruby/builds/155580657

source: https://docs.travis-ci.com/user/caching/#Bundler