### PR TITLE
List branches to build on push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 sudo: false
 
+branches:
+  only:
+    - "master"
+    - "develop"
+
 language: ruby
 
 rvm:


### PR DESCRIPTION
List branches which travis should build on a "push" event. Otherwise you build a branch on push and PR if both options are on (build on push & build on PR) are active, which takes up a lot of time.

![image](https://cloud.githubusercontent.com/assets/282402/18028378/b62f436e-6c7d-11e6-883e-ec368b528427.png)
(Current settings)

## Scenario:

### Steps to reproduce issue

- I push a branch to make a PR (a build is triggered on TravisCI)
- I make a PR on the repo (a build is triggered on TravisCI)

### expected result

- one build triggered

### actual result

- two builds triggered

## New setup

- build branches "master" and "develop" on push
- build PRs when created.
- other branches are ignored on push

## Note

I think this needs to be merged to the repo's main branch before it becomes active on all branches

source: https://docs.travis-ci.com/user/customizing-the-build#Building-Specific-Branches