### PR TITLE
Use GC::Profiler to track garbage collection time

### DIFF
--- a/ext/agent.yml
+++ b/ext/agent.yml
@@ -1,18 +1,18 @@
 ---
-version: '2220960'
+version: de7a331
 triples:
   x86_64-linux:
-    checksum: 189daaef0fcc2fec442ac89227aefa2d3bef762d1cd7736706ae8ef79c40f5a3
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/2220960/appsignal-x86_64-linux-all-static.tar.gz
+    checksum: e2bbd606edf8c415b11129d0a9fca864606134e241d7e5c92e2acfe53d930ef6
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/de7a331/appsignal-x86_64-linux-all-static.tar.gz
   i686-linux:
-    checksum: 714e3759c085a97ec724bab092848513b9090c0ce3c7c8d182991916e592cbdb
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/2220960/appsignal-i686-linux-all-static.tar.gz
+    checksum: 65fbc606996f6ac40f961dc739f8fca85ec041e019b1299bb8176fd2a3fffaa3
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/de7a331/appsignal-i686-linux-all-static.tar.gz
   x86-linux:
-    checksum: 714e3759c085a97ec724bab092848513b9090c0ce3c7c8d182991916e592cbdb
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/2220960/appsignal-i686-linux-all-static.tar.gz
+    checksum: 65fbc606996f6ac40f961dc739f8fca85ec041e019b1299bb8176fd2a3fffaa3
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/de7a331/appsignal-i686-linux-all-static.tar.gz
   x86_64-darwin:
-    checksum: 9b591dee23cbeb31a05c49a1e5c143b7afb37348526d147957238722882c1f9e
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/2220960/appsignal-x86_64-darwin-all-static.tar.gz
+    checksum: cea10b64628f46cdfe881682ac10bd46f0d6ee7e320014b91eacaaa3c5ab956e
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/de7a331/appsignal-x86_64-darwin-all-static.tar.gz
   universal-darwin:
-    checksum: 9b591dee23cbeb31a05c49a1e5c143b7afb37348526d147957238722882c1f9e
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/2220960/appsignal-x86_64-darwin-all-static.tar.gz
+    checksum: cea10b64628f46cdfe881682ac10bd46f0d6ee7e320014b91eacaaa3c5ab956e
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/de7a331/appsignal-x86_64-darwin-all-static.tar.gz

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -58,11 +58,16 @@ module Appsignal
           Appsignal::Hooks.load_hooks
           Appsignal::EventFormatter.initialize_formatters
           initialize_extensions
-          Appsignal::Extension.install_allocation_event_hook if config[:enable_allocation_tracking]
+
+          if config[:enable_allocation_tracking]
+            Appsignal::Extension.install_allocation_event_hook
+          end
+
           if config[:enable_gc_instrumentation]
-            Appsignal::Extension.install_gc_event_hooks
+            GC::Profiler.enable
             Appsignal::Minutely.add_gc_probe
           end
+
           Appsignal::Minutely.start if config[:enable_minutely_probes]
           @subscriber = Appsignal::Subscriber.new
         else
@@ -325,6 +330,7 @@ require 'appsignal/hooks'
 require 'appsignal/marker'
 require 'appsignal/minutely'
 require 'appsignal/params_sanitizer'
+require 'appsignal/garbage_collection_profiler'
 require 'appsignal/integrations/railtie' if defined?(::Rails)
 require 'appsignal/integrations/resque'
 require 'appsignal/integrations/resque_active_job'

--- a/lib/appsignal/garbage_collection_profiler.rb
+++ b/lib/appsignal/garbage_collection_profiler.rb
@@ -1,0 +1,47 @@
+module Appsignal
+  # Appsignal::GarbageCollectionProfiler wraps Ruby's GC::Profiler to be able
+  # to track garbage collection time for multiple transactions, while
+  # constantly clearing GC::Profiler's total_time to make sure it doesn't leak
+  # memory by keeping garbage collection run samples in memory.
+
+  class GarbageCollectionProfiler
+    def initialize
+      @total_time = 0
+    end
+
+    # Whenever #total_time is called, the current GC::Profiler.total_time gets
+    # added to @total_time, after which GC::Profiler.clear is called to prevent
+    # it from leaking memory. A class-level lock is used to make sure garbage
+    # collection time is never counted more than once.
+    #
+    # Whenever @total_time gets above two billion milliseconds (about 23 days),
+    # it's reset to make sure the result fits in a signed 32-bit integer.
+
+    def total_time
+      lock.synchronize do
+        @total_time += (internal_profiler.total_time * 1000).round
+        internal_profiler.clear
+      end
+
+      if @total_time > 2_000_000_000
+        @total_time = 0
+      end
+
+      @total_time
+    end
+
+    private
+
+    def self.lock
+      @lock ||= Mutex.new
+    end
+
+    def internal_profiler
+      GC::Profiler
+    end
+
+    def lock
+      self.class.lock
+    end
+  end
+end

--- a/lib/appsignal/js_exception_transaction.rb
+++ b/lib/appsignal/js_exception_transaction.rb
@@ -5,7 +5,7 @@ module Appsignal
     def initialize(data)
       @data = data
       @uuid = SecureRandom.uuid
-      @ext = Appsignal::Extension.start_transaction(@uuid, Appsignal::Transaction::FRONTEND)
+      @ext = Appsignal::Extension.start_transaction(@uuid, Appsignal::Transaction::FRONTEND, 0)
 
       set_action
       set_metadata

--- a/spec/lib/appsignal/extension_spec.rb
+++ b/spec/lib/appsignal/extension_spec.rb
@@ -37,18 +37,18 @@ describe "extension loading and operation" do
       end
 
       context "with a transaction" do
-        subject { Appsignal::Extension.start_transaction('request_id', 'http_request') }
+        subject { Appsignal::Extension.start_transaction('request_id', 'http_request', 0) }
 
         it "should have a start_event method" do
-          subject.start_event
+          subject.start_event(0)
         end
 
         it "should have a finish_event method" do
-          subject.finish_event('name', 'title', 'body', 0)
+          subject.finish_event('name', 'title', 'body', 0, 0)
         end
 
         it "should have a record_event method" do
-          subject.record_event('name', 'title', 'body', 0, 1000)
+          subject.record_event('name', 'title', 'body', 1000, 0, 1000)
         end
 
         it "should have a set_error method" do
@@ -72,7 +72,7 @@ describe "extension loading and operation" do
         end
 
         it "should have a finish method" do
-          subject.finish
+          subject.finish(0)
         end
 
         it "should have a complete method" do

--- a/spec/lib/appsignal/garbage_collection_profiler_spec.rb
+++ b/spec/lib/appsignal/garbage_collection_profiler_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+require_relative '../../support/mocks/fake_gc_profiler'
+
+describe Appsignal::GarbageCollectionProfiler do
+  let(:internal_profiler) { FakeGCProfiler.new }
+
+  before do
+    allow_any_instance_of(Appsignal::GarbageCollectionProfiler)
+      .to receive(:internal_profiler)
+      .and_return(internal_profiler)
+  end
+
+  it "should have a total time of 0" do
+    expect(Appsignal::GarbageCollectionProfiler.new.total_time).to eq(0)
+  end
+
+  describe "after a GC run" do
+    before do
+      internal_profiler.total_time = 0.12345
+      @profiler = Appsignal::GarbageCollectionProfiler.new
+    end
+
+    it "should take the total time from Ruby's GC::Profiler" do
+      expect(@profiler.total_time).to eq(123)
+    end
+
+    it "should clear Ruby's GC::Profiler" do
+      expect(internal_profiler).to receive(:clear)
+      @profiler.total_time
+    end
+  end
+
+  describe "when the total GC time becomes too high" do
+    it "should reset" do
+      profiler = Appsignal::GarbageCollectionProfiler.new
+        internal_profiler.total_time = 2_147_483_647
+        expect(profiler.total_time).to eq(0)
+    end
+  end
+
+  describe "after multiple GC runs" do
+    it "should add all times from Ruby's GC::Profiler together" do
+      profiler = Appsignal::GarbageCollectionProfiler.new
+
+      2.times do
+        internal_profiler.total_time = 0.12345
+        profiler.total_time
+      end
+
+      expect(profiler.total_time).to eq(246)
+    end
+  end
+
+  describe "in multiple threads, with a slow GC::Profiler" do
+    it "should not count garbage collection times twice" do
+      threads, results = [], []
+      internal_profiler.clear_delay = 0.001
+      internal_profiler.total_time = 0.12345
+
+      2.times do
+        threads << Thread.new do
+          profiler = Appsignal::GarbageCollectionProfiler.new
+          results << profiler.total_time
+        end
+      end
+
+      threads.each(&:join)
+      expect(results).to eq([123, 0])
+    end
+  end
+end

--- a/spec/lib/appsignal/js_exception_transaction_spec.rb
+++ b/spec/lib/appsignal/js_exception_transaction_spec.rb
@@ -21,7 +21,7 @@ describe Appsignal::JSExceptionTransaction do
 
   describe "#initialize" do
     it "should call all required methods" do
-      expect( Appsignal::Extension ).to receive(:start_transaction).with('123abc', 'frontend').and_return(1)
+      expect( Appsignal::Extension ).to receive(:start_transaction).with('123abc', 'frontend', 0).and_return(1)
 
       expect( transaction ).to receive(:set_action)
       expect( transaction ).to receive(:set_metadata)

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -91,18 +91,23 @@ describe Appsignal do
 
       context "when allocation tracking and gc instrumentation have been enabled" do
         before do
+          allow(GC::Profiler).to receive(:enable)
           Appsignal.config.config_hash[:enable_allocation_tracking] = true
           Appsignal.config.config_hash[:enable_gc_instrumentation] = true
         end
 
-        it "should install event hooks" do
-          Appsignal::Extension.should_receive(:install_allocation_event_hook)
-          Appsignal::Extension.should_receive(:install_gc_event_hooks)
+        it "should enable Ruby's GC::Profiler" do
+          expect(GC::Profiler).to receive(:enable)
+          Appsignal.start
+        end
+
+        it "should install the allocation event hook" do
+          expect(Appsignal::Extension).to receive(:install_allocation_event_hook)
           Appsignal.start
         end
 
         it "should add the gc probe to minutely" do
-          Appsignal::Minutely.should_receive(:add_gc_probe)
+          expect(Appsignal::Minutely).to receive(:add_gc_probe)
           Appsignal.start
         end
       end
@@ -113,14 +118,18 @@ describe Appsignal do
           Appsignal.config.config_hash[:enable_gc_instrumentation] = false
         end
 
-        it "should not install event hooks" do
-          Appsignal::Extension.should_not_receive(:install_allocation_event_hook)
-          Appsignal::Extension.should_not_receive(:install_gc_event_hooks)
+        it "should not enable Ruby's GC::Profiler" do
+          expect(GC::Profiler).not_to receive(:enable)
+          Appsignal.start
+        end
+
+        it "should not install the allocation event hook" do
+          expect(Appsignal::Minutely).not_to receive(:install_allocation_event_hook)
           Appsignal.start
         end
 
        it "should not add the gc probe to minutely" do
-          Appsignal::Minutely.should_not_receive(:add_gc_probe)
+          expect(Appsignal::Minutely).not_to receive(:add_gc_probe)
           Appsignal.start
        end
       end

--- a/spec/support/mocks/fake_gc_profiler.rb
+++ b/spec/support/mocks/fake_gc_profiler.rb
@@ -1,0 +1,19 @@
+class FakeGCProfiler
+  attr_accessor :total_time
+  attr_writer :clear_delay
+
+  def initialize(total_time = 0)
+    @total_time = total_time
+  end
+
+  def clear
+    sleep clear_delay
+    @total_time = 0
+  end
+
+  private
+
+  def clear_delay
+    @clear_delay ||= 0
+  end
+end


### PR DESCRIPTION
Instead of using Ruby's internal events, we'll use `GC::Profiler` to send garbage collection time to the agent per event.

### TODO
- [x]  Add a comment with the rationale behind this approach in garbage_collection_profiler.rb?