### PR TITLE
Improve spec suite structure, part 1

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,3 @@
---order default --warnings
+--order default
+--warnings
+--require spec_helper

--- a/spec/lib/appsignal/auth_check_spec.rb
+++ b/spec/lib/appsignal/auth_check_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::AuthCheck do
   let(:config) { project_fixture_config }
   let(:logger) { Logger.new(StringIO.new) }

--- a/spec/lib/appsignal/capistrano2_spec.rb
+++ b/spec/lib/appsignal/capistrano2_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 if capistrano2_present?
   require 'capistrano'
   require 'capistrano/configuration'

--- a/spec/lib/appsignal/capistrano3_spec.rb
+++ b/spec/lib/appsignal/capistrano3_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 if capistrano3_present?
   require 'capistrano/all'
   require 'capistrano/deploy'

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'appsignal/cli'
 
 describe Appsignal::CLI::Diagnose do

--- a/spec/lib/appsignal/cli/install_spec.rb
+++ b/spec/lib/appsignal/cli/install_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'appsignal/cli'
 
 begin

--- a/spec/lib/appsignal/cli/notify_of_deploy_spec.rb
+++ b/spec/lib/appsignal/cli/notify_of_deploy_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'appsignal/cli'
 
 describe Appsignal::CLI::NotifyOfDeploy do

--- a/spec/lib/appsignal/cli_spec.rb
+++ b/spec/lib/appsignal/cli_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'appsignal/cli'
 
 describe Appsignal::CLI do

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::Config do
   subject { config }
 

--- a/spec/lib/appsignal/event_formatter/action_view/render_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/action_view/render_formatter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 if rails_present?
   require 'action_view'
 

--- a/spec/lib/appsignal/event_formatter/active_record/instantiation_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/active_record/instantiation_formatter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::EventFormatter::ActiveRecord::InstantiationFormatter do
   let(:klass)     { Appsignal::EventFormatter::ActiveRecord::InstantiationFormatter }
   let(:formatter) { klass.new }

--- a/spec/lib/appsignal/event_formatter/active_record/sql_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/active_record/sql_formatter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::EventFormatter::ActiveRecord::InstantiationFormatter do
   let(:klass)     { Appsignal::EventFormatter::ActiveRecord::SqlFormatter }
   let(:formatter) { klass.new }

--- a/spec/lib/appsignal/event_formatter/elastic_search/search_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/elastic_search/search_formatter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::EventFormatter::ElasticSearch::SearchFormatter do
   let(:klass)     { Appsignal::EventFormatter::ElasticSearch::SearchFormatter }
   let(:formatter) { klass.new }

--- a/spec/lib/appsignal/event_formatter/faraday/request_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/faraday/request_formatter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::EventFormatter::Faraday::RequestFormatter do
   let(:klass)     { Appsignal::EventFormatter::Faraday::RequestFormatter }
   let(:formatter) { klass.new }

--- a/spec/lib/appsignal/event_formatter/mongo_ruby_driver/query_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/mongo_ruby_driver/query_formatter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::EventFormatter::MongoRubyDriver::QueryFormatter do
   let(:formatter) { Appsignal::EventFormatter::MongoRubyDriver::QueryFormatter }
 

--- a/spec/lib/appsignal/event_formatter/moped/query_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/moped/query_formatter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::EventFormatter::Moped::QueryFormatter do
   let(:klass) { Appsignal::EventFormatter::Moped::QueryFormatter }
   let(:formatter) { klass.new }

--- a/spec/lib/appsignal/event_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 class MockFormatter < Appsignal::EventFormatter
   register 'mock'
 

--- a/spec/lib/appsignal/extension_spec.rb
+++ b/spec/lib/appsignal/extension_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'fileutils'
 
 describe "extension loading and operation" do

--- a/spec/lib/appsignal/hooks/celluloid_spec.rb
+++ b/spec/lib/appsignal/hooks/celluloid_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::Hooks::CelluloidHook do
   context "with celluloid" do
     before :all do

--- a/spec/lib/appsignal/hooks/data_mapper_spec.rb
+++ b/spec/lib/appsignal/hooks/data_mapper_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::Hooks::DataMapperHook do
   context "with datamapper" do
     before :all do

--- a/spec/lib/appsignal/hooks/delayed_job_spec.rb
+++ b/spec/lib/appsignal/hooks/delayed_job_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::Hooks::DelayedJobHook do
   context "with delayed job" do
     before(:all) do

--- a/spec/lib/appsignal/hooks/mongo_ruby_driver_spec.rb
+++ b/spec/lib/appsignal/hooks/mongo_ruby_driver_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::Hooks::MongoRubyDriverHook do
   require 'appsignal/integrations/mongo_ruby_driver'
 

--- a/spec/lib/appsignal/hooks/net_http_spec.rb
+++ b/spec/lib/appsignal/hooks/net_http_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::Hooks::NetHttpHook do
   before :all do
     start_agent

--- a/spec/lib/appsignal/hooks/passenger_spec.rb
+++ b/spec/lib/appsignal/hooks/passenger_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::Hooks::PassengerHook do
   context "with passenger" do
     before(:all) do

--- a/spec/lib/appsignal/hooks/puma_spec.rb
+++ b/spec/lib/appsignal/hooks/puma_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::Hooks::PumaHook do
   context "with puma" do
     before(:all) do

--- a/spec/lib/appsignal/hooks/rake_spec.rb
+++ b/spec/lib/appsignal/hooks/rake_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'rake'
 
 describe Appsignal::Hooks::RakeHook do

--- a/spec/lib/appsignal/hooks/redis_spec.rb
+++ b/spec/lib/appsignal/hooks/redis_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::Hooks::RedisHook do
   before :all do
     start_agent

--- a/spec/lib/appsignal/hooks/sequel_spec.rb
+++ b/spec/lib/appsignal/hooks/sequel_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::Hooks::SequelHook, if: sequel_present? do
   let(:db) { Sequel.sqlite }
 

--- a/spec/lib/appsignal/hooks/shoryuken_spec.rb
+++ b/spec/lib/appsignal/hooks/shoryuken_spec.rb
@@ -51,7 +51,7 @@ describe Appsignal::Hooks::ShoryukenMiddleware do
   end
 
   context "with an erroring call" do
-    let(:error) { VerySpecificError.new('on fire') }
+    let(:error) { VerySpecificError.new }
 
     it "should add the exception to appsignal" do
       Appsignal::Transaction.any_instance.should_receive(:set_error).with(error)

--- a/spec/lib/appsignal/hooks/shoryuken_spec.rb
+++ b/spec/lib/appsignal/hooks/shoryuken_spec.rb
@@ -1,6 +1,3 @@
-require 'spec_helper'
-
-
 describe Appsignal::Hooks::ShoryukenMiddleware do
   let(:current_transaction) { background_job_transaction }
 

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::Hooks::SidekiqPlugin do
   let(:worker) { double }
   let(:queue) { double }

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -79,7 +79,8 @@ describe Appsignal::Hooks::SidekiqPlugin do
   end
 
   context "with an erroring call" do
-    let(:error) { VerySpecificError.new('the roof') }
+    let(:error) { VerySpecificError.new }
+
     it "should add the exception to appsignal" do
       Appsignal::Transaction.any_instance.should_receive(:set_error).with(error)
     end

--- a/spec/lib/appsignal/hooks/unicorn_spec.rb
+++ b/spec/lib/appsignal/hooks/unicorn_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::Hooks::UnicornHook do
   context "with unicorn" do
     before :all do

--- a/spec/lib/appsignal/hooks_spec.rb
+++ b/spec/lib/appsignal/hooks_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 class MockPresentHook < Appsignal::Hooks::Hook
   def dependencies_present?
     true

--- a/spec/lib/appsignal/integrations/data_mapper_spec.rb
+++ b/spec/lib/appsignal/integrations/data_mapper_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'appsignal/integrations/data_mapper'
 
 describe Appsignal::Hooks::DataMapperLogListener do

--- a/spec/lib/appsignal/integrations/grape_spec.rb
+++ b/spec/lib/appsignal/integrations/grape_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 if grape_present?
   require 'appsignal/integrations/grape'
 

--- a/spec/lib/appsignal/integrations/mongo_ruby_driver_spec.rb
+++ b/spec/lib/appsignal/integrations/mongo_ruby_driver_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'appsignal/integrations/mongo_ruby_driver'
 describe Appsignal::Hooks::MongoMonitorSubscriber do
   let(:subscriber) { Appsignal::Hooks::MongoMonitorSubscriber.new }

--- a/spec/lib/appsignal/integrations/object_spec.rb
+++ b/spec/lib/appsignal/integrations/object_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'appsignal/integrations/object'
 
 describe Object do

--- a/spec/lib/appsignal/integrations/padrino_spec.rb
+++ b/spec/lib/appsignal/integrations/padrino_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 begin
   require 'padrino'
 rescue LoadError

--- a/spec/lib/appsignal/integrations/railtie_spec.rb
+++ b/spec/lib/appsignal/integrations/railtie_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 if rails_present?
   describe Appsignal::Integrations::Railtie do
     context "after initializing the app" do

--- a/spec/lib/appsignal/integrations/resque_active_job_spec.rb
+++ b/spec/lib/appsignal/integrations/resque_active_job_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 if resque_present? && active_job_present?
   describe "Resque ActiveJob integration" do
     let(:file) { File.expand_path('lib/appsignal/integrations/resque_active_job.rb') }

--- a/spec/lib/appsignal/integrations/resque_spec.rb
+++ b/spec/lib/appsignal/integrations/resque_spec.rb
@@ -20,7 +20,7 @@ if resque_present?
           extend Appsignal::Integrations::ResquePlugin
 
           def self.perform
-            raise VerySpecificError.new('broken')
+            raise VerySpecificError.new
           end
         end
       end

--- a/spec/lib/appsignal/integrations/resque_spec.rb
+++ b/spec/lib/appsignal/integrations/resque_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 if resque_present?
   describe "Resque integration" do
     let(:file) { File.expand_path('lib/appsignal/integrations/resque.rb') }

--- a/spec/lib/appsignal/integrations/sinatra_spec.rb
+++ b/spec/lib/appsignal/integrations/sinatra_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 if sinatra_present? && !padrino_present?
   ENV['APPSIGNAL_PUSH_API_KEY'] = 'key'
   require 'appsignal/integrations/sinatra'

--- a/spec/lib/appsignal/js_exception_transaction_spec.rb
+++ b/spec/lib/appsignal/js_exception_transaction_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::JSExceptionTransaction do
   before { SecureRandom.stub(:uuid => '123abc') }
 

--- a/spec/lib/appsignal/marker_spec.rb
+++ b/spec/lib/appsignal/marker_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::Marker do
   let(:config) { project_fixture_config }
   let(:marker) {

--- a/spec/lib/appsignal/minutely_spec.rb
+++ b/spec/lib/appsignal/minutely_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::Minutely do
   before do
     Appsignal::Minutely.probes.clear

--- a/spec/lib/appsignal/rack/generic_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/generic_instrumentation_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::Rack::GenericInstrumentation do
   before :all do
     start_agent

--- a/spec/lib/appsignal/rack/js_exception_catcher_spec.rb
+++ b/spec/lib/appsignal/rack/js_exception_catcher_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::Rack::JSExceptionCatcher do
   let(:app)            { double(:call => true) }
   let(:options)        { double }

--- a/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 class MockController
 end
 

--- a/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 begin
   require 'sinatra'
   require 'appsignal/integrations/sinatra'

--- a/spec/lib/appsignal/rack/streaming_listener_spec.rb
+++ b/spec/lib/appsignal/rack/streaming_listener_spec.rb
@@ -89,7 +89,7 @@ describe Appsignal::Rack::StreamingListener do
 
     context "with an exception in the instrumentation call" do
       it "should add the exception to the transaction" do
-        allow( app ).to receive(:call).and_raise(VerySpecificError.new('broken'))
+        allow( app ).to receive(:call).and_raise(VerySpecificError.new)
 
         expect( transaction ).to receive(:set_error)
 
@@ -124,7 +124,7 @@ describe Appsignal::StreamWrapper do
     context "when each raises an error" do
       it "should add the exception to the transaction" do
         allow( stream ).to receive(:each)
-          .and_raise(VerySpecificError.new('broken'))
+          .and_raise(VerySpecificError.new)
 
         expect( transaction ).to receive(:set_error)
 
@@ -144,7 +144,7 @@ describe Appsignal::StreamWrapper do
     context "when each raises an error" do
       it "should add the exception to the transaction and close it" do
         allow( stream ).to receive(:close)
-          .and_raise(VerySpecificError.new('broken'))
+          .and_raise(VerySpecificError.new)
 
         expect( transaction ).to receive(:set_error)
         expect( Appsignal::Transaction ).to receive(:complete_current!)

--- a/spec/lib/appsignal/rack/streaming_listener_spec.rb
+++ b/spec/lib/appsignal/rack/streaming_listener_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'appsignal/rack/streaming_listener'
 
 describe Appsignal::Rack::StreamingListener do

--- a/spec/lib/appsignal/subscriber_spec.rb
+++ b/spec/lib/appsignal/subscriber_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::Subscriber do
   before :all do
     start_agent

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 class Smash < Hash
   def []=(key, val)
     raise 'the roof'

--- a/spec/lib/appsignal/transmitter_spec.rb
+++ b/spec/lib/appsignal/transmitter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::Transmitter do
   let(:config) { project_fixture_config }
   let(:action) { 'action' }

--- a/spec/lib/appsignal/update_active_support_spec.rb
+++ b/spec/lib/appsignal/update_active_support_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Appsignal::UpdateActiveSupport', :if => (
   Gem.loaded_specs['rails'] &&
   Gem.loaded_specs['rails'].version < Gem::Version.create('4.0')

--- a/spec/lib/appsignal/utils/params_sanitizer_spec.rb
+++ b/spec/lib/appsignal/utils/params_sanitizer_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::Utils::ParamsSanitizer do
   let(:file) { uploaded_file }
   let(:params) do

--- a/spec/lib/appsignal/utils/query_params_sanitizer_spec.rb
+++ b/spec/lib/appsignal/utils/query_params_sanitizer_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Appsignal::Utils::QueryParamsSanitizer do
   describe ".sanitize" do
     context "when only_top_level = true" do

--- a/spec/lib/appsignal/utils_spec.rb
+++ b/spec/lib/appsignal/utils_spec.rb
@@ -1,7 +1,5 @@
 # encoding: UTF-8
 
-require 'spec_helper'
-
 describe Appsignal::Utils do
   describe ".json_generate" do
     subject { Appsignal::Utils.json_generate(body) }

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require './spec/support/mocks/mock_extension'
 
 describe Appsignal do

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -361,7 +361,7 @@ describe Appsignal do
       end
 
       context "with an erroring call" do
-        let(:error) { VerySpecificError.new('the roof') }
+        let(:error) { VerySpecificError.new }
 
         it "should add the error to the current transaction and complete" do
           Appsignal::Transaction.any_instance.should_receive(:set_error).with(error)
@@ -392,7 +392,7 @@ describe Appsignal do
       end
 
       context "with an erroring call" do
-        let(:error) { VerySpecificError.new('the roof') }
+        let(:error) { VerySpecificError.new }
 
         it "should call monitor_transaction and stop and then raise the error" do
           Appsignal.should_receive(:monitor_transaction).with(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -155,6 +155,3 @@ RSpec.configure do |config|
     Appsignal.logger = nil
   end
 end
-
-class VerySpecificError < RuntimeError
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,21 @@
 ENV['RAILS_ENV'] ||= 'test'
 ENV['PADRINO_ENV'] ||= 'test'
 
+APPSIGNAL_SPEC_DIR = File.expand_path(File.dirname(__FILE__))
+
 require 'rack'
 require 'rspec'
 require 'pry'
 require 'timecop'
 require 'webmock/rspec'
 
-puts "Runnings specs in #{RUBY_VERSION} on #{RUBY_PLATFORM}"
+Dir[File.join(APPSIGNAL_SPEC_DIR, 'support/helpers', '*.rb')].each do |f|
+  require f
+end
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), 'support/stubs'))
+$LOAD_PATH.unshift(File.join(APPSIGNAL_SPEC_DIR, 'support/stubs'))
+
+puts "Runnings specs in #{RUBY_VERSION} on #{RUBY_PLATFORM}\n\n"
 
 begin
   require 'rails'
@@ -20,6 +26,8 @@ rescue LoadError
   puts 'Rails not present, skipping Rails specific specs'
   RAILS_PRESENT = false
 end
+
+require 'appsignal'
 
 def rails_present?
   RAILS_PRESENT
@@ -101,26 +109,6 @@ rescue LoadError
   false
 end
 
-require 'appsignal'
-
-def spec_dir
-  File.dirname(__FILE__)
-end
-
-def tmp_dir
-  @tmp_dir ||= File.expand_path('tmp', spec_dir)
-end
-
-def fixtures_dir
-  @fixtures_dir ||= File.expand_path('support/fixtures', spec_dir)
-end
-
-def helpers_dir
-  @helpers_dir ||= File.expand_path('support/helpers', spec_dir)
-end
-
-Dir[File.join(helpers_dir, '*.rb')].each { |file| require file }
-
 # Add way to clear subscribers between specs
 module ActiveSupport
   module Notifications
@@ -134,6 +122,7 @@ module ActiveSupport
 end
 
 RSpec.configure do |config|
+  config.include DirectoryHelper
   config.include ConfigHelpers
   config.include EnvHelpers
   config.include NotificationHelpers

--- a/spec/support/helpers/directory_helper.rb
+++ b/spec/support/helpers/directory_helper.rb
@@ -1,0 +1,17 @@
+module DirectoryHelper
+  def spec_dir
+    APPSIGNAL_SPEC_DIR
+  end
+
+  def support_dir
+    @support_dir ||= File.join(spec_dir, 'support')
+  end
+
+  def tmp_dir
+    @tmp_dir ||= File.join(spec_dir, 'tmp')
+  end
+
+  def fixtures_dir
+    @fixtures_dir ||= File.join(support_dir, 'fixtures')
+  end
+end

--- a/spec/support/helpers/very_specific_error.rb
+++ b/spec/support/helpers/very_specific_error.rb
@@ -1,0 +1,8 @@
+# This VerySpecificError is used for throwing errors in specs that are allowed
+# or expected.
+#
+# For example, this error can be thrown to raise an exception in AppSignal's
+# run, which should stop the program and the appsignal gem, but not crash the
+# test suite.
+class VerySpecificError < RuntimeError
+end


### PR DESCRIPTION
PR that updates the test suite to be a little bit more organized. These are the first few things I encountered, but I am working on more. Things that will go in another PR, otherwise this PR will get too big.

- [x] Automatically require spec_helper.rb in the .rspec file.  
  Less code :) Automatic includes :)
- [x] Extract and document `VerySpecificError`  
  It was kind of lost now, defined at the end of the spec_helper, with no idea what it was used for.
- [x] Extract DirectoryHelper module so that we do not define global methods