### PR TITLE
Move dependency checks to their own helper

### DIFF
--- a/gemfiles/resque.gemfile
+++ b/gemfiles/resque.gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'resque'
 gem 'rails', '~> 4.2.0'
+gem 'sinatra'
 gem 'mime-types', '~> 2.6'
 
 gemspec :path => '../'

--- a/spec/lib/appsignal/capistrano2_spec.rb
+++ b/spec/lib/appsignal/capistrano2_spec.rb
@@ -1,4 +1,4 @@
-if capistrano2_present?
+if DependencyHelper.capistrano2_present?
   require 'capistrano'
   require 'capistrano/configuration'
   require 'appsignal/capistrano'

--- a/spec/lib/appsignal/capistrano3_spec.rb
+++ b/spec/lib/appsignal/capistrano3_spec.rb
@@ -1,4 +1,4 @@
-if capistrano3_present?
+if DependencyHelper.capistrano3_present?
   require 'capistrano/all'
   require 'capistrano/deploy'
   require 'appsignal/capistrano'

--- a/spec/lib/appsignal/cli/install_spec.rb
+++ b/spec/lib/appsignal/cli/install_spec.rb
@@ -1,10 +1,5 @@
 require 'appsignal/cli'
 
-begin
-  require 'sinatra'
-rescue LoadError
-end
-
 describe Appsignal::CLI::Install do
   let(:out_stream) { StringIO.new }
   let(:cli) { Appsignal::CLI::Install }

--- a/spec/lib/appsignal/event_formatter/action_view/render_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/action_view/render_formatter_spec.rb
@@ -1,4 +1,4 @@
-if rails_present?
+if DependencyHelper.rails_present?
   require 'action_view'
 
   describe Appsignal::EventFormatter::ActionView::RenderFormatter do

--- a/spec/lib/appsignal/hooks/sequel_spec.rb
+++ b/spec/lib/appsignal/hooks/sequel_spec.rb
@@ -1,26 +1,26 @@
-describe Appsignal::Hooks::SequelHook, if: sequel_present? do
-  let(:db) { Sequel.sqlite }
+describe Appsignal::Hooks::SequelHook do
+  if DependencyHelper.sequel_present?
+    let(:db) { Sequel.sqlite }
 
-  before :all do
-    start_agent
-  end
-
-  its(:dependencies_present?) { should be_true }
-
-  context "with a transaction" do
-    it "should instrument queries" do
-      Appsignal::Transaction.create('uuid', Appsignal::Transaction::HTTP_REQUEST, 'test')
-      expect( Appsignal::Transaction.current ).to receive(:start_event)
-        .at_least(:once)
-      expect( Appsignal::Transaction.current ).to receive(:finish_event)
-        .at_least(:once)
-        .with("sql.sequel", nil, kind_of(String), 1)
-
-      db['SELECT 1'].all.to_a
+    before :all do
+      start_agent
     end
-  end
-end
 
-describe Appsignal::Hooks::SequelHook, unless: sequel_present? do
-  its(:dependencies_present?) { should be_false }
+    its(:dependencies_present?) { should be_true }
+
+    context "with a transaction" do
+      it "should instrument queries" do
+        Appsignal::Transaction.create('uuid', Appsignal::Transaction::HTTP_REQUEST, 'test')
+        expect( Appsignal::Transaction.current ).to receive(:start_event)
+          .at_least(:once)
+        expect( Appsignal::Transaction.current ).to receive(:finish_event)
+          .at_least(:once)
+          .with("sql.sequel", nil, kind_of(String), 1)
+
+        db['SELECT 1'].all.to_a
+      end
+    end
+  else
+    its(:dependencies_present?) { should be_false }
+  end
 end

--- a/spec/lib/appsignal/hooks/webmachine_spec.rb
+++ b/spec/lib/appsignal/hooks/webmachine_spec.rb
@@ -1,5 +1,5 @@
-if webmachine_present?
-  describe Appsignal::Hooks::WebmachineHook do
+describe Appsignal::Hooks::WebmachineHook do
+  if DependencyHelper.webmachine_present?
     context "with webmachine" do
       before(:all) do
         Appsignal::Hooks::WebmachineHook.new.install
@@ -25,5 +25,4 @@ if webmachine_present?
       end
     end
   end
-
 end

--- a/spec/lib/appsignal/integrations/grape_spec.rb
+++ b/spec/lib/appsignal/integrations/grape_spec.rb
@@ -1,4 +1,4 @@
-if grape_present?
+if DependencyHelper.grape_present?
   require 'appsignal/integrations/grape'
 
   describe Appsignal::Grape::Middleware do

--- a/spec/lib/appsignal/integrations/padrino_spec.rb
+++ b/spec/lib/appsignal/integrations/padrino_spec.rb
@@ -1,9 +1,4 @@
-begin
-  require 'padrino'
-rescue LoadError
-end
-
-if padrino_present?
+if DependencyHelper.padrino_present?
   describe "Padrino integration"   do
     require File.expand_path('lib/appsignal/integrations/padrino.rb')
 

--- a/spec/lib/appsignal/integrations/railtie_spec.rb
+++ b/spec/lib/appsignal/integrations/railtie_spec.rb
@@ -1,4 +1,4 @@
-if rails_present?
+if DependencyHelper.rails_present?
   describe Appsignal::Integrations::Railtie do
     context "after initializing the app" do
       it "should call initialize_appsignal" do

--- a/spec/lib/appsignal/integrations/resque_active_job_spec.rb
+++ b/spec/lib/appsignal/integrations/resque_active_job_spec.rb
@@ -1,4 +1,4 @@
-if resque_present? && active_job_present?
+if DependencyHelper.resque_present? && DependencyHelper.active_job_present?
   describe "Resque ActiveJob integration" do
     let(:file) { File.expand_path('lib/appsignal/integrations/resque_active_job.rb') }
 

--- a/spec/lib/appsignal/integrations/resque_spec.rb
+++ b/spec/lib/appsignal/integrations/resque_spec.rb
@@ -1,4 +1,4 @@
-if resque_present?
+if DependencyHelper.resque_present?
   describe "Resque integration" do
     let(:file) { File.expand_path('lib/appsignal/integrations/resque.rb') }
 

--- a/spec/lib/appsignal/integrations/sinatra_spec.rb
+++ b/spec/lib/appsignal/integrations/sinatra_spec.rb
@@ -1,4 +1,4 @@
-if sinatra_present? && !padrino_present?
+if DependencyHelper.sinatra_present?
   ENV['APPSIGNAL_PUSH_API_KEY'] = 'key'
   require 'appsignal/integrations/sinatra'
 

--- a/spec/lib/appsignal/integrations/webmachine_spec.rb
+++ b/spec/lib/appsignal/integrations/webmachine_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
-if webmachine_present?
-
+if DependencyHelper.webmachine_present?
   require 'appsignal/integrations/webmachine'
 
   describe Appsignal::Integrations::WebmachinePlugin::FSM do

--- a/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
@@ -1,7 +1,7 @@
-class MockController
-end
+if DependencyHelper.rails_present?
+  class MockController
+  end
 
-if defined?(::Rails)
   describe Appsignal::Rack::RailsInstrumentation do
     before :all do
       start_agent

--- a/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
@@ -1,10 +1,6 @@
-begin
-  require 'sinatra'
+if DependencyHelper.sinatra_present?
   require 'appsignal/integrations/sinatra'
-rescue LoadError
-end
 
-if defined?(::Sinatra)
   describe Appsignal::Rack::SinatraInstrumentation do
     let(:settings) { double(:raise_errors => false) }
     let(:app) { double(:call => true, :settings => settings) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,9 @@ ENV['RAILS_ENV'] ||= 'test'
 ENV['PADRINO_ENV'] ||= 'test'
 
 APPSIGNAL_SPEC_DIR = File.expand_path(File.dirname(__FILE__))
+$LOAD_PATH.unshift(File.join(APPSIGNAL_SPEC_DIR, 'support/stubs'))
 
+Bundler.require :default
 require 'rack'
 require 'rspec'
 require 'pry'
@@ -12,102 +14,14 @@ require 'webmock/rspec'
 Dir[File.join(APPSIGNAL_SPEC_DIR, 'support/helpers', '*.rb')].each do |f|
   require f
 end
-
-$LOAD_PATH.unshift(File.join(APPSIGNAL_SPEC_DIR, 'support/stubs'))
-
-puts "Running specs in #{RUBY_VERSION} on #{RUBY_PLATFORM}\n\n"
-
-begin
-  require 'rails'
-  Dir[File.expand_path(File.join(File.dirname(__FILE__), 'support/rails','*.rb'))].each {|f| require f}
-  puts 'Rails present, running Rails specific specs'
-  RAILS_PRESENT = true
-rescue LoadError
-  puts 'Rails not present, skipping Rails specific specs'
-  RAILS_PRESENT = false
-end
-
-require 'appsignal'
-
-def rails_present?
-  RAILS_PRESENT
-end
-
-def active_job_present?
-  require 'active_job'
-  true
-rescue LoadError
-  false
-end
-
-def active_record_present?
-  require 'active_record'
-  true
-rescue LoadError
-  false
-end
-
-def running_jruby?
-  defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
-end
-
-def capistrano_present?
-  !! Gem.loaded_specs['capistrano']
-end
-
-def capistrano2_present?
-  capistrano_present? &&
-    Gem.loaded_specs['capistrano'].version < Gem::Version.new('3.0')
-end
-
-def capistrano3_present?
-  capistrano_present? &&
-    Gem.loaded_specs['capistrano'].version >= Gem::Version.new('3.0')
-end
-
-def sequel_present?
-  require 'sequel'
-  true
-rescue LoadError
-  false
-end
-
-def resque_present?
-  require 'resque'
-  true
-rescue LoadError
-  false
-end
-
-def sinatra_present?
-  begin
-    require 'sinatra'
-    true
-  rescue LoadError
-    false
+if DependencyHelper.rails_present?
+  Dir[File.join(DirectoryHelper.support_dir, 'rails', '*.rb')].each do |f|
+    require f
   end
 end
+require 'appsignal'
 
-def padrino_present?
-  require 'padrino'
-  true
-rescue LoadError
-  false
-end
-
-def grape_present?
-  require 'grape'
-  true
-rescue LoadError
-  false
-end
-
-def webmachine_present?
-  require 'webmachine'
-  true
-rescue LoadError
-  false
-end
+puts "Running specs in #{RUBY_VERSION} on #{RUBY_PLATFORM}\n\n"
 
 # Add way to clear subscribers between specs
 module ActiveSupport
@@ -128,6 +42,7 @@ RSpec.configure do |config|
   config.include NotificationHelpers
   config.include TimeHelpers
   config.include TransactionHelpers
+  config.extend DependencyHelper
 
   config.before :all do
     FileUtils.rm_rf(tmp_dir)

--- a/spec/support/helpers/dependency_helper.rb
+++ b/spec/support/helpers/dependency_helper.rb
@@ -1,0 +1,61 @@
+module DependencyHelper
+  module_function
+
+  def running_jruby?
+    defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
+  end
+
+  def rails_present?
+    dependency_present? 'rails'
+  end
+
+  def active_record_present?
+    dependency_present? 'active_record'
+  end
+
+  def sequel_present?
+    dependency_present? 'sequel'
+  end
+
+  def resque_present?
+    dependency_present? 'resque'
+  end
+
+  def active_job_present?
+    dependency_present? 'active_job'
+  end
+
+  def sinatra_present?
+    dependency_present? 'sinatra'
+  end
+
+  def padrino_present?
+    dependency_present? 'padrino'
+  end
+
+  def grape_present?
+    dependency_present? 'grape'
+  end
+
+  def webmachine_present?
+    dependency_present? 'webmachine'
+  end
+
+  def capistrano_present?
+    dependency_present? 'capistrano'
+  end
+
+  def capistrano2_present?
+    capistrano_present? &&
+      Gem.loaded_specs['capistrano'].version < Gem::Version.new('3.0')
+  end
+
+  def capistrano3_present?
+    capistrano_present? &&
+      Gem.loaded_specs['capistrano'].version >= Gem::Version.new('3.0')
+  end
+
+  def dependency_present?(dependency_file)
+    Gem.loaded_specs.key? dependency_file
+  end
+end

--- a/spec/support/helpers/directory_helper.rb
+++ b/spec/support/helpers/directory_helper.rb
@@ -1,4 +1,6 @@
 module DirectoryHelper
+  module_function
+
   def spec_dir
     APPSIGNAL_SPEC_DIR
   end

--- a/spec/support/helpers/transaction_helpers.rb
+++ b/spec/support/helpers/transaction_helpers.rb
@@ -1,6 +1,6 @@
 module TransactionHelpers
   def uploaded_file
-    if rails_present?
+    if DependencyHelper.rails_present?
       ActionDispatch::Http::UploadedFile.new(:tempfile => '/tmp')
     else
       ::Rack::Multipart::UploadedFile.new(File.join(fixtures_dir, '/uploaded_file.txt'))


### PR DESCRIPTION
This PR moves the `rails_present?` (etc) checks to their own helper module.

- Cleans up the spec helper
- No need to try and require a file and rescue `LoadError`s

## TODO

- [x] find a way to not have to extend `main` with `extend DependencyHelper` in spec_helper
- [x] update calls in specs to the DependencyHelper
- [x] remove duplicate methods of checking if a dependency is loaded, eg `if defined?(Rails)`
- [x] rename/move `running_jruby?` method