### PR TITLE
Ensure capistrano2 and 3 have configuration parity

### DIFF
--- a/lib/appsignal/integrations/capistrano/appsignal.cap
+++ b/lib/appsignal/integrations/capistrano/appsignal.cap
@@ -20,7 +20,7 @@ namespace :appsignal do
       marker = Appsignal::Marker.new(marker_data, appsignal_config)
       marker.transmit
     else
-      puts 'Not notifying of deploy, config is not active'
+      puts "Not notifying of deploy, config is not active for environment: #{env}"
     end
   end
 end

--- a/lib/appsignal/integrations/capistrano/capistrano_2_tasks.rb
+++ b/lib/appsignal/integrations/capistrano/capistrano_2_tasks.rb
@@ -7,7 +7,7 @@ module Appsignal
 
         namespace :appsignal do
           task :deploy do
-            env = fetch(:rails_env, fetch(:rack_env, 'production'))
+            env = fetch(:appsignal_env, fetch(:stage, fetch(:rails_env, fetch(:rack_env, 'production'))))
             user = ENV['USER'] || ENV['USERNAME']
             revision = fetch(:appsignal_revision, fetch(:current_revision))
 
@@ -31,7 +31,7 @@ module Appsignal
                 marker.transmit
               end
             else
-              puts 'Not notifying of deploy, config is not active'
+              puts "Not notifying of deploy, config is not active for environment: #{env}"
             end
           end
         end

--- a/spec/lib/appsignal/capistrano2_spec.rb
+++ b/spec/lib/appsignal/capistrano2_spec.rb
@@ -79,9 +79,47 @@ if capistrano2_present?
               )
             end
           end
+
+          context "when stage is used instead of rack_env / rails_env" do
+            before do
+              @capistrano_config.unset(:rails_env)
+              @capistrano_config.set(:stage, 'stage_production')
+            end
+
+            it "should be instantiated with the right params" do
+              Appsignal::Config.should_receive(:new).with(
+                project_fixture_path,
+                'stage_production',
+                {:name => 'AppName'},
+                kind_of(Logger)
+              )
+            end
+          end
+
+          context "when appsignal_env is set" do
+            before do
+              @capistrano_config.set(:rack_env, 'rack_production')
+              @capistrano_config.set(:stage, 'stage_production')
+              @capistrano_config.set(:appsignal_env, 'appsignal_production')
+            end
+
+            it "should prefer the appsignal_env rather than stage, rails_env and rack_env" do
+              Appsignal::Config.should_receive(:new).with(
+                project_fixture_path,
+                'appsignal_production',
+                {:name => 'AppName'},
+                kind_of(Logger)
+              )
+            end
+          end
         end
 
-        after { @capistrano_config.find_and_execute_task('appsignal:deploy') }
+        after do
+          @capistrano_config.find_and_execute_task('appsignal:deploy')
+          @capistrano_config.unset(:stage)
+          @capistrano_config.unset(:rack_env)
+          @capistrano_config.unset(:appsignal_env)
+        end
       end
 
       context "send marker" do
@@ -166,7 +204,7 @@ if capistrano2_present?
           it "should not send deploy marker" do
             Appsignal::Marker.should_not_receive(:new)
             @capistrano_config.find_and_execute_task('appsignal:deploy')
-            out_stream.string.should include('Not notifying of deploy, config is not active')
+            out_stream.string.should include('Not notifying of deploy, config is not active for environment: nonsense')
           end
         end
       end

--- a/spec/lib/appsignal/capistrano3_spec.rb
+++ b/spec/lib/appsignal/capistrano3_spec.rb
@@ -196,7 +196,7 @@ if capistrano3_present?
           it "should not send deploy marker" do
             Appsignal::Marker.should_not_receive(:new)
             invoke('appsignal:deploy')
-            out_stream.string.should include("Not notifying of deploy, config is not active")
+            out_stream.string.should include("Not notifying of deploy, config is not active for environment: nonsense")
           end
         end
       end


### PR DESCRIPTION
Add better error logging

The documentation states that you can set a `stage` config and appsignal will treat the deploy as that environment, however capistrano2 did not have support for this feature.

This commit adds support for the `stage` variable.

It also improves error logging by adding environment name to the message when the environment is not active.