### PR TITLE
Use Appsignal.instrument everywhere

### DIFF
--- a/benchmark.rake
+++ b/benchmark.rake
@@ -42,18 +42,18 @@ def run_benchmark
       )
       Appsignal::Transaction.create("transaction_#{i}", Appsignal::Transaction::HTTP_REQUEST, request)
 
-      ActiveSupport::Notifications.instrument('process_action.action_controller') do
-        ActiveSupport::Notifications.instrument('sql.active_record', :sql => 'SELECT `users`.* FROM `users`
+      Appsignal.instrument('process_action.action_controller') do
+        Appsignal.instrument('sql.active_record', :sql => 'SELECT `users`.* FROM `users`
                                                                               WHERE `users`.`id` = ?')
         10.times do
-          ActiveSupport::Notifications.instrument('sql.active_record', :sql => 'SELECT `todos`.* FROM `todos` WHERE `todos`.`id` = ?')
+          Appsignal.instrument('sql.active_record', :sql => 'SELECT `todos`.* FROM `todos` WHERE `todos`.`id` = ?')
         end
 
-        ActiveSupport::Notifications.instrument('render_template.action_view', :identifier => 'app/views/home/show.html.erb') do
+        Appsignal.instrument('render_template.action_view', :identifier => 'app/views/home/show.html.erb') do
           5.times do
-            ActiveSupport::Notifications.instrument('render_partial.action_view', :identifier => 'app/views/home/_piece.html.erb') do
+            Appsignal.instrument('render_partial.action_view', :identifier => 'app/views/home/_piece.html.erb') do
               3.times do
-                ActiveSupport::Notifications.instrument('cache.read')
+                Appsignal.instrument('cache.read')
               end
             end
           end

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -123,7 +123,7 @@ module Appsignal
         request
       )
       begin
-        ActiveSupport::Notifications.instrument(name) do
+        Appsignal.instrument(name) do
           yield
         end
       rescue => error

--- a/lib/appsignal/integrations/padrino.rb
+++ b/lib/appsignal/integrations/padrino.rb
@@ -33,7 +33,7 @@ module Padrino::Routing::InstanceMethods
       request
     )
     begin
-      ActiveSupport::Notifications.instrument('process_action.padrino') do
+      Appsignal.instrument('process_action.padrino') do
         route_without_appsignal(base, pass_block)
       end
     rescue => error

--- a/lib/appsignal/integrations/webmachine.rb
+++ b/lib/appsignal/integrations/webmachine.rb
@@ -12,7 +12,7 @@ module Appsignal::Integrations
 
         transaction.set_action("#{resource.class.name}##{request.method}")
 
-        ActiveSupport::Notifications.instrument('process_action.webmachine') do
+        Appsignal.instrument('process_action.webmachine') do
           run_without_appsignal
         end
 

--- a/lib/appsignal/rack/generic_instrumentation.rb
+++ b/lib/appsignal/rack/generic_instrumentation.rb
@@ -24,7 +24,7 @@ module Appsignal
           request
         )
         begin
-          ActiveSupport::Notifications.instrument('process_action.generic') do
+          Appsignal.instrument('process_action.generic') do
             @app.call(env)
           end
         rescue => error

--- a/lib/appsignal/rack/sinatra_instrumentation.rb
+++ b/lib/appsignal/rack/sinatra_instrumentation.rb
@@ -52,7 +52,7 @@ module Appsignal
           {:force => @options.include?(:force) && @options[:force]}
         )
         begin
-          ActiveSupport::Notifications.instrument('process_action.sinatra') do
+          Appsignal.instrument('process_action.sinatra') do
             @app.call(env)
           end
         rescue => error

--- a/lib/appsignal/rack/streaming_listener.rb
+++ b/lib/appsignal/rack/streaming_listener.rb
@@ -25,7 +25,7 @@ module Appsignal
 
         # Instrument a `process_action`, to set params/action name
         status, headers, body =
-          ActiveSupport::Notifications.instrument('process_action.rack') do
+          Appsignal.instrument('process_action.rack') do
             begin
               @app.call(env)
             rescue Exception => e

--- a/spec/lib/appsignal/integrations/padrino_spec.rb
+++ b/spec/lib/appsignal/integrations/padrino_spec.rb
@@ -98,7 +98,7 @@ if padrino_present?
           end
 
           it "should not instrument the request" do
-            expect( ActiveSupport::Notifications ).to_not receive(:instrument)
+            expect( Appsignal ).to_not receive(:instrument)
           end
 
           after { router.route!(base) }
@@ -112,7 +112,7 @@ if padrino_present?
           end
 
           it "should not instrument the request" do
-            expect( ActiveSupport::Notifications ).to_not receive(:instrument)
+            expect( Appsignal ).to_not receive(:instrument)
           end
 
           after { router.route!(base) }
@@ -144,7 +144,7 @@ if padrino_present?
             end
 
             it "should instrument the action" do
-              expect( ActiveSupport::Notifications ).to receive(:instrument).with('process_action.padrino')
+              expect( Appsignal ).to receive(:instrument).with('process_action.padrino')
             end
 
             it "should set metadata" do

--- a/spec/lib/appsignal/integrations/webmachine_spec.rb
+++ b/spec/lib/appsignal/integrations/webmachine_spec.rb
@@ -49,7 +49,7 @@ if webmachine_present?
       end
 
       it "should instrument the original method" do
-        expect( ActiveSupport::Notifications ).to receive(:instrument).with('process_action.webmachine')
+        expect( Appsignal ).to receive(:instrument).with('process_action.webmachine')
       end
 
       it "should close the transaction" do

--- a/spec/lib/appsignal/rack/streaming_listener_spec.rb
+++ b/spec/lib/appsignal/rack/streaming_listener_spec.rb
@@ -59,7 +59,7 @@ describe Appsignal::Rack::StreamingListener do
     end
 
     it "should instrument the call" do
-      expect( ActiveSupport::Notifications ).to receive(:instrument)
+      expect( Appsignal ).to receive(:instrument)
         .with('process_action.rack')
         .and_yield
 
@@ -67,7 +67,7 @@ describe Appsignal::Rack::StreamingListener do
     end
 
     it "should add `appsignal.action` to the transaction" do
-      allow( ActiveSupport::Notifications ).to receive(:instrument).and_yield
+      allow( Appsignal ).to receive(:instrument).and_yield
 
       env['appsignal.action'] = 'Action'
 
@@ -77,7 +77,7 @@ describe Appsignal::Rack::StreamingListener do
     end
 
     it "should add the path, method and queue start to the transaction" do
-      allow( ActiveSupport::Notifications ).to receive(:instrument).and_yield
+      allow( Appsignal ).to receive(:instrument).and_yield
 
       expect( transaction ).to receive(:set_metadata).with('path', '/homepage')
       expect( transaction ).to receive(:set_metadata).with('method', 'GET')

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -251,7 +251,7 @@ describe Appsignal do
     describe ".monitor_transaction" do
       it "should do nothing but still yield the block" do
         Appsignal::Transaction.should_not_receive(:create)
-        ActiveSupport::Notifications.should_not_receive(:instrument)
+        Appsignal.should_not_receive(:instrument)
         object = double
         object.should_receive(:some_method).and_return(1)
 
@@ -321,7 +321,7 @@ describe Appsignal do
     describe ".monitor_transaction" do
       context "with a successful call" do
         it "should instrument and complete for a background job" do
-          ActiveSupport::Notifications.should_receive(:instrument).with(
+          Appsignal.should_receive(:instrument).with(
             'perform_job.something'
           ).and_yield
           Appsignal::Transaction.should_receive(:complete_current!)
@@ -340,7 +340,7 @@ describe Appsignal do
         end
 
         it "should instrument and complete for a http request" do
-          ActiveSupport::Notifications.should_receive(:instrument).with(
+          Appsignal.should_receive(:instrument).with(
             'process_action.something'
           ).and_yield
           Appsignal::Transaction.should_receive(:complete_current!)


### PR DESCRIPTION
Instead of ActiveSupport::Notifications, next step towards making
AS completely optional.