### PR TITLE
Add environment to diagnose output

### DIFF
--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -61,12 +61,12 @@ module Appsignal
         def check_ext_install
           require 'bundler/cli'
           require "bundler/cli/common"
-          path     = Bundler::CLI::Common.select_spec('appsignal').full_gem_path
-          install_log_path = "#{path.strip}/ext/install.log"
+          path = Bundler::CLI::Common.select_spec('appsignal').full_gem_path.strip
+          install_log_path = "#{path}/ext/install.log"
           puts "Showing last lines of extension install log: #{install_log_path}"
           puts File.read(install_log_path)
           puts "\n"
-          mkmf_log_path = "#{path.strip}/ext/mkmf.log"
+          mkmf_log_path = "#{path}/ext/mkmf.log"
           if File.exist?(mkmf_log_path)
             puts "Showing last lines of extension compilation log: #{mkmf_log_path}"
             puts File.read(mkmf_log_path)

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -26,6 +26,7 @@ module Appsignal
 
         def config
           start_appsignal
+          puts "Environment: #{Appsignal.config.env}"
           Appsignal.config.config_hash.each do |key, val|
             puts "Config #{key}: #{val}"
           end

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -17,6 +17,7 @@ describe Appsignal::CLI::Diagnose do
 
       out_stream.string.should include('Gem version')
       out_stream.string.should include('Agent version')
+      out_stream.string.should include('Environment')
       out_stream.string.should include('Config')
       out_stream.string.should include('Checking API key')
       out_stream.string.should include('Checking if required paths are writable')

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -3,25 +3,24 @@ require 'appsignal/cli'
 describe Appsignal::CLI::Diagnose do
   let(:out_stream) { StringIO.new }
   let(:cli) { Appsignal::CLI::Diagnose }
-  before do
-    @original_stdout = $stdout
+  around do |example|
+    original_stdout = $stdout
     $stdout = out_stream
-  end
-  after do
-    $stdout = @original_stdout
+    example.run
+    $stdout = original_stdout
   end
 
   describe ".run" do
     it "should output diagnostic information" do
       cli.run
-
-      out_stream.string.should include('Gem version')
-      out_stream.string.should include('Agent version')
-      out_stream.string.should include('Environment')
-      out_stream.string.should include('Config')
-      out_stream.string.should include('Checking API key')
-      out_stream.string.should include('Checking if required paths are writable')
-      out_stream.string.should include('Showing last lines of extension install log')
+      output = out_stream.string
+      expect(output).to include('Gem version')
+      expect(output).to include('Agent version')
+      expect(output).to include('Environment')
+      expect(output).to include('Config')
+      expect(output).to include('Checking API key')
+      expect(output).to include('Checking if required paths are writable')
+      expect(output).to include('Showing last lines of extension install log')
     end
   end
 end


### PR DESCRIPTION
I found that it could be useful to see the environment a person is running diagnose under.

Things like checking the API key usually fails in `development`, because people have disabled AppSignal there. Knowing what env they run the command helps us identify if they should instead run the command with `APPSIGNAL_APP_ENV=production appsignal diagnose` in order to check the API key, for example.

I also updated the spec to avoid the use of an instance variable and not call `#string` for every check.