### PR TITLE
sinatra.route is required for an action name

### DIFF
--- a/lib/appsignal/rack/sinatra_instrumentation.rb
+++ b/lib/appsignal/rack/sinatra_instrumentation.rb
@@ -73,6 +73,8 @@ module Appsignal
       end
 
       def action_name(env)
+        return unless env['sinatra.route']
+
         if @options.fetch(:mounted_at, nil)
           method, route = env['sinatra.route'].split(" ")
           "#{method} #{@options[:mounted_at]}#{route}"

--- a/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
@@ -131,11 +131,27 @@ if defined?(::Sinatra)
           Appsignal::Transaction.any_instance.should_receive(:set_action).with('GET /')
         end
 
+        context "without 'sinatra.route' env" do
+          let(:env) { {:path => '/', :method => 'GET'} }
+
+          it "returns nil" do
+            Appsignal::Transaction.any_instance.should_receive(:set_action).with(nil)
+          end
+        end
+
         context "with option to set path a mounted_at prefix" do
           let(:options) {{ :mounted_at  => "/api/v2" }}
 
           it "should call set_action with a prefix path" do
             Appsignal::Transaction.any_instance.should_receive(:set_action).with("GET /api/v2/")
+          end
+
+          context "without 'sinatra.route' env" do
+            let(:env) { {:path => '/', :method => 'GET'} }
+
+            it "returns nil" do
+              Appsignal::Transaction.any_instance.should_receive(:set_action).with(nil)
+            end
           end
         end
 
@@ -144,6 +160,14 @@ if defined?(::Sinatra)
 
           it "should call set_action with an application prefix path" do
             Appsignal::Transaction.any_instance.should_receive(:set_action).with("GET /api/")
+          end
+
+          context "without 'sinatra.route' env" do
+            let(:env) { {:path => '/', :method => 'GET'} }
+
+            it "returns nil" do
+              Appsignal::Transaction.any_instance.should_receive(:set_action).with(nil)
+            end
           end
         end
       end


### PR DESCRIPTION
Fixes #143

Apparently something goes wrong when a request is send to something like
"/phpmyadmin" and a Sinatra app doesn't listen to that endpoint. Then
the appsignal gem tries to find that endpoint, but can't and crashes the
current transaction.

Most commonly triggered by defining an optional route and then
triggering a request to a page on that route (or even outside that
route) which doesn't exist.

The Sinatra server will then continue to register new requests under
this crashed transaction, but also create new ones. The new requests
will be seen as part of one very long request, because the original
crashed transaction remains open.

This continues until eventually a successful requests finally happens
and the transaction closes, then the original transaction actually
completes.

Problem is that now many more transactions can have started during this
crashed transaction nesting other transactions within one another.
Visually this creates a transaction that could have been open for X
amount of time and has request data from multiple requests merged
together.
