### PR TITLE
Remove mounted_at Sinatra middleware option

### DIFF
--- a/lib/appsignal/rack/sinatra_instrumentation.rb
+++ b/lib/appsignal/rack/sinatra_instrumentation.rb
@@ -75,10 +75,7 @@ module Appsignal
       def action_name(env)
         return unless env['sinatra.route']
 
-        if @options.fetch(:mounted_at, nil)
-          method, route = env['sinatra.route'].split(" ")
-          "#{method} #{@options[:mounted_at]}#{route}"
-        elsif env['SCRIPT_NAME']
+        if env['SCRIPT_NAME']
           method, route = env['sinatra.route'].split(" ")
           "#{method} #{env['SCRIPT_NAME']}#{route}"
         else

--- a/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
@@ -173,22 +173,6 @@ if defined?(::Sinatra)
           end
         end
 
-        context "with option to set path a mounted_at prefix" do
-          let(:options) {{ :mounted_at  => "/api/v2" }}
-
-          it "should call set_action with a prefix path" do
-            Appsignal::Transaction.any_instance.should_receive(:set_action).with("GET /api/v2/")
-          end
-
-          context "without 'sinatra.route' env" do
-            let(:env) { {:path => '/', :method => 'GET'} }
-
-            it "returns nil" do
-              Appsignal::Transaction.any_instance.should_receive(:set_action).with(nil)
-            end
-          end
-        end
-
         context "with mounted modular application" do
           before { env['SCRIPT_NAME'] = '/api' }
 


### PR DESCRIPTION
Reading up on `:mounted_at` in the Sinatra middleware I found there should no longer be a need for it after the improvements in the 1.3 release of the gem.

The change introduced in b6f9c9c5e2363795df4e2e0b4a836f6a193c14f1 ([PR](https://github.com/appsignal/appsignal-ruby-private/pull/295) private repo only) automatically detects a Sinatra's SCRIPT_NAME from the Rack ENV instead. So there should be no need for a manual option anymore.

The manual option was introduced in PR #117.