### PR TITLE
Allow config of ca_file_path

### DIFF
--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -23,7 +23,8 @@ module Appsignal
       :running_in_container           => false,
       :enable_host_metrics            => true,
       :enable_minutely_probes         => false,
-      :hostname                       => ::Socket.gethostname
+      :hostname                       => ::Socket.gethostname,
+      :ca_file_path                   => File.expand_path(File.join('../../../resources/cacert.pem'), __FILE__)
     }.freeze
 
     ENV_TO_KEY_MAPPING = {
@@ -50,7 +51,8 @@ module Appsignal
       'APPSIGNAL_WORKING_DIR_PATH'               => :working_dir_path,
       'APPSIGNAL_ENABLE_HOST_METRICS'            => :enable_host_metrics,
       'APPSIGNAL_ENABLE_MINUTELY_PROBES'         => :enable_minutely_probes,
-      'APPSIGNAL_HOSTNAME'                       => :hostname
+      'APPSIGNAL_HOSTNAME'                       => :hostname,
+      'APPSIGNAL_CA_FILE_PATH'                   => :ca_file_path
     }.freeze
 
     attr_reader :root_path, :env, :initial_config, :config_hash
@@ -127,6 +129,7 @@ module Appsignal
       ENV['APPSIGNAL_ENABLE_MINUTELY_PROBES']       = config_hash[:enable_minutely_probes].to_s
       ENV['APPSIGNAL_HOSTNAME']                     = config_hash[:hostname].to_s
       ENV['APPSIGNAL_PROCESS_NAME']                 = $0
+      ENV['APPSIGNAL_CA_FILE_PATH']                 = config_hash[:ca_file_path].to_s
     end
 
     protected
@@ -175,7 +178,7 @@ module Appsignal
       # Configuration with string type
       %w(APPSIGNAL_PUSH_API_KEY APPSIGNAL_APP_NAME APPSIGNAL_PUSH_API_ENDPOINT
          APPSIGNAL_FRONTEND_ERROR_CATCHING_PATH APPSIGNAL_HTTP_PROXY APPSIGNAL_LOG_PATH
-         APPSIGNAL_WORKING_DIR_PATH APPSIGNAL_HOSTNAME).each do |var|
+         APPSIGNAL_WORKING_DIR_PATH APPSIGNAL_HOSTNAME APPSIGNAL_CA_FILE_PATH).each do |var|
         if env_var = ENV[var]
           config[ENV_TO_KEY_MAPPING[var]] = env_var
         end

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -35,7 +35,8 @@ describe Appsignal::Config do
         :running_in_container           => false,
         :enable_host_metrics            => true,
         :enable_minutely_probes         => false,
-        :hostname                       => Socket.gethostname
+        :hostname                       => Socket.gethostname,
+        :ca_file_path                   => File.join(resources_dir, 'cacert.pem')
       })
     end
 
@@ -130,6 +131,7 @@ describe Appsignal::Config do
         ENV['APPSIGNAL_ENABLE_MINUTELY_PROBES'].should       eq 'false'
         ENV['APPSIGNAL_HOSTNAME'].should                     eq 'app1.local'
         ENV['APPSIGNAL_PROCESS_NAME'].should                 include 'rspec'
+        ENV['APPSIGNAL_CA_FILE_PATH'].should                 eq File.join(resources_dir, "cacert.pem")
       end
 
       context "if working_dir_path is set" do

--- a/spec/lib/appsignal/transmitter_spec.rb
+++ b/spec/lib/appsignal/transmitter_spec.rb
@@ -1,11 +1,14 @@
 describe Appsignal::Transmitter do
   let(:config) { project_fixture_config }
   let(:action) { 'action' }
+  let(:log) { StringIO.new }
   let(:instance) { Appsignal::Transmitter.new(action, config) }
+  before do
+    config.config_hash[:hostname] = 'app1.local'
+    config.logger = Logger.new(log)
+  end
 
   describe "#uri" do
-    before { ENV['APPSIGNAL_HOSTNAME'] = 'app1.local' }
-
     subject { instance.uri.to_s }
 
     it { should include 'https://push.appsignal.com/1/action?' }
@@ -20,7 +23,9 @@ describe Appsignal::Transmitter do
     before do
       stub_request(
         :post,
-        "https://push.appsignal.com/1/action?api_key=abc&environment=production&gem_version=#{Appsignal::VERSION}&hostname=#{Socket.gethostname}&name=TestApp"
+        "https://push.appsignal.com/1/action?api_key=abc"\
+          "&environment=production&gem_version=#{Appsignal::VERSION}"\
+          "&hostname=#{config.config_hash[:hostname]}&name=TestApp"
       ).with(
         :body => Zlib::Deflate.deflate("{\"the\":\"payload\"}", Zlib::BEST_SPEED),
         :headers => {
@@ -31,10 +36,51 @@ describe Appsignal::Transmitter do
         :status => 200
       )
     end
-
     subject { instance.transmit(:the => :payload) }
 
     it { should eq '200' }
+
+    context "with ca_file_path config option set" do
+      context "when not existing file" do
+        before do
+          config.config_hash[:ca_file_path] = File.join(resources_dir, "cacert.pem")
+        end
+
+        it "ignores the config and logs a warning" do
+          expect(subject).to eq '200'
+          expect(log.string).to_not include "Ignoring non-existing or unreadable " \
+            "`ca_file_path`: #{config[:ca_file_path]}"
+        end
+      end
+
+      context "when not existing file" do
+        before do
+          config.config_hash[:ca_file_path] = File.join(tmp_dir, "ca_file_that_does_not_exist")
+        end
+
+        it "ignores the config and logs a warning" do
+          expect(subject).to eq '200'
+          expect(log.string).to include "Ignoring non-existing or unreadable " \
+            "`ca_file_path`: #{config[:ca_file_path]}"
+        end
+      end
+
+      context "when not readable file" do
+        let(:file) { File.join(tmp_dir, "ca_file") }
+        before do
+          config.config_hash[:ca_file_path] = file
+          File.open(file, "w") { |f| f.chmod 0000 }
+        end
+
+        it "ignores the config and logs a warning" do
+          expect(subject).to eq '200'
+          expect(log.string).to include "Ignoring non-existing or unreadable " \
+            "`ca_file_path`: #{config[:ca_file_path]}"
+        end
+
+        after { File.delete file }
+      end
+    end
   end
 
   describe "#http_post" do
@@ -51,13 +97,6 @@ describe Appsignal::Transmitter do
       subject['Content-Type'].should eq 'application/json; charset=UTF-8'
       subject['Content-Encoding'].should eq 'gzip'
     end
-  end
-
-  describe ".CA_FILE_PATH" do
-    subject { Appsignal::Transmitter::CA_FILE_PATH }
-
-    it { should include('resources/cacert.pem') }
-    it("should exist") { File.exist?(subject).should be_true }
   end
 
   describe "#http_client" do
@@ -78,7 +117,7 @@ describe Appsignal::Transmitter do
       its(:proxy?) { should be_false }
       its(:use_ssl?) { should be_true }
       its(:verify_mode) { should eq OpenSSL::SSL::VERIFY_PEER }
-      its(:ca_file) { Appsignal::Transmitter::CA_FILE_PATH }
+      its(:ca_file) { should eq config[:ca_file_path] }
     end
 
     context "with a proxy" do

--- a/spec/support/helpers/directory_helper.rb
+++ b/spec/support/helpers/directory_helper.rb
@@ -1,4 +1,8 @@
 module DirectoryHelper
+  def project_dir
+    @project_dir ||= File.expand_path('..', spec_dir)
+  end
+
   def spec_dir
     APPSIGNAL_SPEC_DIR
   end
@@ -13,5 +17,9 @@ module DirectoryHelper
 
   def fixtures_dir
     @fixtures_dir ||= File.join(support_dir, 'fixtures')
+  end
+
+  def resources_dir
+    @resources_dir ||= File.join(project_dir, 'resources')
   end
 end


### PR DESCRIPTION
Needed to be configured in the agent as well so add a config option for
it to be set to the environment.

It only sets non-default values to the environment so that the default
behavior we have now is not changed.

Agent PRs:
https://github.com/appsignal/appsignal-agent/pull/183
https://github.com/appsignal/appsignal-agent/pull/184

Part of https://github.com/appsignal/appsignal-agent/issues/181