### PR TITLE
Refactor Rakefile and Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,4 +45,6 @@ matrix:
 env:
   global: "RAILS_ENV=test"
 
-script: "bundle exec rake travis"
+before_script: "bundle exec rake extension:install"
+
+script: "bundle exec rake test"


### PR DESCRIPTION
Changes I made while working a lot on the agent. Think this is a bit more organized setup:

- No special rake task for travis, just an extra install step added.
- Organize rake tasks a bit.
  - separate extension namespace with `extension:clean` and `extension:install`
  - rename `rspec` task to the more generic `test` task
  - No need to specify the pattern for the rspec task, this is the
    default.