### PR TITLE
Check for :raise_errors config before calling it

### DIFF
--- a/lib/appsignal/rack/sinatra_instrumentation.rb
+++ b/lib/appsignal/rack/sinatra_instrumentation.rb
@@ -29,7 +29,7 @@ module Appsignal
       def initialize(app, options = {})
         Appsignal.logger.debug 'Initializing Appsignal::Rack::SinatraInstrumentation'
         @app, @options = app, options
-        @raise_errors_on = @app.settings.raise_errors
+        @raise_errors_on = raise_errors?(@app)
       end
 
       def call(env)
@@ -84,6 +84,14 @@ module Appsignal
         else
           env['sinatra.route']
         end
+      end
+
+      private
+
+      def raise_errors?(app)
+        app.respond_to?(:settings) &&
+          app.settings.respond_to?(:raise_errors) &&
+          app.settings.raise_errors
       end
     end
   end

--- a/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
@@ -45,6 +45,40 @@ if defined?(::Sinatra)
     let(:options) { {} }
     let(:middleware) { Appsignal::Rack::SinatraBaseInstrumentation.new(app, options) }
 
+    describe "#initialize" do
+      context "with no settings method in the Sinatra app" do
+        let(:app) { double(:call => true) }
+
+        it "should not raise errors" do
+          expect( middleware.raise_errors_on ).to be(false)
+        end
+      end
+
+      context "with no raise_errors setting in the Sinatra app" do
+        let(:app) { double(:call => true, :settings => double) }
+
+        it "should not raise errors" do
+          expect( middleware.raise_errors_on ).to be(false)
+        end
+      end
+
+      context "with raise_errors turned off in the Sinatra app" do
+        let(:app) { double(:call => true, :settings => double(:raise_errors => false)) }
+
+        it "should raise errors" do
+          expect( middleware.raise_errors_on ).to be(false)
+        end
+      end
+
+      context "with raise_errors turned on in the Sinatra app" do
+        let(:app) { double(:call => true, :settings => double(:raise_errors => true)) }
+
+        it "should raise errors" do
+          expect( middleware.raise_errors_on ).to be(true)
+        end
+      end
+    end
+
     describe "#call" do
       before do
         middleware.stub(:raw_payload => {})


### PR DESCRIPTION
Rack middleware doesn't usually include a #settings method, so we can't
rely on it existing in Appsignal::SinatraBaseInstrumentation.