### PR TITLE
Support APPSIGNAL_APP_ENV for Sinatra

### DIFF
--- a/lib/appsignal/integrations/sinatra.rb
+++ b/lib/appsignal/integrations/sinatra.rb
@@ -6,7 +6,7 @@ Appsignal.logger.info("Loading Sinatra (#{Sinatra::VERSION}) integration")
 app_settings = ::Sinatra::Application.settings
 Appsignal.config = Appsignal::Config.new(
   app_settings.root || Dir.pwd,
-  app_settings.environment
+  ENV.fetch('APPSIGNAL_APP_ENV'.freeze, app_settings.environment)
 )
 
 Appsignal.start_logger

--- a/spec/lib/appsignal/integrations/sinatra_spec.rb
+++ b/spec/lib/appsignal/integrations/sinatra_spec.rb
@@ -3,16 +3,43 @@ if sinatra_present? && !padrino_present?
   require 'appsignal/integrations/sinatra'
 
   describe "Sinatra integration" do
-    context "logger" do
+    context "Appsignal.logger" do
       subject { Appsignal.logger }
 
       it { should be_a Logger }
     end
 
-    it "should have added the instrumentation middleware" do
-      Sinatra::Base.middleware.to_a.should include(
-        [Appsignal::Rack::SinatraBaseInstrumentation, [], nil]
-      )
+    describe "middleware" do
+      it "adds the instrumentation middleware to Sinatra::Base" do
+        Sinatra::Base.middleware.to_a.should include(
+          [Appsignal::Rack::SinatraBaseInstrumentation, [], nil]
+        )
+      end
+    end
+
+    describe "environment" do
+      subject { Appsignal.config.env }
+
+      context "without APPSIGNAL_APP_ENV" do
+        before do
+          load File.expand_path('lib/appsignal/integrations/sinatra.rb', project_dir)
+        end
+
+        it "uses the app environment" do
+          expect(subject).to eq('test')
+        end
+      end
+
+      context "with APPSIGNAL_APP_ENV" do
+        before do
+          ENV['APPSIGNAL_APP_ENV'] = 'env-staging'
+          load File.expand_path('lib/appsignal/integrations/sinatra.rb', project_dir)
+        end
+
+        it "uses the environment variable" do
+          expect(subject).to eq('env-staging')
+        end
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 ENV['RAILS_ENV'] ||= 'test'
+ENV['RACK_ENV'] ||= 'test'
 ENV['PADRINO_ENV'] ||= 'test'
 
 APPSIGNAL_SPEC_DIR = File.expand_path(File.dirname(__FILE__))


### PR DESCRIPTION
As reported in #161 

This PR adds support for the APPSIGNAL_APP_ENV env var in the Sinatra integration.

Closes #161