### PR TITLE
Remove middleware step from Sinatra install in CLI

### DIFF
--- a/lib/appsignal/cli/install.rb
+++ b/lib/appsignal/cli/install.rb
@@ -93,11 +93,6 @@ module Appsignal
           puts
           puts "  require 'appsignal/integrations/sinatra'"
           press_any_key
-          puts "Configure subclass apps"
-          puts "  If your app is a subclass of Sinatra::Base you need to use this middleware:"
-          puts
-          puts "  use Appsignal::Rack::SinatraInstrumentation"
-          press_any_key
           done_notice
         end
 


### PR DESCRIPTION
This is automatically added to Sinatra::Base in
commit 5451374a79abdd93556d92bc30d01cbe04123664.