### PR TITLE
Install appsignal/capistrano to Capfile, not deploy.rb

### DIFF
--- a/lib/appsignal/cli/install.rb
+++ b/lib/appsignal/cli/install.rb
@@ -136,6 +136,21 @@ module Appsignal
           done_notice
         end
 
+        def install_for_capistrano
+          capfile = File.join(Dir.pwd, 'Capfile')
+          return unless File.exist?(capfile)
+          return if File.read(capfile) =~ %r{require ['|"]appsignal/capistrano}
+
+          puts 'Installing for Capistrano'
+          print '  Adding AppSignal integration to Capfile'
+          File.open(capfile, 'a') do |f|
+            f.write "\nrequire 'appsignal/capistrano'\n"
+          end
+          periods
+          puts
+          puts
+        end
+
         def colorize(text, color)
           return text if Gem.win_platform?
           color_code = case color
@@ -187,16 +202,7 @@ module Appsignal
         end
 
         def configure(config, environments, name_overwritten)
-          deploy_rb_file = File.join(Dir.pwd, 'config/deploy.rb')
-          if File.exist?(deploy_rb_file) && (File.read(deploy_rb_file) =~ /require (\'|\").\/appsignal\/capistrano/).nil?
-            print 'Adding AppSignal integration to deploy.rb'
-            File.open(deploy_rb_file, 'a') do |f|
-              f.write "\nrequire 'appsignal/capistrano'\n"
-            end
-            periods
-            puts
-            puts
-          end
+          install_for_capistrano
 
           puts "How do you want to configure AppSignal?"
           puts "  (1) a config file"

--- a/spec/lib/appsignal/cli/install_spec.rb
+++ b/spec/lib/appsignal/cli/install_spec.rb
@@ -13,15 +13,16 @@ describe Appsignal::CLI::Install do
 
   before do
     Dir.stub(:pwd => project_fixture_path)
-    @original_stdout = $stdout
-    $stdout = out_stream
     Appsignal::AuthCheck.stub(:new => auth_check)
     auth_check.stub(:perform => '200')
     cli.stub(:sleep)
     cli.stub(:press_any_key)
   end
-  after do
-    $stdout = @original_stdout
+  around do |example|
+    original_stdout = $stdout
+    $stdout = out_stream
+    example.run
+    $stdout = original_stdout
   end
 
   describe ".run" do
@@ -374,24 +375,50 @@ describe Appsignal::CLI::Install do
       end
     end
 
-    context "when deploy.rb is present" do
-      let(:config_dir) { File.join(tmp_dir, 'config') }
-      let(:deploy_rb_file) { File.join(tmp_dir, 'config/deploy.rb') }
+    context "with capistrano" do
+      let(:capfile) { File.join(tmp_dir, 'Capfile') }
       before do
         Dir.stub(:pwd => tmp_dir)
-        FileUtils.mkdir_p(config_dir)
-        FileUtils.touch(deploy_rb_file)
+        FileUtils.mkdir_p(tmp_dir)
         cli.should_receive(:gets).once.and_return('2')
       end
       after do
-        FileUtils.rm_rf(config_dir)
+        FileUtils.rm_rf(tmp_dir)
       end
 
-      it "should add a require to deploy.rb" do
-        cli.configure(config, [], false)
+      context "without Capfile" do
+        before { cli.configure(config, [], false) }
 
-        out_stream.string.should include 'Adding AppSignal integration to deploy.rb'
-        File.read(deploy_rb_file).should include "require 'appsignal/capistrano'"
+        it "does nothing" do
+          expect(out_stream.string).to_not include 'Adding AppSignal integration to Capfile'
+          expect(File.exist?(capfile)).to be_false
+        end
+      end
+
+      context "with Capfile" do
+        context "when already installed" do
+          before do
+            File.open(capfile, 'w') { |f| f.write("require 'appsignal/capistrano'") }
+            cli.configure(config, [], false)
+          end
+
+          it "does not add another require to Capfile" do
+            expect(out_stream.string).to_not include 'Adding AppSignal integration to Capfile'
+            expect(File.read(capfile).scan(/appsignal/).count).to eq(1)
+          end
+        end
+
+        context "when not installed" do
+          before do
+            FileUtils.touch(capfile)
+            cli.configure(config, [], false)
+          end
+
+          it "adds a require to Capfile" do
+            expect(out_stream.string).to include 'Adding AppSignal integration to Capfile'
+            expect(File.read(capfile)).to include "require 'appsignal/capistrano'"
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
The Capfile is where all the files are required, deploy.rb only configures the deployment.

Closes #140 