### PR TITLE
Move std stream capture logic to helper

### DIFF
--- a/spec/lib/appsignal/capistrano2_spec.rb
+++ b/spec/lib/appsignal/capistrano2_spec.rb
@@ -6,18 +6,12 @@ if capistrano2_present?
   describe "Capistrano 2 integration" do
     let(:out_stream) { StringIO.new }
     let(:config) { project_fixture_config }
-
-    before do
-      @original_stdout = $stdout
-      $stdout = out_stream
-    end
-    after do
-      $stdout = @original_stdout
-    end
-
     before :all do
       @capistrano_config = Capistrano::Configuration.new
       Appsignal::Capistrano.tasks(@capistrano_config)
+    end
+    around do |example|
+      capture_stdout(out_stream) { example.run }
     end
 
     it "should have a deploy task" do

--- a/spec/lib/appsignal/capistrano3_spec.rb
+++ b/spec/lib/appsignal/capistrano3_spec.rb
@@ -14,17 +14,10 @@ if capistrano3_present?
       @capistrano_config = Capistrano::Configuration.env
       @capistrano_config.set(:log_level, :error)
       @capistrano_config.set(:logger, logger)
-    end
-    before do
-      @original_stdout = $stdout
-      $stdout = out_stream
-      @original_stderr = $stderr
-      $stderr = out_stream
-    end
-    after do
-      $stdout = @original_stdout
-      $stderr = @original_stderr
       Rake::Task['appsignal:deploy'].reenable
+    end
+    around do |example|
+      capture_std_streams(out_stream, out_stream) { example.run }
     end
 
     it "should have a deploy task" do

--- a/spec/lib/appsignal/cli/install_spec.rb
+++ b/spec/lib/appsignal/cli/install_spec.rb
@@ -19,10 +19,7 @@ describe Appsignal::CLI::Install do
     cli.stub(:press_any_key)
   end
   around do |example|
-    original_stdout = $stdout
-    $stdout = out_stream
-    example.run
-    $stdout = original_stdout
+    capture_stdout(out_stream) { example.run }
   end
 
   describe ".run" do

--- a/spec/lib/appsignal/cli/notify_of_deploy_spec.rb
+++ b/spec/lib/appsignal/cli/notify_of_deploy_spec.rb
@@ -6,12 +6,10 @@ describe Appsignal::CLI::NotifyOfDeploy do
   let(:config) { Appsignal::Config.new(project_fixture_path, {}) }
   let(:marker_data) { {:revision => 'aaaaa', :user => 'thijs', :environment => 'production'} }
   before do
-    @original_stdout = $stdout
-    $stdout = out_stream
     config.stub(:active? => true)
   end
-  after do
-    $stdout = @original_stdout
+  around do |example|
+    capture_stdout(out_stream) { example.run }
   end
 
   describe ".run" do

--- a/spec/lib/appsignal/cli_spec.rb
+++ b/spec/lib/appsignal/cli_spec.rb
@@ -4,13 +4,11 @@ describe Appsignal::CLI do
   let(:out_stream) { StringIO.new }
   let(:cli) { Appsignal::CLI }
   before do
-    @original_stdout = $stdout
-    $stdout = out_stream
     Dir.stub(:pwd => project_fixture_path)
     cli.options = {:environment => 'production'}
   end
-  after do
-    $stdout = @original_stdout
+  around do |example|
+    capture_stdout(out_stream) { example.run }
   end
 
   describe "#config" do

--- a/spec/lib/appsignal/marker_spec.rb
+++ b/spec/lib/appsignal/marker_spec.rb
@@ -12,12 +12,8 @@ describe Appsignal::Marker do
     )
   }
   let(:out_stream) { StringIO.new }
-  before do
-    @original_stdout = $stdout
-    $stdout = out_stream
-  end
-  after do
-    $stdout = @original_stdout
+  around do |example|
+    capture_stdout(out_stream) { example.run }
   end
 
   context "transmit" do

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -555,16 +555,14 @@ describe Appsignal do
 
       before do
         FileUtils.rm_f(log_file)
-        @original_stdout = $stdout
-        $stdout = out_stream
         Appsignal.logger.error('Log something')
         Appsignal.config = project_fixture_config(
           'production',
           :log_path => log_path
         )
       end
-      after do
-        $stdout = @original_stdout
+      around do |example|
+        capture_stdout(out_stream) { example.run }
       end
 
       context "when the log path is writable" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -124,6 +124,7 @@ end
 
 RSpec.configure do |config|
   config.include DirectoryHelper
+  config.include StdStreamsHelper
   config.include ConfigHelpers
   config.include EnvHelpers
   config.include NotificationHelpers

--- a/spec/support/helpers/std_streams_helper.rb
+++ b/spec/support/helpers/std_streams_helper.rb
@@ -1,0 +1,35 @@
+module StdStreamsHelper
+  # Capture STDOUT in a variable
+  #
+  # Usage
+  #
+  #     out_stream = StringIO.new
+  #     capture_stdout(out_stream) { do_something }
+  def capture_stdout(stdout)
+    original_stdout = $stdout
+    $stdout = stdout
+
+    yield
+
+    $stdout = original_stdout
+  end
+
+  # Capture STDOUT and STDERR in variables
+  #
+  # Usage
+  #
+  #     out_stream = StringIO.new
+  #     err_stream = StringIO.new
+  #     capture_std_streams(out_stream, err_stream) { do_something }
+  def capture_std_streams(stdout, stderr)
+    original_stdout = $stdout
+    $stdout = stdout
+    original_stderr = $stderr
+    $stderr = stderr
+
+    yield
+
+    $stdout = original_stdout
+    $stderr = original_stderr
+  end
+end


### PR DESCRIPTION
We keep repeating ourselves in the specs. With this helper we don't have to be so verbose anymore to capture the STDOUT and STDERR.

---

Note: I think I'm going to make more of these PRs doing small focussed refactors changing 1 type of thing, rather than changing the same thing in 1 spec file at a time in other multiple PRs like I've done with this STDOUT and STDERR capture.