### PR TITLE
Avoid rescue Exception in Marker

### DIFF
--- a/lib/appsignal/marker.rb
+++ b/lib/appsignal/marker.rb
@@ -10,14 +10,15 @@ module Appsignal
 
     def transmit
       transmitter = Transmitter.new(ACTION, config)
-      puts "Notifying Appsignal of deploy with: revision: #{marker_data[:revision]}, user: #{marker_data[:user]}"
+      puts "Notifying Appsignal of deploy with: "\
+        "revision: #{marker_data[:revision]}, user: #{marker_data[:user]}"
       result = transmitter.transmit(marker_data)
       if result == '200'
         puts 'Appsignal has been notified of this deploy!'
       else
         raise "#{result} at #{transmitter.uri}"
       end
-    rescue Exception => e
+    rescue => e
       puts "Something went wrong while trying to notify Appsignal: #{e}"
     end
   end

--- a/lib/appsignal/transmitter.rb
+++ b/lib/appsignal/transmitter.rb
@@ -51,10 +51,8 @@ module Appsignal
       Net::HTTP::Post.new(uri.request_uri).tap do |request|
         request['Content-Type'] = CONTENT_TYPE
         request['Content-Encoding'] = CONTENT_ENCODING
-        request.body = Zlib::Deflate.deflate(
-          Appsignal::Utils.json_generate(payload),
-          Zlib::BEST_SPEED
-        )
+        request.body = Appsignal::Utils::Gzip.compress \
+          Appsignal::Utils::JSON.generate(payload)
       end
     end
 

--- a/lib/appsignal/utils.rb
+++ b/lib/appsignal/utils.rb
@@ -54,13 +54,9 @@ module Appsignal
     end
 
     class Gzip
-      module ClassMethods
-        def compress(body)
-          Zlib::Deflate.deflate(body, Zlib::BEST_SPEED)
-        end
+      def self.compress(body)
+        Zlib::Deflate.deflate(body, Zlib::BEST_SPEED)
       end
-
-      extend ClassMethods
     end
   end
 end

--- a/lib/appsignal/utils.rb
+++ b/lib/appsignal/utils.rb
@@ -52,5 +52,15 @@ module Appsignal
 
       extend ClassMethods
     end
+
+    class Gzip
+      module ClassMethods
+        def compress(body)
+          Zlib::Deflate.deflate(body, Zlib::BEST_SPEED)
+        end
+      end
+
+      extend ClassMethods
+    end
   end
 end

--- a/spec/lib/appsignal/capistrano2_spec.rb
+++ b/spec/lib/appsignal/capistrano2_spec.rb
@@ -6,33 +6,36 @@ if capistrano2_present?
   describe "Capistrano 2 integration" do
     let(:out_stream) { StringIO.new }
     let(:config) { project_fixture_config }
-    before :all do
-      @capistrano_config = Capistrano::Configuration.new
-      Appsignal::Capistrano.tasks(@capistrano_config)
+    let(:capistrano_config) do
+      Capistrano::Configuration.new.tap do |c|
+        c.set(:rails_env, 'production')
+        c.set(:repository, 'master')
+        c.set(:deploy_to, '/home/username/app')
+        c.set(:current_release, '')
+        c.set(:current_revision, '503ce0923ed177a3ce000005')
+        c.dry_run = false
+      end
+    end
+    before do
+      Appsignal::Capistrano.tasks(capistrano_config)
     end
     around do |example|
       capture_stdout(out_stream) { example.run }
     end
 
     it "should have a deploy task" do
-      @capistrano_config.find_task('appsignal:deploy').should_not be_nil
+      capistrano_config.find_task('appsignal:deploy').should_not be_nil
     end
 
     describe "appsignal:deploy task" do
       before do
-        @capistrano_config.set(:rails_env, 'production')
-        @capistrano_config.set(:repository, 'master')
-        @capistrano_config.set(:deploy_to, '/home/username/app')
-        @capistrano_config.set(:current_release, '')
-        @capistrano_config.set(:current_revision, '503ce0923ed177a3ce000005')
-        @capistrano_config.dry_run = false
         ENV['USER'] = 'batman'
         ENV['PWD'] = project_fixture_path
       end
 
       context "config" do
         before do
-          @capistrano_config.dry_run = true
+          capistrano_config.dry_run = true
         end
 
         it "should be instantiated with the right params" do
@@ -46,7 +49,7 @@ if capistrano2_present?
 
         context "when appsignal_config is available" do
           before do
-            @capistrano_config.set(:appsignal_config, :name => 'AppName')
+            capistrano_config.set(:appsignal_config, :name => 'AppName')
           end
 
           it "should be instantiated with the right params" do
@@ -60,8 +63,8 @@ if capistrano2_present?
 
           context "when rack_env is used instead of rails_env" do
             before do
-              @capistrano_config.unset(:rails_env)
-              @capistrano_config.set(:rack_env, 'rack_production')
+              capistrano_config.unset(:rails_env)
+              capistrano_config.set(:rack_env, 'rack_production')
             end
 
             it "should be instantiated with the right params" do
@@ -76,8 +79,8 @@ if capistrano2_present?
 
           context "when stage is used instead of rack_env / rails_env" do
             before do
-              @capistrano_config.unset(:rails_env)
-              @capistrano_config.set(:stage, 'stage_production')
+              capistrano_config.unset(:rails_env)
+              capistrano_config.set(:stage, 'stage_production')
             end
 
             it "should be instantiated with the right params" do
@@ -92,9 +95,9 @@ if capistrano2_present?
 
           context "when appsignal_env is set" do
             before do
-              @capistrano_config.set(:rack_env, 'rack_production')
-              @capistrano_config.set(:stage, 'stage_production')
-              @capistrano_config.set(:appsignal_env, 'appsignal_production')
+              capistrano_config.set(:rack_env, 'rack_production')
+              capistrano_config.set(:stage, 'stage_production')
+              capistrano_config.set(:appsignal_env, 'appsignal_production')
             end
 
             it "should prefer the appsignal_env rather than stage, rails_env and rack_env" do
@@ -109,14 +112,15 @@ if capistrano2_present?
         end
 
         after do
-          @capistrano_config.find_and_execute_task('appsignal:deploy')
-          @capistrano_config.unset(:stage)
-          @capistrano_config.unset(:rack_env)
-          @capistrano_config.unset(:appsignal_env)
+          capistrano_config.find_and_execute_task('appsignal:deploy')
         end
       end
 
-      context "send marker" do
+      describe "markers" do
+        def stub_marker_request(data = {})
+          stub_api_request config, 'markers', marker_data.merge(data)
+        end
+
         let(:marker_data) do
           {
             :revision => '503ce0923ed177a3ce000005',
@@ -125,80 +129,66 @@ if capistrano2_present?
         end
 
         context "when active for this environment" do
-          before do
-            @marker = Appsignal::Marker.new(
-              marker_data,
-              config
-            )
-            Appsignal::Marker.stub(:new => @marker)
+          it "transmits marker" do
+            stub_marker_request.to_return(:status => 200)
+            capistrano_config.find_and_execute_task('appsignal:deploy')
+
+            expect(out_stream.string).to include \
+              'Notifying Appsignal of deploy with: revision: 503ce0923ed177a3ce000005, user: batman',
+              'Appsignal has been notified of this deploy!'
           end
 
-          context "proper setup" do
+          context "with overridden revision" do
             before do
-              @transmitter = double
-              Appsignal::Transmitter.should_receive(:new).and_return(@transmitter)
+              capistrano_config.set(:appsignal_revision, 'abc123')
+              stub_marker_request(:revision => 'abc123').to_return(:status => 200)
+              capistrano_config.find_and_execute_task('appsignal:deploy')
             end
 
-            it "should add the correct marker data" do
-              Appsignal::Marker.should_receive(:new).with(
-                marker_data,
-                kind_of(Appsignal::Config)
-              ).and_return(@marker)
-
-              @capistrano_config.find_and_execute_task('appsignal:deploy')
-            end
-
-            it "should transmit data" do
-              @transmitter.should_receive(:transmit).and_return('200')
-              @capistrano_config.find_and_execute_task('appsignal:deploy')
-              out_stream.string.should include('Notifying Appsignal of deploy with: revision: 503ce0923ed177a3ce000005, user: batman')
-              out_stream.string.should include('Appsignal has been notified of this deploy!')
-            end
-
-            context "with overridden revision" do
-              before do
-                @capistrano_config.set(:appsignal_revision, 'abc123')
-              end
-              it "should add the correct marker data" do
-                Appsignal::Marker.should_receive(:new).with(
-                  {
-                    :revision => 'abc123',
-                    :user => 'batman'
-                  },
-                  kind_of(Appsignal::Config)
-                ).and_return(@marker)
-
-                @capistrano_config.find_and_execute_task('appsignal:deploy')
-              end
+            it "transmits the overriden revision" do
+              expect(out_stream.string).to include \
+                'Notifying Appsignal of deploy with: revision: abc123, user: batman',
+                'Appsignal has been notified of this deploy!'
             end
           end
 
-          it "should not transmit data" do
-            @capistrano_config.find_and_execute_task('appsignal:deploy')
-            out_stream.string.should include('Notifying Appsignal of deploy with: revision: 503ce0923ed177a3ce000005, user: batman')
-            out_stream.string.should include('Something went wrong while trying to notify Appsignal:')
+          context "with failed request" do
+            before do
+              stub_marker_request.to_return(:status => 500)
+              capistrano_config.find_and_execute_task('appsignal:deploy')
+            end
+
+            it "does not transmit marker" do
+              output = out_stream.string
+              expect(output).to include \
+                'Notifying Appsignal of deploy with: revision: 503ce0923ed177a3ce000005, user: batman',
+                'Something went wrong while trying to notify Appsignal:'
+              expect(output).to_not include 'Appsignal has been notified of this deploy!'
+            end
           end
 
-          context "dry run" do
-            before { @capistrano_config.dry_run = true }
+          context "when dry run" do
+            before do
+              capistrano_config.dry_run = true
+              capistrano_config.find_and_execute_task('appsignal:deploy')
+            end
 
-            it "should not send deploy marker" do
-              @marker.should_not_receive(:transmit)
-              @capistrano_config.find_and_execute_task('appsignal:deploy')
-              out_stream.string.should include('Dry run: AppSignal deploy marker not actually sent.')
+            it "does not transmit marker" do
+              expect(out_stream.string).to include \
+                'Dry run: AppSignal deploy marker not actually sent.'
             end
           end
         end
 
         context "when not active for this environment" do
           before do
-            @capistrano_config.set(:rails_env, 'nonsense')
+            capistrano_config.set(:rails_env, 'nonsense')
+            capistrano_config.find_and_execute_task('appsignal:deploy')
           end
 
-          it "should not send deploy marker" do
-            Appsignal::Marker.should_not_receive(:new)
-            @capistrano_config.find_and_execute_task('appsignal:deploy')
-            out_stream.string.should include('Not notifying of deploy, config is not active for environment: nonsense')
+          it "does not transmit marker" do
+            expect(out_stream.string).to include \
+              "Not notifying of deploy, config is not active for environment: nonsense"
           end
         end
       end

--- a/spec/lib/appsignal/capistrano3_spec.rb
+++ b/spec/lib/appsignal/capistrano3_spec.rb
@@ -9,11 +9,19 @@ if capistrano3_present?
     let(:config) { project_fixture_config }
     let(:out_stream) { StringIO.new }
     let(:logger) { Logger.new(out_stream) }
-
+    let!(:capistrano_config) do
+      Capistrano::Configuration.reset!
+      Capistrano::Configuration.env.tap do |c|
+        c.set(:log_level, :error)
+        c.set(:logger, logger)
+        c.set(:rails_env, 'production')
+        c.set(:repository, 'master')
+        c.set(:deploy_to, '/home/username/app')
+        c.set(:current_release, '')
+        c.set(:current_revision, '503ce0923ed177a3ce000005')
+      end
+    end
     before do
-      @capistrano_config = Capistrano::Configuration.env
-      @capistrano_config.set(:log_level, :error)
-      @capistrano_config.set(:logger, logger)
       Rake::Task['appsignal:deploy'].reenable
     end
     around do |example|
@@ -26,11 +34,6 @@ if capistrano3_present?
 
     describe "appsignal:deploy task" do
       before do
-        @capistrano_config.set(:rails_env, 'production')
-        @capistrano_config.set(:repository, 'master')
-        @capistrano_config.set(:deploy_to, '/home/username/app')
-        @capistrano_config.set(:current_release, '')
-        @capistrano_config.set(:current_revision, '503ce0923ed177a3ce000005')
         ENV['USER'] = 'batman'
         ENV['PWD'] = project_fixture_path
       end
@@ -47,7 +50,7 @@ if capistrano3_present?
 
         context "when appsignal_config is available" do
           before do
-            @capistrano_config.set(:appsignal_config, :name => 'AppName')
+            capistrano_config.set(:appsignal_config, :name => 'AppName')
           end
 
           it "should be instantiated with the right params" do
@@ -61,8 +64,8 @@ if capistrano3_present?
 
           context "when rack_env is the only env set" do
             before do
-              @capistrano_config.delete(:rails_env)
-              @capistrano_config.set(:rack_env, 'rack_production')
+              capistrano_config.delete(:rails_env)
+              capistrano_config.set(:rack_env, 'rack_production')
             end
 
             it "should be instantiated with the rack env" do
@@ -77,8 +80,8 @@ if capistrano3_present?
 
           context "when stage is set" do
             before do
-              @capistrano_config.set(:rack_env, 'rack_production')
-              @capistrano_config.set(:stage, 'stage_production')
+              capistrano_config.set(:rack_env, 'rack_production')
+              capistrano_config.set(:stage, 'stage_production')
             end
 
             it "should prefer the stage rather than rails_env and rack_env" do
@@ -93,9 +96,9 @@ if capistrano3_present?
 
           context "when appsignal_env is set" do
             before do
-              @capistrano_config.set(:rack_env, 'rack_production')
-              @capistrano_config.set(:stage, 'stage_production')
-              @capistrano_config.set(:appsignal_env, 'appsignal_production')
+              capistrano_config.set(:rack_env, 'rack_production')
+              capistrano_config.set(:stage, 'stage_production')
+              capistrano_config.set(:appsignal_env, 'appsignal_production')
             end
 
             it "should prefer the appsignal_env rather than stage, rails_env and rack_env" do
@@ -111,13 +114,14 @@ if capistrano3_present?
 
         after do
           invoke('appsignal:deploy')
-          @capistrano_config.delete(:stage)
-          @capistrano_config.delete(:rack_env)
-          @capistrano_config.delete(:appsignal_env)
         end
       end
 
-      context "send marker" do
+      describe "markers" do
+        def stub_marker_request(data = {})
+          stub_api_request config, 'markers', marker_data.merge(data)
+        end
+
         let(:marker_data) do
           {
             :revision => '503ce0923ed177a3ce000005',
@@ -126,70 +130,54 @@ if capistrano3_present?
         end
 
         context "when active for this environment" do
-          before do
-            @marker = Appsignal::Marker.new(
-              marker_data,
-              config
-            )
-            Appsignal::Marker.stub(:new => @marker)
-          end
-
-          context "proper setup" do
-            before do
-              @transmitter = double
-              Appsignal::Transmitter.should_receive(:new).and_return(@transmitter)
-            end
-
-            it "should add the correct marker data" do
-              Appsignal::Marker.should_receive(:new).with(
-                marker_data,
-                kind_of(Appsignal::Config)
-              ).and_return(@marker)
-
-              invoke('appsignal:deploy')
-            end
-
-            it "should transmit data" do
-              @transmitter.should_receive(:transmit).and_return('200')
-              invoke('appsignal:deploy')
-              out_stream.string.should include('Notifying Appsignal of deploy with: revision: 503ce0923ed177a3ce000005, user: batman')
-              out_stream.string.should include('ppsignal has been notified of this deploy!')
-            end
-
-            context "with overridden revision" do
-              before do
-                @capistrano_config.set(:appsignal_revision, 'abc123')
-              end
-              it "should add the correct marker data" do
-                Appsignal::Marker.should_receive(:new).with(
-                  {
-                    :revision => 'abc123',
-                    :user => 'batman'
-                  },
-                  kind_of(Appsignal::Config)
-                ).and_return(@marker)
-
-                invoke('appsignal:deploy')
-              end
-            end
-          end
-
-          it "should not transmit data" do
+          it "transmits marker" do
+            stub_marker_request.to_return(:status => 200)
             invoke('appsignal:deploy')
-            out_stream.string.should include('Notifying Appsignal of deploy with: revision: 503ce0923ed177a3ce000005, user: batman')
-            out_stream.string.should include('Something went wrong while trying to notify Appsignal:')
+
+            expect(out_stream.string).to include \
+              'Notifying Appsignal of deploy with: revision: 503ce0923ed177a3ce000005, user: batman',
+              'Appsignal has been notified of this deploy!'
+          end
+
+          context "with overridden revision" do
+            before do
+              capistrano_config.set(:appsignal_revision, 'abc123')
+              stub_marker_request(:revision => 'abc123').to_return(:status => 200)
+              invoke('appsignal:deploy')
+            end
+
+            it "transmits the overriden revision" do
+              expect(out_stream.string).to include \
+                'Notifying Appsignal of deploy with: revision: abc123, user: batman',
+                'Appsignal has been notified of this deploy!'
+            end
+          end
+
+          context "with failed request" do
+            before do
+              stub_marker_request.to_return(:status => 500)
+              invoke('appsignal:deploy')
+            end
+
+            it "does not transmit marker" do
+              output = out_stream.string
+              expect(output).to include \
+                'Notifying Appsignal of deploy with: revision: 503ce0923ed177a3ce000005, user: batman',
+                'Something went wrong while trying to notify Appsignal:'
+              expect(output).to_not include 'Appsignal has been notified of this deploy!'
+            end
           end
         end
 
         context "when not active for this environment" do
           before do
-            @capistrano_config.set(:rails_env, 'nonsense')
+            capistrano_config.set(:rails_env, 'nonsense')
+            invoke('appsignal:deploy')
           end
 
           it "should not send deploy marker" do
-            Appsignal::Marker.should_not_receive(:new)
-            invoke('appsignal:deploy')
-            out_stream.string.should include("Not notifying of deploy, config is not active for environment: nonsense")
+            expect(out_stream.string).to include \
+              "Not notifying of deploy, config is not active for environment: nonsense"
           end
         end
       end

--- a/spec/lib/appsignal/marker_spec.rb
+++ b/spec/lib/appsignal/marker_spec.rb
@@ -1,7 +1,7 @@
 describe Appsignal::Marker do
   let(:config) { project_fixture_config }
-  let(:marker) {
-    Appsignal::Marker.new(
+  let(:marker) do
+    described_class.new(
       {
         :revision => '503ce0923ed177a3ce000005',
         :repository => 'master',
@@ -10,53 +10,46 @@ describe Appsignal::Marker do
       },
       config
     )
-  }
+  end
   let(:out_stream) { StringIO.new }
   around do |example|
     capture_stdout(out_stream) { example.run }
   end
 
-  context "transmit" do
-    let(:transmitter) { double }
-    before do
-      Appsignal::Transmitter.should_receive(:new).with(
-        'markers', config
-      ).and_return(transmitter)
+  describe "#transmit" do
+    def stub_marker_request
+      stub_api_request config, "markers", marker.marker_data
     end
 
-    it "should transmit data" do
-      transmitter.should_receive(:transmit).with(
-        :revision => '503ce0923ed177a3ce000005',
-        :repository => 'master',
-        :user => 'batman',
-        :rails_env => 'production'
-      )
+    context "when request is valid" do
+      before do
+        stub_marker_request.to_return(:status => 200)
+        marker.transmit
+      end
 
-      marker.transmit
+      it "outputs success" do
+        output = out_stream.string
+        expect(output).to include \
+          'Notifying Appsignal of deploy with: revision: 503ce0923ed177a3ce000005, user: batman',
+          'Appsignal has been notified of this deploy!'
+      end
     end
 
-    it "should log status 200" do
-      transmitter.should_receive(:transmit).and_return('200')
+    context "when request is invalid" do
+      before do
+        stub_marker_request.to_return(:status => 500)
+        marker.transmit
+      end
 
-      marker.transmit
-
-      out_stream.string.should include('Notifying Appsignal of deploy with: revision: 503ce0923ed177a3ce000005, user: batman')
-      out_stream.string.should include('Appsignal has been notified of this deploy!')
-    end
-
-    it "should log other status" do
-      transmitter.should_receive(:transmit).and_return('500')
-      transmitter.should_receive(:uri).and_return('http://localhost:3000/1/markers')
-
-      marker.transmit
-
-      out_stream.string.should include('Notifying Appsignal of deploy with: revision: 503ce0923ed177a3ce000005, user: batman')
-      out_stream.string.should include(
-        'Something went wrong while trying to notify Appsignal: 500 at http://localhost:3000/1/markers'
-      )
-      out_stream.string.should_not include(
-        'Appsignal has been notified of this deploy!'
-      )
+      it "outputs failure" do
+        output = out_stream.string
+        expect(output).to include \
+          'Notifying Appsignal of deploy with: revision: 503ce0923ed177a3ce000005, user: batman',
+          "Something went wrong while trying to notify Appsignal: 500 at "\
+          "#{config[:endpoint]}/1/markers"
+        expect(output).to_not include \
+          'Appsignal has been notified of this deploy!'
+      end
     end
   end
 end

--- a/spec/lib/appsignal/transmitter_spec.rb
+++ b/spec/lib/appsignal/transmitter_spec.rb
@@ -27,7 +27,7 @@ describe Appsignal::Transmitter do
           "&environment=production&gem_version=#{Appsignal::VERSION}"\
           "&hostname=#{config.config_hash[:hostname]}&name=TestApp"
       ).with(
-        :body => Zlib::Deflate.deflate("{\"the\":\"payload\"}", Zlib::BEST_SPEED),
+        :body => Appsignal::Utils::Gzip.compress("{\"the\":\"payload\"}"),
         :headers => {
           'Content-Encoding' => 'gzip',
           'Content-Type' => 'application/json; charset=UTF-8',
@@ -84,13 +84,9 @@ describe Appsignal::Transmitter do
   end
 
   describe "#http_post" do
-    before do
-      Socket.stub(:gethostname => 'app1.local')
-    end
-
     subject { instance.send(:http_post, 'the' => 'payload') }
 
-    its(:body) { should eq Zlib::Deflate.deflate("{\"the\":\"payload\"}", Zlib::BEST_SPEED) }
+    its(:body) { should eq Appsignal::Utils::Gzip.compress("{\"the\":\"payload\"}") }
     its(:path) { should eq instance.uri.request_uri }
 
     it "should have the correct headers" do

--- a/spec/lib/appsignal/utils/gzip_spec.rb
+++ b/spec/lib/appsignal/utils/gzip_spec.rb
@@ -1,0 +1,10 @@
+describe Appsignal::Utils::Gzip do
+  describe ".compress" do
+    let(:value) { "foo" }
+    subject { described_class.compress(value).force_encoding("UTF-8") }
+
+    it "returns a gziped value" do
+      expect(subject).to eq("x\u0001K\xCB\xCF\a\u0000\u0002\x82\u0001E")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -130,6 +130,7 @@ RSpec.configure do |config|
   config.include NotificationHelpers
   config.include TimeHelpers
   config.include TransactionHelpers
+  config.include ApiRequestHelper
 
   config.before :all do
     FileUtils.rm_rf(tmp_dir)

--- a/spec/support/helpers/api_request_helper.rb
+++ b/spec/support/helpers/api_request_helper.rb
@@ -1,0 +1,19 @@
+module ApiRequestHelper
+  def stub_api_request(config, path, body)
+    body = Appsignal::Utils::Gzip.compress(Appsignal::Utils::JSON.generate(body))
+    stub_request(:post, "#{config[:endpoint]}/1/#{path}").with(
+      :body => body,
+        :query => {
+        :api_key => config[:push_api_key],
+        :name => config[:name],
+        :environment => config.env,
+        :hostname => config[:hostname],
+        :gem_version => Appsignal::VERSION
+      },
+      :headers => {
+        'Content-Encoding' => 'gzip',
+        'Content-Type' => 'application/json; charset=UTF-8',
+      }
+    )
+  end
+end


### PR DESCRIPTION
Noticed that if we don't rescue `Exception` but `StandardError` in `marker.rb` we actually have a couple spec failures. This because doubles were actually being called methods that they weren't configured to receive. This particular issue could have been prevented with `instance_double` from RSpec 3, https://relishapp.com/rspec/rspec-mocks/v/3-2/docs/verifying-doubles/using-an-instance-double.

However, instead of using doubles I now stub the HTTP request send by the transmitter. Something which is more stable over longer periods of time and actually tests the feature better without inside knowledge that the transmitter is being used.

Then I also had to fix the capistrano specs, so I did some minor refactoring there to avoid the usage of instance variables, as that was causing problems in the capistano3 spec where config persisted between specs. Solved that two part, by calling `Capistrano::Configuration.reset!` and using a `let!` instead. Applied the same changes to capistrano2's spec to fix those specs.

Along the way I also extracted a Gzip util and committed it separately because I wanted to reuse the compression for the HTTP request stubs

PR is definitely longer than I wanted, but there were quite a few things to fix after the one `rescue` change.

Part 1 of #168 
