### PR TITLE
Fix Transaction#discard! spec

### DIFF
--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -52,7 +52,7 @@ module Appsignal
 
       def complete_current!
         current.complete
-      rescue Exception => e
+      rescue => e
         Appsignal.logger.error("Failed to complete transaction ##{current.transaction_id}. #{e.message}")
       ensure
         Thread.current[:appsignal_transaction] = nil
@@ -269,9 +269,9 @@ module Appsignal
       params =
         begin
           request.send options[:params_method]
-        rescue Exception => ex
+        rescue => e
           # Getting params from the request has been know to fail.
-          Appsignal.logger.debug "Exception while getting params: #{ex}"
+          Appsignal.logger.debug "Exception while getting params: #{e}"
           nil
         end
       return unless params

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -120,10 +120,11 @@ describe Appsignal::Transaction do
 
       context "if a transaction is discarded" do
         it "should not complete the transaction" do
-          Appsignal::Transaction.current.should_not_receive(:complete)
+          expect(Appsignal::Transaction.current.ext).to_not receive(:complete)
 
           Appsignal::Transaction.current.discard!
           expect(Appsignal::Transaction.current.discarded?).to be_true
+
           Appsignal::Transaction.complete_current!
 
           Thread.current[:appsignal_transaction].should be_nil


### PR DESCRIPTION
The spec passed because a stub expection failed, causing "rescue
Exception => e" to be triggered and thus passing the test.

```
Failure/Error: Appsignal::Transaction.complete_current!
  (#<Appsignal::Transaction:0x007fa71d0c3f70>).complete(no args)
      expected: 0 times with any arguments
      received: 1 time
```

Part 2 of #168