### PR TITLE
Fix webmachine handle_exceptions spec

### DIFF
--- a/lib/appsignal/integrations/webmachine.rb
+++ b/lib/appsignal/integrations/webmachine.rb
@@ -25,7 +25,7 @@ module Appsignal::Integrations
         handle_exceptions_without_appsignal do
           begin
             yield
-          rescue Exception => e
+          rescue => e
             Appsignal.set_error(e)
             raise e
           end

--- a/spec/lib/appsignal/hooks/webmachine_spec.rb
+++ b/spec/lib/appsignal/hooks/webmachine_spec.rb
@@ -1,13 +1,10 @@
 if webmachine_present?
   describe Appsignal::Hooks::WebmachineHook do
     context "with webmachine" do
-      before(:all) do
-        Appsignal::Hooks::WebmachineHook.new.install
-      end
+      let(:fsm) { Webmachine::Decision::FSM.new(double(:trace? => false), double, double) }
+      before(:all) { start_agent }
 
       its(:dependencies_present?) { should be_true }
-
-      let(:fsm) { Webmachine::Decision::FSM.new(double(:trace? => false), double, double) }
 
       it "should include the run alias methods" do
         expect( fsm ).to respond_to(:run_with_appsignal)

--- a/spec/lib/appsignal/integrations/webmachine_spec.rb
+++ b/spec/lib/appsignal/integrations/webmachine_spec.rb
@@ -3,17 +3,14 @@ if webmachine_present?
   require 'appsignal/integrations/webmachine'
 
   describe Appsignal::Integrations::WebmachinePlugin::FSM do
-    before(:all) do
-      Appsignal::Hooks::WebmachineHook.new.install
-    end
     let(:request) do
       Webmachine::Request.new('GET', 'http://google.com:80/foo', {}, nil)
     end
     let(:resource)    { double(:trace? => false, :handle_exception => true) }
     let(:response)    { double }
     let(:transaction) { double(:set_action => true) }
-
     let(:fsm) { Webmachine::Decision::FSM.new(resource, request, response) }
+    before(:all) { start_agent }
 
     # Make sure the request responds to the method we need to get query params.
     describe "request" do
@@ -58,18 +55,15 @@ if webmachine_present?
       after { fsm.run }
     end
 
-    describe "handle_exceptions_with_appsignal" do
-      let(:error) { VerySpecificError.new('error') }
+    describe "#handle_exceptions_with_appsignal" do
+      let(:error) { VerySpecificError.new }
 
       it "should catch the error and send it to AppSignal" do
         expect( Appsignal ).to receive(:set_error).with(error)
       end
 
       after do
-        begin
-          fsm.send(:handle_exceptions) { raise error };
-        rescue VerySpecificError
-        end
+        fsm.send(:handle_exceptions) { raise error }
       end
     end
 


### PR DESCRIPTION
When we don't catch Exceptions we actually trigger a "stack level too deep" error. ~~I hope this doesn't happen in a real app every time the app runs into an error~~

Turns out this was because the webmachine hook was installed manually 2 times along with the install when you call the `start_agent` helper. Because the hook was installed multiple times it created a circular referencing issue to the aliased methods.

```
export BUNDLE_GEMFILE=gemfiles/webmachine.gemfile
bundle exec rspec spec
```

```
Failures:

  1) Appsignal::Integrations::WebmachinePlugin::FSM#handle_exceptions_with_appsignal should catch the error and send it to AppSignal
     Failure/Error: fsm.send(:handle_exceptions) { raise error }
     SystemStackError:
       stack level too deep
     # ./lib/appsignal/integrations/webmachine.rb:25:in `handle_exceptions_with_appsignal'
     # ./lib/appsignal/integrations/webmachine.rb:25:in `handle_exceptions_with_appsignal'
     # ./lib/appsignal/integrations/webmachine.rb:25:in `handle_exceptions_with_appsignal'
     # ./lib/appsignal/integrations/webmachine.rb:25:in `handle_exceptions_with_appsignal'
```

Part 3 of #168