### PR TITLE
Fix minor misusage of rescue Exception

### DIFF
--- a/lib/appsignal/event_formatter.rb
+++ b/lib/appsignal/event_formatter.rb
@@ -46,7 +46,7 @@ module Appsignal
             else
               raise "#{f} does not have a format(payload) method"
             end
-          rescue Exception => ex
+          rescue => ex
             formatter_classes.delete(name)
             formatters.delete(name)
             Appsignal.logger.debug("'#{ex.message}' when initializing #{name} event formatter")

--- a/lib/appsignal/rack/streaming_listener.rb
+++ b/lib/appsignal/rack/streaming_listener.rb
@@ -54,13 +54,15 @@ module Appsignal
     def each
       @stream.each { |c| yield(c) }
     rescue Exception => e
-      @transaction.set_error(e); raise e
+      @transaction.set_error(e)
+      raise e
     end
 
     def close
       @stream.close if @stream.respond_to?(:close)
     rescue Exception => e
-      @transaction.set_error(e); raise e
+      @transaction.set_error(e)
+      raise e
     ensure
       Appsignal::Transaction.complete_current!
     end


### PR DESCRIPTION
This PR fixes a minor issue with using `rescue Exception` and not re-raising it.

rescuing StandardError should be enough here.

Also no semicolons 😄 

Part 4 of #168 

PR mainly to see if nothing is broken when it runs on Travis