### PR TITLE
Don't rescue Exception in AuthCheck

### DIFF
--- a/lib/appsignal/auth_check.rb
+++ b/lib/appsignal/auth_check.rb
@@ -26,7 +26,7 @@ module Appsignal
                    "#{status.nil? ? 'nil' : status}"
         end
         [status, result]
-      rescue Exception => e
+      rescue => e
         result = 'Something went wrong while trying to '\
                  "authenticate with AppSignal: #{e}"
         [nil, result]

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -2,15 +2,18 @@ require 'appsignal/cli'
 
 describe Appsignal::CLI::Diagnose do
   let(:out_stream) { StringIO.new }
-  let(:cli) { Appsignal::CLI::Diagnose }
+  let(:config) { project_fixture_config }
+  let(:cli) { described_class }
   around do |example|
-    original_stdout = $stdout
-    $stdout = out_stream
-    example.run
-    $stdout = original_stdout
+    capture_stdout(out_stream) { example.run }
   end
 
   describe ".run" do
+    before do
+      Appsignal.config = config
+      stub_api_request config, 'auth'
+    end
+
     it "should output diagnostic information" do
       cli.run
       output = out_stream.string

--- a/spec/support/helpers/api_request_helper.rb
+++ b/spec/support/helpers/api_request_helper.rb
@@ -1,9 +1,7 @@
 module ApiRequestHelper
-  def stub_api_request(config, path, body)
-    body = Appsignal::Utils::Gzip.compress(Appsignal::Utils::JSON.generate(body))
-    stub_request(:post, "#{config[:endpoint]}/1/#{path}").with(
-      :body => body,
-        :query => {
+  def stub_api_request(config, path, body = nil)
+    options = {
+      :query => {
         :api_key => config[:push_api_key],
         :name => config[:name],
         :environment => config.env,
@@ -14,6 +12,11 @@ module ApiRequestHelper
         'Content-Encoding' => 'gzip',
         'Content-Type' => 'application/json; charset=UTF-8',
       }
-    )
+    }
+    if body.is_a? Hash
+      body = Appsignal::Utils::Gzip.compress(Appsignal::Utils::JSON.generate(body))
+    end
+    options[:body] = body if body
+    stub_request(:post, "#{config[:endpoint]}/1/#{path}").with(options)
   end
 end


### PR DESCRIPTION
It hides a http request failure in the test suite. Stub the request instead and only rescue StandardError.

Also use the `capture_stdout` method from #167 which I missed in the diagnose spec. And allow the stub_api_request to be configured without an explicit body.

Part 5 of #168 

---

The error hidden from us in the test:

```
1) Appsignal::CLI::Diagnose.run should output diagnostic information
     Failure/Error: cli.run
     WebMock::NetConnectNotAllowedError:
       Real HTTP connections are disabled. Unregistered request: POST https://push.appsignal.com/1/auth?api_key&environment=test&gem_version=1.3.6.beta.1&hostname=Akoiwa.local&name with body 'x��u�' with headers {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Encoding'=>'gzip', 'Content-Type'=>'application/json; charset=UTF-8', 'User-Agent'=>'Ruby'}

       You can stub this request with the following snippet:

       stub_request(:post, "https://push.appsignal.com/1/auth?api_key&environment=test&gem_version=1.3.6.beta.1&hostname=Akoiwa.local&name").
         with(:body => "x\x01\xAB\xAE\x05\x00\x01u\x00\xF9",
              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Encoding'=>'gzip', 'Content-Type'=>'application/json; charset=UTF-8', 'User-Agent'=>'Ruby'}).
         to_return(:status => 200, :body => "", :headers => {})

       ============================================================
     # ./lib/appsignal/transmitter.rb:45:in `transmit'
     # ./lib/appsignal/auth_check.rb:13:in `perform'
     # ./lib/appsignal/auth_check.rb:18:in `perform_with_result'
     # ./lib/appsignal/cli/diagnose.rb:53:in `check_api_key'
     # ./lib/appsignal/cli/diagnose.rb:10:in `run'
     # ./spec/lib/appsignal/cli/diagnose_spec.rb:15:in `block (3 levels) in <top (required)>'
     # ./spec/lib/appsignal/cli/diagnose_spec.rb:9:in `block (2 levels) in <top (required)>'
```