### PR TITLE
Change load order to set system config first

### DIFF
--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -65,9 +65,13 @@ module Appsignal
       @initial_config = initial_config
       @logger         = logger
       @valid          = false
+      @config_hash    = Hash[DEFAULT_CONFIG]
+
+      # Set config based on the system
+      detect_from_system
 
       # Initial config
-      @config_hash = DEFAULT_CONFIG.merge(initial_config)
+      merge(@config_hash, initial_config)
 
       # Load config from environment variables
       load_from_environment
@@ -147,6 +151,10 @@ module Appsignal
         root_path.nil? ? nil : File.join(root_path, 'config', 'appsignal.yml')
     end
 
+    def detect_from_system
+      self[:running_in_container] = true if Appsignal::System.container?
+    end
+
     def load_from_disk
       configurations = YAML.load(ERB.new(IO.read(config_file)).result)
       config_for_this_env = configurations[env]
@@ -177,8 +185,6 @@ module Appsignal
       if ENV['APPSIGNAL_PUSH_API_KEY']
         config[:active] = true
       end
-
-      config[:running_in_container] = true if Appsignal::System.container?
 
       # Configuration with string type
       %w(APPSIGNAL_PUSH_API_KEY APPSIGNAL_APP_NAME APPSIGNAL_PUSH_API_ENDPOINT


### PR DESCRIPTION
Would be not be possible to override the `running_in_container` option
with the initial config given to the initializer.

This is used in the agent specs and the previous change
(304549968f287d58a0d9e4803f9f8bc879095c46) caused those specs to fail.

---

This change makes sure that the load order is as follows:

- System detected settings (running_in_container)
- Defaults
- Initial config given to config initializer
- Environment variables
- appsignal.yml file

Note: I'll submit another PR to swap the environment variables with the appsignal.yml file in order.