### PR TITLE
Change load order in config

### DIFF
--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -69,18 +69,12 @@ module Appsignal
 
       # Set config based on the system
       detect_from_system
-
       # Initial config
       merge(@config_hash, initial_config)
-
+      # Load the config file if it exists
+      load_from_disk
       # Load config from environment variables
       load_from_environment
-
-      # Load the config file if it exists
-      if config_file && File.exist?(config_file)
-        load_from_disk
-      end
-
       # Validate that we have a correct config
       validate
     end
@@ -116,7 +110,7 @@ module Appsignal
     end
 
     def active?
-      @valid && self[:active]
+      @valid && config_hash[:active]
     end
 
     def write_to_environment
@@ -156,6 +150,8 @@ module Appsignal
     end
 
     def load_from_disk
+      return if !config_file || !File.exist?(config_file)
+
       configurations = YAML.load(ERB.new(IO.read(config_file)).result)
       config_for_this_env = configurations[env]
       if config_for_this_env

--- a/spec/support/project_fixture/config/appsignal.yml
+++ b/spec/support/project_fixture/config/appsignal.yml
@@ -16,8 +16,17 @@ test:
   debug: true
   active: true
 
-old_api_key:
+old_config:
   api_key: "def"
   active: true
+  ignore_exceptions:
+    - StandardError
+
+old_config_mixed_with_new_config:
+  push_api_key: "ghi"
+  api_key: "def"
+  active: true
+  ignore_errors:
+    - NoMethodError
   ignore_exceptions:
     - StandardError


### PR DESCRIPTION
The new load order will be:

1. Defaults (see Config::DEFAULTS)
2. System detected settings (such as :running_in_container)
3. Initial config given to Config initializer
4. appsignal.yml config file
5. Environment variables

The idea behind this change is:
1. we thought it was already working this way.. and
2. this allows the highest user configurable method to always be
leading: the environment variables. A config file is harder to change
per system while a config variable is easier to change per system.

This change is a little bigger than expected because I began updating
the spec, found duplicate specs, strangely nested specs and not a good
story of what overrides what.

That's now changed.

I updated the specs to reflect this change, remove duplicates, fix the
nesting, remove nesting where it wasn't necessary and reorder specs to
reflect the hierarchy of config loading. Also updated the specs to use
the same `expect` syntax and don't use the `its` syntax in preparation
of an upgrade to RSpec 3.

I can recommend just looking at the new file structure of the config_spec.rb rather than the diff in this PR.