### PR TITLE
Diagnose improvements

### DIFF
--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -1,79 +1,128 @@
+require "bundler/cli"
+require "bundler/cli/common"
+
 module Appsignal
   class CLI
     class Diagnose
       class << self
         def run
-          gem_version
           agent_version
+          empty_line
+
           start_appsignal
           config
+          empty_line
+
           check_api_key
+          empty_line
+
           paths_writable
-          check_ext_install
+          empty_line
+
+          log_files
         end
 
-        def gem_version
-          puts "Gem version: #{Appsignal::VERSION}"
-        end
+        private
 
-        def agent_version
-          puts "Agent version: #{Appsignal::Extension.agent_version}"
+        def empty_line
+          puts "\n"
         end
 
         def start_appsignal
           Appsignal.start
         end
 
+        def agent_version
+          puts "AppSignal agent"
+          puts "  Gem version: #{Appsignal::VERSION}"
+          puts "  Agent version: #{Appsignal::Extension.agent_version}"
+        end
+
+        def environment
+          env = Appsignal.config.env
+          puts "  Environment: #{env}"
+          if env == ""
+            puts "    Warning: No environment set, no config loaded!"
+            puts "    Please make sure appsignal diagnose is run within your "
+            puts "    project directory with an environment."
+            puts "      APPSIGNAL_APP_ENV=production appsignal diagnose"
+          end
+        end
+
         def config
-          start_appsignal
-          puts "Environment: #{Appsignal.config.env}"
-          Appsignal.config.config_hash.each do |key, val|
-            puts "Config #{key}: #{val}"
+          puts "Configuration"
+          environment
+          Appsignal.config.config_hash.each do |key, value|
+            puts "  #{key}: #{value}"
           end
         end
 
         def paths_writable
-          start_appsignal
-          possible_paths = [
-            Appsignal.config.root_path,
-            Appsignal.config.log_file_path
-          ]
+          possible_paths = {
+            :root_path => Appsignal.config.root_path,
+            :log_file_path => Appsignal.config.log_file_path
+          }
 
-          puts "Checking if required paths are writable:"
-          possible_paths.each do |path|
-            result = File.writable?(path) ? 'Ok' : 'Failed'
-            puts "#{path} ...#{result}"
+          puts "Required paths"
+          possible_paths.each do |name, path|
+            result = "Not writable"
+            if path
+              if !File.exist? path
+                result = "Does not exist"
+              elsif File.writable? path
+                result = "Writable"
+              end
+            end
+            puts "  #{name}: #{path.to_s.inspect} - #{result}"
           end
-          puts "\n"
         end
 
         def check_api_key
-          start_appsignal
           auth_check = ::Appsignal::AuthCheck.new(Appsignal.config, Appsignal.logger)
+          print "Validating API key: "
           status, _ = auth_check.perform_with_result
-          if status == '200'
-            puts "Checking API key: Ok"
+          case status
+          when "200"
+            print "Valid"
+          when "401"
+            print "Invalid"
           else
-            puts "Checking API key: Failed"
+            print "Failed with status #{status}"
+          end
+          empty_line
+        end
+
+        def log_files
+          install_log
+          empty_line
+          mkmf_log
+        end
+
+        def install_log
+          install_log_path = File.join(gem_path, "ext", "install.log")
+          puts "Extension install log"
+          output_log_file install_log_path
+        end
+
+        def mkmf_log
+          mkmf_log_path = File.join(gem_path, "ext", "mkmf.log")
+          puts "Makefile install log"
+          output_log_file mkmf_log_path
+        end
+
+        def output_log_file(log_file)
+          puts "  Path: #{log_file.to_s.inspect}"
+          if File.exist? log_file
+            puts "  Contents:"
+            puts File.read(log_file)
+          else
+            puts "  File not found."
           end
         end
 
-        def check_ext_install
-          require 'bundler/cli'
-          require "bundler/cli/common"
-          path = Bundler::CLI::Common.select_spec('appsignal').full_gem_path.strip
-          install_log_path = "#{path}/ext/install.log"
-          puts "Showing last lines of extension install log: #{install_log_path}"
-          puts File.read(install_log_path)
-          puts "\n"
-          mkmf_log_path = "#{path}/ext/mkmf.log"
-          if File.exist?(mkmf_log_path)
-            puts "Showing last lines of extension compilation log: #{mkmf_log_path}"
-            puts File.read(mkmf_log_path)
-            puts "\n"
-          else
-            puts "#{mkmf_log_path} not present"
-          end
+        def gem_path
+          @gem_path ||= \
+            Bundler::CLI::Common.select_spec("appsignal").full_gem_path.strip
         end
       end
     end

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -6,6 +6,9 @@ module Appsignal
     class Diagnose
       class << self
         def run
+          header
+          empty_line
+
           agent_version
           empty_line
 
@@ -30,6 +33,16 @@ module Appsignal
 
         def start_appsignal
           Appsignal.start
+        end
+
+        def header
+          puts "AppSignal diagnose"
+          puts "=" * 80
+          puts "Use this information to debug your configuration."
+          puts "More information is available on the documentation site."
+          puts "http://docs.appsignal.com/"
+          puts "Send this output to support@appsignal.com if you need help."
+          puts "=" * 80
         end
 
         def agent_version

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -62,6 +62,10 @@ module Appsignal
           puts "  Architecture: #{rbconfig["host_cpu"]}"
           puts "  Operating System: #{rbconfig["host_os"]}"
           puts "  Ruby version: #{rbconfig["RUBY_VERSION_NAME"]}"
+          puts "  Heroku: true" if Appsignal::System.heroku?
+          if Appsignal::System.container?
+            puts "  Container id: #{Appsignal::System::Container.id}"
+          end
         end
 
         def environment

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -1,3 +1,4 @@
+require "rbconfig"
 require "bundler/cli"
 require "bundler/cli/common"
 
@@ -10,6 +11,9 @@ module Appsignal
           empty_line
 
           agent_version
+          empty_line
+
+          host_information
           empty_line
 
           start_appsignal
@@ -49,6 +53,14 @@ module Appsignal
           puts "AppSignal agent"
           puts "  Gem version: #{Appsignal::VERSION}"
           puts "  Agent version: #{Appsignal::Extension.agent_version}"
+        end
+
+        def host_information
+          rbconfig = RbConfig::CONFIG
+          puts "Host information"
+          puts "  Architecture: #{rbconfig["host_cpu"]}"
+          puts "  Operating System: #{rbconfig["host_os"]}"
+          puts "  Ruby version: #{rbconfig["RUBY_VERSION_NAME"]}"
         end
 
         def environment

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -53,6 +53,7 @@ module Appsignal
           puts "AppSignal agent"
           puts "  Gem version: #{Appsignal::VERSION}"
           puts "  Agent version: #{Appsignal::Extension.agent_version}"
+          puts "  Gem install path: #{gem_path}"
         end
 
         def host_information

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -38,6 +38,15 @@ describe Appsignal::CLI::Diagnose do
         "Agent version: #{Appsignal::Extension.agent_version}"
     end
 
+    it "outputs host information" do
+      run
+      expect(output).to include \
+        "Host information",
+        "Architecture: #{RbConfig::CONFIG["host_cpu"]}",
+        "Operating System: #{RbConfig::CONFIG["host_os"]}",
+        "Ruby version: #{RbConfig::CONFIG["RUBY_VERSION_NAME"]}"
+    end
+
     describe "configuration" do
       context "without environment" do
         let(:config) { project_fixture_config("") }

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -23,6 +23,14 @@ describe Appsignal::CLI::Diagnose do
       end
     end
 
+    it "outputs header and support text" do
+      run
+      expect(output).to include \
+        "AppSignal diagnose",
+        "http://docs.appsignal.com/",
+        "support@appsignal.com"
+    end
+
     it "outputs version numbers" do
       run
       expect(output).to include \

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -1,29 +1,251 @@
-require 'appsignal/cli'
+require "appsignal/cli"
 
 describe Appsignal::CLI::Diagnose do
-  let(:out_stream) { StringIO.new }
-  let(:config) { project_fixture_config }
-  let(:cli) { described_class }
-  around do |example|
-    capture_stdout(out_stream) { example.run }
-  end
-
   describe ".run" do
+    let(:out_stream) { StringIO.new }
+    let(:config) { project_fixture_config }
+    let(:cli) { described_class }
+    let(:output) { out_stream.string }
     before do
-      Appsignal.config = config
-      stub_api_request config, 'auth'
+      ENV["APPSIGNAL_APP_ENV"] = "production"
+      stub_api_request config, "auth"
+    end
+    after { Appsignal.config = nil }
+    around { |example| capture_stdout(out_stream) { example.run } }
+
+    def run
+      run_within_dir project_fixture_path
     end
 
-    it "should output diagnostic information" do
-      cli.run
-      output = out_stream.string
-      expect(output).to include('Gem version')
-      expect(output).to include('Agent version')
-      expect(output).to include('Environment')
-      expect(output).to include('Config')
-      expect(output).to include('Checking API key')
-      expect(output).to include('Checking if required paths are writable')
-      expect(output).to include('Showing last lines of extension install log')
+    def run_within_dir(chdir)
+      Dir.chdir chdir do
+        cli.run
+      end
+    end
+
+    it "outputs version numbers" do
+      run
+      expect(output).to include \
+        "Gem version: #{Appsignal::VERSION}",
+        "Agent version: #{Appsignal::Extension.agent_version}"
+    end
+
+    describe "configuration" do
+      context "without environment" do
+        let(:config) { project_fixture_config("") }
+        before do
+          ENV["APPSIGNAL_APP_ENV"] = ""
+          run
+        end
+
+        it "outputs a warning that no config is loaded" do
+          expect(output).to include \
+            "Environment: \n    Warning: No environment set, no config loaded!",
+            "  APPSIGNAL_APP_ENV=production appsignal diagnose"
+        end
+
+        it "outputs config defaults" do
+          expect(output).to include("Configuration")
+          Appsignal::Config::DEFAULT_CONFIG.each do |key, value|
+            expect(output).to include("#{key}: #{value}")
+          end
+        end
+      end
+
+      context "with configured environment" do
+        before { run }
+
+        it "outputs environment" do
+          expect(output).to include("Environment: production")
+        end
+
+        it "outputs configuration" do
+          expect(output).to include("Configuration")
+          Appsignal.config.config_hash.each do |key, value|
+            expect(output).to include("#{key}: #{value}")
+          end
+        end
+      end
+
+      context "with unconfigured environment" do
+        let(:config) { project_fixture_config("foobar") }
+        before do
+          ENV["APPSIGNAL_APP_ENV"] = "foobar"
+          run
+        end
+
+        it "outputs environment" do
+          expect(output).to include("Environment: foobar")
+        end
+
+        it "outputs config defaults" do
+          expect(output).to include("Configuration")
+          Appsignal::Config::DEFAULT_CONFIG.each do |key, value|
+            expect(output).to include("#{key}: #{value}")
+          end
+        end
+      end
+    end
+
+    describe "API key validation" do
+      context "with valid key" do
+        before do
+          stub_api_request(config, "auth").to_return(:status => 200)
+          run
+        end
+
+        it "outputs valid" do
+          expect(output).to include("Validating API key: Valid")
+        end
+      end
+
+      context "with invalid key" do
+        before do
+          stub_api_request(config, "auth").to_return(:status => 401)
+          run
+        end
+
+        it "outputs invalid" do
+          expect(output).to include("Validating API key: Invalid")
+        end
+      end
+
+      context "with invalid key" do
+        before do
+          stub_api_request(config, "auth").to_return(:status => 500)
+          run
+        end
+
+        it "outputs failure with status code" do
+          expect(output).to include("Validating API key: Failed with status 500")
+        end
+      end
+    end
+
+    describe "paths" do
+      before { FileUtils.mkdir_p(root_path) }
+
+      context "when a directory is writable" do
+        let(:root_path) { File.join(tmp_dir, "writable_path") }
+        let(:log_file) { File.join(root_path, "appsignal.log") }
+        let(:config) { Appsignal::Config.new(root_path, "production") }
+
+        context "without log file" do
+          before { run_within_dir root_path }
+
+          it "outputs writable" do
+            expect(output).to include \
+              "Required paths",
+              %(root_path: "#{root_path}" - Writable),
+              %(log_file_path: "#{log_file}" - Does not exist)
+          end
+        end
+
+        context "with log file" do
+          context "when writable" do
+            before do
+              FileUtils.touch(log_file)
+              run_within_dir root_path
+            end
+
+            it "lists log file as writable" do
+              expect(output).to include \
+                %(root_path: "#{root_path}" - Writable),
+                %(log_file_path: "#{File.join(root_path, "appsignal.log")}" - Writable)
+            end
+          end
+
+          context "when not writable" do
+            before do
+              FileUtils.touch(log_file)
+              FileUtils.chmod(0444, log_file)
+              run_within_dir root_path
+            end
+
+            it "lists log file as not writable" do
+              expect(output).to include \
+                %(root_path: "#{root_path}" - Writable),
+                %(log_file_path: "#{File.join(root_path, "appsignal.log")}" - Not writable)
+            end
+          end
+        end
+      end
+
+      context "when a directory is not writable" do
+        let(:root_path) { File.join(tmp_dir, "not_writable_path") }
+        let(:config) { Appsignal::Config.new(root_path, "production") }
+        before do
+          FileUtils.chmod(0555, root_path)
+          run_within_dir root_path
+        end
+
+        it "outputs not writable" do
+          expect(output).to include \
+            "Required paths",
+            %(root_path: "#{root_path}" - Not writable),
+            %(log_file_path: "" - Not writable)
+        end
+      end
+
+      after { FileUtils.rm_rf(root_path) }
+    end
+
+    describe "logs" do
+      shared_examples "ext log file" do |log_file|
+        let(:ext_path) { File.join(gem_path, "ext") }
+        let(:log_path) { File.join(ext_path, log_file) }
+        before do
+          allow(cli).to receive(:gem_path).and_return(gem_path)
+        end
+
+        context "when file exists" do
+          let(:gem_path) { File.join(tmp_dir, "gem") }
+          before do
+            FileUtils.mkdir_p ext_path
+            File.open log_path, "a" do |f|
+              f.write "log line 1"
+              f.write "log line 2"
+            end
+            run
+          end
+
+          it "outputs install.log" do
+            expect(output).to include \
+              %(Path: "#{log_path}"),
+              "log line 1",
+              "log line 2"
+          end
+
+          after { FileUtils.rm_rf(gem_path) }
+        end
+
+        context "when file does not exist" do
+          let(:gem_path) { File.join(tmp_dir, "non_existent_path") }
+          before { run }
+
+          it "outputs install.log" do
+            expect(output).to include %(Path: "#{log_path}"\n  File not found.)
+          end
+        end
+      end
+
+      describe "install.log" do
+        it_behaves_like "ext log file", "install.log"
+
+        it "outputs header" do
+          run
+          expect(output).to include("Extension install log")
+        end
+      end
+
+      describe "mkmf.log" do
+        it_behaves_like "ext log file", "mkmf.log"
+
+        it "outputs header" do
+          run
+          expect(output).to include("Extension install log")
+        end
+      end
     end
   end
 end

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -33,9 +33,11 @@ describe Appsignal::CLI::Diagnose do
 
     it "outputs version numbers" do
       run
+      gem_path = Bundler::CLI::Common.select_spec("appsignal").full_gem_path.strip
       expect(output).to include \
         "Gem version: #{Appsignal::VERSION}",
-        "Agent version: #{Appsignal::Extension.agent_version}"
+        "Agent version: #{Appsignal::Extension.agent_version}",
+        "Gem install path: #{gem_path}"
     end
 
     it "outputs host information" do


### PR DESCRIPTION
This PR does three things.

1. It adds tests to the diagnose command.
2. It adds more information to the diagnose command.
3. It improves the formatting of the diagnose command.

Since the diagnose output is a big part of our support procedure, it's important that it contains the information we need and that it's readable for us and the users.

Let me know if you have feedback on what information is still missing, how it looks or how we can make it look even better.

## Detailed changes

- Improve formatting
  - No repetitive `Config #{key}: #{value}`
  - Add headings (Host information, Configuration, paths, {file} log)
- Add AppSignal header and support information
- Add warning when no environment is found (usually not the output we want)
- Add gem install path
- Add host information (ruby, host os, architecture, container id, heroku detection)

## Before

![image](https://cloud.githubusercontent.com/assets/282402/19264185/05ff5fc4-8fa0-11e6-8663-7cd7f8ec391d.png)

## After (macOS)

![image](https://cloud.githubusercontent.com/assets/282402/19264144/d76abda2-8f9f-11e6-89a7-30b12e7a5a34.png)

## After (macOS without environment)
Snippet of config block

![image](https://cloud.githubusercontent.com/assets/282402/19264163/efdc8280-8f9f-11e6-9f37-5b655e229a18.png)

## After (in container)

![image](https://cloud.githubusercontent.com/assets/282402/19264111/be6e246a-8f9f-11e6-879d-5d3827e7c204.png)

Fixes the important points in #181