### PR TITLE
Fix issue where errors without name could be sent

### DIFF
--- a/lib/appsignal/js_exception_transaction.rb
+++ b/lib/appsignal/js_exception_transaction.rb
@@ -14,7 +14,7 @@ module Appsignal
     end
 
     def set_action
-      @ext.set_action(@data['action'])
+      @ext.set_action(@data['action']) if @data['action']
     end
 
     def set_metadata
@@ -26,8 +26,8 @@ module Appsignal
     def set_error
       @ext.set_error(
         @data['name'],
-        @data['message'],
-        Appsignal::Utils.data_generate(@data['backtrace'])
+        @data['message'] || '',
+        Appsignal::Utils.data_generate(@data['backtrace'] || [])
       )
     end
 

--- a/spec/lib/appsignal/js_exception_transaction_spec.rb
+++ b/spec/lib/appsignal/js_exception_transaction_spec.rb
@@ -21,22 +21,22 @@ describe Appsignal::JSExceptionTransaction do
 
   describe "#initialize" do
     it "should call all required methods" do
-      expect( Appsignal::Extension ).to receive(:start_transaction).with('123abc', 'frontend', 0).and_return(1)
+      expect(Appsignal::Extension).to receive(:start_transaction).with('123abc', 'frontend', 0).and_return(1)
 
-      expect( transaction ).to receive(:set_action)
-      expect( transaction ).to receive(:set_metadata)
-      expect( transaction ).to receive(:set_error)
-      expect( transaction ).to receive(:set_sample_data)
+      expect(transaction).to receive(:set_action)
+      expect(transaction).to receive(:set_metadata)
+      expect(transaction).to receive(:set_error)
+      expect(transaction).to receive(:set_sample_data)
 
       transaction.send :initialize, data
 
-      expect( transaction.ext ).not_to be_nil
+      expect(transaction.ext).to_not be_nil
     end
   end
 
-  describe "#set_base_data" do
-    it "should call `Appsignal::Extension.set_transaction_basedata`" do
-      expect( transaction.ext ).to receive(:set_action).with(
+  describe "#set_action" do
+    it "should call `Appsignal::Extension.set_action`" do
+      expect(transaction.ext).to receive(:set_action).with(
         'ExceptionIncidentComponent'
       )
 
@@ -45,43 +45,83 @@ describe Appsignal::JSExceptionTransaction do
   end
 
   describe "#set_metadata" do
-   it "should call `Appsignal::Extension.set_transaction_metadata`" do
-     expect( transaction.ext ).to receive(:set_metadata).with(
-       'path',
-       'foo.bar/moo'
-     )
+    it "should call `Appsignal::Extension.set_transaction_metadata`" do
+      expect(transaction.ext).to receive(:set_metadata).with(
+        'path',
+        'foo.bar/moo'
+      )
 
-     transaction.set_metadata
-   end
+      transaction.set_metadata
+    end
   end
 
   describe "#set_error" do
-   it "should call `Appsignal::Extension.set_transaction_error`" do
-     expect( transaction.ext ).to receive(:set_error).with(
-       'TypeError',
-       'foo is not a valid method',
-       Appsignal::Utils.data_generate(['foo.bar/js:11:1', 'foo.bar/js:22:2'])
-     )
+    it "should call `Appsignal::Extension.set_transaction_error`" do
+      expect(transaction.ext).to receive(:set_error).with(
+        'TypeError',
+        'foo is not a valid method',
+        Appsignal::Utils.data_generate(['foo.bar/js:11:1', 'foo.bar/js:22:2'])
+      )
 
-     transaction.set_error
-   end
+      transaction.set_error
+    end
   end
 
   describe "#set_sample_data" do
-   it "should call `Appsignal::Extension.set_transaction_error_data`" do
-     expect( transaction.ext ).to receive(:set_sample_data).with(
-      'tags',
-      Appsignal::Utils.data_generate(['tag1'])
-     )
+    it "should call `Appsignal::Extension.set_transaction_error_data`" do
+      expect(transaction.ext).to receive(:set_sample_data).with(
+        'tags',
+        Appsignal::Utils.data_generate(['tag1'])
+      )
 
-     transaction.set_sample_data
-   end
+      transaction.set_sample_data
+    end
+  end
+
+  context "when sending just the name" do
+    let(:data) { {'name' => 'TypeError'} }
+
+    describe "#set_action" do
+      it "should not call `Appsignal::Extension.set_action`" do
+        expect(transaction.ext).to_not receive(:set_action)
+
+        transaction.set_action
+      end
+    end
+
+    describe "#set_metadata" do
+      it "should not call `Appsignal::Extension.set_transaction_metadata`" do
+        expect(transaction.ext).to_not receive(:set_metadata)
+
+        transaction.set_metadata
+      end
+    end
+
+    describe "#set_error" do
+      it "should call `Appsignal::Extension.set_transaction_error` with just the name" do
+        expect(transaction.ext).to receive(:set_error).with(
+          'TypeError',
+          '',
+          Appsignal::Utils.data_generate([])
+        )
+
+        transaction.set_error
+      end
+    end
+
+    describe "#set_sample_data" do
+      it "should not call `Appsignal::Extension.set_transaction_error_data`" do
+        expect(transaction.ext).to_not receive(:set_sample_data)
+
+        transaction.set_sample_data
+      end
+    end
   end
 
   describe "#complete!" do
     it "should call all required methods" do
-      expect( transaction.ext ).to receive(:finish)
-      expect( transaction.ext ).to receive(:complete)
+      expect(transaction.ext).to receive(:finish)
+      expect(transaction.ext).to receive(:complete)
       transaction.complete!
     end
   end


### PR DESCRIPTION
The Rack middleware now returns a 422 code when exception name is not set.

Fixes #186 