### PR TITLE
Support namespaces in Grape

### DIFF
--- a/spec/support/helpers/env_helpers.rb
+++ b/spec/support/helpers/env_helpers.rb
@@ -1,7 +1,8 @@
 module EnvHelpers
   def http_request_env_with_data(args={})
+    path = args.delete(:path) || "/blog"
     Rack::MockRequest.env_for(
-      '/blog',
+      path,
       :params => {
         'controller' => 'blog_posts',
         'action' => 'show',


### PR DESCRIPTION
Only the path was used which does not include the namespace. This is
only available on the Grape::Endpoint.

Namespaces and paths can be anything, Symbols or Strings, prefixed with
a / or not.

Brain dump about thoughts on the integration and tests:
> I kept the fallback on the request data the same right now, but I think we can take that out at some point. Same as with the Sinatra integration. If `env["api.endpoint"]` doesn't exist the integration provides poorly structured data and it's of not much use. We should perform some tests later to see if there can ever not be `api.endpoint` in the env. Also see if we can take a different testing approach, something a bit more full stack approach with Rake::Test. Now we control how the middleware is created, something which we don't in grape.

As reported in https://app.intercom.io/a/apps/yzor8gyw/inbox/conversation/5431615974