### PR TITLE
Allow config :log to be explicitly set to `stdout`

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -237,7 +237,7 @@ module Appsignal
     end
 
     def start_logger(path_arg = nil)
-      if config && config.log_file_path
+      if config && config[:log] == "file" && config.log_file_path
         start_file_logger(config.log_file_path)
       else
         start_stdout_logger

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -236,33 +236,26 @@ module Appsignal
       end
     end
 
-    def start_logger(path_arg=nil)
-      path = Appsignal.config ? Appsignal.config.log_file_path : nil
-      if path && !Appsignal::System.heroku?
-        begin
-          @logger = Logger.new(path)
-          @logger.formatter = log_formatter
-        rescue SystemCallError => error
-          start_stdout_logger
-          logger.warn "appsignal: Unable to start logger with log path '#{path}'."
-          logger.warn "appsignal: #{error}"
-        end
+    def start_logger(path_arg = nil)
+      if config && config.log_file_path
+        start_file_logger(config.log_file_path)
       else
         start_stdout_logger
       end
 
-      if config && config[:debug]
-        @logger.level = Logger::DEBUG
-      else
-        @logger.level = Logger::INFO
-      end
+      logger.level =
+        if config && config[:debug]
+          Logger::DEBUG
+        else
+          Logger::INFO
+        end
 
       if in_memory_log
-        @logger << in_memory_log.string
+        logger << in_memory_log.string
       end
 
       if path_arg
-        @logger.info('Setting the path in start_logger has no effect anymore, set it in the config instead')
+        logger.info('Setting the path in start_logger has no effect anymore, set it in the config instead')
       end
     end
 
@@ -300,6 +293,15 @@ module Appsignal
       @logger.formatter = lambda do |severity, datetime, progname, msg|
         "appsignal: #{msg}\n"
       end
+    end
+
+    def start_file_logger(path)
+      @logger = Logger.new(path)
+      @logger.formatter = log_formatter
+    rescue SystemCallError => error
+      start_stdout_logger
+      logger.warn "appsignal: Unable to start logger with log path '#{path}'."
+      logger.warn "appsignal: #{error}"
     end
   end
 end

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -90,8 +90,6 @@ module Appsignal
     end
 
     def log_file_path
-      return unless config_hash[:log] == "file"
-
       path = config_hash[:log_path] || root_path
       if path && File.writable?(path)
         return File.join(File.realpath(path), 'appsignal.log')

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -8,6 +8,7 @@ module Appsignal
     SYSTEM_TMP_DIR = '/tmp'
     DEFAULT_CONFIG = {
       :debug                          => false,
+      :log                            => 'file',
       :ignore_errors                  => [],
       :ignore_actions                 => [],
       :filter_parameters              => [],
@@ -35,6 +36,7 @@ module Appsignal
       'APPSIGNAL_PUSH_API_ENDPOINT'              => :endpoint,
       'APPSIGNAL_FRONTEND_ERROR_CATCHING_PATH'   => :frontend_error_catching_path,
       'APPSIGNAL_DEBUG'                          => :debug,
+      'APPSIGNAL_LOG'                            => :log,
       'APPSIGNAL_LOG_PATH'                       => :log_path,
       'APPSIGNAL_INSTRUMENT_NET_HTTP'            => :instrument_net_http,
       'APPSIGNAL_INSTRUMENT_REDIS'               => :instrument_redis,
@@ -88,6 +90,8 @@ module Appsignal
     end
 
     def log_file_path
+      return unless config_hash[:log] == "file"
+
       path = config_hash[:log_path] || root_path
       if path && File.writable?(path)
         return File.join(File.realpath(path), 'appsignal.log')
@@ -96,7 +100,7 @@ module Appsignal
       if File.writable? SYSTEM_TMP_DIR
         $stdout.puts "appsignal: Unable to log to '#{path}'. Logging to "\
           "'#{SYSTEM_TMP_DIR}' instead. Please check the "\
-          "permissions for the application's log directory."
+          "permissions for the application's (log) directory."
         File.join(SYSTEM_TMP_DIR, 'appsignal.log')
       else
         $stdout.puts "appsignal: Unable to log to '#{path}' or the "\
@@ -146,7 +150,8 @@ module Appsignal
     end
 
     def detect_from_system
-      self[:running_in_container] = true if Appsignal::System.container?
+      config_hash[:running_in_container] = true if Appsignal::System.container?
+      config_hash[:log] = 'stdout' if Appsignal::System.heroku?
     end
 
     def load_from_disk
@@ -184,8 +189,9 @@ module Appsignal
 
       # Configuration with string type
       %w(APPSIGNAL_PUSH_API_KEY APPSIGNAL_APP_NAME APPSIGNAL_PUSH_API_ENDPOINT
-         APPSIGNAL_FRONTEND_ERROR_CATCHING_PATH APPSIGNAL_HTTP_PROXY APPSIGNAL_LOG_PATH
-         APPSIGNAL_WORKING_DIR_PATH APPSIGNAL_HOSTNAME APPSIGNAL_CA_FILE_PATH).each do |var|
+         APPSIGNAL_FRONTEND_ERROR_CATCHING_PATH APPSIGNAL_HTTP_PROXY
+         APPSIGNAL_LOG APPSIGNAL_LOG_PATH APPSIGNAL_WORKING_DIR_PATH
+         APPSIGNAL_HOSTNAME APPSIGNAL_CA_FILE_PATH).each do |var|
         if env_var = ENV[var]
           config[ENV_TO_KEY_MAPPING[var]] = env_var
         end

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -368,6 +368,7 @@ describe Appsignal::Config do
 
   describe "#log_file_path" do
     let(:stdout) { StringIO.new }
+    let(:config) { project_fixture_config('production', :log_path => log_path) }
     subject { config.log_file_path }
     around do |example|
       recognize_as_container(:none) do
@@ -375,27 +376,67 @@ describe Appsignal::Config do
       end
     end
 
-    context "when :log is stdout" do
-      before { config[:log] = "stdout" }
+    context "when path is writable" do
+      let(:log_path) { File.join(tmp_dir, 'writable-path') }
+      before { FileUtils.mkdir_p(log_path, :mode => 0755) }
+      after { FileUtils.rm_rf(log_path) }
 
-      context "with :log_path" do
-        let(:config) { project_fixture_config('production', :log_path => tmp_dir) }
+      it "returns log file path" do
+        expect(subject).to eq File.join(log_path, 'appsignal.log')
+      end
 
-        it "returns nil" do
-          expect(subject).to be_nil
+      it "prints no warning" do
+        subject
+        expect(stdout.string).to be_empty
+      end
+    end
+
+    shared_examples '#log_file_path: tmp path' do
+      let(:system_tmp_dir) { described_class::SYSTEM_TMP_DIR }
+      before { FileUtils.mkdir_p(system_tmp_dir) }
+      after { FileUtils.rm_rf(system_tmp_dir) }
+
+      context "when the /tmp fallback path is writable" do
+        before { FileUtils.chmod(0777, system_tmp_dir) }
+
+        it "returns returns the tmp location" do
+          expect(subject).to eq(File.join(system_tmp_dir, 'appsignal.log'))
         end
 
-        it "prints no warning" do
+        it "prints a warning" do
           subject
-          expect(stdout.string).to be_empty
+          expect(stdout.string).to include "appsignal: Unable to log to '#{log_path}'. "\
+            "Logging to '#{system_tmp_dir}' instead."
         end
       end
 
-      context "without :log_path" do
-        let(:config) { project_fixture_config('production') }
+      context "when the /tmp fallback path is not writable" do
+        before { FileUtils.chmod(0555, system_tmp_dir) }
 
         it "returns nil" do
           expect(subject).to be_nil
+        end
+
+        it "prints a warning" do
+          subject
+          expect(stdout.string).to include "appsignal: Unable to log to '#{log_path}' "\
+            "or the '#{system_tmp_dir}' fallback."
+        end
+      end
+    end
+
+    context "when path is nil" do
+      let(:log_path) { nil }
+
+      context "when root_path is nil" do
+        before { allow(config).to receive(:root_path).and_return(nil) }
+
+        include_examples '#log_file_path: tmp path'
+      end
+
+      context "when root_path is set" do
+        it "returns returns the project log location" do
+          expect(subject).to eq File.join(config.root_path, 'appsignal.log')
         end
 
         it "prints no warning" do
@@ -405,135 +446,61 @@ describe Appsignal::Config do
       end
     end
 
-    context "when :log is file" do
-      let(:config) { project_fixture_config('production', :log_path => log_path) }
+    context "when path does not exist" do
+      let(:log_path) { '/non-existing' }
 
-      context "when path is writable" do
-        let(:log_path) { File.join(tmp_dir, 'writable-path') }
-        before { FileUtils.mkdir_p(log_path, :mode => 0755) }
-        after { FileUtils.rm_rf(log_path) }
+      include_examples '#log_file_path: tmp path'
+    end
 
-        it "returns log file path" do
-          expect(subject).to eq File.join(log_path, 'appsignal.log')
-        end
+    context "when path is not writable" do
+      let(:log_path) { File.join(tmp_dir, 'not-writable-path') }
+      before { FileUtils.mkdir_p(log_path, :mode => 0555) }
+      after { FileUtils.rm_rf(log_path) }
 
-        it "prints no warning" do
-          subject
-          expect(stdout.string).to be_empty
-        end
-      end
+      include_examples '#log_file_path: tmp path'
+    end
 
-      shared_examples '#log_file_path: tmp path' do
-        let(:system_tmp_dir) { described_class::SYSTEM_TMP_DIR }
-        before { FileUtils.mkdir_p(system_tmp_dir) }
-        after { FileUtils.rm_rf(system_tmp_dir) }
-
-        context "when the /tmp fallback path is writable" do
-          before { FileUtils.chmod(0777, system_tmp_dir) }
-
-          it "returns returns the tmp location" do
-            expect(subject).to eq(File.join(system_tmp_dir, 'appsignal.log'))
-          end
-
-          it "prints a warning" do
-            subject
-            expect(stdout.string).to include "appsignal: Unable to log to '#{log_path}'. "\
-              "Logging to '#{system_tmp_dir}' instead."
-          end
-        end
-
-        context "when the /tmp fallback path is not writable" do
-          before { FileUtils.chmod(0555, system_tmp_dir) }
-
-          it "returns nil" do
-            expect(subject).to be_nil
-          end
-
-          it "prints a warning" do
-            subject
-            expect(stdout.string).to include "appsignal: Unable to log to '#{log_path}' "\
-              "or the '#{system_tmp_dir}' fallback."
-          end
-        end
-      end
-
-      context "when path is nil" do
-        let(:log_path) { nil }
-
-        context "when root_path is nil" do
-          before { allow(config).to receive(:root_path).and_return(nil) }
-
-          include_examples '#log_file_path: tmp path'
-        end
-
-        context "when root_path is set" do
-          it "returns returns the project log location" do
-            expect(subject).to eq File.join(config.root_path, 'appsignal.log')
-          end
-
-          it "prints no warning" do
-            subject
-            expect(stdout.string).to be_empty
-          end
-        end
-      end
-
-      context "when path does not exist" do
-        let(:log_path) { '/non-existing' }
+    context "when path is a symlink" do
+      context "when linked path does not exist" do
+        let(:real_path) { File.join(tmp_dir, 'real-path') }
+        let(:log_path) { File.join(tmp_dir, 'symlink-path') }
+        before { File.symlink(real_path, log_path) }
+        after { FileUtils.rm(log_path) }
 
         include_examples '#log_file_path: tmp path'
       end
 
-      context "when path is not writable" do
-        let(:log_path) { File.join(tmp_dir, 'not-writable-path') }
-        before { FileUtils.mkdir_p(log_path, :mode => 0555) }
-        after { FileUtils.rm_rf(log_path) }
-
-        include_examples '#log_file_path: tmp path'
-      end
-
-      context "when path is a symlink" do
-        context "when linked path does not exist" do
+      context "when linked path exists" do
+        context "when linked path is not writable" do
           let(:real_path) { File.join(tmp_dir, 'real-path') }
           let(:log_path) { File.join(tmp_dir, 'symlink-path') }
-          before { File.symlink(real_path, log_path) }
-          after { FileUtils.rm(log_path) }
+          before do
+            FileUtils.mkdir_p(real_path)
+            FileUtils.chmod(0444, real_path)
+            File.symlink(real_path, log_path)
+          end
+          after do
+            FileUtils.rm_rf(real_path)
+            FileUtils.rm(log_path)
+          end
 
           include_examples '#log_file_path: tmp path'
         end
 
-        context "when linked path exists" do
-          context "when linked path is not writable" do
-            let(:real_path) { File.join(tmp_dir, 'real-path') }
-            let(:log_path) { File.join(tmp_dir, 'symlink-path') }
-            before do
-              FileUtils.mkdir_p(real_path)
-              FileUtils.chmod(0444, real_path)
-              File.symlink(real_path, log_path)
-            end
-            after do
-              FileUtils.rm_rf(real_path)
-              FileUtils.rm(log_path)
-            end
-
-            include_examples '#log_file_path: tmp path'
+        context "when linked path is writable" do
+          let(:real_path) { File.join(tmp_dir, 'real-path') }
+          let(:log_path) { File.join(tmp_dir, 'symlink-path') }
+          before do
+            FileUtils.mkdir_p(real_path)
+            File.symlink(real_path, log_path)
+          end
+          after do
+            FileUtils.rm_rf(real_path)
+            FileUtils.rm(log_path)
           end
 
-          context "when linked path is writable" do
-            let(:real_path) { File.join(tmp_dir, 'real-path') }
-            let(:log_path) { File.join(tmp_dir, 'symlink-path') }
-            before do
-              FileUtils.mkdir_p(real_path)
-              File.symlink(real_path, log_path)
-            end
-            after do
-              FileUtils.rm_rf(real_path)
-              FileUtils.rm(log_path)
-            end
-
-            it "returns real path of log path" do
-              expect(subject).to eq(File.join(real_path, 'appsignal.log'))
-            end
+          it "returns real path of log path" do
+            expect(subject).to eq(File.join(real_path, 'appsignal.log'))
           end
         end
       end

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -565,7 +565,9 @@ describe Appsignal do
         )
       end
       around do |example|
-        capture_stdout(out_stream) { example.run }
+        recognize_as_container(:none) do
+          capture_stdout(out_stream) { example.run }
+        end
       end
       after { FileUtils.rm_rf(log_path) }
 


### PR DESCRIPTION
Will silence any warnings of not writable log file paths when set to
`log: stdout`.

Part of #184
Doesn't fix it entirely as it only redirects the ruby gem's output.

This allows the user to have some choice in the matter where
things are logged.
It not perfect system, but expect a RFC for the agent's side.