### PR TITLE
AppSignal, not Appsignal

### DIFF
--- a/lib/appsignal/cli.rb
+++ b/lib/appsignal/cli.rb
@@ -58,7 +58,7 @@ module Appsignal
           o.banner = 'Usage: appsignal <command> [options]'
 
           o.on '-v', '--version', "Print version and exit" do |arg|
-            puts "Appsignal #{Appsignal::VERSION}"
+            puts "AppSignal #{Appsignal::VERSION}"
             exit(0)
           end
 

--- a/lib/appsignal/marker.rb
+++ b/lib/appsignal/marker.rb
@@ -10,16 +10,17 @@ module Appsignal
 
     def transmit
       transmitter = Transmitter.new(ACTION, config)
-      puts "Notifying Appsignal of deploy with: "\
+      puts "Notifying AppSignal of deploy with: "\
         "revision: #{marker_data[:revision]}, user: #{marker_data[:user]}"
+
       result = transmitter.transmit(marker_data)
       if result == '200'
-        puts 'Appsignal has been notified of this deploy!'
+        puts 'AppSignal has been notified of this deploy!'
       else
         raise "#{result} at #{transmitter.uri}"
       end
     rescue => e
-      puts "Something went wrong while trying to notify Appsignal: #{e}"
+      puts "Something went wrong while trying to notify AppSignal: #{e}"
     end
   end
 end

--- a/spec/lib/appsignal/capistrano2_spec.rb
+++ b/spec/lib/appsignal/capistrano2_spec.rb
@@ -134,8 +134,8 @@ if DependencyHelper.capistrano2_present?
             capistrano_config.find_and_execute_task('appsignal:deploy')
 
             expect(out_stream.string).to include \
-              'Notifying Appsignal of deploy with: revision: 503ce0923ed177a3ce000005, user: batman',
-              'Appsignal has been notified of this deploy!'
+              'Notifying AppSignal of deploy with: revision: 503ce0923ed177a3ce000005, user: batman',
+              'AppSignal has been notified of this deploy!'
           end
 
           context "with overridden revision" do
@@ -147,8 +147,8 @@ if DependencyHelper.capistrano2_present?
 
             it "transmits the overriden revision" do
               expect(out_stream.string).to include \
-                'Notifying Appsignal of deploy with: revision: abc123, user: batman',
-                'Appsignal has been notified of this deploy!'
+                'Notifying AppSignal of deploy with: revision: abc123, user: batman',
+                'AppSignal has been notified of this deploy!'
             end
           end
 
@@ -161,9 +161,9 @@ if DependencyHelper.capistrano2_present?
             it "does not transmit marker" do
               output = out_stream.string
               expect(output).to include \
-                'Notifying Appsignal of deploy with: revision: 503ce0923ed177a3ce000005, user: batman',
-                'Something went wrong while trying to notify Appsignal:'
-              expect(output).to_not include 'Appsignal has been notified of this deploy!'
+                'Notifying AppSignal of deploy with: revision: 503ce0923ed177a3ce000005, user: batman',
+                'Something went wrong while trying to notify AppSignal:'
+              expect(output).to_not include 'AppSignal has been notified of this deploy!'
             end
           end
 

--- a/spec/lib/appsignal/capistrano3_spec.rb
+++ b/spec/lib/appsignal/capistrano3_spec.rb
@@ -135,8 +135,8 @@ if DependencyHelper.capistrano3_present?
             invoke('appsignal:deploy')
 
             expect(out_stream.string).to include \
-              'Notifying Appsignal of deploy with: revision: 503ce0923ed177a3ce000005, user: batman',
-              'Appsignal has been notified of this deploy!'
+              'Notifying AppSignal of deploy with: revision: 503ce0923ed177a3ce000005, user: batman',
+              'AppSignal has been notified of this deploy!'
           end
 
           context "with overridden revision" do
@@ -148,8 +148,8 @@ if DependencyHelper.capistrano3_present?
 
             it "transmits the overriden revision" do
               expect(out_stream.string).to include \
-                'Notifying Appsignal of deploy with: revision: abc123, user: batman',
-                'Appsignal has been notified of this deploy!'
+                'Notifying AppSignal of deploy with: revision: abc123, user: batman',
+                'AppSignal has been notified of this deploy!'
             end
           end
 
@@ -162,9 +162,9 @@ if DependencyHelper.capistrano3_present?
             it "does not transmit marker" do
               output = out_stream.string
               expect(output).to include \
-                'Notifying Appsignal of deploy with: revision: 503ce0923ed177a3ce000005, user: batman',
-                'Something went wrong while trying to notify Appsignal:'
-              expect(output).to_not include 'Appsignal has been notified of this deploy!'
+                'Notifying AppSignal of deploy with: revision: 503ce0923ed177a3ce000005, user: batman',
+                'Something went wrong while trying to notify AppSignal:'
+              expect(output).to_not include 'AppSignal has been notified of this deploy!'
             end
           end
         end

--- a/spec/lib/appsignal/cli_spec.rb
+++ b/spec/lib/appsignal/cli_spec.rb
@@ -35,7 +35,7 @@ describe Appsignal::CLI do
         cli.run([arg])
       }.should raise_error(SystemExit)
 
-      out_stream.string.should include 'Appsignal'
+      out_stream.string.should include 'AppSignal'
       out_stream.string.should include '.'
     end
   end

--- a/spec/lib/appsignal/marker_spec.rb
+++ b/spec/lib/appsignal/marker_spec.rb
@@ -30,8 +30,8 @@ describe Appsignal::Marker do
       it "outputs success" do
         output = out_stream.string
         expect(output).to include \
-          'Notifying Appsignal of deploy with: revision: 503ce0923ed177a3ce000005, user: batman',
-          'Appsignal has been notified of this deploy!'
+          'Notifying AppSignal of deploy with: revision: 503ce0923ed177a3ce000005, user: batman',
+          'AppSignal has been notified of this deploy!'
       end
     end
 
@@ -44,11 +44,11 @@ describe Appsignal::Marker do
       it "outputs failure" do
         output = out_stream.string
         expect(output).to include \
-          'Notifying Appsignal of deploy with: revision: 503ce0923ed177a3ce000005, user: batman',
-          "Something went wrong while trying to notify Appsignal: 500 at "\
+          'Notifying AppSignal of deploy with: revision: 503ce0923ed177a3ce000005, user: batman',
+          "Something went wrong while trying to notify AppSignal: 500 at "\
           "#{config[:endpoint]}/1/markers"
         expect(output).to_not include \
-          'Appsignal has been notified of this deploy!'
+          'AppSignal has been notified of this deploy!'
       end
     end
   end


### PR DESCRIPTION
Fix capitalization using "Appsignal".

It is written `AppSignal` and we should communicate that everywhere.
Exceptions being code examples where we reference the `Appsignal` module
and when referencing the gem name `appsignal`.

I assume everyone agrees on this 😇 
The PR is really only for the CI build.