### PR TITLE
Notify of deploy command refactor

### DIFF
--- a/lib/appsignal/cli.rb
+++ b/lib/appsignal/cli.rb
@@ -11,12 +11,11 @@ module Appsignal
     AVAILABLE_COMMANDS = %w(diagnose install notify_of_deploy).freeze
 
     class << self
-      attr_accessor :options, :initial_config
+      attr_accessor :options
       attr_writer :config
 
       def run(argv=ARGV)
         @options = {}
-        @initial_config = {}
         global = global_option_parser
         commands = command_option_parser
         global.order!(argv)
@@ -48,7 +47,7 @@ module Appsignal
         Appsignal::Config.new(
           Dir.pwd,
           options[:environment],
-          initial_config,
+          {},
           Logger.new(StringIO.new)
         )
       end
@@ -92,7 +91,7 @@ module Appsignal
             end
 
             o.on '--name=<name>', "The name of the app (optional)" do |arg|
-              initial_config[:name] = arg
+              options[:name] = arg
             end
           end
         }

--- a/lib/appsignal/cli.rb
+++ b/lib/appsignal/cli.rb
@@ -12,7 +12,6 @@ module Appsignal
 
     class << self
       attr_accessor :options
-      attr_writer :config
 
       def run(argv=ARGV)
         @options = {}
@@ -29,7 +28,7 @@ module Appsignal
             when :install
               Appsignal::CLI::Install.run(argv.shift, config)
             when :notify_of_deploy
-              Appsignal::CLI::NotifyOfDeploy.run(options, config)
+              Appsignal::CLI::NotifyOfDeploy.run(options)
             end
           else
             puts "Command '#{command}' does not exist, run appsignal -h to "\

--- a/lib/appsignal/cli/notify_of_deploy.rb
+++ b/lib/appsignal/cli/notify_of_deploy.rb
@@ -3,8 +3,11 @@ module Appsignal
     class NotifyOfDeploy
       class << self
         def run(options, config)
+          config[:name] = options[:name] if options[:name]
           validate_active_config(config)
-          validate_required_options(options, [:revision, :user, :environment])
+          required_config = [:revision, :user, :environment]
+          required_config << :name if !config[:name] || config[:name].empty?
+          validate_required_options(options, required_config)
 
           Appsignal::Marker.new(
             {

--- a/lib/appsignal/cli/notify_of_deploy.rb
+++ b/lib/appsignal/cli/notify_of_deploy.rb
@@ -2,10 +2,13 @@ module Appsignal
   class CLI
     class NotifyOfDeploy
       class << self
-        def run(options, config)
+        def run(options)
+          config = config_for(options[:environment])
           config[:name] = options[:name] if options[:name]
+
           validate_active_config(config)
-          required_config = [:revision, :user, :environment]
+          required_config = [:revision, :user]
+          required_config << :environment if config.env.empty?
           required_config << :name if !config[:name] || config[:name].empty?
           validate_required_options(options, required_config)
 
@@ -18,24 +21,33 @@ module Appsignal
           ).transmit
         end
 
-        protected
+        private
 
         def validate_required_options(options, required_options)
           missing = required_options.select do |required_option|
             val = options[required_option]
             val.nil? || (val.respond_to?(:empty?) && val.empty?)
           end
-          if missing.any?
-            puts "Missing options: #{missing.join(', ')}"
-            exit 1
-          end
+          return unless missing.any?
+
+          puts "Error: Missing options: #{missing.join(', ')}"
+          exit 1
         end
 
         def validate_active_config(config)
-          unless config.active?
-            puts 'Exiting: No config file or push api key env var found'
-            exit 1
-          end
+          return if config.active?
+
+          puts "Error: No valid config found."
+          exit 1
+        end
+
+        def config_for(environment)
+          Appsignal::Config.new(
+            Dir.pwd,
+            environment,
+            {},
+            Logger.new(StringIO.new)
+          )
         end
       end
     end

--- a/spec/lib/appsignal/cli_spec.rb
+++ b/spec/lib/appsignal/cli_spec.rb
@@ -72,26 +72,4 @@ describe Appsignal::CLI do
       ])
     end
   end
-
-  describe "notify_of_deploy" do
-    it "should call Appsignal::Install.install" do
-      Appsignal::CLI::NotifyOfDeploy.should_receive(:run).with(
-        {
-           :revision => "aaaaa",
-           :user => "thijs",
-           :environment => "production",
-           :name => "project-production"
-        },
-        instance_of(Appsignal::Config)
-      )
-
-      cli.run([
-        'notify_of_deploy',
-        '--name=project-production',
-        '--revision=aaaaa',
-        '--user=thijs',
-        '--environment=production'
-      ])
-    end
-  end
 end

--- a/spec/lib/appsignal/cli_spec.rb
+++ b/spec/lib/appsignal/cli_spec.rb
@@ -76,7 +76,12 @@ describe Appsignal::CLI do
   describe "notify_of_deploy" do
     it "should call Appsignal::Install.install" do
       Appsignal::CLI::NotifyOfDeploy.should_receive(:run).with(
-        {:revision=>"aaaaa", :user=>"thijs", :environment=>"production"},
+        {
+           :revision => "aaaaa",
+           :user => "thijs",
+           :environment => "production",
+           :name => "project-production"
+        },
         instance_of(Appsignal::Config)
       )
 

--- a/spec/support/helpers/cli_helpers.rb
+++ b/spec/support/helpers/cli_helpers.rb
@@ -1,0 +1,17 @@
+module CLIHelpers
+  def cli
+    Appsignal::CLI
+  end
+
+  def run_cli(command, options = {})
+    cli.run(format_cli_arguments_and_options(command, options))
+  end
+
+  def format_cli_arguments_and_options(command, options = {})
+    [*command].tap do |o|
+      options.each do |key, value|
+        o << "--#{key}=#{value}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Run command through full CLI stack on test, testing the whole process
removing the need for a separate cli_spec.

Environment is required only when its not set through the environment,
APPSIGNAL_APP_ENV.

`--name` is required if the config (either from the config file or the
environment) does not include a name.

Config is not passed to the CLI but initialized in the notify_of_deploy
command itself allowing for better control over how its initialized per
command. Only updating notify_of_deploy for now to reduce the scope of
the change.

---

Change to `--name` option (first commit)

> When notify_of_deploy was run in a path with a valid config or with the
environment variable APPSIGNAL_APP_NAME these two values would be
leading. The name option would only be applied when the config and the
environment had no mention of it.

> Since --name is the last thing a user would set when running this
command, the config file already exists and the environment is set on
the machine, it should override any previous config to be applied.

> This means setting it on the initial_config of the config wouldn't do
anything in most cases.

---

This PR is part of a larger refactor. Expect more PRs to change more CLI specs and classes.