### PR TITLE
Send demonstration example samples upon install

### DIFF
--- a/lib/appsignal/cli/install.rb
+++ b/lib/appsignal/cli/install.rb
@@ -1,6 +1,7 @@
 require 'erb'
 require 'ostruct'
 require 'io/console'
+require 'appsignal/demo'
 
 module Appsignal
   class CLI
@@ -199,6 +200,8 @@ module Appsignal
         def configure(config, environments, name_overwritten)
           install_for_capistrano
 
+          ENV["APPSIGNAL_APP_ENV"] = "development"
+
           puts "How do you want to configure AppSignal?"
           puts "  (1) a config file"
           puts "  (2) environment variables"
@@ -219,6 +222,10 @@ module Appsignal
               puts
               break
             elsif input == '2'
+              ENV["APPSIGNAL_ACTIVE"] = "true"
+              ENV["APPSIGNAL_PUSH_API_KEY"] = config[:push_api_key]
+              ENV["APPSIGNAL_APP_NAME"] = config[:name]
+
               puts
               puts "Add the following environment variables to configure AppSignal:"
               puts "  export APPSIGNAL_ACTIVE=true"
@@ -242,20 +249,19 @@ module Appsignal
           puts colorize "#####################################", :green
           sleep 0.3
           puts
-          puts '  Now you need to send us some data...'
-          puts
           if Gem.win_platform?
             puts 'The AppSignal agent currently does not work on Windows, please push these changes to your test/staging/production environment'
           else
-            puts "  Run your app with AppSignal activated:"
-            puts "  - You can do this on your dev environment"
-            puts "  - Or deploy to staging or production"
-            puts
-            puts "  Test if AppSignal is receiving data:"
-            puts "  - Requests > 200ms are shown in AppSignal"
-            puts "  - Generate an error to test (e.g. add .xml to a url)"
-            puts
-            puts "Please return to your browser and follow the instructions."
+            puts "  Sending example data to AppSignal..."
+            if Appsignal::Demo.transmit
+              puts "  Example data sent!"
+              puts "  It may take about a minute for the data to appear on AppSignal.com/accounts"
+              puts
+              puts "  Please return to your browser and follow the instructions."
+            else
+              puts "  Couldn't start the AppSignal agent and send example data to AppSignal.com"
+              puts "  Please use `appsignal diagnose` to debug your configuration."
+            end
           end
         end
 

--- a/lib/appsignal/demo.rb
+++ b/lib/appsignal/demo.rb
@@ -1,0 +1,87 @@
+require "rack/mock"
+
+module Appsignal
+  class Demo
+    class TestError < StandardError; end
+
+    class << self
+      def transmit
+        Appsignal.start
+        Appsignal.start_logger
+        return false unless Appsignal.active?
+
+        create_example_error_request
+        create_example_performance_request
+        true
+      end
+
+      private
+
+      def create_example_error_request
+        transaction = Appsignal::Transaction.create(
+          SecureRandom.uuid,
+          Appsignal::Transaction::HTTP_REQUEST,
+          rack_request
+        )
+        begin
+          raise TestError,
+            "Hello world! This is an error used for demonstration purposes."
+        rescue => error
+          Appsignal.set_error(error)
+        end
+        transaction.set_http_or_background_queue_start
+        transaction.set_metadata("path", "/hello")
+        transaction.set_metadata("method", "GET")
+        transaction.set_action("DemoController#hello")
+        add_demo_metadata_to transaction
+        Appsignal::Transaction.complete_current!
+      end
+
+      def create_example_performance_request
+        transaction = Appsignal::Transaction.create(
+          SecureRandom.uuid,
+          Appsignal::Transaction::HTTP_REQUEST,
+          rack_request
+        )
+        Appsignal.instrument "action_view.render", "Render hello.html.erb", "<h1>Hello world!</h1>" do
+          sleep 2
+        end
+        transaction.set_http_or_background_queue_start
+        transaction.set_metadata("path", "/hello")
+        transaction.set_metadata("method", "GET")
+        transaction.set_action("DemoController#hello")
+        add_demo_metadata_to transaction
+        Appsignal::Transaction.complete_current!
+      end
+
+      def add_demo_metadata_to(transaction)
+        transaction.set_metadata("demo_sample", "true")
+      end
+
+      def rack_request
+        env = ::Rack::MockRequest.env_for(
+          "/demo",
+          :params => {
+            "controller" => "demo",
+            "action" => "hello"
+          },
+          "REMOTE_ADDR" => "127.0.0.1",
+          "REQUEST_METHOD" => "GET",
+          "SERVER_NAME" => "localhost",
+          "SERVER_PORT" => "80",
+          "SERVER_PROTOCOL" => "HTTP/1.1",
+          "REQUEST_URI" => "/hello",
+          "PATH_INFO" => "/hello",
+          "HTTP_ACCEPT" => "text/html,application/xhtml+xml",
+          "HTTP_ACCEPT_ENCODING" => "gzip, deflate, sdch",
+          "HTTP_ACCEPT_LANGUAGE" => "en-US,en;q=0.8,nl;q=0.6",
+          "HTTP_CACHE_CONTROL" => "max-age=0",
+          "HTTP_CONNECTION" => "keep-alive",
+          "HTTP_USER_AGENT" => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0)",
+          "HTTP_REFERER" => "http://appsignal.com/accounts"
+        )
+        ::Rack::Request.new(env)
+      end
+    end
+  end
+end

--- a/spec/lib/appsignal/cli/install_spec.rb
+++ b/spec/lib/appsignal/cli/install_spec.rb
@@ -429,13 +429,31 @@ describe Appsignal::CLI::Install do
     end
 
     context "not on windows" do
-      before do
-        Gem.stub(:win_platform? => false)
-        cli.done_notice
+      before { Gem.stub(:win_platform? => false) }
+
+      context "with demo data sent" do
+        before do
+          expect(Appsignal::Demo).to receive(:transmit).and_return(true)
+          cli.done_notice
+        end
+
+        it "prints sending demo data" do
+          expect(subject).to include "Sending example data to AppSignal", "Example data sent!"
+        end
       end
 
-      it { should include('You can do this on your dev environment') }
-      it { should include('Or deploy to staging or production') }
+      context "without demo data being sent" do
+        before do
+          expect(Appsignal::Demo).to receive(:transmit).and_return(false)
+          cli.done_notice
+        end
+
+        it "prints that it couldn't send the demo data" do
+          expect(subject).to include "Sending example data to AppSignal",
+            "Couldn't start the AppSignal agent and send example data",
+            "`appsignal diagnose`"
+        end
+      end
     end
   end
 

--- a/spec/lib/appsignal/demo_spec.rb
+++ b/spec/lib/appsignal/demo_spec.rb
@@ -1,0 +1,80 @@
+require "appsignal/demo"
+
+describe Appsignal::Demo do
+  before do
+    # Ignore sleeps to speed up the test
+    allow(described_class).to receive(:sleep)
+  end
+
+  describe ".transmit" do
+    subject { described_class.transmit }
+
+    context "without config" do
+      it "returns false" do
+        expect(subject).to be_false
+      end
+    end
+
+    context "with config" do
+      let(:config) { project_fixture_config("production") }
+      before { Appsignal.config = config }
+
+      it "returns true" do
+        expect(subject).to be_true
+      end
+
+      it "creates demonstration samples" do
+        expect(described_class).to receive(:create_example_error_request)
+        expect(described_class).to receive(:create_example_performance_request)
+        subject
+      end
+    end
+  end
+
+  describe ".create_example_error_request" do
+    let!(:error_transaction) { http_request_transaction }
+    let(:config) { project_fixture_config("production") }
+    before do
+      Appsignal.config = config
+      expect(Appsignal::Transaction).to receive(:create)
+        .ordered
+        .with(kind_of(String), Appsignal::Transaction::HTTP_REQUEST, kind_of(::Rack::Request))
+        .and_return(error_transaction)
+    end
+    subject { described_class.send(:create_example_error_request) }
+
+    it "sets an error" do
+      expect(error_transaction).to receive(:set_error).with(kind_of(described_class::TestError))
+      expect(error_transaction).to receive(:set_metadata).with("path", "/hello")
+      expect(error_transaction).to receive(:set_metadata).with("method", "GET")
+      expect(error_transaction).to receive(:set_metadata).with("demo_sample", "true")
+      subject
+    end
+  end
+
+  describe ".create_example_performance_request" do
+    let!(:performance_transaction) { http_request_transaction }
+    let(:config) { project_fixture_config("production") }
+    before do
+      Appsignal.config = config
+      expect(Appsignal::Transaction).to receive(:create)
+        .with(kind_of(String), Appsignal::Transaction::HTTP_REQUEST, kind_of(::Rack::Request))
+        .and_return(performance_transaction)
+    end
+    subject { described_class.send(:create_example_performance_request) }
+
+    it "sends a performance sample" do
+      expect(performance_transaction).to receive(:start_event)
+      expect(performance_transaction).to receive(:finish_event).with(
+        "action_view.render",
+        "Render hello.html.erb",
+        "<h1>Hello world!</h1>",
+        Appsignal::EventFormatter::DEFAULT
+      )
+      expect(performance_transaction).to receive(:set_metadata).with("path", "/hello")
+      expect(performance_transaction).to receive(:set_metadata).with("method", "GET")
+      expect(performance_transaction).to receive(:set_metadata).with("demo_sample", "true")
+      subject
+    end
+  end
+end


### PR DESCRIPTION
Appsignal::Demo will send two samples for demonstration purposes. This
prevents us from asking the user to click through their site and somehow
trigger an error or a slow request. We can just as well send samples
ourselves.

This will allow us to send samples used for demonstration purposes to
the application of user once the installation is completed.

---

It will create these samples in the `development` environment of the chosen application name during installation. In the screenshots I used `Demo test` but for the user it will be their own application name.

Partially closes issue https://github.com/appsignal/appsignal-server/issues/1683
The partially refers to the UI changes we discuss below.

---

## Screenshots

Error sample

![image](https://cloud.githubusercontent.com/assets/282402/19562173/a67ab8c6-96db-11e6-96d3-0d6b4905c169.png)

Performance sample

![image](https://cloud.githubusercontent.com/assets/282402/19562157/99f55b88-96db-11e6-8377-4d27dc3fbeac.png)
