### PR TITLE
Put ruby in language integration version string

### DIFF
--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -121,7 +121,7 @@ module Appsignal
       ENV['APPSIGNAL_AGENT_PATH']                   = File.expand_path('../../../ext', __FILE__).to_s
       ENV['APPSIGNAL_ENVIRONMENT']                  = env
       ENV['APPSIGNAL_AGENT_VERSION']                = Appsignal::Extension.agent_version
-      ENV['APPSIGNAL_LANGUAGE_INTEGRATION_VERSION'] = Appsignal::VERSION
+      ENV['APPSIGNAL_LANGUAGE_INTEGRATION_VERSION'] = "ruby-#{Appsignal::VERSION}"
       ENV['APPSIGNAL_DEBUG_LOGGING']                = config_hash[:debug].to_s
       ENV['APPSIGNAL_LOG_FILE_PATH']                = log_file_path.to_s if log_file_path
       ENV['APPSIGNAL_PUSH_API_ENDPOINT']            = config_hash[:endpoint]

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -340,7 +340,7 @@ describe Appsignal::Config do
       expect(ENV['APPSIGNAL_APP_NAME']).to                     eq 'TestApp'
       expect(ENV['APPSIGNAL_ENVIRONMENT']).to                  eq 'production'
       expect(ENV['APPSIGNAL_AGENT_VERSION']).to                eq Appsignal::Extension.agent_version
-      expect(ENV['APPSIGNAL_LANGUAGE_INTEGRATION_VERSION']).to eq Appsignal::VERSION
+      expect(ENV['APPSIGNAL_LANGUAGE_INTEGRATION_VERSION']).to eq "ruby-#{Appsignal::VERSION}"
       expect(ENV['APPSIGNAL_HTTP_PROXY']).to                   eq 'http://localhost'
       expect(ENV['APPSIGNAL_IGNORE_ACTIONS']).to               eq 'action1,action2'
       expect(ENV['APPSIGNAL_FILTER_PARAMETERS']).to            eq 'password,confirm_password'


### PR DESCRIPTION
To make the version string consistent with the Elixir integration.