### PR TITLE
Add `appsignal demo` command

### DIFF
--- a/lib/appsignal/cli.rb
+++ b/lib/appsignal/cli.rb
@@ -2,13 +2,14 @@ require 'optparse'
 require 'logger'
 require 'yaml'
 require 'appsignal'
+require 'appsignal/cli/demo'
 require 'appsignal/cli/diagnose'
 require 'appsignal/cli/install'
 require 'appsignal/cli/notify_of_deploy'
 
 module Appsignal
   class CLI
-    AVAILABLE_COMMANDS = %w(diagnose install notify_of_deploy).freeze
+    AVAILABLE_COMMANDS = %w(demo diagnose install notify_of_deploy).freeze
 
     class << self
       attr_accessor :options
@@ -23,6 +24,8 @@ module Appsignal
           if AVAILABLE_COMMANDS.include?(command)
             commands[command].parse!(argv)
             case command.to_sym
+            when :demo
+              Appsignal::CLI::Demo.run(options)
             when :diagnose
               Appsignal::CLI::Diagnose.run
             when :install
@@ -72,6 +75,13 @@ module Appsignal
 
       def command_option_parser
         {
+          'demo' => OptionParser.new do |o|
+            o.banner = 'Usage: appsignal demo [options]'
+
+            o.on '--environment=<rails_env>', "The environment to demo" do |arg|
+              options[:environment] = arg
+            end
+          end,
           'diagnose' => OptionParser.new,
           'install' => OptionParser.new,
           'notify_of_deploy' => OptionParser.new do |o|

--- a/lib/appsignal/cli/demo.rb
+++ b/lib/appsignal/cli/demo.rb
@@ -1,0 +1,23 @@
+require "appsignal/demo"
+
+module Appsignal
+  class CLI
+    class Demo
+      class << self
+        def run(options = {})
+          ENV["APPSIGNAL_APP_ENV"] = options[:environment] if options[:environment]
+
+          puts "Sending demonstration sample data..."
+          if Appsignal::Demo.transmit
+            puts "Demonstration sample data sent!"
+            puts "It may take about a minute for the data to appear on AppSignal.com/accounts"
+          else
+            puts "Error: Unable to start the AppSignal agent and send data to AppSignal.com"
+            puts "Please use `appsignal diagnose` to debug your configuration."
+            exit 1
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/appsignal/cli/demo_spec.rb
+++ b/spec/lib/appsignal/cli/demo_spec.rb
@@ -1,0 +1,67 @@
+require "appsignal/cli"
+
+describe Appsignal::CLI::Demo do
+  include CLIHelpers
+
+  let(:options) { {} }
+  let(:out_stream) { StringIO.new }
+  let(:output) { out_stream.string }
+  before do
+    ENV.delete("APPSIGNAL_APP_ENV")
+    ENV.delete("RAILS_ENV")
+    ENV.delete("RACK_ENV")
+    stub_api_request config, "auth"
+  end
+  after { Appsignal.config = nil }
+  around { |example| capture_stdout(out_stream) { example.run } }
+
+  def run
+    run_within_dir project_fixture_path
+  end
+
+  def run_within_dir(chdir)
+    Dir.chdir chdir do
+      run_cli("demo", options)
+    end
+  end
+
+  context "without configuration" do
+    let(:config) { Appsignal::Config.new("development", tmp_dir) }
+
+    it "returns an error" do
+      expect { run_within_dir tmp_dir }.to raise_error(SystemExit)
+
+      expect(output).to include("Error: Unable to start the AppSignal agent")
+    end
+  end
+
+  context "with configuration" do
+    let(:config) { project_fixture_config }
+    before do
+      # Ignore sleeps to speed up the test
+      allow(Appsignal::Demo).to receive(:sleep)
+    end
+
+    context "without environment" do
+      it "returns an error" do
+        expect { run_within_dir tmp_dir }.to raise_error(SystemExit)
+
+        expect(output).to include("Error: Unable to start the AppSignal agent")
+      end
+    end
+
+    context "with environment" do
+      let(:options) { { :environment => "development" } }
+
+      it "calls Appsignal::Demo transmitter" do
+        expect(Appsignal::Demo).to receive(:transmit).and_return(true)
+        run
+      end
+
+      it "outputs message" do
+        run
+        expect(output).to include("Demonstration sample data sent!")
+      end
+    end
+  end
+end

--- a/spec/lib/appsignal/cli_spec.rb
+++ b/spec/lib/appsignal/cli_spec.rb
@@ -25,7 +25,8 @@ describe Appsignal::CLI do
       }.should raise_error(SystemExit)
 
       out_stream.string.should include 'appsignal <command> [options]'
-      out_stream.string.should include 'Available commands: diagnose, install, notify_of_deploy'
+      out_stream.string.should include \
+        'Available commands: demo, diagnose, install, notify_of_deploy'
     end
   end
 


### PR DESCRIPTION
This command will allow users to debug their AppSignal configuration
without integration in their application. Running `appsignal demo`
in a configured environment or project path will allow debugging of
purely AppSignal's side of the instrumenting.

This way we can isolate the problem to either the agent or the
application.

Follow up from #196, as discussed in https://github.com/appsignal/appsignal-server/issues/1683