### PR TITLE
Refactor install command spec

### DIFF
--- a/lib/appsignal/cli.rb
+++ b/lib/appsignal/cli.rb
@@ -2,6 +2,7 @@ require 'optparse'
 require 'logger'
 require 'yaml'
 require 'appsignal'
+require 'appsignal/cli/helpers'
 require 'appsignal/cli/demo'
 require 'appsignal/cli/diagnose'
 require 'appsignal/cli/install'
@@ -29,7 +30,7 @@ module Appsignal
             when :diagnose
               Appsignal::CLI::Diagnose.run
             when :install
-              Appsignal::CLI::Install.run(argv.shift, config)
+              Appsignal::CLI::Install.run(argv.shift)
             when :notify_of_deploy
               Appsignal::CLI::NotifyOfDeploy.run(options)
             end
@@ -43,15 +44,6 @@ module Appsignal
           puts global
           exit(0)
         end
-      end
-
-      def config
-        Appsignal::Config.new(
-          Dir.pwd,
-          options[:environment],
-          {},
-          Logger.new(StringIO.new)
-        )
       end
 
       def global_option_parser

--- a/lib/appsignal/cli/helpers.rb
+++ b/lib/appsignal/cli/helpers.rb
@@ -1,0 +1,67 @@
+module Appsignal
+  class CLI
+    module Helpers
+      private
+
+      def colorize(text, color)
+        return text if Gem.win_platform?
+
+        color_code =
+          case color
+          when :red then 31
+          when :green then 32
+          when :yellow then 33
+          when :blue then 34
+          when :pink then 35
+          else 0
+          end
+
+        "\e[#{color_code}m#{text}\e[0m"
+      end
+
+      def periods
+        3.times do
+          print "."
+          sleep 0.5
+        end
+      end
+
+      def press_any_key
+        puts
+        print "  Ready? Press any key:"
+        stdin.getch
+        puts
+        puts
+      end
+
+      def ask_for_input
+        value = stdin.gets
+        value ? value.chomp : ""
+      end
+
+      def required_input(prompt)
+        loop do
+          print prompt
+          value = ask_for_input
+          return value if value.length > 0
+        end
+      end
+
+      def yes_or_no(prompt)
+        loop do
+          print prompt
+          case ask_for_input
+          when "y"
+            return true
+          when "n"
+            return false
+          end
+        end
+      end
+
+      def stdin
+        $stdin
+      end
+    end
+  end
+end

--- a/spec/lib/appsignal/cli/helpers_spec.rb
+++ b/spec/lib/appsignal/cli/helpers_spec.rb
@@ -1,0 +1,91 @@
+require "appsignal/cli/helpers"
+
+describe Appsignal::CLI::Helpers do
+  include CLIHelpers
+
+  let(:out_stream) { StringIO.new }
+  let(:output) { out_stream.string }
+  let(:cli) do
+    Class.new do
+      extend Appsignal::CLI::Helpers
+    end
+  end
+  before do
+    # Speed up tests
+    allow(cli).to receive(:sleep)
+  end
+  around do |example|
+    original_stdin = $stdin
+    $stdin = StringIO.new
+    capture_stdout(out_stream) { example.run }
+    $stdin = original_stdin
+  end
+
+  describe ".colorize" do
+    subject { cli.send(:colorize, "text", :green) }
+
+    context "on windows" do
+      before { allow(Gem).to receive(:win_platform?).and_return(true) }
+
+      it "outputs plain string" do
+        expect(subject).to eq "text"
+      end
+    end
+
+    context "not on windows" do
+      before { allow(Gem).to receive(:win_platform?).and_return(false) }
+
+      it "wraps text in color tags" do
+        expect(subject).to eq "\e[32mtext\e[0m"
+      end
+    end
+  end
+
+  describe ".periods" do
+    it "prints three periods" do
+      cli.send :periods
+      expect(output).to include("...")
+    end
+  end
+
+  describe ".press_any_key" do
+    before do
+      set_input "a" # a as in any
+    end
+
+    it "continues after press" do
+      cli.send :press_any_key
+      expect(output).to include("Press any key")
+    end
+  end
+
+  describe ".yes_or_no" do
+    it "takes yes for an answer" do
+      set_input ""
+      set_input "nonsense"
+      set_input "y"
+      prepare_input
+
+      expect(cli.send(:yes_or_no, "yes or no?: ")).to be_true
+    end
+
+    it "takes no for an answer" do
+      set_input ""
+      set_input "nonsense"
+      set_input "n"
+      prepare_input
+
+      expect(cli.send(:yes_or_no, "yes or no?: ")).to be_false
+    end
+  end
+
+  describe ".required_input" do
+    it "collects required input" do
+      set_input ""
+      set_input "value"
+      prepare_input
+
+      expect(cli.send(:required_input, "provide: ")).to eq("value")
+    end
+  end
+end

--- a/spec/lib/appsignal/cli_spec.rb
+++ b/spec/lib/appsignal/cli_spec.rb
@@ -5,17 +5,9 @@ describe Appsignal::CLI do
   let(:cli) { Appsignal::CLI }
   before do
     Dir.stub(:pwd => project_fixture_path)
-    cli.options = {:environment => 'production'}
   end
   around do |example|
     capture_stdout(out_stream) { example.run }
-  end
-
-  describe "#config" do
-    subject { cli.config }
-
-    it { should be_instance_of(Appsignal::Config) }
-    its(:valid?) { should be_true }
   end
 
   it "should print the help with no arguments, -h and --help" do
@@ -56,20 +48,6 @@ describe Appsignal::CLI do
 
       cli.run([
         'diagnose'
-      ])
-    end
-  end
-
-  describe "install" do
-    it "should call Appsignal::Install.install" do
-      Appsignal::CLI::Install.should_receive(:run).with(
-        'api-key',
-        instance_of(Appsignal::Config)
-      )
-
-      cli.run([
-        'install',
-        'api-key'
       ])
     end
   end

--- a/spec/support/helpers/cli_helpers.rb
+++ b/spec/support/helpers/cli_helpers.rb
@@ -14,4 +14,13 @@ module CLIHelpers
       end
     end
   end
+
+  def set_input(value)
+    $stdin.puts value
+  end
+
+  def prepare_input
+    # Prepare the input by rewinding the pointer in the StringIO
+    $stdin.rewind
+  end
 end


### PR DESCRIPTION
Update the spec to test the whole command for every scenario. This
increases the test coverage but also the setup. Using shared examples
and matchers for repeated checks this should be much easier.

The changes to the CLI's code have been kept to a minimum, but some
helpers are extracted and tested separably.

Small conflict needs to be resolved after merging #199 
