### PR TITLE
Use consistent log formatter per log type

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -230,9 +230,10 @@ module Appsignal
       end
     end
 
-    def log_formatter
+    def log_formatter(prefix = nil)
+      prefix = "#{prefix}: " if prefix
       proc do |severity, datetime, progname, msg|
-        "[#{datetime.strftime('%Y-%m-%dT%H:%M:%S')} (process) ##{Process.pid}][#{severity}] #{msg}\n"
+        "[#{datetime.strftime('%Y-%m-%dT%H:%M:%S')} (process) ##{Process.pid}][#{severity}] #{prefix}#{msg}\n"
       end
     end
 
@@ -249,7 +250,6 @@ module Appsignal
         else
           Logger::INFO
         end
-      logger.formatter = log_formatter
 
       if in_memory_log
         logger << in_memory_log.string
@@ -289,12 +289,14 @@ module Appsignal
 
     private
 
-    def start_stdout_logger
+    def start_stdout_logger(prefix = "appsignal")
       @logger = Logger.new($stdout)
+      logger.formatter = log_formatter(prefix)
     end
 
     def start_file_logger(path)
       @logger = Logger.new(path)
+      logger.formatter = log_formatter
     rescue SystemCallError => error
       start_stdout_logger
       logger.warn "appsignal: Unable to start logger with log path '#{path}'."

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -249,6 +249,7 @@ module Appsignal
         else
           Logger::INFO
         end
+      logger.formatter = log_formatter
 
       if in_memory_log
         logger << in_memory_log.string
@@ -290,14 +291,10 @@ module Appsignal
 
     def start_stdout_logger
       @logger = Logger.new($stdout)
-      @logger.formatter = lambda do |severity, datetime, progname, msg|
-        "appsignal: #{msg}\n"
-      end
     end
 
     def start_file_logger(path)
       @logger = Logger.new(path)
-      @logger.formatter = log_formatter
     rescue SystemCallError => error
       start_stdout_logger
       logger.warn "appsignal: Unable to start logger with log path '#{path}'."

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -226,14 +226,14 @@ module Appsignal
     def logger
       @logger ||= Logger.new(in_memory_log).tap do |l|
         l.level = Logger::INFO
-        l.formatter = log_formatter
+        l.formatter = log_formatter("appsignal")
       end
     end
 
     def log_formatter(prefix = nil)
-      prefix = "#{prefix}: " if prefix
+      pre = "#{prefix}: " if prefix
       proc do |severity, datetime, progname, msg|
-        "[#{datetime.strftime('%Y-%m-%dT%H:%M:%S')} (process) ##{Process.pid}][#{severity}] #{prefix}#{msg}\n"
+        "[#{datetime.strftime('%Y-%m-%dT%H:%M:%S')} (process) ##{Process.pid}][#{severity}] #{pre}#{msg}\n"
       end
     end
 
@@ -289,9 +289,9 @@ module Appsignal
 
     private
 
-    def start_stdout_logger(prefix = "appsignal")
+    def start_stdout_logger
       @logger = Logger.new($stdout)
-      logger.formatter = log_formatter(prefix)
+      logger.formatter = log_formatter("appsignal")
     end
 
     def start_file_logger(path)
@@ -299,8 +299,8 @@ module Appsignal
       logger.formatter = log_formatter
     rescue SystemCallError => error
       start_stdout_logger
-      logger.warn "appsignal: Unable to start logger with log path '#{path}'."
-      logger.warn "appsignal: #{error}"
+      logger.warn "Unable to start logger with log path '#{path}'."
+      logger.warn "#{error}"
     end
   end
 end

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -600,11 +600,11 @@ describe Appsignal do
 
           it "logs to stdout" do
             expect(File.writable?(log_file)).to be_false
-            expect(out_stream.string).to include 'Log to not writable log file'
+            expect(out_stream.string).to include '[ERROR] appsignal: Log to not writable log file'
           end
 
           it "amends in memory log to stdout" do
-            expect(out_stream.string).to include 'Log in memory'
+            expect(out_stream.string).to include '[ERROR] Log in memory'
           end
 
           it "outputs a warning" do
@@ -625,11 +625,11 @@ describe Appsignal do
 
         it "logs to stdout" do
           expect(File.writable?(log_path)).to be_false
-          expect(out_stream.string).to include 'Log to not writable log path'
+          expect(out_stream.string).to include 'appsignal: Log to not writable log path'
         end
 
         it "amends in memory log to stdout" do
-          expect(out_stream.string).to include 'Log in memory'
+          expect(out_stream.string).to include '] Log in memory'
         end
 
         it "outputs a warning" do
@@ -685,11 +685,10 @@ describe Appsignal do
     end
 
     describe ".log_formatter" do
-      subject { Appsignal.log_formatter }
+      subject { Appsignal.log_formatter.call('Debug', Time.parse('2015-07-08'), nil, 'log line') }
 
-      it "should format a log line" do
-        Process.stub(:pid => 100)
-        subject.call('Debug', Time.parse('2015-07-08'), nil, 'log line').should eq "[2015-07-08T00:00:00 (process) #100][Debug] log line\n"
+      it "formats a log" do
+        expect(subject).to eq "[2015-07-08T00:00:00 (process) ##{Process.pid}][Debug] log line\n"
       end
     end
 

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -581,11 +581,11 @@ describe Appsignal do
 
           it "logs to file" do
             expect(File.exist?(log_file)).to be_true
-            expect(log_file_contents).to include 'Log to file'
+            expect(log_file_contents).to include '[ERROR] Log to file'
           end
 
           it "amends in memory log to log file" do
-            expect(log_file_contents).to include 'Log in memory'
+            expect(log_file_contents).to include '[ERROR] appsignal: Log in memory'
           end
         end
 
@@ -604,13 +604,13 @@ describe Appsignal do
           end
 
           it "amends in memory log to stdout" do
-            expect(out_stream.string).to include '[ERROR] Log in memory'
+            expect(out_stream.string).to include '[ERROR] appsignal: Log in memory'
           end
 
           it "outputs a warning" do
             expect(out_stream.string).to include \
-              "appsignal: Unable to start logger with log path '#{log_file}'.",
-              "appsignal: Permission denied"
+              "[WARN] appsignal: Unable to start logger with log path '#{log_file}'.",
+              "[WARN] appsignal: Permission denied"
           end
         end
       end
@@ -625,11 +625,11 @@ describe Appsignal do
 
         it "logs to stdout" do
           expect(File.writable?(log_path)).to be_false
-          expect(out_stream.string).to include 'appsignal: Log to not writable log path'
+          expect(out_stream.string).to include '[ERROR] appsignal: Log to not writable log path'
         end
 
         it "amends in memory log to stdout" do
-          expect(out_stream.string).to include '] Log in memory'
+          expect(out_stream.string).to include '[ERROR] appsignal: Log in memory'
         end
 
         it "outputs a warning" do
@@ -647,11 +647,11 @@ describe Appsignal do
         around { |example| recognize_as_heroku { example.run } }
 
         it "logs to stdout" do
-          expect(out_stream.string).to include 'Log to stdout'
+          expect(out_stream.string).to include '[ERROR] appsignal: Log to stdout'
         end
 
         it "amends in memory log to stdout" do
-          expect(out_stream.string).to include 'Log in memory'
+          expect(out_stream.string).to include '[ERROR] appsignal: Log in memory'
         end
       end
 
@@ -689,6 +689,17 @@ describe Appsignal do
 
       it "formats a log" do
         expect(subject).to eq "[2015-07-08T00:00:00 (process) ##{Process.pid}][Debug] log line\n"
+      end
+
+      context "with prefix" do
+        subject do
+          Appsignal.log_formatter("prefix").call('Debug', Time.parse('2015-07-08'), nil, 'log line')
+        end
+
+        it "adds a prefix" do
+          expect(subject)
+            .to eq "[2015-07-08T00:00:00 (process) ##{Process.pid}][Debug] prefix: log line\n"
+        end
       end
     end
 

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -647,7 +647,7 @@ describe Appsignal do
         around { |example| recognize_as_heroku { example.run } }
 
         it "logs to stdout" do
-          expect(out_stream.string).to include 'appsignal: Log to stdout'
+          expect(out_stream.string).to include 'Log to stdout'
         end
 
         it "amends in memory log to stdout" do


### PR DESCRIPTION
The custom log format for the stdout logger was used primary for Heroku.
On Heroku the logs are prefixed with a timestamp and this custom format
did not include one.

Not a lot of other libraries offer special log formats for Heroku and if
this is the only exception there is not a huge incentive to omit the
timestamp from the log.

Forgot I had this locally. Would have been nice to put this change in 2.0.
