### PR TITLE
Load APPSIGNAL_APP_ENV consistently

### DIFF
--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -63,7 +63,7 @@ module Appsignal
 
     def initialize(root_path, env, initial_config={}, logger=Appsignal.logger)
       @root_path      = root_path
-      @env            = env.to_s
+      @env            = ENV.fetch("APPSIGNAL_APP_ENV".freeze, env.to_s)
       @initial_config = initial_config
       @logger         = logger
       @valid          = false

--- a/lib/appsignal/integrations/padrino.rb
+++ b/lib/appsignal/integrations/padrino.rb
@@ -8,7 +8,7 @@ module Appsignal::Integrations
       root             = Padrino.mounted_root
       Appsignal.config = Appsignal::Config.new(
         root,
-        ENV.fetch('APPSIGNAL_APP_ENV'.freeze, Padrino.env.to_s),
+        Padrino.env,
         :log_path => File.join(root, 'log')
       )
 

--- a/lib/appsignal/integrations/railtie.rb
+++ b/lib/appsignal/integrations/railtie.rb
@@ -13,7 +13,7 @@ module Appsignal
         # Load config
         Appsignal.config = Appsignal::Config.new(
           Rails.root,
-          ENV.fetch('APPSIGNAL_APP_ENV', Rails.env),
+          Rails.env,
           :name => Rails.application.class.parent_name,
           :log_path => Rails.root.join('log')
         )

--- a/lib/appsignal/integrations/sinatra.rb
+++ b/lib/appsignal/integrations/sinatra.rb
@@ -6,7 +6,7 @@ Appsignal.logger.info("Loading Sinatra (#{Sinatra::VERSION}) integration")
 app_settings = ::Sinatra::Application.settings
 Appsignal.config = Appsignal::Config.new(
   app_settings.root || Dir.pwd,
-  ENV.fetch('APPSIGNAL_APP_ENV'.freeze, app_settings.environment)
+  app_settings.environment
 )
 
 Appsignal.start_logger

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -1,4 +1,34 @@
 describe Appsignal::Config do
+  describe "#initialize" do
+    subject { config.env }
+
+    describe "environment" do
+      context "when environment is nil" do
+        let(:config) { described_class.new("", "") }
+
+        it "sets an empty string" do
+          expect(subject).to eq("")
+        end
+      end
+
+      context "when environment is given" do
+        let(:config) { described_class.new("", "my_env") }
+
+        it "sets the environment" do
+          expect(subject).to eq("my_env")
+        end
+
+        context "with APPSIGNAL_APP_ENV environment variable" do
+          before { ENV["APPSIGNAL_APP_ENV"] = "my_env_env" }
+
+          it "uses the environment variable" do
+            expect(subject).to eq("my_env_env")
+          end
+        end
+      end
+    end
+  end
+
   describe "config based on the system" do
     let(:config) { project_fixture_config(:none) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,12 +58,13 @@ RSpec.configure do |config|
   end
 
   config.before do
-    ENV['RAILS_ENV'] = 'test'
-    ENV['PADRINO_ENV'] = 'test'
+    ENV['RAILS_ENV'] ||= 'test'
+    ENV['RACK_ENV'] ||= 'test'
+    ENV['PADRINO_ENV'] ||= 'test'
 
     # Clean environment
     ENV.keys.select { |key| key.start_with?('APPSIGNAL_') }.each do |key|
-      ENV[key] = nil
+      ENV.delete(key)
     end
   end
 


### PR DESCRIPTION
Do not rely on integrations or manual configuration for plain old ruby
apps.

Instead load `APPSIGNAL_APP_ENV` always. And prefer it over the given
value, which is consistent with our new load order introduced in PR #180
and 2ea99d72c100fd7f4bd36a4336b196c09f45a631.

Also fix specs and spec_helper. Do not set the ENV variable to `nil`,
that still gives it a value and could screw up some config. Instead,
unset the variable.
