### PR TITLE
No auto current transaction in specs

### DIFF
--- a/spec/lib/appsignal/demo_spec.rb
+++ b/spec/lib/appsignal/demo_spec.rb
@@ -36,10 +36,12 @@ describe Appsignal::Demo do
     let(:config) { project_fixture_config("production") }
     before do
       Appsignal.config = config
-      expect(Appsignal::Transaction).to receive(:create)
-        .ordered
-        .with(kind_of(String), Appsignal::Transaction::HTTP_REQUEST, kind_of(::Rack::Request))
-        .and_return(error_transaction)
+      expect(Appsignal::Transaction).to receive(:new).with(
+        kind_of(String),
+        Appsignal::Transaction::HTTP_REQUEST,
+        kind_of(::Rack::Request),
+        kind_of(Hash)
+      ).and_return(error_transaction)
     end
     subject { described_class.send(:create_example_error_request) }
 
@@ -57,9 +59,12 @@ describe Appsignal::Demo do
     let(:config) { project_fixture_config("production") }
     before do
       Appsignal.config = config
-      expect(Appsignal::Transaction).to receive(:create)
-        .with(kind_of(String), Appsignal::Transaction::HTTP_REQUEST, kind_of(::Rack::Request))
-        .and_return(performance_transaction)
+      expect(Appsignal::Transaction).to receive(:new).with(
+        kind_of(String),
+        Appsignal::Transaction::HTTP_REQUEST,
+        kind_of(::Rack::Request),
+        kind_of(Hash)
+      ).and_return(performance_transaction)
     end
     subject { described_class.send(:create_example_performance_request) }
 

--- a/spec/lib/appsignal/integrations/object_spec.rb
+++ b/spec/lib/appsignal/integrations/object_spec.rb
@@ -15,7 +15,10 @@ describe Object do
 
       context "when active" do
         let(:transaction) { http_request_transaction }
-        before { Appsignal.config = project_fixture_config }
+        before do
+          expect(Appsignal::Transaction).to receive(:current).at_least(:once).and_return(transaction)
+          Appsignal.config = project_fixture_config
+        end
         after { Appsignal.config = nil }
 
         context "with anonymous class" do
@@ -132,7 +135,11 @@ describe Object do
 
       context "when active" do
         let(:transaction) { http_request_transaction }
-        before { Appsignal.config = project_fixture_config }
+        before do
+          expect(Appsignal::Transaction).to receive(:current).at_least(:once)
+            .and_return(transaction)
+          Appsignal.config = project_fixture_config
+        end
         after { Appsignal.config = nil }
 
         context "with anonymous class" do

--- a/spec/lib/appsignal/integrations/object_spec.rb
+++ b/spec/lib/appsignal/integrations/object_spec.rb
@@ -24,9 +24,9 @@ describe Object do
         context "with anonymous class" do
           it "instruments the method and calls it" do
             expect(Appsignal.active?).to be_true
-            transaction.should_receive(:start_event)
-            transaction.should_receive(:finish_event).with \
-              "foo.AnonymousClass.other", nil, nil, 0
+            expect(transaction).to receive(:start_event)
+            expect(transaction).to receive(:finish_event).with \
+              "foo.AnonymousClass.other", nil, nil, Appsignal::EventFormatter::DEFAULT
             expect(instance.foo).to eq(1)
           end
         end
@@ -45,9 +45,9 @@ describe Object do
 
           it "instruments the method and calls it" do
             expect(Appsignal.active?).to be_true
-            transaction.should_receive(:start_event)
-            transaction.should_receive(:finish_event).with \
-              "foo.NamedClass.other", nil, nil, 0
+            expect(transaction).to receive(:start_event)
+            expect(transaction).to receive(:finish_event).with \
+              "foo.NamedClass.other", nil, nil, Appsignal::EventFormatter::DEFAULT
             expect(instance.foo).to eq(1)
           end
         end
@@ -70,9 +70,10 @@ describe Object do
 
           it "instruments the method and calls it" do
             expect(Appsignal.active?).to be_true
-            transaction.should_receive(:start_event)
-            transaction.should_receive(:finish_event).with \
-              "bar.NamedClass.NestedModule.MyModule.other", nil, nil, 0
+            expect(transaction).to receive(:start_event)
+            expect(transaction).to receive(:finish_event).with \
+              "bar.NamedClass.NestedModule.MyModule.other", nil, nil,
+              Appsignal::EventFormatter::DEFAULT
             expect(instance.bar).to eq(2)
           end
         end
@@ -89,9 +90,9 @@ describe Object do
 
           it "instruments with custom name" do
             expect(Appsignal.active?).to be_true
-            transaction.should_receive(:start_event)
-            transaction.should_receive(:finish_event).with \
-              "my_method.group", nil, nil, 0
+            expect(transaction).to receive(:start_event)
+            expect(transaction).to receive(:finish_event).with \
+              "my_method.group", nil, nil, Appsignal::EventFormatter::DEFAULT
             expect(instance.foo).to eq(1)
           end
         end
@@ -145,9 +146,9 @@ describe Object do
         context "with anonymous class" do
           it "instruments the method and calls it" do
             expect(Appsignal.active?).to be_true
-            transaction.should_receive(:start_event)
-            transaction.should_receive(:finish_event).with \
-              "bar.class_method.AnonymousClass.other", nil, nil, 0
+            expect(transaction).to receive(:start_event)
+            expect(transaction).to receive(:finish_event).with \
+              "bar.class_method.AnonymousClass.other", nil, nil, Appsignal::EventFormatter::DEFAULT
             expect(klass.bar).to eq(2)
           end
         end
@@ -166,9 +167,9 @@ describe Object do
 
           it "instruments the method and calls it" do
             expect(Appsignal.active?).to be_true
-            transaction.should_receive(:start_event)
-            transaction.should_receive(:finish_event).with \
-              "bar.class_method.NamedClass.other", nil, nil, 0
+            expect(transaction).to receive(:start_event)
+            expect(transaction).to receive(:finish_event).with \
+              "bar.class_method.NamedClass.other", nil, nil, Appsignal::EventFormatter::DEFAULT
             expect(klass.bar).to eq(2)
           end
 
@@ -190,9 +191,10 @@ describe Object do
 
             it "instruments the method and calls it" do
               expect(Appsignal.active?).to be_true
-              transaction.should_receive(:start_event)
-              transaction.should_receive(:finish_event).with \
-                "bar.class_method.NamedClass.NestedModule.MyModule.other", nil, nil, 0
+              expect(transaction).to receive(:start_event)
+              expect(transaction).to receive(:finish_event).with \
+                "bar.class_method.NamedClass.NestedModule.MyModule.other", nil, nil,
+                Appsignal::EventFormatter::DEFAULT
               expect(klass.bar).to eq(2)
             end
           end
@@ -210,9 +212,9 @@ describe Object do
 
           it "instruments with custom name" do
             expect(Appsignal.active?).to be_true
-            transaction.should_receive(:start_event)
-            transaction.should_receive(:finish_event).with \
-              "my_method.group", nil, nil, 0
+            expect(transaction).to receive(:start_event)
+            expect(transaction).to receive(:finish_event).with \
+              "my_method.group", nil, nil, Appsignal::EventFormatter::DEFAULT
             expect(klass.bar).to eq(2)
           end
         end

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -792,6 +792,10 @@ describe Appsignal do
     end
 
     describe ".instrument" do
+      before do
+        expect(Appsignal::Transaction).to receive(:current).at_least(:once).and_return(transaction)
+      end
+
       it "should instrument through the transaction" do
         stub = double
         stub.should_receive(:method_call).and_return('return value')
@@ -811,6 +815,10 @@ describe Appsignal do
     end
 
     describe ".instrument_sql" do
+      before do
+        expect(Appsignal::Transaction).to receive(:current).at_least(:once).and_return(transaction)
+      end
+
       it "should instrument sql through the transaction" do
         stub = double
         stub.should_receive(:method_call).and_return('return value')

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -797,20 +797,14 @@ describe Appsignal do
       end
 
       it "should instrument through the transaction" do
-        stub = double
-        stub.should_receive(:method_call).and_return('return value')
+        expect(transaction).to receive(:start_event)
+        expect(transaction).to receive(:finish_event)
+          .with('name', 'title', 'body', Appsignal::EventFormatter::DEFAULT)
 
-        transaction.should_receive(:start_event)
-        transaction.should_receive(:finish_event).with(
-          'name',
-          'title',
-          'body',
-          0
-        )
-
-        Appsignal.instrument 'name', 'title', 'body' do
-          stub.method_call
-        end.should eq 'return value'
+        result = Appsignal.instrument 'name', 'title', 'body' do
+          'return value'
+        end
+        expect(result).to eq 'return value'
       end
     end
 
@@ -820,20 +814,14 @@ describe Appsignal do
       end
 
       it "should instrument sql through the transaction" do
-        stub = double
-        stub.should_receive(:method_call).and_return('return value')
+        expect(transaction).to receive(:start_event)
+        expect(transaction).to receive(:finish_event)
+          .with('name', 'title', 'body', Appsignal::EventFormatter::SQL_BODY_FORMAT)
 
-        transaction.should_receive(:start_event)
-        transaction.should_receive(:finish_event).with(
-          'name',
-          'title',
-          'body',
-          1
-        )
-
-        Appsignal.instrument_sql 'name', 'title', 'body' do
-          stub.method_call
-        end.should eq 'return value'
+        result = Appsignal.instrument_sql 'name', 'title', 'body' do
+          'return value'
+        end
+        expect(result).to eq 'return value'
       end
     end
 

--- a/spec/support/helpers/transaction_helpers.rb
+++ b/spec/support/helpers/transaction_helpers.rb
@@ -8,7 +8,7 @@ module TransactionHelpers
   end
 
   def background_job_transaction(args={})
-    Appsignal::Transaction.create(
+    Appsignal::Transaction.new(
       '1',
       Appsignal::Transaction::BACKGROUND_JOB,
       Appsignal::Transaction::GenericRequest.new({
@@ -19,7 +19,7 @@ module TransactionHelpers
   end
 
   def http_request_transaction(args={})
-    Appsignal::Transaction.create(
+    Appsignal::Transaction.new(
       '1',
       Appsignal::Transaction::HTTP_REQUEST,
       Appsignal::Transaction::GenericRequest.new({


### PR DESCRIPTION
Specs that assume that a transaction is already active and current fail
if this logic is not automatic. This indicates some requirements up
front that are not explicitly defined in the specs.

This changes makes this requirements more specific by not automatically
setting stub transactions as the current transaction.

Split the PR in two commits. 1 just the change we're talking about.
The other is testing code style updates since this code was introduced.