### PR TITLE
Avoid confusion with APPSIGNAL_PUSH_API_KEY env

### DIFF
--- a/resources/appsignal.yml.erb
+++ b/resources/appsignal.yml.erb
@@ -1,6 +1,6 @@
 default: &defaults
   # Your push api key, it is possible to set this dynamically using ERB:
-  # push_api_key: "<%%= ENV['APPSIGNAL_PUSH_API_KEY'] %>"
+  # push_api_key: "<%%= ENV['APPSIGNAL_APP_PUSH_API_KEY'] %>"
   push_api_key: "<%= push_api_key %>"
 
   # Your app's name


### PR DESCRIPTION
Do not recommend using APPSIGNAL_APP_PUSH_API_KEY in the appsignal.yml
template. Setting that also has the side effect of setting
Appsignal.active to true.

WDYT? Good replacement name or should we recommend something else entirely? Recommending the `APPSIGNAL_` env var namespace for the configuration file screws up the load order.