### PR TITLE
Fix APPSIGNAL_PUSH_API_KEY activation behavior

### DIFF
--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -150,6 +150,9 @@ module Appsignal
     def detect_from_system
       config_hash[:running_in_container] = true if Appsignal::System.container?
       config_hash[:log] = 'stdout' if Appsignal::System.heroku?
+
+      # Make active by default if APPSIGNAL_PUSH_API_KEY is present
+      config_hash[:active] = true if ENV['APPSIGNAL_PUSH_API_KEY']
     end
 
     def load_from_disk
@@ -179,11 +182,6 @@ module Appsignal
 
     def load_from_environment
       config = {}
-
-      # Make active by default if APPSIGNAL_PUSH_API_KEY is present
-      if ENV['APPSIGNAL_PUSH_API_KEY']
-        config[:active] = true
-      end
 
       # Configuration with string type
       %w(APPSIGNAL_PUSH_API_KEY APPSIGNAL_APP_NAME APPSIGNAL_PUSH_API_ENDPOINT


### PR DESCRIPTION
Regression fix compared to version 1.3.6 and 2.0.0.

This fix will restore the original behavior of APPSIGNAL_PUSH_API_KEY
setting Appsignal.active to true if it's in the environment, but it will
be unset again if the appsignal.yml configuration file is loaded as
well and sets `active` to another value.

By moving the APPSIGNAL_PUSH_API_KEY "activation" behavior from the last
step (loading environment variables) to the second step (system detected
settings) the original behavior from gem =< 1.3.6 is restored.

If the behavior is located in the last step any other configuration step
setting the `active` config would be undone.

Related PR #207 
Regression was added in: #180