### PR TITLE
Sequel instrumentation calls original method

### DIFF
--- a/lib/appsignal/hooks/sequel.rb
+++ b/lib/appsignal/hooks/sequel.rb
@@ -9,7 +9,7 @@ module Appsignal
           sql,
           Appsignal::EventFormatter::SQL_BODY_FORMAT
         ) do
-          yield
+          super
         end
       end
     end
@@ -23,7 +23,7 @@ module Appsignal
           sql,
           Appsignal::EventFormatter::SQL_BODY_FORMAT
         ) do
-          yield
+          super
         end
       end
     end


### PR DESCRIPTION
This allows us to not break any existing implementations from the
`Sequel::Database` class or any extensions like `error_log`.

As experienced as a problem here: https://app.intercom.io/a/apps/yzor8gyw/inbox/conversation/6744780041