### PR TITLE
Fix JS transaction finish call

### DIFF
--- a/lib/appsignal/js_exception_transaction.rb
+++ b/lib/appsignal/js_exception_transaction.rb
@@ -47,7 +47,7 @@ module Appsignal
     end
 
     def complete!
-      @ext.finish
+      @ext.finish(0)
       @ext.complete
     end
   end

--- a/spec/lib/appsignal/js_exception_transaction_spec.rb
+++ b/spec/lib/appsignal/js_exception_transaction_spec.rb
@@ -120,8 +120,8 @@ describe Appsignal::JSExceptionTransaction do
 
   describe "#complete!" do
     it "should call all required methods" do
-      expect(transaction.ext).to receive(:finish)
-      expect(transaction.ext).to receive(:complete)
+      expect(transaction.ext).to receive(:finish).and_call_original
+      expect(transaction.ext).to receive(:complete).and_call_original
       transaction.complete!
     end
   end


### PR DESCRIPTION
The finish call needs a GC end time, but a JS transaction has no
Ruby-time and no GC-time. Because of too much mocking the error wasn't
caught in the test suite.

Regression introduced in: f77788cbbc5b1558441294808122e751c5955bc8
adding a GC profiler to the Ruby gem.

This is a quick fix, which highlights the need to upgrade RSpec and go through the test suite to see if we mock to much in other places as well.