### PR TITLE
Support --environment on appsignal diagnose

### DIFF
--- a/lib/appsignal/cli.rb
+++ b/lib/appsignal/cli.rb
@@ -28,7 +28,7 @@ module Appsignal
             when :demo
               Appsignal::CLI::Demo.run(options)
             when :diagnose
-              Appsignal::CLI::Diagnose.run
+              Appsignal::CLI::Diagnose.run(options)
             when :install
               Appsignal::CLI::Install.run(argv.shift)
             when :notify_of_deploy
@@ -70,11 +70,17 @@ module Appsignal
           'demo' => OptionParser.new do |o|
             o.banner = 'Usage: appsignal demo [options]'
 
-            o.on '--environment=<rails_env>', "The environment to demo" do |arg|
+            o.on '--environment=<app_env>', "The environment to demo" do |arg|
               options[:environment] = arg
             end
           end,
-          'diagnose' => OptionParser.new,
+          'diagnose' => OptionParser.new do |o|
+            o.banner = 'Usage: appsignal diagnose [options]'
+
+            o.on '--environment=<app_env>', "The environment to diagnose" do |arg|
+              options[:environment] = arg
+            end
+          end,
           'install' => OptionParser.new,
           'notify_of_deploy' => OptionParser.new do |o|
             o.banner = 'Usage: appsignal notify_of_deploy [options]'
@@ -87,7 +93,7 @@ module Appsignal
               options[:user] = arg
             end
 
-            o.on '--environment=<rails_env>', "The environment you're deploying to" do |arg|
+            o.on '--environment=<app_env>', "The environment you're deploying to" do |arg|
               options[:environment] = arg
             end
 

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -6,7 +6,9 @@ module Appsignal
   class CLI
     class Diagnose
       class << self
-        def run
+        def run(options = {})
+          ENV["APPSIGNAL_APP_ENV"] = options[:environment] if options[:environment]
+
           header
           empty_line
 
@@ -89,7 +91,7 @@ module Appsignal
             puts "    Warning: No environment set, no config loaded!"
             puts "    Please make sure appsignal diagnose is run within your "
             puts "    project directory with an environment."
-            puts "      APPSIGNAL_APP_ENV=production appsignal diagnose"
+            puts "      appsignal diagnose --environment=production"
           end
         end
 

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -6,8 +6,8 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
     let(:config) { project_fixture_config }
     let(:cli) { described_class }
     let(:output) { out_stream.string }
+    let(:options) { { :environment => config.env } }
 
-    before { ENV["APPSIGNAL_APP_ENV"] = config.env }
     before :api_stub => true do
       stub_api_request config, "auth"
     end
@@ -20,7 +20,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
 
     def run_within_dir(chdir)
       Dir.chdir chdir do
-        cli.run
+        cli.run(options)
       end
     end
 
@@ -116,8 +116,8 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
 
       context "without environment", :api_stub => false do
         let(:config) { project_fixture_config(nil) }
+        let(:options) { {} }
         before do
-          ENV.delete("APPSIGNAL_APP_ENV")
           ENV.delete("RAILS_ENV") # From spec_helper
           ENV.delete("RACK_ENV")
           stub_api_request config, "auth"
@@ -128,7 +128,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
           expect(output).to_not include "Error"
           expect(output).to include \
             "Environment: \n    Warning: No environment set, no config loaded!",
-            "  APPSIGNAL_APP_ENV=production appsignal diagnose"
+            "  appsignal diagnose --environment=production"
         end
 
         it "outputs config defaults" do


### PR DESCRIPTION
Creates consistent options among cli commands we provide.

Closes last TODO item on #181 

I recommend we keep suggesting the `APPSIGNAL_APP_ENV=production appsignal diagnose` command in the support channel for now though. Since not everyone will the latest version this will ship with.