### PR TITLE
Add root user detection to diagnose

### DIFF
--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -67,6 +67,8 @@ module Appsignal
           puts "  Operating System: #{rbconfig["host_os"]}"
           puts "  Ruby version: #{rbconfig["RUBY_VERSION_NAME"]}"
           puts "  Heroku: true" if Appsignal::System.heroku?
+          print "  root user: "
+          puts Process.uid == 0 ? "yes (not recommended)" : "no"
           if Appsignal::System.container?
             puts "  Container id: #{Appsignal::System::Container.id}"
           end

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -51,6 +51,26 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
           "Ruby version: #{RbConfig::CONFIG["RUBY_VERSION_NAME"]}"
       end
 
+      describe "root user detection" do
+        context "when not root user" do
+          it "prints no" do
+            run
+            expect(output).to include "root user: no"
+          end
+        end
+
+        context "when root user" do
+          before do
+            allow(Process).to receive(:uid).and_return(0)
+            run
+          end
+
+          it "prints yes, with warning" do
+            expect(output).to include "root user: yes (not recommended)"
+          end
+        end
+      end
+
       describe "Heroku detection" do
         context "when not on Heroku" do
           before { recognize_as_container(:none) { run } }


### PR DESCRIPTION
It's really not recommended you run your application, AppSignal or
appsignal diagnose as the root user.

Fixes TODO item 2 of #213 