### PR TITLE
Use the real system tmp dir, not a symlink

### DIFF
--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'rack'
   gem.add_dependency 'thread_safe'
 
-  gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'rake', '~> 11'
   gem.add_development_dependency 'rspec', '~> 2.14.1'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'timecop'

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -5,7 +5,7 @@ require 'socket'
 
 module Appsignal
   class Config
-    SYSTEM_TMP_DIR = '/tmp'
+    SYSTEM_TMP_DIR = File.realpath('/tmp')
     DEFAULT_CONFIG = {
       :debug                          => false,
       :log                            => 'file',


### PR DESCRIPTION
Just like we do for project paths we should also link to the real path
of the system's tmp dir, not just a symlinked path.