### PR TITLE
Make log to stdout clearer and don't log in project root

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -291,7 +291,7 @@ module Appsignal
     def start_stdout_logger
       @logger = Logger.new($stdout)
       @logger.formatter = lambda do |severity, datetime, progname, msg|
-        "appsignal: #{msg}\n"
+        "appsignal (process): [#{severity}] #{msg}\n"
       end
     end
 

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -90,7 +90,8 @@ module Appsignal
     end
 
     def log_file_path
-      path = config_hash[:log_path] || root_path
+      path = config_hash[:log_path] ||
+        (root_path.nil? ? nil : File.join(root_path, '/log'))
       if path && File.writable?(path)
         return File.join(File.realpath(path), 'appsignal.log')
       end

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -101,7 +101,7 @@ module Appsignal
           "permissions for the application's (log) directory."
         File.join(SYSTEM_TMP_DIR, 'appsignal.log')
       else
-        $stdout.puts "appsignal: Unable to log to '#{path}' or the "\
+        $stdout.puts "appsignal: WARNING: Unable to log to '#{path}' or the "\
           "'#{SYSTEM_TMP_DIR}' fallback. Please check the permissions "\
           "for the application's (log) directory."
       end

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -208,11 +208,11 @@ describe Appsignal::CLI::Diagnose do
     end
 
     describe "paths" do
-      before { FileUtils.mkdir_p(root_path) }
+      before { FileUtils.mkdir_p(File.join(root_path, 'log')) }
 
       context "when a directory is writable" do
         let(:root_path) { File.join(tmp_dir, "writable_path") }
-        let(:log_file) { File.join(root_path, "appsignal.log") }
+        let(:log_file) { File.join(root_path, "log/appsignal.log") }
         let(:config) { Appsignal::Config.new(root_path, "production") }
 
         context "without log file" do
@@ -236,7 +236,7 @@ describe Appsignal::CLI::Diagnose do
             it "lists log file as writable" do
               expect(output).to include \
                 %(root_path: "#{root_path}" - Writable),
-                %(log_file_path: "#{File.join(root_path, "appsignal.log")}" - Writable)
+                %(log_file_path: "#{File.join(root_path, "log/appsignal.log")}" - Writable)
             end
           end
 
@@ -250,7 +250,7 @@ describe Appsignal::CLI::Diagnose do
             it "lists log file as not writable" do
               expect(output).to include \
                 %(root_path: "#{root_path}" - Writable),
-                %(log_file_path: "#{File.join(root_path, "appsignal.log")}" - Not writable)
+                %(log_file_path: "#{File.join(root_path, "log/appsignal.log")}" - Not writable)
             end
           end
         end
@@ -268,7 +268,7 @@ describe Appsignal::CLI::Diagnose do
           expect(output).to include \
             "Required paths",
             %(root_path: "#{root_path}" - Not writable),
-            %(log_file_path: "" - Not writable)
+            %(log_file_path: "#{File.join(tmp_dir, "system-tmp")}/appsignal.log" - Does not exist)
         end
       end
 

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -459,7 +459,7 @@ describe Appsignal::Config do
 
         it "prints a warning" do
           subject
-          expect(stdout.string).to include "appsignal: Unable to log to '#{log_path}' "\
+          expect(stdout.string).to include "appsignal: WARNING: Unable to log to '#{log_path}' "\
             "or the '#{system_tmp_dir}' fallback."
         end
       end

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -374,7 +374,7 @@ describe Appsignal::Config do
       expect(ENV['APPSIGNAL_APP_PATH']).to                     end_with('spec/support/project_fixture')
       expect(ENV['APPSIGNAL_AGENT_PATH']).to                   end_with('/ext')
       expect(ENV['APPSIGNAL_DEBUG_LOGGING']).to                eq 'false'
-      expect(ENV['APPSIGNAL_LOG_FILE_PATH']).to                end_with('/tmp/appsignal.log')
+      expect(ENV['APPSIGNAL_LOG_FILE_PATH']).to                end_with('tmp/appsignal.log')
       expect(ENV['APPSIGNAL_PUSH_API_ENDPOINT']).to            eq 'https://push.appsignal.com'
       expect(ENV['APPSIGNAL_PUSH_API_KEY']).to                 eq 'abc'
       expect(ENV['APPSIGNAL_APP_NAME']).to                     eq 'TestApp'
@@ -476,7 +476,7 @@ describe Appsignal::Config do
 
       context "when root_path is set" do
         it "returns returns the project log location" do
-          expect(subject).to eq File.join(config.root_path, 'appsignal.log')
+          expect(subject).to eq File.join(config.root_path, 'log/appsignal.log')
         end
 
         it "prints no warning" do

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -634,7 +634,7 @@ describe Appsignal do
 
         it "outputs a warning" do
           expect(out_stream.string).to include \
-            "appsignal: Unable to log to '#{log_path}' "\
+            "appsignal: WARNING: Unable to log to '#{log_path}' "\
             "or the '#{Appsignal::Config::SYSTEM_TMP_DIR}' fallback."
         end
       end
@@ -647,7 +647,7 @@ describe Appsignal do
         around { |example| recognize_as_heroku { example.run } }
 
         it "logs to stdout" do
-          expect(out_stream.string).to include 'appsignal: Log to stdout'
+          expect(out_stream.string).to include 'appsignal (process): [ERROR] Log to stdout'
         end
 
         it "amends in memory log to stdout" do

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -574,6 +574,7 @@ describe Appsignal do
       context "when the log path is writable" do
         context "when the log file is writable" do
           let(:log_file_contents) { File.open(log_file).read }
+
           before do
             Appsignal.start_logger
             Appsignal.logger.error('Log to file')
@@ -615,12 +616,16 @@ describe Appsignal do
         end
       end
 
-      context "when the log path is not writable" do
+      context "when the log path and fallback path are not writable" do
         before do
           FileUtils.chmod 0444, log_path
+          FileUtils.chmod 0444, Appsignal::Config::SYSTEM_TMP_DIR
 
           Appsignal.start_logger
           Appsignal.logger.error('Log to not writable log path')
+        end
+        after do
+          FileUtils.chmod 0755, Appsignal::Config::SYSTEM_TMP_DIR
         end
 
         it "logs to stdout" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,7 +49,7 @@ RSpec.configure do |config|
 
   config.before :all do
     FileUtils.rm_rf(tmp_dir)
-    FileUtils.mkdir_p(tmp_dir)
+    FileUtils.mkdir_p(File.join(tmp_dir, 'system-tmp'))
 
     # Use modifiable SYSTEM_TMP_DIR
     Appsignal::Config.send :remove_const, :SYSTEM_TMP_DIR


### PR DESCRIPTION
Make two logging improvements:

* Make output to stdout clearer and better filterable
* Don't log to a project's root dir by default. This can cause problems if this is a symlinked release directory.