### PR TITLE
Enable agent diagnostics in diagnose command

### DIFF
--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -42,6 +42,7 @@ module Appsignal
             initial_config[:log_path] = Rails.root.join("log")
           end
 
+          ENV['APPSIGNAL_DIAGNOSE'] = 'true'
           Appsignal.config = Appsignal::Config.new(
             current_path,
             options[:environment],

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -11,13 +11,13 @@ module Appsignal
           header
           empty_line
 
-          start_appsignal(options)
-
           agent_version
           empty_line
 
           host_information
           empty_line
+
+          start_appsignal(options)
 
           config
           empty_line

--- a/spec/lib/appsignal/cli/demo_spec.rb
+++ b/spec/lib/appsignal/cli/demo_spec.rb
@@ -4,8 +4,9 @@ describe Appsignal::CLI::Demo do
   include CLIHelpers
 
   let(:options) { {} }
-  let(:out_stream) { StringIO.new }
-  let(:output) { out_stream.string }
+  let(:out_stream) { std_stream }
+  let(:output) { out_stream.read }
+  before(:all) { Appsignal.stop }
   before do
     ENV.delete("APPSIGNAL_APP_ENV")
     ENV.delete("RAILS_ENV")
@@ -13,7 +14,6 @@ describe Appsignal::CLI::Demo do
     stub_api_request config, "auth"
   end
   after { Appsignal.config = nil }
-  around { |example| capture_stdout(out_stream) { example.run } }
 
   def run
     run_within_dir project_fixture_path
@@ -21,7 +21,7 @@ describe Appsignal::CLI::Demo do
 
   def run_within_dir(chdir)
     Dir.chdir chdir do
-      run_cli("demo", options)
+      capture_stdout(out_stream) { run_cli("demo", options) }
     end
   end
 

--- a/spec/lib/appsignal/cli/helpers_spec.rb
+++ b/spec/lib/appsignal/cli/helpers_spec.rb
@@ -3,8 +3,8 @@ require "appsignal/cli/helpers"
 describe Appsignal::CLI::Helpers do
   include CLIHelpers
 
-  let(:out_stream) { StringIO.new }
-  let(:output) { out_stream.string }
+  let(:out_stream) { std_stream }
+  let(:output) { out_stream.read }
   let(:cli) do
     Class.new do
       extend Appsignal::CLI::Helpers
@@ -17,7 +17,7 @@ describe Appsignal::CLI::Helpers do
   around do |example|
     original_stdin = $stdin
     $stdin = StringIO.new
-    capture_stdout(out_stream) { example.run }
+    example.run
     $stdin = original_stdin
   end
 
@@ -43,7 +43,7 @@ describe Appsignal::CLI::Helpers do
 
   describe ".periods" do
     it "prints three periods" do
-      cli.send :periods
+      capture_stdout(out_stream) { cli.send :periods }
       expect(output).to include("...")
     end
   end
@@ -54,19 +54,23 @@ describe Appsignal::CLI::Helpers do
     end
 
     it "continues after press" do
-      cli.send :press_any_key
+      capture_stdout(out_stream) { cli.send :press_any_key }
       expect(output).to include("Press any key")
     end
   end
 
   describe ".yes_or_no" do
+    def yes_or_no
+      capture_stdout(out_stream) { cli.send(:yes_or_no, "yes or no?: ") }
+    end
+
     it "takes yes for an answer" do
       set_input ""
       set_input "nonsense"
       set_input "y"
       prepare_input
 
-      expect(cli.send(:yes_or_no, "yes or no?: ")).to be_true
+      expect(yes_or_no).to be_true
     end
 
     it "takes no for an answer" do
@@ -75,17 +79,21 @@ describe Appsignal::CLI::Helpers do
       set_input "n"
       prepare_input
 
-      expect(cli.send(:yes_or_no, "yes or no?: ")).to be_false
+      expect(yes_or_no).to be_false
     end
   end
 
   describe ".required_input" do
+    def required_input
+      capture_stdout(out_stream) { cli.send(:required_input, "provide: ") }
+    end
+
     it "collects required input" do
       set_input ""
       set_input "value"
       prepare_input
 
-      expect(cli.send(:required_input, "provide: ")).to eq("value")
+      expect(required_input).to eq("value")
     end
   end
 end

--- a/spec/lib/appsignal/cli/install_spec.rb
+++ b/spec/lib/appsignal/cli/install_spec.rb
@@ -3,8 +3,8 @@ require "appsignal/cli"
 describe Appsignal::CLI::Install do
   include CLIHelpers
 
-  let(:out_stream) { StringIO.new }
-  let(:output) { out_stream.string }
+  let(:out_stream) { std_stream }
+  let(:output) { out_stream.read }
   let(:push_api_key) { "my_key" }
   let(:config) { Appsignal::Config.new(tmp_dir, "") }
   let(:config_file_path) { File.join(tmp_dir, "config", "appsignal.yml") }
@@ -19,7 +19,7 @@ describe Appsignal::CLI::Install do
   around do |example|
     original_stdin = $stdin
     $stdin = StringIO.new
-    capture_stdout(out_stream) { example.run }
+    example.run
     $stdin = original_stdin
   end
 
@@ -86,7 +86,9 @@ describe Appsignal::CLI::Install do
   def run
     Dir.chdir tmp_dir do
       prepare_input
-      run_cli(["install", push_api_key])
+      capture_stdout(out_stream) do
+        run_cli(["install", push_api_key])
+      end
     end
   end
 

--- a/spec/lib/appsignal/cli/notify_of_deploy_spec.rb
+++ b/spec/lib/appsignal/cli/notify_of_deploy_spec.rb
@@ -3,11 +3,8 @@ require "appsignal/cli"
 describe Appsignal::CLI::NotifyOfDeploy do
   include CLIHelpers
 
-  let(:out_stream) { StringIO.new }
-  let(:output) { out_stream.string }
-  around do |example|
-    capture_stdout(out_stream) { example.run }
-  end
+  let(:out_stream) { std_stream }
+  let(:output) { out_stream.read }
 
   define :include_deploy_notification do
     match do |log|
@@ -35,7 +32,9 @@ describe Appsignal::CLI::NotifyOfDeploy do
   end
 
   def run
-    run_cli("notify_of_deploy", options)
+    capture_stdout(out_stream) do
+      run_cli("notify_of_deploy", options)
+    end
   end
 
   context "without config" do

--- a/spec/lib/appsignal/cli_spec.rb
+++ b/spec/lib/appsignal/cli_spec.rb
@@ -1,44 +1,46 @@
 require 'appsignal/cli'
 
 describe Appsignal::CLI do
-  let(:out_stream) { StringIO.new }
+  let(:out_stream) { std_stream }
+  let(:output) { out_stream.read }
   let(:cli) { Appsignal::CLI }
-  before do
-    Dir.stub(:pwd => project_fixture_path)
-  end
-  around do |example|
-    capture_stdout(out_stream) { example.run }
-  end
+  before { Dir.stub(:pwd => project_fixture_path) }
 
   it "should print the help with no arguments, -h and --help" do
     [nil, '-h', '--help'].each do |arg|
-      lambda {
-        cli.run([arg].compact)
-      }.should raise_error(SystemExit)
+      expect do
+        capture_stdout(out_stream) do
+          cli.run([arg].compact)
+        end
+      end.to raise_error(SystemExit)
 
-      out_stream.string.should include 'appsignal <command> [options]'
-      out_stream.string.should include \
+      expect(output).to include 'appsignal <command> [options]'
+      expect(output).to include \
         'Available commands: demo, diagnose, install, notify_of_deploy'
     end
   end
 
   it "should print the version with -v and --version" do
     ['-v', '--version'].each do |arg|
-      lambda {
-        cli.run([arg])
-      }.should raise_error(SystemExit)
+      expect do
+        capture_stdout(out_stream) do
+          cli.run([arg])
+        end
+      end.to raise_error(SystemExit)
 
-      out_stream.string.should include 'AppSignal'
-      out_stream.string.should include '.'
+      expect(output).to include 'AppSignal'
+      expect(output).to include '.'
     end
   end
 
   it "should print a notice if a command does not exist" do
-    lambda {
+    expect do
+      capture_stdout(out_stream) do
         cli.run(['nonsense'])
-      }.should raise_error(SystemExit)
+      end
+    end.to raise_error(SystemExit)
 
-    out_stream.string.should include "Command 'nonsense' does not exist, run "\
+    expect(output).to include "Command 'nonsense' does not exist, run "\
       "appsignal -h to see the help"
   end
 

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -437,12 +437,13 @@ describe Appsignal::Config do
   end
 
   describe "#log_file_path" do
-    let(:stdout) { StringIO.new }
+    let(:out_stream) { std_stream }
+    let(:output) { out_stream.read }
     let(:config) { project_fixture_config('production', :log_path => log_path) }
-    subject { config.log_file_path }
+    subject { capture_stdout(out_stream) { config.log_file_path } }
     around do |example|
       recognize_as_container(:none) do
-        capture_stdout(stdout) { example.run }
+        example.run
       end
     end
 
@@ -457,7 +458,7 @@ describe Appsignal::Config do
 
       it "prints no warning" do
         subject
-        expect(stdout.string).to be_empty
+        expect(output).to be_empty
       end
     end
 
@@ -475,7 +476,7 @@ describe Appsignal::Config do
 
         it "prints a warning" do
           subject
-          expect(stdout.string).to include "appsignal: Unable to log to '#{log_path}'. "\
+          expect(output).to include "appsignal: Unable to log to '#{log_path}'. "\
             "Logging to '#{system_tmp_dir}' instead."
         end
       end
@@ -489,7 +490,7 @@ describe Appsignal::Config do
 
         it "prints a warning" do
           subject
-          expect(stdout.string).to include "appsignal: Unable to log to '#{log_path}' "\
+          expect(output).to include "appsignal: Unable to log to '#{log_path}' "\
             "or the '#{system_tmp_dir}' fallback."
         end
       end
@@ -511,7 +512,7 @@ describe Appsignal::Config do
 
         it "prints no warning" do
           subject
-          expect(stdout.string).to be_empty
+          expect(output).to be_empty
         end
       end
     end

--- a/spec/support/helpers/std_streams_helper.rb
+++ b/spec/support/helpers/std_streams_helper.rb
@@ -1,36 +1,52 @@
 module StdStreamsHelper
+  def std_stream
+    Tempfile.new SecureRandom.uuid
+  end
+
   # Capture STDOUT in a variable
+  #
+  # Given tempfiles are rewinded and unlinked after yield, so no cleanup
+  # required. You can read from the stream using `stdout.read`.
   #
   # Usage
   #
-  #     out_stream = StringIO.new
+  #     out_stream = Tempfile.new
   #     capture_stdout(out_stream) { do_something }
   def capture_stdout(stdout)
-    original_stdout = $stdout
-    $stdout = stdout
+    original_stdout = $stdout.dup
+    $stdout.reopen stdout
 
     yield
-
-    $stdout = original_stdout
+  ensure
+    $stdout.reopen original_stdout
+    stdout.rewind
+    stdout.unlink
   end
 
   # Capture STDOUT and STDERR in variables
   #
+  # Given tempfiles are rewinded and unlinked after yield, so no cleanup
+  # required. You can read from the stream using `stdout.read`.
+  #
   # Usage
   #
-  #     out_stream = StringIO.new
-  #     err_stream = StringIO.new
+  #     out_stream = Tempfile.new
+  #     err_stream = Tempfile.new
   #     capture_std_streams(out_stream, err_stream) { do_something }
   def capture_std_streams(stdout, stderr)
-    original_stdout = $stdout
-    $stdout = stdout
-    original_stderr = $stderr
-    $stderr = stderr
+    original_stdout = $stdout.dup
+    $stdout.reopen stdout
+    original_stderr = $stderr.dup
+    $stderr.reopen stderr
 
     yield
-
-    $stdout = original_stdout
-    $stderr = original_stderr
+  ensure
+    $stdout.reopen original_stdout
+    $stderr.reopen original_stderr
+    stdout.rewind
+    stdout.unlink
+    stderr.rewind
+    stderr.unlink
   end
 
   def silence


### PR DESCRIPTION
This allows us to test the agent in diagnose mode as well rather than just the Ruby gem.