### PR TITLE
Always log in `log/` path

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -300,7 +300,7 @@ module Appsignal
     rescue SystemCallError => error
       start_stdout_logger
       logger.warn "Unable to start logger with log path '#{path}'."
-      logger.warn "#{error}"
+      logger.warn error
     end
   end
 end

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -90,7 +90,7 @@ module Appsignal
     end
 
     def log_file_path
-      path = config_hash[:log_path] || root_path
+      path = config_hash[:log_path] || root_path && File.join(root_path, 'log')
       if path && File.writable?(path)
         return File.join(File.realpath(path), 'appsignal.log')
       end

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -506,7 +506,7 @@ describe Appsignal::Config do
 
       context "when root_path is set" do
         it "returns returns the project log location" do
-          expect(subject).to eq File.join(config.root_path, 'appsignal.log')
+          expect(subject).to eq File.join(config.root_path, 'log/appsignal.log')
         end
 
         it "prints no warning" do

--- a/spec/lib/appsignal/demo_spec.rb
+++ b/spec/lib/appsignal/demo_spec.rb
@@ -11,7 +11,7 @@ describe Appsignal::Demo do
 
     context "without config" do
       it "returns false" do
-        expect(subject).to be_false
+        expect(silence { subject }).to be_false
       end
     end
 

--- a/spec/lib/appsignal/hooks_spec.rb
+++ b/spec/lib/appsignal/hooks_spec.rb
@@ -44,6 +44,7 @@ describe Appsignal::Hooks do
     Appsignal::Hooks.load_hooks
     Appsignal::Hooks.load_hooks
     Appsignal::Hooks.hooks[:mock_present_hook].installed?.should be_true
+    Appsignal::Hooks.hooks.delete(:mock_present_hook)
   end
 
   it "should not install if depencies are not present" do
@@ -57,6 +58,7 @@ describe Appsignal::Hooks do
     Appsignal::Hooks.load_hooks
 
     Appsignal::Hooks.hooks[:mock_not_present_hook].installed?.should be_false
+    Appsignal::Hooks.hooks.delete(:mock_not_present_hook)
   end
 
   it "should not install if there is an error while installing" do
@@ -70,6 +72,7 @@ describe Appsignal::Hooks do
     Appsignal::Hooks.load_hooks
 
     Appsignal::Hooks.hooks[:mock_error_hook].installed?.should be_false
+    Appsignal::Hooks.hooks.delete(:mock_error_hook)
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,13 +48,13 @@ RSpec.configure do |config|
   config.extend DependencyHelper
 
   config.before :all do
-    FileUtils.rm_rf(tmp_dir)
-    FileUtils.mkdir_p(tmp_dir)
-
-    # Use modifiable SYSTEM_TMP_DIR
+    # Use modified SYSTEM_TMP_DIR
     Appsignal::Config.send :remove_const, :SYSTEM_TMP_DIR
     Appsignal::Config.send :const_set, :SYSTEM_TMP_DIR,
       File.join(tmp_dir, 'system-tmp')
+
+    FileUtils.rm_rf(tmp_dir)
+    FileUtils.mkdir_p(Appsignal::Config::SYSTEM_TMP_DIR)
   end
 
   config.before do

--- a/spec/support/helpers/std_streams_helper.rb
+++ b/spec/support/helpers/std_streams_helper.rb
@@ -32,4 +32,19 @@ module StdStreamsHelper
     $stdout = original_stdout
     $stderr = original_stderr
   end
+
+  def silence
+    std_stream = Tempfile.new(SecureRandom.uuid)
+    original_stdout = $stdout.dup
+    original_stderr = $stderr.dup
+    $stdout.reopen std_stream
+    $stderr.reopen std_stream
+
+    yield
+  ensure
+    $stdout.reopen original_stdout
+    $stderr.reopen original_stderr
+    std_stream.rewind
+    std_stream.unlink
+  end
 end


### PR DESCRIPTION
Avoid logging in the project's root path, but log to a `log/`
directory when it's available otherwise fallback on the system `tmp/`
directory.

Also fixed the test suite from outputting unrelated warnings in other tests.

Continued from #220 