### PR TITLE
Write log path permission warnings to log

### DIFF
--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -96,14 +96,15 @@ module Appsignal
       end
 
       if File.writable? SYSTEM_TMP_DIR
-        $stdout.puts "appsignal: Unable to log to '#{path}'. Logging to "\
+        logger.warn "Unable to log to '#{path}'. Logging to "\
           "'#{SYSTEM_TMP_DIR}' instead. Please check the "\
           "permissions for the application's (log) directory."
         File.join(SYSTEM_TMP_DIR, 'appsignal.log')
       else
-        $stdout.puts "appsignal: Unable to log to '#{path}' or the "\
+        logger.warn "Unable to log to '#{path}' or the "\
           "'#{SYSTEM_TMP_DIR}' fallback. Please check the permissions "\
           "for the application's (log) directory."
+        nil
       end
     end
 

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -437,15 +437,9 @@ describe Appsignal::Config do
   end
 
   describe "#log_file_path" do
-    let(:out_stream) { std_stream }
-    let(:output) { out_stream.read }
     let(:config) { project_fixture_config('production', :log_path => log_path) }
-    subject { capture_stdout(out_stream) { config.log_file_path } }
-    around do |example|
-      recognize_as_container(:none) do
-        example.run
-      end
-    end
+    subject { config.log_file_path }
+    around { |example| recognize_as_container(:none) { example.run } }
 
     context "when path is writable" do
       let(:log_path) { File.join(tmp_dir, 'writable-path') }
@@ -457,8 +451,8 @@ describe Appsignal::Config do
       end
 
       it "prints no warning" do
+        expect(Appsignal.logger).not_to receive(:warn)
         subject
-        expect(output).to be_empty
       end
     end
 
@@ -475,9 +469,10 @@ describe Appsignal::Config do
         end
 
         it "prints a warning" do
+          expect(Appsignal.logger).to receive(:warn).with(
+            /Unable to log to '#{log_path}'. Logging to '#{system_tmp_dir}' instead/
+          )
           subject
-          expect(output).to include "appsignal: Unable to log to '#{log_path}'. "\
-            "Logging to '#{system_tmp_dir}' instead."
         end
       end
 
@@ -489,9 +484,10 @@ describe Appsignal::Config do
         end
 
         it "prints a warning" do
+          expect(Appsignal.logger).to receive(:warn).with(
+            /Unable to log to '#{log_path}' or the '#{system_tmp_dir}' fallback/
+          )
           subject
-          expect(output).to include "appsignal: Unable to log to '#{log_path}' "\
-            "or the '#{system_tmp_dir}' fallback."
         end
       end
     end
@@ -511,8 +507,8 @@ describe Appsignal::Config do
         end
 
         it "prints no warning" do
+          expect(Appsignal.logger).not_to receive(:warn)
           subject
-          expect(output).to be_empty
         end
       end
     end


### PR DESCRIPTION
Previously it was written to STDOUT, but I think it's okay now to write
it to the log and avoid spamming the STDOUT with (not always) very
important warnings.

Especially useful for users now that we change the log path to `log/`
in the project's `root_path` in #222 . If people upgrade and they don't have a
`log/` path, because they are not using Rails and have not customized
their `log_path`, they won't see any warnings in STDOUT, but the log
file instead.

Notes:

- logger.warn returns true/false
- Moved the `.logger`, `.start_logger` and `.log_formatter` specs in
  `appsignal_spec.rb` from the context "with config and started" to the
  root level of the spec file, because they set their own config if
  needed and don't require a started Appsignal.

Based on #221 because that already includes some test refactors and helpers I needed for this PR.