### PR TITLE
Remove ignored errors

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -4,6 +4,8 @@ require 'securerandom'
 
 module Appsignal
   class << self
+    extend Gem::Deprecate
+
     attr_accessor :config, :agent, :extension_loaded
     attr_writer :logger, :in_memory_log
 
@@ -148,7 +150,7 @@ module Appsignal
     alias :listen_for_exception :listen_for_error
 
     def send_error(error, tags=nil, namespace=Appsignal::Transaction::HTTP_REQUEST)
-      return if !active? || is_ignored_error?(error)
+      return if !active?
       unless error.is_a?(Exception)
         logger.error('Can\'t send error, given value is not an exception')
         return
@@ -167,8 +169,7 @@ module Appsignal
     def set_error(exception)
       return if !active? ||
                 Appsignal::Transaction.current.nil? ||
-                exception.nil? ||
-                is_ignored_error?(exception)
+                exception.nil?
       Appsignal::Transaction.current.set_error(exception)
     end
     alias :set_exception :set_error
@@ -272,6 +273,7 @@ module Appsignal
       Appsignal.config[:ignore_errors].include?(error.class.name)
     end
     alias :is_ignored_exception? :is_ignored_error?
+    deprecate :is_ignored_error?, :none, 2017, 3
 
     def is_ignored_action?(action)
       Appsignal.config[:ignore_actions].include?(action)

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -278,6 +278,7 @@ module Appsignal
     def is_ignored_action?(action)
       Appsignal.config[:ignore_actions].include?(action)
     end
+    deprecate :is_ignored_action?, :none, 2017, 3
 
     # Convenience method for skipping instrumentations around a block of code.
     #

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -129,6 +129,7 @@ module Appsignal
       ENV['APPSIGNAL_APP_NAME']                     = config_hash[:name]
       ENV['APPSIGNAL_HTTP_PROXY']                   = config_hash[:http_proxy]
       ENV['APPSIGNAL_IGNORE_ACTIONS']               = config_hash[:ignore_actions].join(',')
+      ENV['APPSIGNAL_IGNORE_ERRORS']                = config_hash[:ignore_errors].join(',')
       ENV['APPSIGNAL_FILTER_PARAMETERS']            = config_hash[:filter_parameters].join(',')
       ENV['APPSIGNAL_SEND_PARAMS']                  = config_hash[:send_params].to_s
       ENV['APPSIGNAL_RUNNING_IN_CONTAINER']         = config_hash[:running_in_container].to_s

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -182,7 +182,6 @@ module Appsignal
     def set_error(error)
       return unless error
       return unless Appsignal.active?
-      return if Appsignal.is_ignored_error?(error)
 
       backtrace = cleaned_backtrace(error.backtrace)
       @ext.set_error(

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -392,6 +392,7 @@ describe Appsignal::Config do
     before do
       config[:http_proxy] = 'http://localhost'
       config[:ignore_actions] = ['action1', 'action2']
+      config[:ignore_errors] = ['VerySpecificError', 'AnotherError']
       config[:log_path] = '/tmp'
       config[:hostname] = 'app1.local'
       config[:filter_parameters] = %w(password confirm_password)
@@ -413,6 +414,7 @@ describe Appsignal::Config do
       expect(ENV['APPSIGNAL_LANGUAGE_INTEGRATION_VERSION']).to eq "ruby-#{Appsignal::VERSION}"
       expect(ENV['APPSIGNAL_HTTP_PROXY']).to                   eq 'http://localhost'
       expect(ENV['APPSIGNAL_IGNORE_ACTIONS']).to               eq 'action1,action2'
+      expect(ENV['APPSIGNAL_IGNORE_ERRORS']).to                eq 'VerySpecificError,AnotherError'
       expect(ENV['APPSIGNAL_FILTER_PARAMETERS']).to            eq 'password,confirm_password'
       expect(ENV['APPSIGNAL_SEND_PARAMS']).to                  eq 'true'
       expect(ENV['APPSIGNAL_RUNNING_IN_CONTAINER']).to         eq 'false'

--- a/spec/lib/appsignal/hooks/shoryuken_spec.rb
+++ b/spec/lib/appsignal/hooks/shoryuken_spec.rb
@@ -9,7 +9,6 @@ describe Appsignal::Hooks::ShoryukenMiddleware do
   let(:body) {{}}
 
   before do
-    Appsignal.stub(:is_ignored_exception? => false)
     Appsignal::Transaction.stub(:current => current_transaction)
     start_agent
   end

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -13,7 +13,6 @@ describe Appsignal::Hooks::SidekiqPlugin do
   let(:plugin) { Appsignal::Hooks::SidekiqPlugin.new }
 
   before do
-    Appsignal.stub(:is_ignored_exception? => false)
     Appsignal::Transaction.stub(:current => current_transaction)
     start_agent
   end

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -419,13 +419,6 @@ describe Appsignal::Transaction do
         transaction.should respond_to(:add_exception)
       end
 
-      it "should not add the error if it's in the ignored list" do
-        Appsignal.stub(:is_ignored_error? => true)
-        transaction.ext.should_not_receive(:set_error)
-
-        transaction.set_error(error)
-      end
-
       it "should not add the error if appsignal is not active" do
         Appsignal.stub(:active? => false)
         transaction.ext.should_not_receive(:set_error)

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -899,16 +899,27 @@ describe Appsignal do
 
     describe ".is_ignored_action?" do
       let(:action) { 'TestController#isup' }
+      let(:err_stream) { std_stream }
+      let(:stderr) { err_stream.read }
       before do
         Appsignal.stub(
           :config => {:ignore_actions => 'TestController#isup'}
         )
       end
 
-      subject { Appsignal.is_ignored_action?(action) }
+      subject do
+        capture_std_streams(std_stream, err_stream) do
+          Appsignal.is_ignored_action?(action)
+        end
+      end
 
       it "should return true if it's in the ignored list" do
         should be_true
+      end
+
+      it "outputs deprecated warning" do
+        subject
+        expect(stderr).to include("Appsignal.is_ignored_action? is deprecated with no replacement.")
       end
 
       context "when action is not in the ingore list" do


### PR DESCRIPTION
Ignored errors will be handled by the agent. The Ruby and Elixir integrations should only set the APPSIGNAL_IGNORE_ERRORS env var and the agent will handle the ignoring (like with ignored actions).