### PR TITLE
Fix builds for nokogiri on Ruby 2.0

### DIFF
--- a/gemfiles/rails-4.2.gemfile
+++ b/gemfiles/rails-4.2.gemfile
@@ -4,3 +4,7 @@ gem 'rails', '~> 4.2.0'
 gem 'mime-types', '~> 2.6'
 
 gemspec :path => '../'
+
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1.0")
+  gem 'nokogiri', '~> 1.6.0'
+end

--- a/gemfiles/resque.gemfile
+++ b/gemfiles/resque.gemfile
@@ -6,3 +6,7 @@ gem 'sinatra'
 gem 'mime-types', '~> 2.6'
 
 gemspec :path => '../'
+
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1.0")
+  gem 'nokogiri', '~> 1.6.0'
+end


### PR DESCRIPTION
Ruby 2.0 is end-of-life and nokogiri dropped support in 1.7 so we build
our builds on nokogiri < 1.7 for Ruby 2.0 builds that automatically install a nokogiri 1.7 or higher.