### PR TITLE
Use experimental alpha musl agent and extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ branches:
   only:
     - "master"
     - "develop"
+    - "musl"
 
 language: ruby
 cache: bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.1.0
+* Add support for musl libc
+
 # 2.0.4
 * Use consistent log format for both file and STDOUT logs. PR #203
 * Fix log path in `appsignal diagnose` for Rails applications. PR #218, #222

--- a/Rakefile
+++ b/Rakefile
@@ -57,7 +57,7 @@ task :publish do
       puts "# Creating tag #{version}"
       puts `git tag #{version}`
       puts `git push origin #{version}`
-      puts `git push origin #{branch}`
+      puts `git push origin #{current_branch}`
     rescue
       raise "Tag: '#{version}' already exists"
     end
@@ -75,14 +75,8 @@ task :publish do
     @version ||= 'v' << gem_version
   end
 
-  def branch
-    if gem_version.include?('alpha') ||
-         gem_version.include?('beta') ||
-         gem_version.include?('rc')
-      'develop'
-    else
-      'master'
-    end
+  def current_branch
+    `git rev-parse --abbrev-ref HEAD`.chomp
   end
 
   def git_status_to_array(changes)

--- a/ext/agent.yml
+++ b/ext/agent.yml
@@ -1,18 +1,18 @@
 ---
-version: 65936ce
+version: 5f0c552
 triples:
   x86_64-linux:
-    checksum: b727df7862e9849788f76b3d8640d03ec4fde382da70e8d7f388ffa56e170d84
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/65936ce/appsignal-x86_64-linux-all-static.tar.gz
+    checksum: ded20da060a8c05c7551e9d86067ce7eecefca4ee3f8ddf286f79146d0895fd1
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/5f0c552/appsignal-x86_64-linux-all-static.tar.gz
   i686-linux:
-    checksum: c9ec34f8f70ffe00e109f6a01d73fc17449ba965957fa8edec54ba2bcab75578
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/65936ce/appsignal-i686-linux-all-static.tar.gz
+    checksum: 0332a1d256612b6230212ab5c503b53cf7e4121ff14c9df481d5a08545da89ba
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/5f0c552/appsignal-i686-linux-all-static.tar.gz
   x86-linux:
-    checksum: c9ec34f8f70ffe00e109f6a01d73fc17449ba965957fa8edec54ba2bcab75578
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/65936ce/appsignal-i686-linux-all-static.tar.gz
+    checksum: 0332a1d256612b6230212ab5c503b53cf7e4121ff14c9df481d5a08545da89ba
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/5f0c552/appsignal-i686-linux-all-static.tar.gz
   x86_64-darwin:
-    checksum: dec1ec6196f0b463e660b1bc5bee9200c40b5a2d5e6900e64dc1bc44a17c240b
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/65936ce/appsignal-x86_64-darwin-all-static.tar.gz
+    checksum: f4eaf9ef17f0c95adcc3b853f00134b28e1a50e33db48677dc3adfcbe48b14b4
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/5f0c552/appsignal-x86_64-darwin-all-static.tar.gz
   universal-darwin:
-    checksum: dec1ec6196f0b463e660b1bc5bee9200c40b5a2d5e6900e64dc1bc44a17c240b
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/65936ce/appsignal-x86_64-darwin-all-static.tar.gz
+    checksum: f4eaf9ef17f0c95adcc3b853f00134b28e1a50e33db48677dc3adfcbe48b14b4
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/5f0c552/appsignal-x86_64-darwin-all-static.tar.gz

--- a/ext/agent.yml
+++ b/ext/agent.yml
@@ -1,6 +1,6 @@
 ---
-version: 21f0b26
+version: d2e9bb9
 triples:
   x86_64-linux:
-    checksum: e965ea8d4a01ea2caf9b50a6520c2f2385a00c00bc5d259079f93baddca0b28c
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/21f0b26/appsignal-x86_64-linux-all-static.tar.gz
+    checksum: 4de36bfc1b196dc75b7024e79f8d142d80d9a748db2cb275f6e44f4bcb3ad9bf
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/d2e9bb9/appsignal-x86_64-linux-all-static.tar.gz

--- a/ext/agent.yml
+++ b/ext/agent.yml
@@ -1,18 +1,6 @@
 ---
-version: c18d324
+version: 21f0b26
 triples:
   x86_64-linux:
-    checksum: 67a21c8481684466b39a55a6b7418fa838d98e3e4570c9a082ba23e5147d5a64
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/c18d324/appsignal-x86_64-linux-all-static.tar.gz
-  i686-linux:
-    checksum: 958cc0a742bea1e411bb6dbe0f7f124fe6ec273b8ae0d9b9317f306d60ee0b5d
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/c18d324/appsignal-i686-linux-all-static.tar.gz
-  x86-linux:
-    checksum: 958cc0a742bea1e411bb6dbe0f7f124fe6ec273b8ae0d9b9317f306d60ee0b5d
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/c18d324/appsignal-i686-linux-all-static.tar.gz
-  x86_64-darwin:
-    checksum: 89053389ddf816aaefc1580899eca8bcac9837dfdfabf6f333a853d17f2edec8
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/c18d324/appsignal-x86_64-darwin-all-static.tar.gz
-  universal-darwin:
-    checksum: 89053389ddf816aaefc1580899eca8bcac9837dfdfabf6f333a853d17f2edec8
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/c18d324/appsignal-x86_64-darwin-all-static.tar.gz
+    checksum: e965ea8d4a01ea2caf9b50a6520c2f2385a00c00bc5d259079f93baddca0b28c
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/21f0b26/appsignal-x86_64-linux-all-static.tar.gz

--- a/ext/agent.yml
+++ b/ext/agent.yml
@@ -1,6 +1,18 @@
 ---
-version: d2e9bb9
+version: 65936ce
 triples:
   x86_64-linux:
-    checksum: 4de36bfc1b196dc75b7024e79f8d142d80d9a748db2cb275f6e44f4bcb3ad9bf
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/d2e9bb9/appsignal-x86_64-linux-all-static.tar.gz
+    checksum: b727df7862e9849788f76b3d8640d03ec4fde382da70e8d7f388ffa56e170d84
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/65936ce/appsignal-x86_64-linux-all-static.tar.gz
+  i686-linux:
+    checksum: c9ec34f8f70ffe00e109f6a01d73fc17449ba965957fa8edec54ba2bcab75578
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/65936ce/appsignal-i686-linux-all-static.tar.gz
+  x86-linux:
+    checksum: c9ec34f8f70ffe00e109f6a01d73fc17449ba965957fa8edec54ba2bcab75578
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/65936ce/appsignal-i686-linux-all-static.tar.gz
+  x86_64-darwin:
+    checksum: dec1ec6196f0b463e660b1bc5bee9200c40b5a2d5e6900e64dc1bc44a17c240b
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/65936ce/appsignal-x86_64-darwin-all-static.tar.gz
+  universal-darwin:
+    checksum: dec1ec6196f0b463e660b1bc5bee9200c40b5a2d5e6900e64dc1bc44a17c240b
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/65936ce/appsignal-x86_64-darwin-all-static.tar.gz

--- a/lib/appsignal/version.rb
+++ b/lib/appsignal/version.rb
@@ -1,5 +1,5 @@
 require 'yaml'
 
 module Appsignal
-  VERSION = '2.1.0.alpha.2'
+  VERSION = '2.1.0.alpha.3'
 end

--- a/lib/appsignal/version.rb
+++ b/lib/appsignal/version.rb
@@ -1,5 +1,5 @@
 require 'yaml'
 
 module Appsignal
-  VERSION = '2.0.4'
+  VERSION = '2.1.0.alpha.1'
 end

--- a/lib/appsignal/version.rb
+++ b/lib/appsignal/version.rb
@@ -1,5 +1,5 @@
 require 'yaml'
 
 module Appsignal
-  VERSION = '2.1.0.alpha.1'
+  VERSION = '2.1.0.alpha.2'
 end


### PR DESCRIPTION
Add support for Alpine Linux to the AppSignal Ruby gem :tada:

## Alpha release for testing purposes only

Works on 64bit hosts, 32bit hosts and macOS.
Tested on Debian and Alpine Linux.

Tested environments:

- Alpine Linux docker image: https://hub.docker.com/_/ruby/ tag `2.3.3-alpine`
- Debian Linux docker image: https://hub.docker.com/_/ruby/ tag: `2.3.3`
- Alpine 32bit VirtualBox machine: custom build based on "Standard" iso image at https://alpinelinux.org/downloads/
- Ubuntu 16.04 64bit vagrant box: https://atlas.hashicorp.com/bento/boxes/ubuntu-16.04
- Ubuntu 16.04 32bit vagrant box: https://atlas.hashicorp.com/bento/boxes/ubuntu-16.04-i386
- Ubuntu 10.04 64bit vagrant box: https://atlas.hashicorp.com/bento/boxes/ubuntu-10.04
- Ubuntu 10.04 32bit vagrant box: https://atlas.hashicorp.com/bento/boxes/ubuntu-10.04-i386


## Installing

Specify the latest version in your `Gemfile`

```ruby
# Gemfile
gem "appsignal", "2.1.0.alpha.3"
```

and run `bundle install`

No additional steps needed for installing :)

Let me know if you run into any problems!

## Docker Alpine Linux image

When using the Docker Ruby Alpine image please install the build tools before installing the AppSignal gem:

```
apk add --update alpine-sdk coreutils
```

## Docker Debian Linux image

When using the Docker Ruby Debian image please install the build tools before installing the AppSignal gem:

```
apt-get update && apt-get install -y build-essential
```

## Vagrant Ubuntu boxes

```
apt-get update
apt-get install -y cmake make build-essential ruby ruby-dev
```

## TODO

- [x] Create 32bit build
- [x] Enable macOS build again
- [x] Replace normal libc builds with musl builds
- [x] Extensive testing ❗️
- [ ] Release 2.1.0