### PR TITLE
Fix capistrano 3 specs

### DIFF
--- a/spec/lib/appsignal/capistrano3_spec.rb
+++ b/spec/lib/appsignal/capistrano3_spec.rb
@@ -3,9 +3,8 @@ if DependencyHelper.capistrano3_present?
   require 'capistrano/deploy'
   require 'appsignal/capistrano'
 
-  include Capistrano::DSL
-
   describe "Capistrano 3 integration" do
+    let(:capistrano) { Class.new.extend(Capistrano::DSL) }
     let(:config) { project_fixture_config }
     let(:out_stream) { std_stream }
     let(:output) { out_stream.read }
@@ -26,7 +25,7 @@ if DependencyHelper.capistrano3_present?
 
     def run
       capture_std_streams(out_stream, out_stream) do
-        invoke('appsignal:deploy')
+        capistrano.invoke('appsignal:deploy')
       end
     end
 


### PR DESCRIPTION
We included the DSL on `main` which overwrote some of our own methods in
other classes.

By creating a wrapper class we can now invoke Capistrano without
including it in `main`.

Issue introduced in #231 where we introduce our own `#env` method on `Appsignal::Transaction`