### PR TITLE
RSpec upgrade

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
---order default
+--order defined
+--color
 --warnings
 --require spec_helper

--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'thread_safe'
 
   gem.add_development_dependency 'rake', '~> 11'
-  gem.add_development_dependency 'rspec', '~> 2.14.1'
+  gem.add_development_dependency 'rspec', '~> 2.99'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'timecop'
   gem.add_development_dependency 'webmock'

--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'thread_safe'
 
   gem.add_development_dependency 'rake', '~> 11'
-  gem.add_development_dependency 'rspec', '~> 2.99'
+  gem.add_development_dependency 'rspec', '~> 3.5'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'timecop'
   gem.add_development_dependency 'webmock'

--- a/spec/lib/appsignal/auth_check_spec.rb
+++ b/spec/lib/appsignal/auth_check_spec.rb
@@ -5,25 +5,25 @@ describe Appsignal::AuthCheck do
 
   describe "#perform_with_result" do
     it "should give success message" do
-      auth_check.should_receive(:perform).and_return("200")
-      auth_check.perform_with_result.should eq ["200", "AppSignal has confirmed authorization!"]
+      expect(auth_check).to receive(:perform).and_return("200")
+      expect(auth_check.perform_with_result).to eq ["200", "AppSignal has confirmed authorization!"]
     end
 
     it "should give 401 message" do
-      auth_check.should_receive(:perform).and_return("401")
-      auth_check.perform_with_result.should eq ["401", "API key not valid with AppSignal..."]
+      expect(auth_check).to receive(:perform).and_return("401")
+      expect(auth_check.perform_with_result).to eq ["401", "API key not valid with AppSignal..."]
     end
 
     it "should give an error message" do
-      auth_check.should_receive(:perform).and_return("402")
-      auth_check.perform_with_result.should eq ["402", "Could not confirm authorization: 402"]
+      expect(auth_check).to receive(:perform).and_return("402")
+      expect(auth_check.perform_with_result).to eq ["402", "Could not confirm authorization: 402"]
     end
   end
 
   context "transmitting" do
     before do
       @transmitter = double
-      Appsignal::Transmitter.should_receive(:new).with(
+      expect(Appsignal::Transmitter).to receive(:new).with(
         "auth",
         kind_of(Appsignal::Config)
       ).and_return(@transmitter)
@@ -31,7 +31,7 @@ describe Appsignal::AuthCheck do
 
     describe "#perform" do
       it "should not transmit any extra data" do
-        @transmitter.should_receive(:transmit).with({}).and_return({})
+        expect(@transmitter).to receive(:transmit).with({}).and_return({})
         auth_check.perform
       end
     end

--- a/spec/lib/appsignal/capistrano2_spec.rb
+++ b/spec/lib/appsignal/capistrano2_spec.rb
@@ -26,7 +26,7 @@ if DependencyHelper.capistrano2_present?
     end
 
     it "should have a deploy task" do
-      capistrano_config.find_task("appsignal:deploy").should_not be_nil
+      expect(capistrano_config.find_task("appsignal:deploy")).to_not be_nil
     end
 
     describe "appsignal:deploy task" do
@@ -41,7 +41,7 @@ if DependencyHelper.capistrano2_present?
         end
 
         it "should be instantiated with the right params" do
-          Appsignal::Config.should_receive(:new).with(
+          expect(Appsignal::Config).to receive(:new).with(
             project_fixture_path,
             "production",
             {},
@@ -55,7 +55,7 @@ if DependencyHelper.capistrano2_present?
           end
 
           it "should be instantiated with the right params" do
-            Appsignal::Config.should_receive(:new).with(
+            expect(Appsignal::Config).to receive(:new).with(
               project_fixture_path,
               "production",
               { :name => "AppName" },
@@ -70,7 +70,7 @@ if DependencyHelper.capistrano2_present?
             end
 
             it "should be instantiated with the right params" do
-              Appsignal::Config.should_receive(:new).with(
+              expect(Appsignal::Config).to receive(:new).with(
                 project_fixture_path,
                 "rack_production",
                 { :name => "AppName" },
@@ -86,7 +86,7 @@ if DependencyHelper.capistrano2_present?
             end
 
             it "should be instantiated with the right params" do
-              Appsignal::Config.should_receive(:new).with(
+              expect(Appsignal::Config).to receive(:new).with(
                 project_fixture_path,
                 "stage_production",
                 { :name => "AppName" },
@@ -103,7 +103,7 @@ if DependencyHelper.capistrano2_present?
             end
 
             it "should prefer the appsignal_env rather than stage, rails_env and rack_env" do
-              Appsignal::Config.should_receive(:new).with(
+              expect(Appsignal::Config).to receive(:new).with(
                 project_fixture_path,
                 "appsignal_production",
                 { :name => "AppName" },

--- a/spec/lib/appsignal/capistrano3_spec.rb
+++ b/spec/lib/appsignal/capistrano3_spec.rb
@@ -30,7 +30,7 @@ if DependencyHelper.capistrano3_present?
     end
 
     it "should have a deploy task" do
-      Rake::Task.task_defined?("appsignal:deploy").should be_true
+      expect(Rake::Task.task_defined?("appsignal:deploy")).to be_truthy
     end
 
     describe "appsignal:deploy task" do
@@ -41,7 +41,7 @@ if DependencyHelper.capistrano3_present?
 
       context "config" do
         it "should be instantiated with the right params" do
-          Appsignal::Config.should_receive(:new).with(
+          expect(Appsignal::Config).to receive(:new).with(
             project_fixture_path,
             "production",
             {},
@@ -55,7 +55,7 @@ if DependencyHelper.capistrano3_present?
           end
 
           it "should be instantiated with the right params" do
-            Appsignal::Config.should_receive(:new).with(
+            expect(Appsignal::Config).to receive(:new).with(
               project_fixture_path,
               "production",
               { :name => "AppName" },
@@ -70,7 +70,7 @@ if DependencyHelper.capistrano3_present?
             end
 
             it "should be instantiated with the rack env" do
-              Appsignal::Config.should_receive(:new).with(
+              expect(Appsignal::Config).to receive(:new).with(
                 project_fixture_path,
                 "rack_production",
                 { :name => "AppName" },
@@ -86,7 +86,7 @@ if DependencyHelper.capistrano3_present?
             end
 
             it "should prefer the stage rather than rails_env and rack_env" do
-              Appsignal::Config.should_receive(:new).with(
+              expect(Appsignal::Config).to receive(:new).with(
                 project_fixture_path,
                 "stage_production",
                 { :name => "AppName" },
@@ -103,7 +103,7 @@ if DependencyHelper.capistrano3_present?
             end
 
             it "should prefer the appsignal_env rather than stage, rails_env and rack_env" do
-              Appsignal::Config.should_receive(:new).with(
+              expect(Appsignal::Config).to receive(:new).with(
                 project_fixture_path,
                 "appsignal_production",
                 { :name => "AppName" },

--- a/spec/lib/appsignal/cli/demo_spec.rb
+++ b/spec/lib/appsignal/cli/demo_spec.rb
@@ -6,7 +6,7 @@ describe Appsignal::CLI::Demo do
   let(:options) { {} }
   let(:out_stream) { std_stream }
   let(:output) { out_stream.read }
-  before(:all) { Appsignal.stop }
+  before(:context) { Appsignal.stop }
   before do
     ENV.delete("APPSIGNAL_APP_ENV")
     ENV.delete("RAILS_ENV")

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -7,7 +7,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
     let(:config) { project_fixture_config }
     let(:cli) { described_class }
     let(:options) { { :environment => config.env } }
-    before(:all) { Appsignal.stop }
+    before(:context) { Appsignal.stop }
     before do
       if DependencyHelper.rails_present?
         allow(Rails).to receive(:root).and_return(Pathname.new(config.root_path))

--- a/spec/lib/appsignal/cli/helpers_spec.rb
+++ b/spec/lib/appsignal/cli/helpers_spec.rb
@@ -70,7 +70,7 @@ describe Appsignal::CLI::Helpers do
       set_input "y"
       prepare_input
 
-      expect(yes_or_no).to be_true
+      expect(yes_or_no).to be_truthy
     end
 
     it "takes no for an answer" do
@@ -79,7 +79,7 @@ describe Appsignal::CLI::Helpers do
       set_input "n"
       prepare_input
 
-      expect(yes_or_no).to be_false
+      expect(yes_or_no).to be_falsy
     end
   end
 

--- a/spec/lib/appsignal/cli/install_spec.rb
+++ b/spec/lib/appsignal/cli/install_spec.rb
@@ -173,7 +173,7 @@ describe Appsignal::CLI::Install do
         run
 
         expect(output).to_not include "Adding AppSignal integration to Capfile"
-        expect(File.exist?(capfile)).to be_false
+        expect(File.exist?(capfile)).to be_falsy
       end
     end
 
@@ -622,7 +622,7 @@ describe Appsignal::CLI::Install do
         expect(output).to include "We could not detect which framework you are using."
         expect(output).to_not include_env_push_api_key
         expect(output).to_not include_env_app_name
-        expect(File.exist?(config_file_path)).to be_false
+        expect(File.exist?(config_file_path)).to be_falsy
       end
     end
   end

--- a/spec/lib/appsignal/cli_spec.rb
+++ b/spec/lib/appsignal/cli_spec.rb
@@ -4,7 +4,7 @@ describe Appsignal::CLI do
   let(:out_stream) { std_stream }
   let(:output) { out_stream.read }
   let(:cli) { Appsignal::CLI }
-  before { Dir.stub(:pwd => project_fixture_path) }
+  before { allow(Dir).to receive(:pwd).and_return(project_fixture_path) }
 
   it "should print the help with no arguments, -h and --help" do
     [nil, "-h", "--help"].each do |arg|
@@ -46,7 +46,7 @@ describe Appsignal::CLI do
 
   describe "diagnose" do
     it "should call Appsignal::Diagnose.install" do
-      Appsignal::CLI::Diagnose.should_receive(:run)
+      expect(Appsignal::CLI::Diagnose).to receive(:run)
 
       cli.run([
         "diagnose"

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -39,13 +39,13 @@ describe Appsignal::Config do
         before { ENV["APPSIGNAL_PUSH_API_KEY"] = "abc" }
 
         it "becomes active" do
-          expect(subject).to be_true
+          expect(subject).to be_truthy
         end
       end
 
       context "without APPSIGNAL_PUSH_API_KEY env variable" do
         it "remains inactive" do
-          expect(subject).to be_false
+          expect(subject).to be_falsy
         end
       end
     end
@@ -57,7 +57,7 @@ describe Appsignal::Config do
         around { |example| recognize_as_heroku { example.run } }
 
         it "is set to true" do
-          expect(subject).to be_true
+          expect(subject).to be_truthy
         end
       end
 
@@ -65,7 +65,7 @@ describe Appsignal::Config do
         around { |example| recognize_as_container(:docker) { example.run } }
 
         it "is set to true" do
-          expect(subject).to be_true
+          expect(subject).to be_truthy
         end
       end
 
@@ -73,7 +73,7 @@ describe Appsignal::Config do
         around { |example| recognize_as_container(:none) { example.run } }
 
         it "is set to false" do
-          expect(subject).to be_false
+          expect(subject).to be_falsy
         end
       end
     end
@@ -151,7 +151,7 @@ describe Appsignal::Config do
         subject { config[:running_in_container] }
 
         it "overrides system detected config" do
-          expect(subject).to be_true
+          expect(subject).to be_truthy
         end
       end
 
@@ -169,7 +169,7 @@ describe Appsignal::Config do
           before { ENV["APPSIGNAL_PUSH_API_KEY"] = "abc" }
 
           it "sets given config rather than env variable" do
-            expect(subject).to be_false
+            expect(subject).to be_falsy
           end
         end
       end
@@ -180,8 +180,8 @@ describe Appsignal::Config do
     let(:config) { described_class.new(nil, "production") }
 
     it "is not valid or active" do
-      expect(config.valid?).to be_false
-      expect(config.active?).to be_false
+      expect(config.valid?).to be_falsy
+      expect(config.active?).to be_falsy
     end
   end
 
@@ -189,8 +189,8 @@ describe Appsignal::Config do
     let(:config) { described_class.new(tmp_dir, "production") }
 
     it "is not valid or active" do
-      expect(config.valid?).to be_false
-      expect(config.active?).to be_false
+      expect(config.valid?).to be_falsy
+      expect(config.active?).to be_falsy
     end
   end
 
@@ -198,8 +198,8 @@ describe Appsignal::Config do
     let(:config) { project_fixture_config("production") }
 
     it "is not valid or active" do
-      expect(config.valid?).to be_true
-      expect(config.active?).to be_true
+      expect(config.valid?).to be_truthy
+      expect(config.active?).to be_truthy
     end
 
     it "does not log an error" do
@@ -219,8 +219,8 @@ describe Appsignal::Config do
       around { |example| recognize_as_container(:none) { example.run } }
 
       it "overrides system detected and defaults config" do
-        expect(config[:running_in_container]).to be_true
-        expect(config[:debug]).to be_true
+        expect(config[:running_in_container]).to be_truthy
+        expect(config[:debug]).to be_truthy
       end
     end
 
@@ -228,8 +228,8 @@ describe Appsignal::Config do
       let(:config) { project_fixture_config(:production) }
 
       it "loads the config" do
-        expect(config.valid?).to be_true
-        expect(config.active?).to be_true
+        expect(config.valid?).to be_truthy
+        expect(config.active?).to be_truthy
 
         expect(config[:push_api_key]).to eq("abc")
       end
@@ -239,8 +239,8 @@ describe Appsignal::Config do
       let(:config) { project_fixture_config("nonsense") }
 
       it "is not valid or active" do
-        expect(config.valid?).to be_false
-        expect(config.active?).to be_false
+        expect(config.valid?).to be_falsy
+        expect(config.active?).to be_falsy
       end
 
       it "logs an error" do
@@ -315,14 +315,14 @@ describe Appsignal::Config do
     around { |example| recognize_as_container(:none) { example.run } }
 
     it "overrides config with environment values" do
-      expect(config.valid?).to be_true
-      expect(config.active?).to be_true
+      expect(config.valid?).to be_truthy
+      expect(config.active?).to be_truthy
 
-      expect(config[:running_in_container]).to be_true
+      expect(config[:running_in_container]).to be_truthy
       expect(config[:push_api_key]).to eq "aaa-bbb-ccc"
-      expect(config[:active]).to be_true
+      expect(config[:active]).to be_truthy
       expect(config[:name]).to eq "App name"
-      expect(config[:debug]).to be_true
+      expect(config[:debug]).to be_truthy
       expect(config[:ignore_actions]).to eq ["action1", "action2"]
     end
   end

--- a/spec/lib/appsignal/demo_spec.rb
+++ b/spec/lib/appsignal/demo_spec.rb
@@ -11,7 +11,7 @@ describe Appsignal::Demo do
 
     context "without config" do
       it "returns false" do
-        expect(silence { subject }).to be_false
+        expect(silence { subject }).to be_falsy
       end
     end
 
@@ -20,7 +20,7 @@ describe Appsignal::Demo do
       before { Appsignal.config = config }
 
       it "returns true" do
-        expect(subject).to be_true
+        expect(subject).to be_truthy
       end
 
       it "creates demonstration samples" do

--- a/spec/lib/appsignal/event_formatter/action_view/render_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/action_view/render_formatter_spec.rb
@@ -2,17 +2,20 @@ if DependencyHelper.rails_present?
   require "action_view"
 
   describe Appsignal::EventFormatter::ActionView::RenderFormatter do
-    before { Rails.root.stub(:to_s => "/var/www/app/20130101") }
+    before { allow(Rails.root).to receive(:to_s).and_return("/var/www/app/20130101") }
     let(:klass) { Appsignal::EventFormatter::ActionView::RenderFormatter }
     let(:formatter) { klass.new }
 
     it "should register render_partial.action_view and render_template.action_view" do
-      Appsignal::EventFormatter.registered?("render_partial.action_view", klass).should be_true
-      Appsignal::EventFormatter.registered?("render_template.action_view", klass).should be_true
+      expect(Appsignal::EventFormatter.registered?("render_partial.action_view", klass)).to be_truthy
+      expect(Appsignal::EventFormatter.registered?("render_template.action_view", klass)).to be_truthy
     end
 
     describe "#root_path" do
-      its(:root_path) { should eq "/var/www/app/20130101/" }
+      describe '#root_path' do
+        subject { super().root_path }
+        it { is_expected.to eq "/var/www/app/20130101/" }
+      end
     end
 
     describe "#format" do
@@ -21,19 +24,19 @@ if DependencyHelper.rails_present?
       context "with an identifier" do
         let(:payload) { { :identifier => "/var/www/app/20130101/app/views/home/index/html.erb" } }
 
-        it { should eq ["app/views/home/index/html.erb", nil] }
+        it { is_expected.to eq ["app/views/home/index/html.erb", nil] }
       end
 
       context "with a frozen identifier" do
         let(:payload) { { :identifier => "/var/www/app/20130101/app/views/home/index/html.erb".freeze } }
 
-        it { should eq ["app/views/home/index/html.erb", nil] }
+        it { is_expected.to eq ["app/views/home/index/html.erb", nil] }
       end
 
       context "without an identifier" do
         let(:payload) { {} }
 
-        it { should be_nil }
+        it { is_expected.to be_nil }
       end
     end
   end

--- a/spec/lib/appsignal/event_formatter/action_view/render_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/action_view/render_formatter_spec.rb
@@ -12,9 +12,10 @@ if DependencyHelper.rails_present?
     end
 
     describe "#root_path" do
-      describe '#root_path' do
-        subject { super().root_path }
-        it { is_expected.to eq "/var/www/app/20130101/" }
+      subject { formatter.root_path }
+
+      it "returns Rails root path" do
+        is_expected.to eq "/var/www/app/20130101/"
       end
     end
 

--- a/spec/lib/appsignal/event_formatter/active_record/instantiation_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/active_record/instantiation_formatter_spec.rb
@@ -3,7 +3,7 @@ describe Appsignal::EventFormatter::ActiveRecord::InstantiationFormatter do
   let(:formatter) { klass.new }
 
   it "should register instantiation.active_record" do
-    Appsignal::EventFormatter.registered?("instantiation.active_record", klass).should be_true
+    expect(Appsignal::EventFormatter.registered?("instantiation.active_record", klass)).to be_truthy
   end
 
   describe "#format" do
@@ -16,6 +16,6 @@ describe Appsignal::EventFormatter::ActiveRecord::InstantiationFormatter do
 
     subject { formatter.format(payload) }
 
-    it { should eq ["User", nil] }
+    it { is_expected.to eq ["User", nil] }
   end
 end

--- a/spec/lib/appsignal/event_formatter/active_record/sql_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/active_record/sql_formatter_spec.rb
@@ -3,7 +3,7 @@ describe Appsignal::EventFormatter::ActiveRecord::InstantiationFormatter do
   let(:formatter) { klass.new }
 
   it "should register sql.active_record" do
-    Appsignal::EventFormatter.registered?("sql.active_record", klass).should be_true
+    expect(Appsignal::EventFormatter.registered?("sql.active_record", klass)).to be_truthy
   end
 
   describe "#format" do
@@ -16,6 +16,6 @@ describe Appsignal::EventFormatter::ActiveRecord::InstantiationFormatter do
 
     subject { formatter.format(payload) }
 
-    it { should eq ["User load", "SELECT * FROM users", 1] }
+    it { is_expected.to eq ["User load", "SELECT * FROM users", 1] }
   end
 end

--- a/spec/lib/appsignal/event_formatter/elastic_search/search_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/elastic_search/search_formatter_spec.rb
@@ -5,7 +5,7 @@ describe Appsignal::EventFormatter::ElasticSearch::SearchFormatter do
   it "should register query.moped" do
     expect(
       Appsignal::EventFormatter.registered?("search.elasticsearch", klass)
-    ).to be_true
+    ).to be_truthy
   end
 
   describe "#format" do

--- a/spec/lib/appsignal/event_formatter/faraday/request_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/faraday/request_formatter_spec.rb
@@ -3,7 +3,7 @@ describe Appsignal::EventFormatter::Faraday::RequestFormatter do
   let(:formatter) { klass.new }
 
   it "should register request.faraday" do
-    Appsignal::EventFormatter.registered?("request.faraday", klass).should be_true
+    expect(Appsignal::EventFormatter.registered?("request.faraday", klass)).to be_truthy
   end
 
   describe "#format" do
@@ -16,6 +16,6 @@ describe Appsignal::EventFormatter::Faraday::RequestFormatter do
 
     subject { formatter.format(payload) }
 
-    it { should eq ["GET http://example.org", "GET http://example.org/hello/world"] }
+    it { is_expected.to eq ["GET http://example.org", "GET http://example.org/hello/world"] }
   end
 end

--- a/spec/lib/appsignal/event_formatter/moped/query_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/moped/query_formatter_spec.rb
@@ -3,7 +3,7 @@ describe Appsignal::EventFormatter::Moped::QueryFormatter do
   let(:formatter) { klass.new }
 
   it "should register query.moped" do
-    Appsignal::EventFormatter.registered?("query.moped", klass).should be_true
+    expect(Appsignal::EventFormatter.registered?("query.moped", klass)).to be_truthy
   end
 
   describe "#format" do
@@ -13,7 +13,7 @@ describe Appsignal::EventFormatter::Moped::QueryFormatter do
     context "without ops in the payload" do
       let(:payload) { {} }
 
-      it { should be_nil }
+      it { is_expected.to be_nil }
     end
 
     context "Moped::Protocol::Command" do
@@ -25,7 +25,7 @@ describe Appsignal::EventFormatter::Moped::QueryFormatter do
         )
       end
 
-      it { should eq ["Command", '{:database=>"database.collection", :selector=>{"query"=>"?"}}'] }
+      it { is_expected.to eq ["Command", '{:database=>"database.collection", :selector=>{"query"=>"?"}}'] }
     end
 
     context "Moped::Protocol::Query" do
@@ -41,7 +41,7 @@ describe Appsignal::EventFormatter::Moped::QueryFormatter do
         )
       end
 
-      it { should eq ["Query", '{:database=>"database.collection", :selector=>{"_id"=>"?"}, :flags=>[], :limit=>0, :skip=>0, :fields=>nil}'] }
+      it { is_expected.to eq ["Query", '{:database=>"database.collection", :selector=>{"_id"=>"?"}, :flags=>[], :limit=>0, :skip=>0, :fields=>nil}'] }
     end
 
     context "Moped::Protocol::Delete" do
@@ -54,7 +54,7 @@ describe Appsignal::EventFormatter::Moped::QueryFormatter do
         )
       end
 
-      it { should eq ["Delete", '{:database=>"database.collection", :selector=>{"_id"=>"?"}, :flags=>[]}'] }
+      it { is_expected.to eq ["Delete", '{:database=>"database.collection", :selector=>{"_id"=>"?"}, :flags=>[]}'] }
     end
 
     context "Moped::Protocol::Insert" do
@@ -70,7 +70,7 @@ describe Appsignal::EventFormatter::Moped::QueryFormatter do
         )
       end
 
-      it { should eq ["Insert", '{:database=>"database.collection", :documents=>{"_id"=>"?", "events"=>"?"}, :count=>2, :flags=>[]}'] }
+      it { is_expected.to eq ["Insert", '{:database=>"database.collection", :documents=>{"_id"=>"?", "events"=>"?"}, :count=>2, :flags=>[]}'] }
     end
 
     context "Moped::Protocol::Update" do
@@ -84,7 +84,7 @@ describe Appsignal::EventFormatter::Moped::QueryFormatter do
         )
       end
 
-      it { should eq ["Update", '{:database=>"database.collection", :selector=>{"_id"=>"?"}, :update=>{"user.?"=>"?"}, :flags=>[]}'] }
+      it { is_expected.to eq ["Update", '{:database=>"database.collection", :selector=>{"_id"=>"?"}, :update=>{"user.?"=>"?"}, :flags=>[]}'] }
     end
 
     context "Moped::Protocol::KillCursors" do
@@ -95,7 +95,7 @@ describe Appsignal::EventFormatter::Moped::QueryFormatter do
         )
       end
 
-      it { should eq ["KillCursors", "{:number_of_cursor_ids=>2}"] }
+      it { is_expected.to eq ["KillCursors", "{:number_of_cursor_ids=>2}"] }
     end
 
     context "Moped::Protocol::Other" do
@@ -106,7 +106,7 @@ describe Appsignal::EventFormatter::Moped::QueryFormatter do
         )
       end
 
-      it { should eq ["Other", '{:database=>"database.collection"}'] }
+      it { is_expected.to eq ["Other", '{:database=>"database.collection"}'] }
     end
   end
 end

--- a/spec/lib/appsignal/event_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter_spec.rb
@@ -39,18 +39,18 @@ describe Appsignal::EventFormatter do
 
   context "registering and unregistering formatters" do
     it "should register a formatter" do
-      klass.formatters["mock"].should be_instance_of(MockFormatter)
+      expect(klass.formatters["mock"]).to be_instance_of(MockFormatter)
     end
 
     it "should know wether a formatter is registered" do
-      klass.registered?("mock").should be_true
-      klass.registered?("mock", MockFormatter).should be_true
-      klass.registered?("mock", Hash).should be_false
-      klass.registered?("nonsense").should be_false
+      expect(klass.registered?("mock")).to be_truthy
+      expect(klass.registered?("mock", MockFormatter)).to be_truthy
+      expect(klass.registered?("mock", Hash)).to be_falsy
+      expect(klass.registered?("nonsense")).to be_falsy
     end
 
     it "doesn't register formatters that raise a name error in the initializer" do
-      klass.registered?("mock.dependent").should be_false
+      expect(klass.registered?("mock.dependent")).to be_falsy
     end
 
     it "doesn't register formatters that don't have a format(payload) method" do
@@ -59,42 +59,42 @@ describe Appsignal::EventFormatter do
 
       Appsignal::EventFormatter.initialize_formatters
 
-      klass.registered?("mock.missing_format").should be_false
-      klass.registered?("mock.incorrect_format").should be_false
+      expect(klass.registered?("mock.missing_format")).to be_falsy
+      expect(klass.registered?("mock.incorrect_format")).to be_falsy
     end
 
     it "should register a custom formatter" do
       klass.register("mock.specific", MockFormatter)
       Appsignal::EventFormatter.initialize_formatters
 
-      klass.formatter_classes["mock.specific"].should eq MockFormatter
-      klass.registered?("mock.specific").should be_true
-      klass.formatters["mock.specific"].should be_instance_of(MockFormatter)
-      klass.formatters["mock.specific"].body.should eq "some value"
+      expect(klass.formatter_classes["mock.specific"]).to eq MockFormatter
+      expect(klass.registered?("mock.specific")).to be_truthy
+      expect(klass.formatters["mock.specific"]).to be_instance_of(MockFormatter)
+      expect(klass.formatters["mock.specific"].body).to eq "some value"
     end
 
     it "should not have a formatter that's not registered" do
-      klass.formatters["nonsense"].should be_nil
+      expect(klass.formatters["nonsense"]).to be_nil
     end
 
     it "should unregister a formatter if the registered one has the same class" do
       klass.register("mock.unregister", MockFormatter)
 
       klass.unregister("mock.unregister", Hash)
-      klass.registered?("mock.unregister").should be_true
+      expect(klass.registered?("mock.unregister")).to be_truthy
 
       klass.unregister("mock.unregister", MockFormatter)
-      klass.registered?("mock.unregister").should be_false
+      expect(klass.registered?("mock.unregister")).to be_falsy
     end
   end
 
   context "calling formatters" do
     it "should return nil if there is no formatter registered" do
-      klass.format("nonsense", {}).should be_nil
+      expect(klass.format("nonsense", {})).to be_nil
     end
 
     it "should call the formatter if it is registered and use a value set in the initializer" do
-      klass.format("mock", {}).should eq ["title", "some value"]
+      expect(klass.format("mock", {})).to eq ["title", "some value"]
     end
   end
 end

--- a/spec/lib/appsignal/extension_spec.rb
+++ b/spec/lib/appsignal/extension_spec.rb
@@ -97,10 +97,10 @@ describe "extension loading and operation" do
   context "when the extension library cannot be loaded" do
     subject { Appsignal::Extension }
 
-    before :all do
+    before :context do
       Appsignal.extension_loaded = false
     end
-    after :all do
+    after :context do
       Appsignal.extension_loaded = true
     end
 

--- a/spec/lib/appsignal/extension_spec.rb
+++ b/spec/lib/appsignal/extension_spec.rb
@@ -4,21 +4,21 @@ describe "extension loading and operation" do
   describe ".agent_config" do
     subject { Appsignal::Extension.agent_config }
 
-    it { should have_key("version") }
-    it { should have_key("triples") }
+    it { is_expected.to have_key("version") }
+    it { is_expected.to have_key("triples") }
   end
 
   describe ".agent_version" do
     subject { Appsignal::Extension.agent_version }
 
-    it { should_not be_nil }
+    it { is_expected.to_not be_nil }
   end
 
   context "when the extension library can be loaded" do
     subject { Appsignal::Extension }
 
     it "should indicate that the extension is loaded" do
-      Appsignal.extension_loaded?.should be_true
+      expect(Appsignal.extension_loaded?).to be_truthy
     end
 
     it "should have a start and stop method" do
@@ -105,7 +105,7 @@ describe "extension loading and operation" do
     end
 
     it "should indicate that the extension is not loaded" do
-      Appsignal.extension_loaded?.should be_false
+      expect(Appsignal.extension_loaded?).to be_falsy
     end
 
     it "should not raise errors when methods are called" do

--- a/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
@@ -1,6 +1,6 @@
 describe Appsignal::Hooks::ActiveSupportNotificationsHook do
   if active_support_present?
-    before :all do
+    before :context do
       start_agent
     end
     before do

--- a/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
@@ -10,8 +10,9 @@ describe Appsignal::Hooks::ActiveSupportNotificationsHook do
     let(:notifier) { ActiveSupport::Notifications::Fanout.new }
     let(:instrumenter) { ActiveSupport::Notifications::Instrumenter.new(notifier) }
 
-    describe '#dependencies_present?' do
-      subject { super().dependencies_present? }
+    describe "#dependencies_present?" do
+      subject { described_class.new.dependencies_present? }
+
       it { is_expected.to be_truthy }
     end
 
@@ -40,8 +41,9 @@ describe Appsignal::Hooks::ActiveSupportNotificationsHook do
       expect(return_value).to eq "value"
     end
   else
-    describe '#dependencies_present?' do
-      subject { super().dependencies_present? }
+    describe "#dependencies_present?" do
+      subject { described_class.new.dependencies_present? }
+
       it { is_expected.to be_falsy }
     end
   end

--- a/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
@@ -10,7 +10,10 @@ describe Appsignal::Hooks::ActiveSupportNotificationsHook do
     let(:notifier) { ActiveSupport::Notifications::Fanout.new }
     let(:instrumenter) { ActiveSupport::Notifications::Instrumenter.new(notifier) }
 
-    its(:dependencies_present?) { should be_true }
+    describe '#dependencies_present?' do
+      subject { super().dependencies_present? }
+      it { is_expected.to be_truthy }
+    end
 
     it "should instrument an AS notifications instrument call with a block" do
       expect(Appsignal::Transaction.current).to receive(:start_event)
@@ -37,6 +40,9 @@ describe Appsignal::Hooks::ActiveSupportNotificationsHook do
       expect(return_value).to eq "value"
     end
   else
-    its(:dependencies_present?) { should be_false }
+    describe '#dependencies_present?' do
+      subject { super().dependencies_present? }
+      it { is_expected.to be_falsy }
+    end
   end
 end

--- a/spec/lib/appsignal/hooks/celluloid_spec.rb
+++ b/spec/lib/appsignal/hooks/celluloid_spec.rb
@@ -1,13 +1,13 @@
 describe Appsignal::Hooks::CelluloidHook do
   context "with celluloid" do
-    before :all do
+    before :context do
       module Celluloid
         def self.shutdown
         end
       end
       Appsignal::Hooks::CelluloidHook.new.install
     end
-    after :all do
+    after :context do
       Object.send(:remove_const, :Celluloid)
     end
 

--- a/spec/lib/appsignal/hooks/celluloid_spec.rb
+++ b/spec/lib/appsignal/hooks/celluloid_spec.rb
@@ -11,8 +11,9 @@ describe Appsignal::Hooks::CelluloidHook do
       Object.send(:remove_const, :Celluloid)
     end
 
-    describe '#dependencies_present?' do
-      subject { super().dependencies_present? }
+    describe "#dependencies_present?" do
+      subject { described_class.new.dependencies_present? }
+
       it { is_expected.to be_truthy }
     end
 
@@ -25,8 +26,9 @@ describe Appsignal::Hooks::CelluloidHook do
   end
 
   context "without celluloid" do
-    describe '#dependencies_present?' do
-      subject { super().dependencies_present? }
+    describe "#dependencies_present?" do
+      subject { described_class.new.dependencies_present? }
+
       it { is_expected.to be_falsy }
     end
   end

--- a/spec/lib/appsignal/hooks/celluloid_spec.rb
+++ b/spec/lib/appsignal/hooks/celluloid_spec.rb
@@ -11,7 +11,10 @@ describe Appsignal::Hooks::CelluloidHook do
       Object.send(:remove_const, :Celluloid)
     end
 
-    its(:dependencies_present?) { should be_true }
+    describe '#dependencies_present?' do
+      subject { super().dependencies_present? }
+      it { is_expected.to be_truthy }
+    end
 
     specify { expect(Appsignal).to receive(:stop) }
     specify { expect(Celluloid).to receive(:shutdown_without_appsignal) }
@@ -22,6 +25,9 @@ describe Appsignal::Hooks::CelluloidHook do
   end
 
   context "without celluloid" do
-    its(:dependencies_present?) { should be_false }
+    describe '#dependencies_present?' do
+      subject { super().dependencies_present? }
+      it { is_expected.to be_falsy }
+    end
   end
 end

--- a/spec/lib/appsignal/hooks/data_mapper_spec.rb
+++ b/spec/lib/appsignal/hooks/data_mapper_spec.rb
@@ -15,8 +15,9 @@ describe Appsignal::Hooks::DataMapperHook do
       Object.send(:remove_const, :DataObjects)
     end
 
-    describe '#dependencies_present?' do
-      subject { super().dependencies_present? }
+    describe "#dependencies_present?" do
+      subject { described_class.new.dependencies_present? }
+
       it { is_expected.to be_truthy }
     end
 
@@ -29,8 +30,9 @@ describe Appsignal::Hooks::DataMapperHook do
   end
 
   context "without datamapper" do
-    describe '#dependencies_present?' do
-      subject { super().dependencies_present? }
+    describe "#dependencies_present?" do
+      subject { described_class.new.dependencies_present? }
+
       it { is_expected.to be_falsy }
     end
   end

--- a/spec/lib/appsignal/hooks/data_mapper_spec.rb
+++ b/spec/lib/appsignal/hooks/data_mapper_spec.rb
@@ -1,6 +1,6 @@
 describe Appsignal::Hooks::DataMapperHook do
   context "with datamapper" do
-    before :all do
+    before :context do
       module DataMapper
       end
       module DataObjects
@@ -10,7 +10,7 @@ describe Appsignal::Hooks::DataMapperHook do
       Appsignal::Hooks::DataMapperHook.new.install
     end
 
-    after :all do
+    after :context do
       Object.send(:remove_const, :DataMapper)
       Object.send(:remove_const, :DataObjects)
     end

--- a/spec/lib/appsignal/hooks/data_mapper_spec.rb
+++ b/spec/lib/appsignal/hooks/data_mapper_spec.rb
@@ -15,7 +15,10 @@ describe Appsignal::Hooks::DataMapperHook do
       Object.send(:remove_const, :DataObjects)
     end
 
-    its(:dependencies_present?) { should be_true }
+    describe '#dependencies_present?' do
+      subject { super().dependencies_present? }
+      it { is_expected.to be_truthy }
+    end
 
     it "should install the listener" do
       expect(::DataObjects::Connection).to receive(:include)
@@ -26,6 +29,9 @@ describe Appsignal::Hooks::DataMapperHook do
   end
 
   context "without datamapper" do
-    its(:dependencies_present?) { should be_false }
+    describe '#dependencies_present?' do
+      subject { super().dependencies_present? }
+      it { is_expected.to be_falsy }
+    end
   end
 end

--- a/spec/lib/appsignal/hooks/delayed_job_spec.rb
+++ b/spec/lib/appsignal/hooks/delayed_job_spec.rb
@@ -19,8 +19,9 @@ describe Appsignal::Hooks::DelayedJobHook do
       start_agent
     end
 
-    describe '#dependencies_present?' do
-      subject { super().dependencies_present? }
+    describe "#dependencies_present?" do
+      subject { described_class.new.dependencies_present? }
+
       it { is_expected.to be_truthy }
     end
 
@@ -153,8 +154,9 @@ describe Appsignal::Hooks::DelayedJobHook do
   end
 
   context "without delayed job" do
-    describe '#dependencies_present?' do
-      subject { super().dependencies_present? }
+    describe "#dependencies_present?" do
+      subject { described_class.new.dependencies_present? }
+
       it { is_expected.to be_falsy }
     end
   end

--- a/spec/lib/appsignal/hooks/delayed_job_spec.rb
+++ b/spec/lib/appsignal/hooks/delayed_job_spec.rb
@@ -1,6 +1,6 @@
 describe Appsignal::Hooks::DelayedJobHook do
   context "with delayed job" do
-    before(:all) do
+    before(:context) do
       module Delayed
         class Plugin
           def self.callbacks
@@ -14,7 +14,7 @@ describe Appsignal::Hooks::DelayedJobHook do
         end
       end
     end
-    after(:all) { Object.send(:remove_const, :Delayed) }
+    after(:context) { Object.send(:remove_const, :Delayed) }
     before do
       start_agent
     end

--- a/spec/lib/appsignal/hooks/mongo_ruby_driver_spec.rb
+++ b/spec/lib/appsignal/hooks/mongo_ruby_driver_spec.rb
@@ -3,7 +3,7 @@ describe Appsignal::Hooks::MongoRubyDriverHook do
 
   context "with mongo ruby driver" do
     let(:subscriber) { Appsignal::Hooks::MongoMonitorSubscriber.new }
-    before { Appsignal::Hooks::MongoMonitorSubscriber.stub(:new => subscriber) }
+    before { allow(Appsignal::Hooks::MongoMonitorSubscriber).to receive(:new).and_return(subscriber) }
 
     before(:all) do
       module Mongo
@@ -19,10 +19,13 @@ describe Appsignal::Hooks::MongoRubyDriverHook do
     end
     after(:all) { Object.send(:remove_const, :Mongo) }
 
-    its(:dependencies_present?) { should be_true }
+    describe '#dependencies_present?' do
+      subject { super().dependencies_present? }
+      it { is_expected.to be_truthy }
+    end
 
     it "adds a subscriber to Mongo::Monitoring" do
-      Mongo::Monitoring::Global.should receive(:subscribe)
+      expect(Mongo::Monitoring::Global).to receive(:subscribe)
         .with("command", subscriber)
         .at_least(:once)
 
@@ -31,6 +34,9 @@ describe Appsignal::Hooks::MongoRubyDriverHook do
   end
 
   context "without mongo ruby driver" do
-    its(:dependencies_present?) { should be_false }
+    describe '#dependencies_present?' do
+      subject { super().dependencies_present? }
+      it { is_expected.to be_falsy }
+    end
   end
 end

--- a/spec/lib/appsignal/hooks/mongo_ruby_driver_spec.rb
+++ b/spec/lib/appsignal/hooks/mongo_ruby_driver_spec.rb
@@ -19,8 +19,9 @@ describe Appsignal::Hooks::MongoRubyDriverHook do
     end
     after(:all) { Object.send(:remove_const, :Mongo) }
 
-    describe '#dependencies_present?' do
-      subject { super().dependencies_present? }
+    describe "#dependencies_present?" do
+      subject { described_class.new.dependencies_present? }
+
       it { is_expected.to be_truthy }
     end
 
@@ -34,8 +35,9 @@ describe Appsignal::Hooks::MongoRubyDriverHook do
   end
 
   context "without mongo ruby driver" do
-    describe '#dependencies_present?' do
-      subject { super().dependencies_present? }
+    describe "#dependencies_present?" do
+      subject { described_class.new.dependencies_present? }
+
       it { is_expected.to be_falsy }
     end
   end

--- a/spec/lib/appsignal/hooks/mongo_ruby_driver_spec.rb
+++ b/spec/lib/appsignal/hooks/mongo_ruby_driver_spec.rb
@@ -5,7 +5,7 @@ describe Appsignal::Hooks::MongoRubyDriverHook do
     let(:subscriber) { Appsignal::Hooks::MongoMonitorSubscriber.new }
     before { allow(Appsignal::Hooks::MongoMonitorSubscriber).to receive(:new).and_return(subscriber) }
 
-    before(:all) do
+    before(:context) do
       module Mongo
         module Monitoring
           COMMAND = "command"
@@ -17,7 +17,7 @@ describe Appsignal::Hooks::MongoRubyDriverHook do
         end
       end
     end
-    after(:all) { Object.send(:remove_const, :Mongo) }
+    after(:context) { Object.send(:remove_const, :Mongo) }
 
     describe "#dependencies_present?" do
       subject { described_class.new.dependencies_present? }

--- a/spec/lib/appsignal/hooks/net_http_spec.rb
+++ b/spec/lib/appsignal/hooks/net_http_spec.rb
@@ -1,5 +1,5 @@
 describe Appsignal::Hooks::NetHttpHook do
-  before :all do
+  before :context do
     start_agent
   end
 

--- a/spec/lib/appsignal/hooks/net_http_spec.rb
+++ b/spec/lib/appsignal/hooks/net_http_spec.rb
@@ -4,7 +4,10 @@ describe Appsignal::Hooks::NetHttpHook do
   end
 
   context "with Net::HTTP instrumentation enabled" do
-    its(:dependencies_present?) { should be_true }
+    describe '#dependencies_present?' do
+      subject { super().dependencies_present? }
+      it { is_expected.to be_truthy }
+    end
 
     it "should instrument a http request" do
       Appsignal::Transaction.create("uuid", Appsignal::Transaction::HTTP_REQUEST, "test")
@@ -40,6 +43,9 @@ describe Appsignal::Hooks::NetHttpHook do
     before { Appsignal.config.config_hash[:instrument_net_http] = false }
     after { Appsignal.config.config_hash[:instrument_net_http] = true }
 
-    its(:dependencies_present?) { should be_false }
+    describe '#dependencies_present?' do
+      subject { super().dependencies_present? }
+      it { is_expected.to be_falsy }
+    end
   end
 end

--- a/spec/lib/appsignal/hooks/net_http_spec.rb
+++ b/spec/lib/appsignal/hooks/net_http_spec.rb
@@ -4,8 +4,9 @@ describe Appsignal::Hooks::NetHttpHook do
   end
 
   context "with Net::HTTP instrumentation enabled" do
-    describe '#dependencies_present?' do
-      subject { super().dependencies_present? }
+    describe "#dependencies_present?" do
+      subject { described_class.new.dependencies_present? }
+
       it { is_expected.to be_truthy }
     end
 
@@ -43,8 +44,9 @@ describe Appsignal::Hooks::NetHttpHook do
     before { Appsignal.config.config_hash[:instrument_net_http] = false }
     after { Appsignal.config.config_hash[:instrument_net_http] = true }
 
-    describe '#dependencies_present?' do
-      subject { super().dependencies_present? }
+    describe "#dependencies_present?" do
+      subject { described_class.new.dependencies_present? }
+
       it { is_expected.to be_falsy }
     end
   end

--- a/spec/lib/appsignal/hooks/passenger_spec.rb
+++ b/spec/lib/appsignal/hooks/passenger_spec.rb
@@ -1,10 +1,10 @@
 describe Appsignal::Hooks::PassengerHook do
   context "with passenger" do
-    before(:all) do
+    before(:context) do
       module PhusionPassenger
       end
     end
-    after(:all) { Object.send(:remove_const, :PhusionPassenger) }
+    after(:context) { Object.send(:remove_const, :PhusionPassenger) }
 
     describe "#dependencies_present?" do
       subject { described_class.new.dependencies_present? }

--- a/spec/lib/appsignal/hooks/passenger_spec.rb
+++ b/spec/lib/appsignal/hooks/passenger_spec.rb
@@ -6,17 +6,23 @@ describe Appsignal::Hooks::PassengerHook do
     end
     after(:all) { Object.send(:remove_const, :PhusionPassenger) }
 
-    its(:dependencies_present?) { should be_true }
+    describe '#dependencies_present?' do
+      subject { super().dependencies_present? }
+      it { is_expected.to be_truthy }
+    end
 
     it "adds behavior to stopping_worker_process and starting_worker_process" do
-      PhusionPassenger.should_receive(:on_event).with(:starting_worker_process)
-      PhusionPassenger.should_receive(:on_event).with(:stopping_worker_process)
+      expect(PhusionPassenger).to receive(:on_event).with(:starting_worker_process)
+      expect(PhusionPassenger).to receive(:on_event).with(:stopping_worker_process)
 
       Appsignal::Hooks::PassengerHook.new.install
     end
   end
 
   context "without passenger" do
-    its(:dependencies_present?) { should be_false }
+    describe '#dependencies_present?' do
+      subject { super().dependencies_present? }
+      it { is_expected.to be_falsy }
+    end
   end
 end

--- a/spec/lib/appsignal/hooks/passenger_spec.rb
+++ b/spec/lib/appsignal/hooks/passenger_spec.rb
@@ -6,8 +6,9 @@ describe Appsignal::Hooks::PassengerHook do
     end
     after(:all) { Object.send(:remove_const, :PhusionPassenger) }
 
-    describe '#dependencies_present?' do
-      subject { super().dependencies_present? }
+    describe "#dependencies_present?" do
+      subject { described_class.new.dependencies_present? }
+
       it { is_expected.to be_truthy }
     end
 
@@ -20,8 +21,9 @@ describe Appsignal::Hooks::PassengerHook do
   end
 
   context "without passenger" do
-    describe '#dependencies_present?' do
-      subject { super().dependencies_present? }
+    describe "#dependencies_present?" do
+      subject { described_class.new.dependencies_present? }
+
       it { is_expected.to be_falsy }
     end
   end

--- a/spec/lib/appsignal/hooks/puma_spec.rb
+++ b/spec/lib/appsignal/hooks/puma_spec.rb
@@ -22,7 +22,10 @@ describe Appsignal::Hooks::PumaHook do
     end
     after(:all) { Object.send(:remove_const, :Puma) }
 
-    its(:dependencies_present?) { should be_true }
+    describe '#dependencies_present?' do
+      subject { super().dependencies_present? }
+      it { is_expected.to be_truthy }
+    end
 
     context "when installed" do
       before do
@@ -32,8 +35,8 @@ describe Appsignal::Hooks::PumaHook do
       it "adds behavior to Unicorn::Worker#close" do
         cluster = Puma::Cluster.new
 
-        Appsignal.should_receive(:stop)
-        cluster.should_receive(:stop_workers_without_appsignal)
+        expect(Appsignal).to receive(:stop)
+        expect(cluster).to receive(:stop_workers_without_appsignal)
 
         cluster.stop_workers
       end
@@ -47,8 +50,8 @@ describe Appsignal::Hooks::PumaHook do
       end
 
       it "should add a before shutdown worker callback" do
-        Puma.cli_config.options[:before_worker_boot].first.should be_a(Proc)
-        Puma.cli_config.options[:before_worker_shutdown].first.should be_a(Proc)
+        expect(Puma.cli_config.options[:before_worker_boot].first).to be_a(Proc)
+        expect(Puma.cli_config.options[:before_worker_shutdown].first).to be_a(Proc)
       end
     end
 
@@ -60,13 +63,16 @@ describe Appsignal::Hooks::PumaHook do
       end
 
       it "should add a before shutdown worker callback" do
-        Puma.cli_config.options[:before_worker_boot].first.should be_a(Proc)
-        Puma.cli_config.options[:before_worker_shutdown].first.should be_a(Proc)
+        expect(Puma.cli_config.options[:before_worker_boot].first).to be_a(Proc)
+        expect(Puma.cli_config.options[:before_worker_shutdown].first).to be_a(Proc)
       end
     end
   end
 
   context "without puma" do
-    its(:dependencies_present?) { should be_false }
+    describe '#dependencies_present?' do
+      subject { super().dependencies_present? }
+      it { is_expected.to be_falsy }
+    end
   end
 end

--- a/spec/lib/appsignal/hooks/puma_spec.rb
+++ b/spec/lib/appsignal/hooks/puma_spec.rb
@@ -22,8 +22,9 @@ describe Appsignal::Hooks::PumaHook do
     end
     after(:all) { Object.send(:remove_const, :Puma) }
 
-    describe '#dependencies_present?' do
-      subject { super().dependencies_present? }
+    describe "#dependencies_present?" do
+      subject { described_class.new.dependencies_present? }
+
       it { is_expected.to be_truthy }
     end
 
@@ -70,8 +71,9 @@ describe Appsignal::Hooks::PumaHook do
   end
 
   context "without puma" do
-    describe '#dependencies_present?' do
-      subject { super().dependencies_present? }
+    describe "#dependencies_present?" do
+      subject { described_class.new.dependencies_present? }
+
       it { is_expected.to be_falsy }
     end
   end

--- a/spec/lib/appsignal/hooks/puma_spec.rb
+++ b/spec/lib/appsignal/hooks/puma_spec.rb
@@ -1,6 +1,6 @@
 describe Appsignal::Hooks::PumaHook do
   context "with puma" do
-    before(:all) do
+    before(:context) do
       class Puma
         def self.cli_config
           @cli_config ||= CliConfig.new
@@ -20,7 +20,7 @@ describe Appsignal::Hooks::PumaHook do
         end
       end
     end
-    after(:all) { Object.send(:remove_const, :Puma) }
+    after(:context) { Object.send(:remove_const, :Puma) }
 
     describe "#dependencies_present?" do
       subject { described_class.new.dependencies_present? }

--- a/spec/lib/appsignal/hooks/rake_spec.rb
+++ b/spec/lib/appsignal/hooks/rake_spec.rb
@@ -4,7 +4,7 @@ describe Appsignal::Hooks::RakeHook do
   let(:task) { Rake::Task.new("task:name", Rake::Application.new) }
   before(:all) do
     Appsignal.config = project_fixture_config
-    expect(Appsignal.active?).to be_true
+    expect(Appsignal.active?).to be_truthy
     Appsignal::Hooks.load_hooks
   end
 

--- a/spec/lib/appsignal/hooks/rake_spec.rb
+++ b/spec/lib/appsignal/hooks/rake_spec.rb
@@ -2,7 +2,7 @@ require "rake"
 
 describe Appsignal::Hooks::RakeHook do
   let(:task) { Rake::Task.new("task:name", Rake::Application.new) }
-  before(:all) do
+  before(:context) do
     Appsignal.config = project_fixture_config
     expect(Appsignal.active?).to be_truthy
     Appsignal::Hooks.load_hooks

--- a/spec/lib/appsignal/hooks/redis_spec.rb
+++ b/spec/lib/appsignal/hooks/redis_spec.rb
@@ -1,10 +1,10 @@
 describe Appsignal::Hooks::RedisHook do
-  before :all do
+  before :context do
     start_agent
   end
 
   context "with redis" do
-    before :all do
+    before :context do
       class Redis
         class Client
           def process(_commands)
@@ -16,11 +16,11 @@ describe Appsignal::Hooks::RedisHook do
     end
 
     context "with instrumentation enabled" do
-      before :all do
+      before :context do
         Appsignal.config.config_hash[:instrument_redis] = true
         Appsignal::Hooks::RedisHook.new.install
       end
-      after(:all) { Object.send(:remove_const, :Redis) }
+      after(:context) { Object.send(:remove_const, :Redis) }
 
       describe "#dependencies_present?" do
         subject { described_class.new.dependencies_present? }
@@ -43,7 +43,7 @@ describe Appsignal::Hooks::RedisHook do
     end
 
     context "with instrumentation disabled" do
-      before :all do
+      before :context do
         Appsignal.config.config_hash[:instrument_net_http] = false
       end
 

--- a/spec/lib/appsignal/hooks/redis_spec.rb
+++ b/spec/lib/appsignal/hooks/redis_spec.rb
@@ -4,60 +4,61 @@ describe Appsignal::Hooks::RedisHook do
   end
 
   context "with redis" do
-    context "with redis" do
-      before :all do
-        class Redis
-          class Client
-            def process(_commands)
-              1
-            end
+    before :all do
+      class Redis
+        class Client
+          def process(_commands)
+            1
           end
-          VERSION = "1.0"
         end
-      end
-
-      context "and redis instrumentation enabled" do
-        before :all do
-          Appsignal.config.config_hash[:instrument_redis] = true
-          Appsignal::Hooks::RedisHook.new.install
-        end
-        after(:all) { Object.send(:remove_const, :Redis) }
-
-        describe '#dependencies_present?' do
-          subject { super().dependencies_present? }
-          it { is_expected.to be_truthy }
-        end
-
-        it "should instrument a redis call" do
-          Appsignal::Transaction.create("uuid", Appsignal::Transaction::HTTP_REQUEST, "test")
-          expect(Appsignal::Transaction.current).to receive(:start_event)
-            .at_least(:once)
-          expect(Appsignal::Transaction.current).to receive(:finish_event)
-            .at_least(:once)
-            .with("query.redis", nil, nil, 0)
-
-          client = Redis::Client.new
-
-          expect(client.process([])).to eq 1
-        end
+        VERSION = "1.0"
       end
     end
 
-    context "and redis instrumentation disabled" do
+    context "with instrumentation enabled" do
+      before :all do
+        Appsignal.config.config_hash[:instrument_redis] = true
+        Appsignal::Hooks::RedisHook.new.install
+      end
+      after(:all) { Object.send(:remove_const, :Redis) }
+
+      describe "#dependencies_present?" do
+        subject { described_class.new.dependencies_present? }
+
+        it { is_expected.to be_truthy }
+      end
+
+      it "should instrument a redis call" do
+        Appsignal::Transaction.create("uuid", Appsignal::Transaction::HTTP_REQUEST, "test")
+        expect(Appsignal::Transaction.current).to receive(:start_event)
+          .at_least(:once)
+        expect(Appsignal::Transaction.current).to receive(:finish_event)
+          .at_least(:once)
+          .with("query.redis", nil, nil, 0)
+
+        client = Redis::Client.new
+
+        expect(client.process([])).to eq 1
+      end
+    end
+
+    context "with instrumentation disabled" do
       before :all do
         Appsignal.config.config_hash[:instrument_net_http] = false
       end
 
-      describe '#dependencies_present?' do
-        subject { super().dependencies_present? }
+      describe "#dependencies_present?" do
+        subject { described_class.new.dependencies_present? }
+
         it { is_expected.to be_falsy }
       end
     end
   end
 
   context "without redis" do
-    describe '#dependencies_present?' do
-      subject { super().dependencies_present? }
+    describe "#dependencies_present?" do
+      subject { described_class.new.dependencies_present? }
+
       it { is_expected.to be_falsy }
     end
   end

--- a/spec/lib/appsignal/hooks/redis_spec.rb
+++ b/spec/lib/appsignal/hooks/redis_spec.rb
@@ -23,7 +23,10 @@ describe Appsignal::Hooks::RedisHook do
         end
         after(:all) { Object.send(:remove_const, :Redis) }
 
-        its(:dependencies_present?) { should be_true }
+        describe '#dependencies_present?' do
+          subject { super().dependencies_present? }
+          it { is_expected.to be_truthy }
+        end
 
         it "should instrument a redis call" do
           Appsignal::Transaction.create("uuid", Appsignal::Transaction::HTTP_REQUEST, "test")
@@ -35,7 +38,7 @@ describe Appsignal::Hooks::RedisHook do
 
           client = Redis::Client.new
 
-          client.process([]).should eq 1
+          expect(client.process([])).to eq 1
         end
       end
     end
@@ -45,11 +48,17 @@ describe Appsignal::Hooks::RedisHook do
         Appsignal.config.config_hash[:instrument_net_http] = false
       end
 
-      its(:dependencies_present?) { should be_false }
+      describe '#dependencies_present?' do
+        subject { super().dependencies_present? }
+        it { is_expected.to be_falsy }
+      end
     end
   end
 
   context "without redis" do
-    its(:dependencies_present?) { should be_false }
+    describe '#dependencies_present?' do
+      subject { super().dependencies_present? }
+      it { is_expected.to be_falsy }
+    end
   end
 end

--- a/spec/lib/appsignal/hooks/sequel_spec.rb
+++ b/spec/lib/appsignal/hooks/sequel_spec.rb
@@ -6,7 +6,10 @@ describe Appsignal::Hooks::SequelHook do
       start_agent
     end
 
-    its(:dependencies_present?) { should be_true }
+    describe '#dependencies_present?' do
+      subject { super().dependencies_present? }
+      it { is_expected.to be_truthy }
+    end
 
     context "with a transaction" do
       let(:transaction) { Appsignal::Transaction.current }
@@ -27,6 +30,9 @@ describe Appsignal::Hooks::SequelHook do
       end
     end
   else
-    its(:dependencies_present?) { should be_false }
+    describe '#dependencies_present?' do
+      subject { super().dependencies_present? }
+      it { is_expected.to be_falsy }
+    end
   end
 end

--- a/spec/lib/appsignal/hooks/sequel_spec.rb
+++ b/spec/lib/appsignal/hooks/sequel_spec.rb
@@ -6,8 +6,9 @@ describe Appsignal::Hooks::SequelHook do
       start_agent
     end
 
-    describe '#dependencies_present?' do
-      subject { super().dependencies_present? }
+    describe "#dependencies_present?" do
+      subject { described_class.new.dependencies_present? }
+
       it { is_expected.to be_truthy }
     end
 
@@ -30,8 +31,9 @@ describe Appsignal::Hooks::SequelHook do
       end
     end
   else
-    describe '#dependencies_present?' do
-      subject { super().dependencies_present? }
+    describe "#dependencies_present?" do
+      subject { described_class.new.dependencies_present? }
+
       it { is_expected.to be_falsy }
     end
   end

--- a/spec/lib/appsignal/hooks/sequel_spec.rb
+++ b/spec/lib/appsignal/hooks/sequel_spec.rb
@@ -2,7 +2,7 @@ describe Appsignal::Hooks::SequelHook do
   if DependencyHelper.sequel_present?
     let(:db) { Sequel.sqlite }
 
-    before :all do
+    before :context do
       start_agent
     end
 

--- a/spec/lib/appsignal/hooks/shoryuken_spec.rb
+++ b/spec/lib/appsignal/hooks/shoryuken_spec.rb
@@ -7,7 +7,7 @@ describe Appsignal::Hooks::ShoryukenMiddleware do
   let(:body) { {} }
 
   before do
-    Appsignal::Transaction.stub(:current => current_transaction)
+    allow(Appsignal::Transaction).to receive(:current).and_return(current_transaction)
     start_agent
   end
 
@@ -24,7 +24,7 @@ describe Appsignal::Hooks::ShoryukenMiddleware do
     end
 
     it "should wrap in a transaction with the correct params" do
-      Appsignal.should_receive(:monitor_transaction).with(
+      expect(Appsignal).to receive(:monitor_transaction).with(
         "perform_job.shoryuken",
         :class => "TestClass",
         :method => "perform",
@@ -50,7 +50,7 @@ describe Appsignal::Hooks::ShoryukenMiddleware do
     let(:error) { VerySpecificError.new }
 
     it "should add the exception to appsignal" do
-      Appsignal::Transaction.any_instance.should_receive(:set_error).with(error)
+      expect_any_instance_of(Appsignal::Transaction).to receive(:set_error).with(error)
     end
 
     after do
@@ -80,10 +80,16 @@ describe Appsignal::Hooks::ShoryukenHook do
       Object.send(:remove_const, :Shoryuken)
     end
 
-    its(:dependencies_present?) { should be_true }
+    describe '#dependencies_present?' do
+      subject { super().dependencies_present? }
+      it { is_expected.to be_truthy }
+    end
   end
 
   context "without shoryuken" do
-    its(:dependencies_present?) { should be_false }
+    describe '#dependencies_present?' do
+      subject { super().dependencies_present? }
+      it { is_expected.to be_falsy }
+    end
   end
 end

--- a/spec/lib/appsignal/hooks/shoryuken_spec.rb
+++ b/spec/lib/appsignal/hooks/shoryuken_spec.rb
@@ -80,15 +80,17 @@ describe Appsignal::Hooks::ShoryukenHook do
       Object.send(:remove_const, :Shoryuken)
     end
 
-    describe '#dependencies_present?' do
-      subject { super().dependencies_present? }
+    describe "#dependencies_present?" do
+      subject { described_class.new.dependencies_present? }
+
       it { is_expected.to be_truthy }
     end
   end
 
   context "without shoryuken" do
-    describe '#dependencies_present?' do
-      subject { super().dependencies_present? }
+    describe "#dependencies_present?" do
+      subject { described_class.new.dependencies_present? }
+
       it { is_expected.to be_falsy }
     end
   end

--- a/spec/lib/appsignal/hooks/shoryuken_spec.rb
+++ b/spec/lib/appsignal/hooks/shoryuken_spec.rb
@@ -68,7 +68,7 @@ end
 
 describe Appsignal::Hooks::ShoryukenHook do
   context "with shoryuken" do
-    before(:all) do
+    before(:context) do
       module Shoryuken
         def self.configure_server
         end
@@ -76,7 +76,7 @@ describe Appsignal::Hooks::ShoryukenHook do
       Appsignal::Hooks::ShoryukenHook.new.install
     end
 
-    after(:all) do
+    after(:context) do
       Object.send(:remove_const, :Shoryuken)
     end
 

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -114,14 +114,14 @@ end
 
 describe Appsignal::Hooks::SidekiqHook do
   context "with sidekiq" do
-    before :all do
+    before :context do
       module Sidekiq
         def self.configure_server
         end
       end
       Appsignal::Hooks::SidekiqHook.new.install
     end
-    after(:all) { Object.send(:remove_const, :Sidekiq) }
+    after(:context) { Object.send(:remove_const, :Sidekiq) }
 
     describe "#dependencies_present?" do
       subject { described_class.new.dependencies_present? }

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -15,13 +15,13 @@ describe Appsignal::Hooks::SidekiqPlugin do
   let(:plugin) { Appsignal::Hooks::SidekiqPlugin.new }
 
   before do
-    Appsignal::Transaction.stub(:current => current_transaction)
+    allow(Appsignal::Transaction).to receive(:current).and_return(current_transaction)
     start_agent
   end
 
   context "with a performance call" do
     it "should wrap in a transaction with the correct params" do
-      Appsignal.should_receive(:monitor_transaction).with(
+      expect(Appsignal).to receive(:monitor_transaction).with(
         "perform_job.sidekiq",
         :class    => "TestClass",
         :method   => "perform",
@@ -56,7 +56,7 @@ describe Appsignal::Hooks::SidekiqPlugin do
       end
 
       it "should wrap in a transaction with the correct params" do
-        Appsignal.should_receive(:monitor_transaction).with(
+        expect(Appsignal).to receive(:monitor_transaction).with(
           "perform_job.sidekiq",
           :class    => "TestClass",
           :method   => "perform",
@@ -83,7 +83,7 @@ describe Appsignal::Hooks::SidekiqPlugin do
     let(:error) { VerySpecificError.new }
 
     it "should add the exception to appsignal" do
-      Appsignal::Transaction.any_instance.should_receive(:set_error).with(error)
+      expect_any_instance_of(Appsignal::Transaction).to receive(:set_error).with(error)
     end
 
     after do
@@ -107,7 +107,7 @@ describe Appsignal::Hooks::SidekiqPlugin do
     end
 
     it "should only add items to the hash that do not appear in JOB_KEYS" do
-      plugin.formatted_metadata(item).should eq("foo" => "bar")
+      expect(plugin.formatted_metadata(item)).to eq("foo" => "bar")
     end
   end
 end
@@ -123,10 +123,16 @@ describe Appsignal::Hooks::SidekiqHook do
     end
     after(:all) { Object.send(:remove_const, :Sidekiq) }
 
-    its(:dependencies_present?) { should be_true }
+    describe '#dependencies_present?' do
+      subject { super().dependencies_present? }
+      it { is_expected.to be_truthy }
+    end
   end
 
   context "without sidekiq" do
-    its(:dependencies_present?) { should be_false }
+    describe '#dependencies_present?' do
+      subject { super().dependencies_present? }
+      it { is_expected.to be_falsy }
+    end
   end
 end

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -123,15 +123,17 @@ describe Appsignal::Hooks::SidekiqHook do
     end
     after(:all) { Object.send(:remove_const, :Sidekiq) }
 
-    describe '#dependencies_present?' do
-      subject { super().dependencies_present? }
+    describe "#dependencies_present?" do
+      subject { described_class.new.dependencies_present? }
+
       it { is_expected.to be_truthy }
     end
   end
 
   context "without sidekiq" do
-    describe '#dependencies_present?' do
-      subject { super().dependencies_present? }
+    describe "#dependencies_present?" do
+      subject { described_class.new.dependencies_present? }
+
       it { is_expected.to be_falsy }
     end
   end

--- a/spec/lib/appsignal/hooks/unicorn_spec.rb
+++ b/spec/lib/appsignal/hooks/unicorn_spec.rb
@@ -16,8 +16,9 @@ describe Appsignal::Hooks::UnicornHook do
     end
     after(:all) { Object.send(:remove_const, :Unicorn) }
 
-    describe '#dependencies_present?' do
-      subject { super().dependencies_present? }
+    describe "#dependencies_present?" do
+      subject { described_class.new.dependencies_present? }
+
       it { is_expected.to be_truthy }
     end
 
@@ -42,8 +43,9 @@ describe Appsignal::Hooks::UnicornHook do
   end
 
   context "without unicorn" do
-    describe '#dependencies_present?' do
-      subject { super().dependencies_present? }
+    describe "#dependencies_present?" do
+      subject { described_class.new.dependencies_present? }
+
       it { is_expected.to be_falsy }
     end
   end

--- a/spec/lib/appsignal/hooks/unicorn_spec.rb
+++ b/spec/lib/appsignal/hooks/unicorn_spec.rb
@@ -1,6 +1,6 @@
 describe Appsignal::Hooks::UnicornHook do
   context "with unicorn" do
-    before :all do
+    before :context do
       module Unicorn
         class HttpServer
           def worker_loop(worker)
@@ -14,7 +14,7 @@ describe Appsignal::Hooks::UnicornHook do
       end
       Appsignal::Hooks::UnicornHook.new.install
     end
-    after(:all) { Object.send(:remove_const, :Unicorn) }
+    after(:context) { Object.send(:remove_const, :Unicorn) }
 
     describe "#dependencies_present?" do
       subject { described_class.new.dependencies_present? }

--- a/spec/lib/appsignal/hooks/unicorn_spec.rb
+++ b/spec/lib/appsignal/hooks/unicorn_spec.rb
@@ -16,14 +16,17 @@ describe Appsignal::Hooks::UnicornHook do
     end
     after(:all) { Object.send(:remove_const, :Unicorn) }
 
-    its(:dependencies_present?) { should be_true }
+    describe '#dependencies_present?' do
+      subject { super().dependencies_present? }
+      it { is_expected.to be_truthy }
+    end
 
     it "adds behavior to Unicorn::HttpServer#worker_loop" do
       server = Unicorn::HttpServer.new
       worker = double
 
-      Appsignal.should_receive(:forked)
-      server.should_receive(:worker_loop_without_appsignal).with(worker)
+      expect(Appsignal).to receive(:forked)
+      expect(server).to receive(:worker_loop_without_appsignal).with(worker)
 
       server.worker_loop(worker)
     end
@@ -31,14 +34,17 @@ describe Appsignal::Hooks::UnicornHook do
     it "adds behavior to Unicorn::Worker#close" do
       worker = Unicorn::Worker.new
 
-      Appsignal.should_receive(:stop)
-      worker.should_receive(:close_without_appsignal)
+      expect(Appsignal).to receive(:stop)
+      expect(worker).to receive(:close_without_appsignal)
 
       worker.close
     end
   end
 
   context "without unicorn" do
-    its(:dependencies_present?) { should be_false }
+    describe '#dependencies_present?' do
+      subject { super().dependencies_present? }
+      it { is_expected.to be_falsy }
+    end
   end
 end

--- a/spec/lib/appsignal/hooks/webmachine_spec.rb
+++ b/spec/lib/appsignal/hooks/webmachine_spec.rb
@@ -2,7 +2,7 @@ describe Appsignal::Hooks::WebmachineHook do
   if DependencyHelper.webmachine_present?
     context "with webmachine" do
       let(:fsm) { Webmachine::Decision::FSM.new(double(:trace? => false), double, double) }
-      before(:all) { start_agent }
+      before(:context) { start_agent }
 
       describe "#dependencies_present?" do
         subject { described_class.new.dependencies_present? }

--- a/spec/lib/appsignal/hooks/webmachine_spec.rb
+++ b/spec/lib/appsignal/hooks/webmachine_spec.rb
@@ -4,7 +4,10 @@ describe Appsignal::Hooks::WebmachineHook do
       let(:fsm) { Webmachine::Decision::FSM.new(double(:trace? => false), double, double) }
       before(:all) { start_agent }
 
-      its(:dependencies_present?) { should be_true }
+      describe '#dependencies_present?' do
+        subject { super().dependencies_present? }
+        it { is_expected.to be_truthy }
+      end
 
       it "should include the run alias methods" do
         expect(fsm).to respond_to(:run_with_appsignal)
@@ -14,11 +17,11 @@ describe Appsignal::Hooks::WebmachineHook do
       it "should include the handle_exceptions alias methods" do
         expect(
           fsm.respond_to?(:handle_exceptions_with_appsignal, true)
-        ).to be_true
+        ).to be_truthy
 
         expect(
           fsm.respond_to?(:handle_exceptions_without_appsignal, true)
-        ).to be_true
+        ).to be_truthy
       end
     end
   end

--- a/spec/lib/appsignal/hooks/webmachine_spec.rb
+++ b/spec/lib/appsignal/hooks/webmachine_spec.rb
@@ -4,8 +4,9 @@ describe Appsignal::Hooks::WebmachineHook do
       let(:fsm) { Webmachine::Decision::FSM.new(double(:trace? => false), double, double) }
       before(:all) { start_agent }
 
-      describe '#dependencies_present?' do
-        subject { super().dependencies_present? }
+      describe "#dependencies_present?" do
+        subject { described_class.new.dependencies_present? }
+
         it { is_expected.to be_truthy }
       end
 
@@ -23,6 +24,12 @@ describe Appsignal::Hooks::WebmachineHook do
           fsm.respond_to?(:handle_exceptions_without_appsignal, true)
         ).to be_truthy
       end
+    end
+  else
+    describe "#dependencies_present?" do
+      subject { described_class.new.dependencies_present? }
+
+      it { is_expected.to be_falsy }
     end
   end
 end

--- a/spec/lib/appsignal/hooks_spec.rb
+++ b/spec/lib/appsignal/hooks_spec.rb
@@ -138,7 +138,7 @@ describe Appsignal::Hooks::Helpers do
     end
 
     context "for a struct" do
-      before :all do
+      before :context do
         TestStruct = Struct.new(:key)
       end
       let(:struct) { TestStruct.new("value") }

--- a/spec/lib/appsignal/hooks_spec.rb
+++ b/spec/lib/appsignal/hooks_spec.rb
@@ -35,43 +35,43 @@ describe Appsignal::Hooks do
   it "should register and install a hook once" do
     Appsignal::Hooks::Hook.register(:mock_present_hook, MockPresentHook)
 
-    Appsignal::Hooks.hooks[:mock_present_hook].should be_instance_of(MockPresentHook)
-    Appsignal::Hooks.hooks[:mock_present_hook].installed?.should be_false
+    expect(Appsignal::Hooks.hooks[:mock_present_hook]).to be_instance_of(MockPresentHook)
+    expect(Appsignal::Hooks.hooks[:mock_present_hook].installed?).to be_falsy
 
-    MockPresentHook.should_receive(:call_something).once
+    expect(MockPresentHook).to receive(:call_something).once
 
     Appsignal::Hooks.load_hooks
     Appsignal::Hooks.load_hooks
     Appsignal::Hooks.load_hooks
-    Appsignal::Hooks.hooks[:mock_present_hook].installed?.should be_true
+    expect(Appsignal::Hooks.hooks[:mock_present_hook].installed?).to be_truthy
     Appsignal::Hooks.hooks.delete(:mock_present_hook)
   end
 
   it "should not install if depencies are not present" do
     Appsignal::Hooks::Hook.register(:mock_not_present_hook, MockNotPresentHook)
 
-    Appsignal::Hooks.hooks[:mock_not_present_hook].should be_instance_of(MockNotPresentHook)
-    Appsignal::Hooks.hooks[:mock_not_present_hook].installed?.should be_false
+    expect(Appsignal::Hooks.hooks[:mock_not_present_hook]).to be_instance_of(MockNotPresentHook)
+    expect(Appsignal::Hooks.hooks[:mock_not_present_hook].installed?).to be_falsy
 
-    MockPresentHook.should_not_receive(:call_something)
+    expect(MockPresentHook).to_not receive(:call_something)
 
     Appsignal::Hooks.load_hooks
 
-    Appsignal::Hooks.hooks[:mock_not_present_hook].installed?.should be_false
+    expect(Appsignal::Hooks.hooks[:mock_not_present_hook].installed?).to be_falsy
     Appsignal::Hooks.hooks.delete(:mock_not_present_hook)
   end
 
   it "should not install if there is an error while installing" do
     Appsignal::Hooks::Hook.register(:mock_error_hook, MockErrorHook)
 
-    Appsignal::Hooks.hooks[:mock_error_hook].should be_instance_of(MockErrorHook)
-    Appsignal::Hooks.hooks[:mock_error_hook].installed?.should be_false
+    expect(Appsignal::Hooks.hooks[:mock_error_hook]).to be_instance_of(MockErrorHook)
+    expect(Appsignal::Hooks.hooks[:mock_error_hook].installed?).to be_falsy
 
-    Appsignal.logger.should_receive(:error).with("Error while installing mock_error_hook hook: error").once
+    expect(Appsignal.logger).to receive(:error).with("Error while installing mock_error_hook hook: error").once
 
     Appsignal::Hooks.load_hooks
 
-    Appsignal::Hooks.hooks[:mock_error_hook].installed?.should be_false
+    expect(Appsignal::Hooks.hooks[:mock_error_hook].installed?).to be_falsy
     Appsignal::Hooks.hooks.delete(:mock_error_hook)
   end
 end
@@ -88,20 +88,20 @@ describe Appsignal::Hooks::Helpers do
     end
 
     it "should truncate the text to 200 chars max" do
-      with_helpers.truncate(very_long_text).should eq "#{"a" * 197}..."
+      expect(with_helpers.truncate(very_long_text)).to eq "#{"a" * 197}..."
     end
   end
 
   describe "#string_or_inspect" do
     context "when string" do
       it "should return the string" do
-        with_helpers.string_or_inspect("foo").should eq "foo"
+        expect(with_helpers.string_or_inspect("foo")).to eq "foo"
       end
     end
 
     context "when integer" do
       it "should return the string" do
-        with_helpers.string_or_inspect(1).should eq "1"
+        expect(with_helpers.string_or_inspect(1)).to eq "1"
       end
     end
 
@@ -109,7 +109,7 @@ describe Appsignal::Hooks::Helpers do
       let(:object) { Object.new }
 
       it "should return the string" do
-        with_helpers.string_or_inspect(object).should eq object.inspect
+        expect(with_helpers.string_or_inspect(object)).to eq object.inspect
       end
     end
   end
@@ -121,18 +121,18 @@ describe Appsignal::Hooks::Helpers do
       context "when the key exists" do
         subject { with_helpers.extract_value(hash, :key) }
 
-        it { should eq "value" }
+        it { is_expected.to eq "value" }
       end
 
       context "when the key does not exist" do
         subject { with_helpers.extract_value(hash, :nonexistent_key) }
 
-        it { should be_nil }
+        it { is_expected.to be_nil }
 
         context "with a default value" do
           subject { with_helpers.extract_value(hash, :nonexistent_key, 1) }
 
-          it { should eq 1 }
+          it { is_expected.to eq 1 }
         end
       end
     end
@@ -146,18 +146,18 @@ describe Appsignal::Hooks::Helpers do
       context "when the key exists" do
         subject { with_helpers.extract_value(struct, :key) }
 
-        it { should eq "value" }
+        it { is_expected.to eq "value" }
       end
 
       context "when the key does not exist" do
         subject { with_helpers.extract_value(struct, :nonexistent_key) }
 
-        it { should be_nil }
+        it { is_expected.to be_nil }
 
         context "with a default value" do
           subject { with_helpers.extract_value(struct, :nonexistent_key, 1) }
 
-          it { should eq 1 }
+          it { is_expected.to eq 1 }
         end
       end
     end
@@ -168,18 +168,18 @@ describe Appsignal::Hooks::Helpers do
       context "when the method exists" do
         subject { with_helpers.extract_value(object, :existing_method) }
 
-        it { should eq "value" }
+        it { is_expected.to eq "value" }
       end
 
       context "when the method does not exist" do
         subject { with_helpers.extract_value(object, :nonexistent_method) }
 
-        it { should be_nil }
+        it { is_expected.to be_nil }
 
         context "and there is a default value" do
           subject { with_helpers.extract_value(object, :nonexistent_method, 1) }
 
-          it { should eq 1 }
+          it { is_expected.to eq 1 }
         end
       end
     end
@@ -189,7 +189,7 @@ describe Appsignal::Hooks::Helpers do
 
       subject { with_helpers.extract_value(object, :existing_method, nil, true) }
 
-      it { should eq "1" }
+      it { is_expected.to eq "1" }
     end
   end
 
@@ -205,7 +205,7 @@ describe Appsignal::Hooks::Helpers do
     end
 
     it "should format the arguments" do
-      with_helpers.format_args(args).should eq([
+      expect(with_helpers.format_args(args)).to eq([
         "Model",
         "1",
         object.inspect,

--- a/spec/lib/appsignal/integrations/data_mapper_spec.rb
+++ b/spec/lib/appsignal/integrations/data_mapper_spec.rb
@@ -25,7 +25,7 @@ describe Appsignal::Hooks::DataMapperLogListener do
       end
     end
 
-    before { Appsignal::Transaction.stub(:current) { transaction } }
+    before { allow(Appsignal::Transaction).to receive(:current) { transaction } }
 
     it "should record the log entry in an event" do
       expect(transaction).to receive(:record_event).with(

--- a/spec/lib/appsignal/integrations/grape_spec.rb
+++ b/spec/lib/appsignal/integrations/grape_spec.rb
@@ -47,7 +47,7 @@ if DependencyHelper.grape_present?
         let(:transaction) { http_request_transaction }
         before :all do
           Appsignal.config = project_fixture_config
-          expect(Appsignal.active?).to be_true
+          expect(Appsignal.active?).to be_truthy
         end
         before do
           expect(Appsignal::Transaction).to receive(:create).with(

--- a/spec/lib/appsignal/integrations/grape_spec.rb
+++ b/spec/lib/appsignal/integrations/grape_spec.rb
@@ -27,7 +27,7 @@ if DependencyHelper.grape_present?
 
     describe "#call" do
       context "when AppSignal is not active" do
-        before(:all) do
+        before(:context) do
           Appsignal.config = nil
           Appsignal::Hooks.load_hooks
         end
@@ -45,7 +45,7 @@ if DependencyHelper.grape_present?
 
       context "when AppSignal is active" do
         let(:transaction) { http_request_transaction }
-        before :all do
+        before :context do
           Appsignal.config = project_fixture_config
           expect(Appsignal.active?).to be_truthy
         end

--- a/spec/lib/appsignal/integrations/object_spec.rb
+++ b/spec/lib/appsignal/integrations/object_spec.rb
@@ -23,7 +23,7 @@ describe Object do
 
         context "with anonymous class" do
           it "instruments the method and calls it" do
-            expect(Appsignal.active?).to be_true
+            expect(Appsignal.active?).to be_truthy
             expect(transaction).to receive(:start_event)
             expect(transaction).to receive(:finish_event).with \
               "foo.AnonymousClass.other", nil, nil, Appsignal::EventFormatter::DEFAULT
@@ -44,7 +44,7 @@ describe Object do
           let(:klass) { NamedClass }
 
           it "instruments the method and calls it" do
-            expect(Appsignal.active?).to be_true
+            expect(Appsignal.active?).to be_truthy
             expect(transaction).to receive(:start_event)
             expect(transaction).to receive(:finish_event).with \
               "foo.NamedClass.other", nil, nil, Appsignal::EventFormatter::DEFAULT
@@ -69,7 +69,7 @@ describe Object do
           let(:klass) { MyModule::NestedModule::NamedClass }
 
           it "instruments the method and calls it" do
-            expect(Appsignal.active?).to be_true
+            expect(Appsignal.active?).to be_truthy
             expect(transaction).to receive(:start_event)
             expect(transaction).to receive(:finish_event).with \
               "bar.NamedClass.NestedModule.MyModule.other", nil, nil,
@@ -89,7 +89,7 @@ describe Object do
           end
 
           it "instruments with custom name" do
-            expect(Appsignal.active?).to be_true
+            expect(Appsignal.active?).to be_truthy
             expect(transaction).to receive(:start_event)
             expect(transaction).to receive(:finish_event).with \
               "my_method.group", nil, nil, Appsignal::EventFormatter::DEFAULT
@@ -117,7 +117,7 @@ describe Object do
         let(:transaction) { Appsignal::Transaction.current }
 
         it "should not instrument, but still call the method" do
-          expect(Appsignal.active?).to be_false
+          expect(Appsignal.active?).to be_falsy
           expect(transaction).to_not receive(:start_event)
           expect(instance.foo).to eq(1)
         end
@@ -145,7 +145,7 @@ describe Object do
 
         context "with anonymous class" do
           it "instruments the method and calls it" do
-            expect(Appsignal.active?).to be_true
+            expect(Appsignal.active?).to be_truthy
             expect(transaction).to receive(:start_event)
             expect(transaction).to receive(:finish_event).with \
               "bar.class_method.AnonymousClass.other", nil, nil, Appsignal::EventFormatter::DEFAULT
@@ -166,7 +166,7 @@ describe Object do
           let(:klass) { NamedClass }
 
           it "instruments the method and calls it" do
-            expect(Appsignal.active?).to be_true
+            expect(Appsignal.active?).to be_truthy
             expect(transaction).to receive(:start_event)
             expect(transaction).to receive(:finish_event).with \
               "bar.class_method.NamedClass.other", nil, nil, Appsignal::EventFormatter::DEFAULT
@@ -190,7 +190,7 @@ describe Object do
             let(:klass) { MyModule::NestedModule::NamedClass }
 
             it "instruments the method and calls it" do
-              expect(Appsignal.active?).to be_true
+              expect(Appsignal.active?).to be_truthy
               expect(transaction).to receive(:start_event)
               expect(transaction).to receive(:finish_event).with \
                 "bar.class_method.NamedClass.NestedModule.MyModule.other", nil, nil,
@@ -211,7 +211,7 @@ describe Object do
           end
 
           it "instruments with custom name" do
-            expect(Appsignal.active?).to be_true
+            expect(Appsignal.active?).to be_truthy
             expect(transaction).to receive(:start_event)
             expect(transaction).to receive(:finish_event).with \
               "my_method.group", nil, nil, Appsignal::EventFormatter::DEFAULT
@@ -239,7 +239,7 @@ describe Object do
         let(:transaction) { Appsignal::Transaction.current }
 
         it "should not instrument, but still call the method" do
-          expect(Appsignal.active?).to be_false
+          expect(Appsignal.active?).to be_falsy
           expect(transaction).to_not receive(:start_event)
           expect(klass.bar).to eq(2)
         end

--- a/spec/lib/appsignal/integrations/padrino_spec.rb
+++ b/spec/lib/appsignal/integrations/padrino_spec.rb
@@ -7,11 +7,9 @@ if DependencyHelper.padrino_present?
     end
 
     before do
-      Appsignal.stub(
-        :active?      => true,
-        :start        => true,
-        :start_logger => true
-      )
+      allow(Appsignal).to receive(:active?).and_return(true)
+      allow(Appsignal).to receive(:start).and_return(true)
+      allow(Appsignal).to receive(:start_logger).and_return(true)
     end
 
     describe "Appsignal::Integrations::PadrinoPlugin" do
@@ -24,7 +22,7 @@ if DependencyHelper.padrino_present?
       end
 
       context "when not active" do
-        before { Appsignal.stub(:active? => false) }
+        before { allow(Appsignal).to receive(:active?).and_return(false) }
 
         it "should not add the Listener middleware to the stack" do
           expect(Padrino).to_not receive(:use)
@@ -76,13 +74,11 @@ if DependencyHelper.padrino_present?
         end
 
         before do
-          router.stub(
-            :route_without_appsignal => true,
-            :request                 => request,
-            :env                     => env,
-            :settings                => settings,
-            :get_payload_action      => "controller#action"
-          )
+          allow(router).to receive(:route_without_appsignal).and_return(true)
+          allow(router).to receive(:request).and_return(request)
+          allow(router).to receive(:env).and_return(env)
+          allow(router).to receive(:settings).and_return(settings)
+          allow(router).to receive(:get_payload_action).and_return("controller#action")
         end
 
         context "when Sinatra tells us it's a static file" do
@@ -100,7 +96,7 @@ if DependencyHelper.padrino_present?
         end
 
         context "when appsignal is not active" do
-          before { Appsignal.stub(:active? => false) }
+          before { allow(Appsignal).to receive(:active?).and_return(false) }
 
           it "should call the original method" do
             expect(router).to receive(:route_without_appsignal)
@@ -123,7 +119,7 @@ if DependencyHelper.padrino_present?
               :set_error => nil
             )
           end
-          before { Appsignal::Transaction.stub(:create => transaction) }
+          before { allow(Appsignal::Transaction).to receive(:create).and_return(transaction) }
 
           context "without an error" do
             it "should create a transaction" do
@@ -155,7 +151,7 @@ if DependencyHelper.padrino_present?
 
           context "with an error" do
             let(:error) { VerySpecificError.new }
-            before { router.stub(:route_without_appsignal).and_raise(error) }
+            before { allow(router).to receive(:route_without_appsignal).and_raise(error) }
 
             it "should add the exception to the current transaction" do
               expect(transaction).to receive(:set_error).with(error)
@@ -167,7 +163,7 @@ if DependencyHelper.padrino_present?
       end
 
       describe "#get_payload_action" do
-        before { router.stub(:settings => settings) }
+        before { allow(router).to receive(:settings).and_return(settings) }
 
         context "when request is nil" do
           it "should return the site" do
@@ -194,7 +190,7 @@ if DependencyHelper.padrino_present?
         context "when request has a route object" do
           let(:request)      { double }
           let(:route_object) { double(:original_path => "/accounts/edit/:id") }
-          before             { request.stub(:route_obj => route_object) }
+          before             { allow(request).to receive(:route_obj).and_return(route_object) }
 
           it "should return the original path" do
             expect(router.get_payload_action(request)).to eql("TestApp:/accounts/edit/:id")

--- a/spec/lib/appsignal/integrations/railtie_spec.rb
+++ b/spec/lib/appsignal/integrations/railtie_spec.rb
@@ -11,13 +11,13 @@ if DependencyHelper.rails_present?
 
     describe "#initialize_appsignal" do
       let(:app) { MyApp::Application }
-      before { app.middleware.stub(:insert_before => true) }
+      before { allow(app.middleware).to receive(:insert_before).and_return(true) }
 
       context "logger" do
         before  { Appsignal::Integrations::Railtie.initialize_appsignal(app) }
         subject { Appsignal.logger }
 
-        it { should be_a Logger }
+        it { is_expected.to be_a Logger }
       end
 
       context "config" do
@@ -25,28 +25,49 @@ if DependencyHelper.rails_present?
         context "basics" do
           before { Appsignal::Integrations::Railtie.initialize_appsignal(app) }
 
-          it { should be_a(Appsignal::Config) }
+          it { is_expected.to be_a(Appsignal::Config) }
 
-          its(:root_path)  { should eq Pathname.new(project_fixture_path) }
-          its(:env)        { should eq "test" }
-          its([:name])     { should eq "TestApp" }
-          its([:log_path]) { should eq Pathname.new(File.join(project_fixture_path, "log")) }
+          describe '#root_path' do
+            subject { super().root_path }
+            it { is_expected.to eq Pathname.new(project_fixture_path) }
+          end
+
+          describe '#env' do
+            subject { super().env }
+            it { is_expected.to eq "test" }
+          end
+
+          describe '[:name]' do
+            subject { super()[:name] }
+            it { is_expected.to eq "TestApp" }
+          end
+
+          describe '[:log_path]' do
+            subject { super()[:log_path] }
+            it { is_expected.to eq Pathname.new(File.join(project_fixture_path, "log")) }
+          end
         end
 
         context "initial config" do
           before  { Appsignal::Integrations::Railtie.initialize_appsignal(app) }
           subject { Appsignal.config.initial_config }
 
-          its([:name]) { should eq "MyApp" }
+          describe '[:name]' do
+            subject { super()[:name] }
+            it { is_expected.to eq "MyApp" }
+          end
         end
 
         context "with APPSIGNAL_APP_ENV ENV var set" do
           before do
-            ENV.should_receive(:fetch).with("APPSIGNAL_APP_ENV", "test").and_return("env_test")
+            expect(ENV).to receive(:fetch).with("APPSIGNAL_APP_ENV", "test").and_return("env_test")
             Appsignal::Integrations::Railtie.initialize_appsignal(app)
           end
 
-          its(:env) { should eq "env_test" }
+          describe '#env' do
+            subject { super().env }
+            it { is_expected.to eq "env_test" }
+          end
         end
       end
 
@@ -69,7 +90,7 @@ if DependencyHelper.rails_present?
           end
 
           before do
-            Appsignal.stub(:config => config)
+            allow(Appsignal).to receive(:config).and_return(config)
           end
 
           it "should have added the listener and JSExceptionCatcher middleware" do

--- a/spec/lib/appsignal/integrations/railtie_spec.rb
+++ b/spec/lib/appsignal/integrations/railtie_spec.rb
@@ -13,61 +13,56 @@ if DependencyHelper.rails_present?
       let(:app) { MyApp::Application }
       before { allow(app.middleware).to receive(:insert_before).and_return(true) }
 
-      context "logger" do
+      describe ".logger" do
         before  { Appsignal::Integrations::Railtie.initialize_appsignal(app) }
         subject { Appsignal.logger }
 
         it { is_expected.to be_a Logger }
       end
 
-      context "config" do
-        subject { Appsignal.config }
-        context "basics" do
+      describe ".config" do
+        let(:config) { Appsignal.config }
+
+        describe "basic configuration" do
           before { Appsignal::Integrations::Railtie.initialize_appsignal(app) }
 
-          it { is_expected.to be_a(Appsignal::Config) }
+          it { expect(config).to be_a(Appsignal::Config) }
 
-          describe '#root_path' do
-            subject { super().root_path }
-            it { is_expected.to eq Pathname.new(project_fixture_path) }
+          it "sets the root_path" do
+            expect(config.root_path).to eq Pathname.new(project_fixture_path)
           end
 
-          describe '#env' do
-            subject { super().env }
-            it { is_expected.to eq "test" }
+          it "sets the detected environment" do
+            expect(config.env).to eq "test"
           end
 
-          describe '[:name]' do
-            subject { super()[:name] }
-            it { is_expected.to eq "TestApp" }
+          it "loads the app name" do
+            expect(config[:name]).to eq "TestApp"
           end
 
-          describe '[:log_path]' do
-            subject { super()[:log_path] }
-            it { is_expected.to eq Pathname.new(File.join(project_fixture_path, "log")) }
-          end
-        end
-
-        context "initial config" do
-          before  { Appsignal::Integrations::Railtie.initialize_appsignal(app) }
-          subject { Appsignal.config.initial_config }
-
-          describe '[:name]' do
-            subject { super()[:name] }
-            it { is_expected.to eq "MyApp" }
+          it "sets the log_path based on the root_path" do
+            expect(config[:log_path]).to eq Pathname.new(File.join(project_fixture_path, "log"))
           end
         end
 
         context "with APPSIGNAL_APP_ENV ENV var set" do
           before do
-            expect(ENV).to receive(:fetch).with("APPSIGNAL_APP_ENV", "test").and_return("env_test")
+            ENV["APPSIGNAL_APP_ENV"] = "env_test"
             Appsignal::Integrations::Railtie.initialize_appsignal(app)
           end
 
-          describe '#env' do
-            subject { super().env }
-            it { is_expected.to eq "env_test" }
+          it "uses the environment variable value as the environment" do
+            expect(config.env).to eq "env_test"
           end
+        end
+      end
+
+      describe ".initial_config" do
+        before { Appsignal::Integrations::Railtie.initialize_appsignal(app) }
+        let(:config) { Appsignal.config.initial_config }
+
+        it "returns the initial config" do
+          expect(config[:name]).to eq "MyApp"
         end
       end
 

--- a/spec/lib/appsignal/integrations/resque_active_job_spec.rb
+++ b/spec/lib/appsignal/integrations/resque_active_job_spec.rb
@@ -16,11 +16,11 @@ if DependencyHelper.resque_present? && DependencyHelper.active_job_present?
       end
 
       describe :around_perform_plugin do
-        before    { SecureRandom.stub(:uuid => 123) }
+        before    { allow(SecureRandom).to receive(:uuid).and_return(123) }
         let(:job) { TestActiveJob.new("moo") }
 
         it "should wrap in a transaction with the correct params" do
-          Appsignal.should_receive(:monitor_single_transaction).with(
+          expect(Appsignal).to receive(:monitor_single_transaction).with(
             "perform_job.resque",
             :class  => "TestActiveJob",
             :method => "perform",

--- a/spec/lib/appsignal/integrations/resque_spec.rb
+++ b/spec/lib/appsignal/integrations/resque_spec.rb
@@ -71,7 +71,7 @@ if DependencyHelper.resque_present?
     end
 
     context "without resque" do
-      before(:all) { Object.send(:remove_const, :Resque) }
+      before(:context) { Object.send(:remove_const, :Resque) }
 
       specify { expect { ::Resque }.to raise_error(NameError) }
       specify { expect { load file }.to_not raise_error }

--- a/spec/lib/appsignal/integrations/resque_spec.rb
+++ b/spec/lib/appsignal/integrations/resque_spec.rb
@@ -27,18 +27,18 @@ if DependencyHelper.resque_present?
         let(:transaction) { Appsignal::Transaction.new("1", "background", {}, {}) }
         let(:job) { ::Resque::Job.new("default", "class" => "TestJob") }
         before do
-          transaction.stub(:complete => true)
-          Appsignal::Transaction.stub(:current => transaction)
-          Appsignal.should_receive(:stop)
+          allow(transaction).to receive(:complete).and_return(true)
+          allow(Appsignal::Transaction).to receive(:current).and_return(transaction)
+          expect(Appsignal).to receive(:stop)
         end
 
         context "without exception" do
           it "should create a new transaction" do
-            Appsignal::Transaction.should_receive(:create).and_return(transaction)
+            expect(Appsignal::Transaction).to receive(:create).and_return(transaction)
           end
 
           it "should wrap in a transaction with the correct params" do
-            Appsignal.should_receive(:monitor_transaction).with(
+            expect(Appsignal).to receive(:monitor_transaction).with(
               "perform_job.resque",
               :class => "TestJob",
               :method => "perform"
@@ -46,7 +46,7 @@ if DependencyHelper.resque_present?
           end
 
           it "should close the transaction" do
-            transaction.should_receive(:complete)
+            expect(transaction).to receive(:complete)
           end
 
           after { job.perform }
@@ -56,7 +56,7 @@ if DependencyHelper.resque_present?
           let(:job) { ::Resque::Job.new("default", "class" => "BrokenTestJob") }
 
           it "should set the exception" do
-            Appsignal::Transaction.any_instance.should_receive(:set_error)
+            expect_any_instance_of(Appsignal::Transaction).to receive(:set_error)
           end
 
           after do

--- a/spec/lib/appsignal/integrations/sinatra_spec.rb
+++ b/spec/lib/appsignal/integrations/sinatra_spec.rb
@@ -6,12 +6,12 @@ if DependencyHelper.sinatra_present?
     context "Appsignal.logger" do
       subject { Appsignal.logger }
 
-      it { should be_a Logger }
+      it { is_expected.to be_a Logger }
     end
 
     describe "middleware" do
       it "adds the instrumentation middleware to Sinatra::Base" do
-        Sinatra::Base.middleware.to_a.should include(
+        expect(Sinatra::Base.middleware.to_a).to include(
           [Appsignal::Rack::SinatraBaseInstrumentation, [], nil]
         )
       end

--- a/spec/lib/appsignal/integrations/webmachine_spec.rb
+++ b/spec/lib/appsignal/integrations/webmachine_spec.rb
@@ -9,7 +9,7 @@ if DependencyHelper.webmachine_present?
     let(:response)    { double }
     let(:transaction) { double(:set_action => true) }
     let(:fsm) { Webmachine::Decision::FSM.new(resource, request, response) }
-    before(:all) { start_agent }
+    before(:context) { start_agent }
 
     # Make sure the request responds to the method we need to get query params.
     describe "request" do

--- a/spec/lib/appsignal/js_exception_transaction_spec.rb
+++ b/spec/lib/appsignal/js_exception_transaction_spec.rb
@@ -1,5 +1,5 @@
 describe Appsignal::JSExceptionTransaction do
-  before { SecureRandom.stub(:uuid => "123abc") }
+  before { allow(SecureRandom).to receive(:uuid).and_return("123abc") }
 
   let!(:transaction) { Appsignal::JSExceptionTransaction.new(data) }
   let(:data) do

--- a/spec/lib/appsignal/minutely_spec.rb
+++ b/spec/lib/appsignal/minutely_spec.rb
@@ -12,7 +12,7 @@ describe Appsignal::Minutely do
       probe = double
       expect(probe).to receive(:call).at_least(:twice)
       Appsignal::Minutely.probes << probe
-      Appsignal::Minutely.stub(:wait_time => 0.1)
+      allow(Appsignal::Minutely).to receive(:wait_time).and_return(0.1)
 
       Appsignal::Minutely.start
 
@@ -22,7 +22,7 @@ describe Appsignal::Minutely do
 
   describe ".wait_time" do
     it "should get the time to the next minute" do
-      Time.any_instance.stub(:sec => 30)
+      allow_any_instance_of(Time).to receive(:sec).and_return(30)
       expect(Appsignal::Minutely.wait_time).to eq 30
     end
   end
@@ -33,7 +33,7 @@ describe Appsignal::Minutely do
 
       Appsignal::Minutely.add_gc_probe
 
-      expect(Appsignal::Minutely.probes).to have(1).item
+      expect(Appsignal::Minutely.probes.size).to eq(1)
       expect(Appsignal::Minutely.probes[0]).to be_instance_of(Appsignal::Minutely::GCProbe)
     end
   end

--- a/spec/lib/appsignal/rack/generic_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/generic_instrumentation_spec.rb
@@ -1,5 +1,5 @@
 describe Appsignal::Rack::GenericInstrumentation do
-  before :all do
+  before :context do
     start_agent
   end
 

--- a/spec/lib/appsignal/rack/generic_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/generic_instrumentation_spec.rb
@@ -10,11 +10,11 @@ describe Appsignal::Rack::GenericInstrumentation do
 
   describe "#call" do
     before do
-      middleware.stub(:raw_payload => {})
+      allow(middleware).to receive(:raw_payload).and_return({})
     end
 
     context "when appsignal is active" do
-      before { Appsignal.stub(:active? => true) }
+      before { allow(Appsignal).to receive(:active?).and_return(true) }
 
       it "should call with monitoring" do
         expect(middleware).to receive(:call_with_appsignal_monitoring).with(env)
@@ -22,7 +22,7 @@ describe Appsignal::Rack::GenericInstrumentation do
     end
 
     context "when appsignal is not active" do
-      before { Appsignal.stub(:active? => false) }
+      before { allow(Appsignal).to receive(:active?).and_return(false) }
 
       it "should not call with monitoring" do
         expect(middleware).to_not receive(:call_with_appsignal_monitoring)
@@ -38,7 +38,7 @@ describe Appsignal::Rack::GenericInstrumentation do
 
   describe "#call_with_appsignal_monitoring" do
     it "should create a transaction" do
-      Appsignal::Transaction.should_receive(:create).with(
+      expect(Appsignal::Transaction).to receive(:create).with(
         kind_of(String),
         Appsignal::Transaction::HTTP_REQUEST,
         kind_of(Rack::Request)
@@ -46,24 +46,24 @@ describe Appsignal::Rack::GenericInstrumentation do
     end
 
     it "should call the app" do
-      app.should_receive(:call).with(env)
+      expect(app).to receive(:call).with(env)
     end
 
     context "with an error" do
       let(:error) { VerySpecificError.new }
       let(:app) do
         double.tap do |d|
-          d.stub(:call).and_raise(error)
+          allow(d).to receive(:call).and_raise(error)
         end
       end
 
       it "should set the error" do
-        Appsignal::Transaction.any_instance.should_receive(:set_error).with(error)
+        expect_any_instance_of(Appsignal::Transaction).to receive(:set_error).with(error)
       end
     end
 
     it "should set the action to unknown" do
-      Appsignal::Transaction.any_instance.should_receive(:set_action).with("unknown")
+      expect_any_instance_of(Appsignal::Transaction).to receive(:set_action).with("unknown")
     end
 
     context "with a route specified in the env" do
@@ -72,16 +72,16 @@ describe Appsignal::Rack::GenericInstrumentation do
       end
 
       it "should set the action" do
-        Appsignal::Transaction.any_instance.should_receive(:set_action).with("GET /")
+        expect_any_instance_of(Appsignal::Transaction).to receive(:set_action).with("GET /")
       end
     end
 
     it "should set metadata" do
-      Appsignal::Transaction.any_instance.should_receive(:set_metadata).twice
+      expect_any_instance_of(Appsignal::Transaction).to receive(:set_metadata).twice
     end
 
     it "should set the queue start" do
-      Appsignal::Transaction.any_instance.should_receive(:set_http_or_background_queue_start)
+      expect_any_instance_of(Appsignal::Transaction).to receive(:set_http_or_background_queue_start)
     end
 
     after { middleware.call(env) rescue VerySpecificError }

--- a/spec/lib/appsignal/rack/js_exception_catcher_spec.rb
+++ b/spec/lib/appsignal/rack/js_exception_catcher_spec.rb
@@ -6,8 +6,8 @@ describe Appsignal::Rack::JSExceptionCatcher do
   let(:config)         { project_fixture_config("production", config_options) }
 
   before do
-    Appsignal.stub(:config => config)
-    config.stub(:active? => active)
+    allow(Appsignal).to receive(:config).and_return(config)
+    allow(config).to receive(:active?).and_return(active)
   end
 
   describe "#initialize" do

--- a/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
@@ -3,7 +3,7 @@ if DependencyHelper.rails_present?
   end
 
   describe Appsignal::Rack::RailsInstrumentation do
-    before :all do
+    before :context do
       start_agent
     end
 

--- a/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
@@ -94,18 +94,19 @@ if DependencyHelper.rails_present?
     describe "#request_id" do
       subject { middleware.request_id(env) }
 
-      context "with request id set" do
+      context "with request id present" do
         let(:env) { { "action_dispatch.request_id" => "id" } }
 
-        it { is_expected.to eq "id" }
+        it "returns the present id" do
+          is_expected.to eq "id"
+        end
       end
 
-      context "with request id not set" do
+      context "with request id not present" do
         let(:env) { {} }
 
-        describe '#length' do
-          subject { super().length }
-          it { is_expected.to eq 36 }
+        it "sets a new id" do
+          expect(subject.length).to eq 36
         end
       end
     end

--- a/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
@@ -31,7 +31,7 @@ if DependencyHelper.sinatra_present?
   end
 
   describe Appsignal::Rack::SinatraBaseInstrumentation do
-    before :all do
+    before :context do
       start_agent
     end
 

--- a/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
@@ -10,8 +10,8 @@ if DependencyHelper.sinatra_present?
     describe "#call" do
       before do
         start_agent
-        middleware.stub(:raw_payload => {})
-        Appsignal.stub(:active? => true)
+        allow(middleware).to receive(:raw_payload).and_return({})
+        allow(Appsignal).to receive(:active?).and_return(true)
       end
 
       it "should call without monitoring" do
@@ -77,11 +77,11 @@ if DependencyHelper.sinatra_present?
 
     describe "#call" do
       before do
-        middleware.stub(:raw_payload => {})
+        allow(middleware).to receive(:raw_payload).and_return({})
       end
 
       context "when appsignal is active" do
-        before { Appsignal.stub(:active? => true) }
+        before { allow(Appsignal).to receive(:active?).and_return(true) }
 
         it "should call with monitoring" do
           expect(middleware).to receive(:call_with_appsignal_monitoring).with(env)
@@ -89,7 +89,7 @@ if DependencyHelper.sinatra_present?
       end
 
       context "when appsignal is not active" do
-        before { Appsignal.stub(:active? => false) }
+        before { allow(Appsignal).to receive(:active?).and_return(false) }
 
         it "should not call with monitoring" do
           expect(middleware).to_not receive(:call_with_appsignal_monitoring)
@@ -105,7 +105,7 @@ if DependencyHelper.sinatra_present?
 
     describe "#call_with_appsignal_monitoring" do
       it "should create a transaction" do
-        Appsignal::Transaction.should_receive(:create).with(
+        expect(Appsignal::Transaction).to receive(:create).with(
           kind_of(String),
           Appsignal::Transaction::HTTP_REQUEST,
           kind_of(Sinatra::Request),
@@ -114,20 +114,20 @@ if DependencyHelper.sinatra_present?
       end
 
       it "should call the app" do
-        app.should_receive(:call).with(env)
+        expect(app).to receive(:call).with(env)
       end
 
       context "with an error" do
         let(:error) { VerySpecificError.new }
         let(:app) do
           double.tap do |d|
-            d.stub(:call).and_raise(error)
-            d.stub(:settings => settings)
+            allow(d).to receive(:call).and_raise(error)
+            allow(d).to receive(:settings).and_return(settings)
           end
         end
 
         it "should set the error" do
-          Appsignal::Transaction.any_instance.should_receive(:set_error).with(error)
+          expect_any_instance_of(Appsignal::Transaction).to receive(:set_error).with(error)
         end
       end
 
@@ -136,14 +136,14 @@ if DependencyHelper.sinatra_present?
         let(:env) { { "sinatra.error" => error } }
 
         it "should set the error" do
-          Appsignal::Transaction.any_instance.should_receive(:set_error).with(error)
+          expect_any_instance_of(Appsignal::Transaction).to receive(:set_error).with(error)
         end
 
         context "if raise_errors is on" do
           let(:settings) { double(:raise_errors => true) }
 
           it "should not set the error" do
-            Appsignal::Transaction.any_instance.should_not_receive(:set_error)
+            expect_any_instance_of(Appsignal::Transaction).to_not receive(:set_error)
           end
         end
 
@@ -151,21 +151,21 @@ if DependencyHelper.sinatra_present?
           let(:env) { { "sinatra.error" => error, "sinatra.skip_appsignal_error" => true } }
 
           it "should not set the error" do
-            Appsignal::Transaction.any_instance.should_not_receive(:set_error)
+            expect_any_instance_of(Appsignal::Transaction).to_not receive(:set_error)
           end
         end
       end
 
       describe "action name" do
         it "should set the action" do
-          Appsignal::Transaction.any_instance.should_receive(:set_action).with("GET /")
+          expect_any_instance_of(Appsignal::Transaction).to receive(:set_action).with("GET /")
         end
 
         context "without 'sinatra.route' env" do
           let(:env) { { :path => "/", :method => "GET" } }
 
           it "returns nil" do
-            Appsignal::Transaction.any_instance.should_receive(:set_action).with(nil)
+            expect_any_instance_of(Appsignal::Transaction).to receive(:set_action).with(nil)
           end
         end
 
@@ -173,25 +173,25 @@ if DependencyHelper.sinatra_present?
           before { env["SCRIPT_NAME"] = "/api" }
 
           it "should call set_action with an application prefix path" do
-            Appsignal::Transaction.any_instance.should_receive(:set_action).with("GET /api/")
+            expect_any_instance_of(Appsignal::Transaction).to receive(:set_action).with("GET /api/")
           end
 
           context "without 'sinatra.route' env" do
             let(:env) { { :path => "/", :method => "GET" } }
 
             it "returns nil" do
-              Appsignal::Transaction.any_instance.should_receive(:set_action).with(nil)
+              expect_any_instance_of(Appsignal::Transaction).to receive(:set_action).with(nil)
             end
           end
         end
       end
 
       it "should set metadata" do
-        Appsignal::Transaction.any_instance.should_receive(:set_metadata).twice
+        expect_any_instance_of(Appsignal::Transaction).to receive(:set_metadata).twice
       end
 
       it "should set the queue start" do
-        Appsignal::Transaction.any_instance.should_receive(:set_http_or_background_queue_start)
+        expect_any_instance_of(Appsignal::Transaction).to receive(:set_http_or_background_queue_start)
       end
 
       context "with overridden request class and params method" do
@@ -199,7 +199,7 @@ if DependencyHelper.sinatra_present?
 
         it "should use the overridden request class and params method" do
           request = ::Rack::Request.new(env)
-          ::Rack::Request.should_receive(:new)
+          expect(::Rack::Request).to receive(:new)
             .with(env.merge(:params_method => :filtered_params))
             .at_least(:once)
             .and_return(request)

--- a/spec/lib/appsignal/rack/streaming_listener_spec.rb
+++ b/spec/lib/appsignal/rack/streaming_listener_spec.rb
@@ -15,7 +15,7 @@ describe Appsignal::Rack::StreamingListener do
 
   describe "#call" do
     context "when Appsignal is active" do
-      before { Appsignal.stub(:active? => true) }
+      before { allow(Appsignal).to receive(:active?).and_return(true) }
 
       it "should call `call_with_appsignal_monitoring`" do
         expect(listener).to receive(:call_with_appsignal_monitoring)
@@ -23,7 +23,7 @@ describe Appsignal::Rack::StreamingListener do
     end
 
     context "when Appsignal is not active" do
-      before { Appsignal.stub(:active? => false) }
+      before { allow(Appsignal).to receive(:active?).and_return(false) }
 
       it "should not call `call_with_appsignal_monitoring`" do
         expect(listener).to_not receive(:call_with_appsignal_monitoring)
@@ -45,9 +45,9 @@ describe Appsignal::Rack::StreamingListener do
     let(:raw_payload) { { :foo => :bar } }
 
     before do
-      SecureRandom.stub(:uuid => "123")
-      listener.stub(:raw_payload => raw_payload)
-      Appsignal::Transaction.stub(:create => transaction)
+      allow(SecureRandom).to receive(:uuid).and_return("123")
+      allow(listener).to receive(:raw_payload).and_return(raw_payload)
+      allow(Appsignal::Transaction).to receive(:create).and_return(transaction)
     end
 
     it "should create a transaction" do

--- a/spec/lib/appsignal/system_spec.rb
+++ b/spec/lib/appsignal/system_spec.rb
@@ -6,7 +6,7 @@ describe Appsignal::System do
       around { |example| recognize_as_heroku { example.run } }
 
       it "returns true" do
-        expect(subject).to be_true
+        expect(subject).to be_truthy
       end
     end
 
@@ -14,7 +14,7 @@ describe Appsignal::System do
       around { |example| recognize_as_container(:docker) { example.run } }
 
       it "returns true" do
-        expect(subject).to be_true
+        expect(subject).to be_truthy
       end
     end
 
@@ -22,7 +22,7 @@ describe Appsignal::System do
       around { |example| recognize_as_container(:none) { example.run } }
 
       it "returns false" do
-        expect(subject).to be_false
+        expect(subject).to be_falsy
       end
     end
   end
@@ -34,7 +34,7 @@ describe Appsignal::System do
       around { |example| recognize_as_heroku { example.run } }
 
       it "returns true" do
-        expect(subject).to be_true
+        expect(subject).to be_truthy
       end
     end
 
@@ -42,7 +42,7 @@ describe Appsignal::System do
       around { |example| recognize_as_container(:none) { example.run } }
 
       it "returns false" do
-        expect(subject).to be_false
+        expect(subject).to be_falsy
       end
     end
   end

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -25,19 +25,19 @@ describe Appsignal::Transaction do
   describe "class methods" do
     describe ".create" do
       it "should add the transaction to thread local" do
-        Appsignal::Extension.should_receive(:start_transaction).with("1", "http_request", 0)
+        expect(Appsignal::Extension).to receive(:start_transaction).with("1", "http_request", 0)
 
         created_transaction = Appsignal::Transaction.create("1", namespace, request, options)
 
-        Thread.current[:appsignal_transaction].should eq created_transaction
+        expect(Thread.current[:appsignal_transaction]).to eq created_transaction
       end
 
       it "should create a transaction" do
         created_transaction = Appsignal::Transaction.create("1", namespace, request, options)
 
-        created_transaction.should be_a Appsignal::Transaction
-        created_transaction.transaction_id.should eq "1"
-        created_transaction.namespace.should eq "http_request"
+        expect(created_transaction).to be_a Appsignal::Transaction
+        expect(created_transaction.transaction_id).to eq "1"
+        expect(created_transaction.namespace).to eq "http_request"
       end
 
       context "when a transaction is already running" do
@@ -77,11 +77,11 @@ describe Appsignal::Transaction do
         before { Appsignal::Transaction.create("1", namespace, request, options) }
 
         it "should return the correct transaction" do
-          should eq transaction
+          is_expected.to eq transaction
         end
 
         it "should indicate it's not a nil transaction" do
-          subject.nil_transaction?.should be_false
+          expect(subject.nil_transaction?).to be_falsy
         end
       end
 
@@ -91,11 +91,11 @@ describe Appsignal::Transaction do
         end
 
         it "should return a nil transaction stub" do
-          should be_a Appsignal::Transaction::NilTransaction
+          is_expected.to be_a Appsignal::Transaction::NilTransaction
         end
 
         it "should indicate it's a nil transaction" do
-          subject.nil_transaction?.should be_true
+          expect(subject.nil_transaction?).to be_truthy
         end
       end
     end
@@ -104,19 +104,19 @@ describe Appsignal::Transaction do
       before { Appsignal::Transaction.create("2", Appsignal::Transaction::HTTP_REQUEST, {}) }
 
       it "should complete the current transaction and set the thread appsignal_transaction to nil" do
-        Appsignal::Transaction.current.should_receive(:complete)
+        expect(Appsignal::Transaction.current).to receive(:complete)
 
         Appsignal::Transaction.complete_current!
 
-        Thread.current[:appsignal_transaction].should be_nil
+        expect(Thread.current[:appsignal_transaction]).to be_nil
       end
 
       it "should still clear the transaction if there is an error" do
-        Appsignal::Transaction.current.should_receive(:complete).and_raise "Error"
+        expect(Appsignal::Transaction.current).to receive(:complete).and_raise "Error"
 
         Appsignal::Transaction.complete_current!
 
-        Thread.current[:appsignal_transaction].should be_nil
+        expect(Thread.current[:appsignal_transaction]).to be_nil
       end
 
       context "if a transaction is discarded" do
@@ -124,18 +124,18 @@ describe Appsignal::Transaction do
           expect(Appsignal::Transaction.current.ext).to_not receive(:complete)
 
           Appsignal::Transaction.current.discard!
-          expect(Appsignal::Transaction.current.discarded?).to be_true
+          expect(Appsignal::Transaction.current.discarded?).to be_truthy
 
           Appsignal::Transaction.complete_current!
 
-          Thread.current[:appsignal_transaction].should be_nil
+          expect(Thread.current[:appsignal_transaction]).to be_nil
         end
 
         it "should not be discarded when restore! is called" do
           Appsignal::Transaction.current.discard!
-          expect(Appsignal::Transaction.current.discarded?).to be_true
+          expect(Appsignal::Transaction.current.discarded?).to be_truthy
           Appsignal::Transaction.current.restore!
-          expect(Appsignal::Transaction.current.discarded?).to be_false
+          expect(Appsignal::Transaction.current.discarded?).to be_falsy
         end
       end
     end
@@ -143,17 +143,17 @@ describe Appsignal::Transaction do
 
   describe "#complete" do
     it "should sample data if it needs to be sampled" do
-      transaction.ext.should_receive(:finish).and_return(true)
-      transaction.should_receive(:sample_data)
-      transaction.ext.should_receive(:complete)
+      expect(transaction.ext).to receive(:finish).and_return(true)
+      expect(transaction).to receive(:sample_data)
+      expect(transaction.ext).to receive(:complete)
 
       transaction.complete
     end
 
     it "should not sample data if it does not need to be sampled" do
-      transaction.ext.should_receive(:finish).and_return(false)
-      transaction.should_not_receive(:sample_data)
-      transaction.ext.should_receive(:complete)
+      expect(transaction.ext).to receive(:finish).and_return(false)
+      expect(transaction).to_not receive(:sample_data)
+      expect(transaction.ext).to receive(:complete)
 
       transaction.complete
     end
@@ -180,14 +180,14 @@ describe Appsignal::Transaction do
 
     describe "#paused?" do
       it "should return the pause state" do
-        expect(transaction.paused?).to be_false
+        expect(transaction.paused?).to be_falsy
       end
 
       context "when paused" do
         before { transaction.pause! }
 
         it "should return the pause state" do
-          expect(transaction.paused?).to be_true
+          expect(transaction.paused?).to be_truthy
         end
       end
     end
@@ -197,22 +197,51 @@ describe Appsignal::Transaction do
     context "initialization" do
       subject { transaction }
 
-      its(:ext)                { should_not be_nil }
-      its(:transaction_id)     { should eq "1" }
-      its(:namespace)          { should eq "http_request" }
-      its(:request)            { should_not be_nil }
-      its(:paused)             { should be_false }
-      its(:tags)               { should eq({}) }
+      describe '#ext' do
+        subject { super().ext }
+        it { is_expected.to_not be_nil }
+      end
+
+      describe '#transaction_id' do
+        subject { super().transaction_id }
+        it { is_expected.to eq "1" }
+      end
+
+      describe '#namespace' do
+        subject { super().namespace }
+        it { is_expected.to eq "http_request" }
+      end
+
+      describe '#request' do
+        subject { super().request }
+        it { is_expected.to_not be_nil }
+      end
+
+      describe '#paused' do
+        subject { super().paused }
+        it { is_expected.to be_falsy }
+      end
+
+      describe '#tags' do
+        subject { super().tags }
+        it { is_expected.to eq({}) }
+      end
 
       context "options" do
         subject { transaction.options }
 
-        its([:params_method]) { should eq :params }
+        describe '[:params_method]' do
+          subject { super()[:params_method] }
+          it { is_expected.to eq :params }
+        end
 
         context "with overridden options" do
           let(:options) { { :params_method => :filtered_params } }
 
-          its([:params_method]) { should eq :filtered_params }
+          describe '[:params_method]' do
+            subject { super()[:params_method] }
+            it { is_expected.to eq :filtered_params }
+          end
         end
       end
     end
@@ -240,7 +269,7 @@ describe Appsignal::Transaction do
 
     describe "set_action" do
       it "should set the action in extension" do
-        transaction.ext.should_receive(:set_action).with(
+        expect(transaction.ext).to receive(:set_action).with(
           "PagesController#show"
         ).once
 
@@ -248,7 +277,7 @@ describe Appsignal::Transaction do
       end
 
       it "should not set the action in extension when value is nil" do
-        Appsignal::Extension.should_not_receive(:set_transaction_action)
+        expect(Appsignal::Extension).to_not receive(:set_transaction_action)
 
         transaction.set_action(nil)
       end
@@ -259,7 +288,7 @@ describe Appsignal::Transaction do
         let(:from) { { :controller => "HomeController", :action => "show" } }
 
         it "should set the action" do
-          transaction.should_receive(:set_action).with("HomeController#show")
+          expect(transaction).to receive(:set_action).with("HomeController#show")
         end
       end
 
@@ -267,7 +296,7 @@ describe Appsignal::Transaction do
         let(:from) { { :action => "show" } }
 
         it "should set the action" do
-          transaction.should_receive(:set_action).with("show")
+          expect(transaction).to receive(:set_action).with("show")
         end
       end
 
@@ -275,7 +304,7 @@ describe Appsignal::Transaction do
         let(:from) { { :class => "Worker", :method => "perform" } }
 
         it "should set the action" do
-          transaction.should_receive(:set_action).with("Worker#perform")
+          expect(transaction).to receive(:set_action).with("Worker#perform")
         end
       end
 
@@ -284,7 +313,7 @@ describe Appsignal::Transaction do
 
     describe "set_queue_start" do
       it "should set the queue start in extension" do
-        transaction.ext.should_receive(:set_queue_start).with(
+        expect(transaction.ext).to receive(:set_queue_start).with(
           10.0
         ).once
 
@@ -292,19 +321,19 @@ describe Appsignal::Transaction do
       end
 
       it "should not set the queue start in extension when value is nil" do
-        transaction.ext.should_not_receive(:set_queue_start)
+        expect(transaction.ext).to_not receive(:set_queue_start)
 
         transaction.set_queue_start(nil)
       end
 
       it "should not raise an error when the queue start is too big" do
-        transaction.ext.should_receive(:set_queue_start).and_raise(RangeError)
+        expect(transaction.ext).to receive(:set_queue_start).and_raise(RangeError)
 
-        Appsignal.logger.should_receive(:warn).with("Queue start value 10 is too big")
+        expect(Appsignal.logger).to receive(:warn).with("Queue start value 10 is too big")
 
-        lambda do
+        expect do
           transaction.set_queue_start(10)
-        end.should_not raise_error
+        end.to_not raise_error
       end
     end
 
@@ -314,7 +343,7 @@ describe Appsignal::Transaction do
         let(:env) { { "HTTP_X_REQUEST_START" => (fixed_time * 1000).to_s } }
 
         it "should set the queue start on the transaction" do
-          transaction.should_receive(:set_queue_start).with(13_897_836_000)
+          expect(transaction).to receive(:set_queue_start).with(13_897_836_000)
 
           transaction.set_http_or_background_queue_start
         end
@@ -325,7 +354,7 @@ describe Appsignal::Transaction do
         let(:env) { { :queue_start => fixed_time } }
 
         it "should set the queue start on the transaction" do
-          transaction.should_receive(:set_queue_start).with(1_389_783_600_000)
+          expect(transaction).to receive(:set_queue_start).with(1_389_783_600_000)
 
           transaction.set_http_or_background_queue_start
         end
@@ -334,7 +363,7 @@ describe Appsignal::Transaction do
 
     describe "#set_metadata" do
       it "should set the metdata in extension" do
-        transaction.ext.should_receive(:set_metadata).with(
+        expect(transaction.ext).to receive(:set_metadata).with(
           "request_method",
           "GET"
         ).once
@@ -343,7 +372,7 @@ describe Appsignal::Transaction do
       end
 
       it "should not set the metdata in extension when value is nil" do
-        transaction.ext.should_not_receive(:set_metadata)
+        expect(transaction.ext).to_not receive(:set_metadata)
 
         transaction.set_metadata("request_method", nil)
       end
@@ -351,7 +380,7 @@ describe Appsignal::Transaction do
 
     describe "set_sample_data" do
       it "should set the data" do
-        transaction.ext.should_receive(:set_sample_data).with(
+        expect(transaction.ext).to receive(:set_sample_data).with(
           "params",
           Appsignal::Utils.data_generate("controller" => "blog_posts", "action" => "show", "id" => "1")
         ).once
@@ -365,7 +394,7 @@ describe Appsignal::Transaction do
       end
 
       it "should do nothing if the data cannot be converted to json" do
-        transaction.ext.should_not_receive(:set_sample_data).with(
+        expect(transaction.ext).to_not receive(:set_sample_data).with(
           "params",
           kind_of(String)
         )
@@ -376,7 +405,7 @@ describe Appsignal::Transaction do
 
     describe "#sample_data" do
       it "should sample data" do
-        transaction.ext.should_receive(:set_sample_data).with(
+        expect(transaction.ext).to receive(:set_sample_data).with(
           "environment",
           Appsignal::Utils.data_generate(
             "CONTENT_LENGTH" => "0",
@@ -386,19 +415,19 @@ describe Appsignal::Transaction do
             "PATH_INFO" => "/blog"
           )
         ).once
-        transaction.ext.should_receive(:set_sample_data).with(
+        expect(transaction.ext).to receive(:set_sample_data).with(
           "session_data",
           Appsignal::Utils.data_generate({})
         ).once
-        transaction.ext.should_receive(:set_sample_data).with(
+        expect(transaction.ext).to receive(:set_sample_data).with(
           "params",
           Appsignal::Utils.data_generate("controller" => "blog_posts", "action" => "show", "id" => "1")
         ).once
-        transaction.ext.should_receive(:set_sample_data).with(
+        expect(transaction.ext).to receive(:set_sample_data).with(
           "metadata",
           Appsignal::Utils.data_generate("key" => "value")
         ).once
-        transaction.ext.should_receive(:set_sample_data).with(
+        expect(transaction.ext).to receive(:set_sample_data).with(
           "tags",
           Appsignal::Utils.data_generate({})
         ).once
@@ -412,19 +441,19 @@ describe Appsignal::Transaction do
       let(:error) { double(:error, :message => "test message", :backtrace => ["line 1"]) }
 
       it "should also respond to add_exception for backwords compatibility" do
-        transaction.should respond_to(:add_exception)
+        expect(transaction).to respond_to(:add_exception)
       end
 
       it "should not add the error if appsignal is not active" do
-        Appsignal.stub(:active? => false)
-        transaction.ext.should_not_receive(:set_error)
+        allow(Appsignal).to receive(:active?).and_return(false)
+        expect(transaction.ext).to_not receive(:set_error)
 
         transaction.set_error(error)
       end
 
       context "for a http request" do
         it "should set an error in the extension" do
-          transaction.ext.should_receive(:set_error).with(
+          expect(transaction.ext).to receive(:set_error).with(
             "RSpec::Mocks::Double",
             "test message",
             Appsignal::Utils.data_generate(["line 1"])
@@ -442,7 +471,7 @@ describe Appsignal::Transaction do
         end
 
         it "should set an error in the extension" do
-          transaction.ext.should_receive(:set_error).with(
+          expect(transaction.ext).to receive(:set_error).with(
             "RSpec::Mocks::Double",
             "",
             Appsignal::Utils.data_generate(["line 1"])
@@ -455,7 +484,7 @@ describe Appsignal::Transaction do
 
     describe "#start_event" do
       it "should start the event in the extension" do
-        transaction.ext.should_receive(:start_event)
+        expect(transaction.ext).to receive(:start_event)
 
         transaction.start_event
       end
@@ -463,7 +492,7 @@ describe Appsignal::Transaction do
 
     describe "#finish_event" do
       it "should finish the event in the extension" do
-        transaction.ext.should_receive(:finish_event).with(
+        expect(transaction.ext).to receive(:finish_event).with(
           "name",
           "title",
           "body",
@@ -480,7 +509,7 @@ describe Appsignal::Transaction do
       end
 
       it "should finish the event in the extension with nil arguments" do
-        transaction.ext.should_receive(:finish_event).with(
+        expect(transaction.ext).to receive(:finish_event).with(
           "name",
           "",
           "",
@@ -507,7 +536,7 @@ describe Appsignal::Transaction do
 
     describe "#record_event" do
       it "should record the event in the extension" do
-        transaction.ext.should_receive(:record_event).with(
+        expect(transaction.ext).to receive(:record_event).with(
           "name",
           "title",
           "body",
@@ -525,7 +554,7 @@ describe Appsignal::Transaction do
       end
 
       it "should finish the event in the extension with nil arguments" do
-        transaction.ext.should_receive(:record_event).with(
+        expect(transaction.ext).to receive(:record_event).with(
           "name",
           "",
           "",
@@ -546,19 +575,19 @@ describe Appsignal::Transaction do
     describe "#instrument" do
       it "should start and finish an event around the given block" do
         stub = double
-        stub.should_receive(:method_call).and_return("return value")
+        expect(stub).to receive(:method_call).and_return("return value")
 
-        transaction.should_receive(:start_event)
-        transaction.should_receive(:finish_event).with(
+        expect(transaction).to receive(:start_event)
+        expect(transaction).to receive(:finish_event).with(
           "name",
           "title",
           "body",
           0
         )
 
-        transaction.instrument "name", "title", "body" do
+        expect(transaction.instrument "name", "title", "body" do
           stub.method_call
-        end.should eq "return value"
+        end).to eq "return value"
       end
     end
 
@@ -567,7 +596,7 @@ describe Appsignal::Transaction do
       subject { Appsignal::Transaction::GenericRequest.new(env) }
 
       it "should initialize with an empty env" do
-        subject.env.should be_empty
+        expect(subject.env).to be_empty
       end
 
       context "with a filled env" do
@@ -578,8 +607,15 @@ describe Appsignal::Transaction do
           }
         end
 
-        its(:env) { should eq env }
-        its(:params) { should eq(:id => 1) }
+        describe '#env' do
+          subject { super().env }
+          it { is_expected.to eq env }
+        end
+
+        describe '#params' do
+          subject { super().params }
+          it { is_expected.to eq(:id => 1) }
+        end
       end
     end
 
@@ -591,23 +627,23 @@ describe Appsignal::Transaction do
       context "when request is nil" do
         let(:request) { nil }
 
-        it { should eq nil }
+        it { is_expected.to eq nil }
       end
 
       context "when env is nil" do
         before { expect(transaction.request).to receive(:env).and_return(nil) }
 
-        it { should eq nil }
+        it { is_expected.to eq nil }
       end
 
       context "when queue start is nil" do
-        it { should eq nil }
+        it { is_expected.to eq nil }
       end
 
       context "when queue start is set" do
         let(:env) { background_env_with_data }
 
-        it { should eq 1_389_783_590_000 }
+        it { is_expected.to eq 1_389_783_590_000 }
       end
     end
 
@@ -620,48 +656,48 @@ describe Appsignal::Transaction do
         context "when request is nil" do
           let(:request) { nil }
 
-          it { should be_nil }
+          it { is_expected.to be_nil }
         end
 
         context "when env is nil" do
           before { expect(transaction.request).to receive(:env).and_return(nil) }
 
-          it { should be_nil }
+          it { is_expected.to be_nil }
         end
 
         context "with no relevant header set" do
           let(:env) { {} }
 
-          it { should be_nil }
+          it { is_expected.to be_nil }
         end
 
         context "with the HTTP_X_REQUEST_START header set" do
           let(:env) { { "HTTP_X_REQUEST_START" => "t=#{slightly_earlier_time_value}" } }
 
-          it { should eq 1_389_783_599_600 }
+          it { is_expected.to eq 1_389_783_599_600 }
 
           context "with unparsable content" do
             let(:env) { { "HTTP_X_REQUEST_START" => "something" } }
 
-            it { should be_nil }
+            it { is_expected.to be_nil }
           end
 
           context "with some cruft" do
             let(:env) { { "HTTP_X_REQUEST_START" => "t=#{slightly_earlier_time_value}aaaa" } }
 
-            it { should eq 1_389_783_599_600 }
+            it { is_expected.to eq 1_389_783_599_600 }
           end
 
           context "with a really low number" do
             let(:env) { { "HTTP_X_REQUEST_START" => "t=100" } }
 
-            it { should be_nil }
+            it { is_expected.to be_nil }
           end
 
           context "with the alternate HTTP_X_QUEUE_START header set" do
             let(:env) { { "HTTP_X_QUEUE_START" => "t=#{slightly_earlier_time_value}" } }
 
-            it { should eq 1_389_783_599_600 }
+            it { is_expected.to eq 1_389_783_599_600 }
           end
         end
       end
@@ -683,28 +719,28 @@ describe Appsignal::Transaction do
       subject { transaction.send(:sanitized_params) }
 
       context "without params" do
-        before { transaction.request.stub(:params => nil) }
+        before { allow(transaction.request).to receive(:params).and_return(nil) }
 
-        it { should be_nil }
+        it { is_expected.to be_nil }
       end
 
       context "when params crashes" do
-        before { transaction.request.stub(:params).and_raise(NoMethodError) }
+        before { allow(transaction.request).to receive(:params).and_raise(NoMethodError) }
 
-        it { should be_nil }
+        it { is_expected.to be_nil }
       end
 
       context "when params method does not exist" do
         let(:options) { { :params_method => :nonsense } }
 
-        it { should be_nil }
+        it { is_expected.to be_nil }
       end
 
       context "when not sending params" do
         before { Appsignal.config.config_hash[:send_params] = false }
         after { Appsignal.config.config_hash[:send_params] = true }
 
-        it { should be_nil }
+        it { is_expected.to be_nil }
       end
 
       context "with an array" do
@@ -712,13 +748,13 @@ describe Appsignal::Transaction do
           Appsignal::Transaction::GenericRequest.new(background_env_with_data(:params => ["arg1", "arg2"]))
         end
 
-        it { should eq ["arg1", "arg2"] }
+        it { is_expected.to eq ["arg1", "arg2"] }
 
         context "with AppSignal filtering" do
           before { Appsignal.config.config_hash[:filter_parameters] = %w(foo) }
           after { Appsignal.config.config_hash[:filter_parameters] = [] }
 
-          it { should eq ["arg1", "arg2"] }
+          it { is_expected.to eq ["arg1", "arg2"] }
         end
       end
 
@@ -731,7 +767,7 @@ describe Appsignal::Transaction do
 
           it "should call the params sanitizer" do
             puts Appsignal.config.config_hash[:filter_parameters].inspect
-            subject.should eq(:foo => :bar)
+            expect(subject).to eq(:foo => :bar)
           end
         end
 
@@ -744,7 +780,7 @@ describe Appsignal::Transaction do
           after { Appsignal.config.config_hash[:filter_parameters] = [] }
 
           it "should call the params sanitizer with filtering" do
-            subject.should eq(:foo => "[FILTERED]", :baz => :bat)
+            expect(subject).to eq(:foo => "[FILTERED]", :baz => :bat)
           end
         end
       end
@@ -766,7 +802,7 @@ describe Appsignal::Transaction do
       context "when env is nil" do
         before { expect(transaction.request).to receive(:env).and_return(nil) }
 
-        it { should be_nil }
+        it { is_expected.to be_nil }
       end
 
       context "when env is present" do
@@ -778,7 +814,10 @@ describe Appsignal::Transaction do
           end
         end
 
-        its(:keys) { should =~ whitelisted_keys[0, whitelisted_keys.length] }
+        describe '#keys' do
+          subject { super().keys }
+          it { is_expected.to match_array(whitelisted_keys[0, whitelisted_keys.length]) }
+        end
       end
     end
 
@@ -796,44 +835,44 @@ describe Appsignal::Transaction do
       context "when session is nil" do
         before { expect(transaction.request).to receive(:session).and_return(nil) }
 
-        it { should be_nil }
+        it { is_expected.to be_nil }
       end
 
       context "when session is empty" do
         before { expect(transaction.request).to receive(:session).and_return({}) }
 
-        it { should eq({}) }
+        it { is_expected.to eq({}) }
       end
 
       context "when request class does not have a session method" do
         let(:request) { Appsignal::Transaction::GenericRequest.new({}) }
 
-        it { should be_nil }
+        it { is_expected.to be_nil }
       end
 
       context "when there is a session" do
         before do
-          transaction.should respond_to(:request)
+          expect(transaction).to respond_to(:request)
           transaction.stub_chain(:request, :session => { :foo => :bar })
           transaction.stub_chain(:request, :fullpath => :bar)
         end
 
         it "passes the session data into the params sanitizer" do
-          Appsignal::Utils::ParamsSanitizer.should_receive(:sanitize).with(:foo => :bar)
+          expect(Appsignal::Utils::ParamsSanitizer).to receive(:sanitize).with(:foo => :bar)
             .and_return(:sanitized_foo)
-          subject.should eq :sanitized_foo
+          expect(subject).to eq :sanitized_foo
         end
 
         if defined? ActionDispatch::Request::Session
           context "with ActionDispatch::Request::Session" do
             before do
-              transaction.should respond_to(:request)
+              expect(transaction).to respond_to(:request)
               transaction.stub_chain(:request, :session => action_dispatch_session)
               transaction.stub_chain(:request, :fullpath => :bar)
             end
 
             it "should return an session hash" do
-              Appsignal::Utils::ParamsSanitizer.should_receive(:sanitize).with("foo" => :bar)
+              expect(Appsignal::Utils::ParamsSanitizer).to receive(:sanitize).with("foo" => :bar)
                 .and_return(:sanitized_foo)
               subject
             end
@@ -859,8 +898,8 @@ describe Appsignal::Transaction do
           end
 
           it "does not pass the session data into the params sanitizer" do
-            Appsignal::Utils::ParamsSanitizer.should_not_receive(:sanitize)
-            subject.should be_nil
+            expect(Appsignal::Utils::ParamsSanitizer).to_not receive(:sanitize)
+            expect(subject).to be_nil
           end
         end
       end
@@ -872,19 +911,19 @@ describe Appsignal::Transaction do
       context "when request is nil" do
         let(:request) { nil }
 
-        it { should be_nil }
+        it { is_expected.to be_nil }
       end
 
       context "when env is nil" do
         before { expect(transaction.request).to receive(:env).and_return(nil) }
 
-        it { should be_nil }
+        it { is_expected.to be_nil }
       end
 
       context "when env is present" do
         let(:env) { { :metadata => { :key => "value" } } }
 
-        it { should eq env[:metadata] }
+        it { is_expected.to eq env[:metadata] }
       end
     end
 
@@ -905,12 +944,12 @@ describe Appsignal::Transaction do
       subject { transaction.send(:sanitized_tags).keys }
 
       it "should only return whitelisted data" do
-        should =~ [
+        is_expected.to match_array([
           :valid_key,
           "valid_string_key",
           :both_symbols,
           :integer_value
-        ]
+        ])
       end
     end
 
@@ -938,7 +977,7 @@ describe Appsignal::Transaction do
     subject { Appsignal::Transaction::NilTransaction.new }
 
     it "should have method stubs" do
-      lambda do
+      expect do
         subject.complete
         subject.pause!
         subject.resume!
@@ -953,7 +992,7 @@ describe Appsignal::Transaction do
         subject.set_sample_data("key", "data")
         subject.sample_data
         subject.set_error("a")
-      end.should_not raise_error
+      end.to_not raise_error
     end
   end
 end

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -195,52 +195,42 @@ describe Appsignal::Transaction do
 
   context "with transaction instance" do
     context "initialization" do
-      subject { transaction }
-
-      describe '#ext' do
-        subject { super().ext }
-        it { is_expected.to_not be_nil }
+      it "loads the AppSignal extension" do
+        expect(transaction.ext).to_not be_nil
       end
 
-      describe '#transaction_id' do
-        subject { super().transaction_id }
-        it { is_expected.to eq "1" }
+      it "sets the transaction id" do
+        expect(transaction.transaction_id).to eq "1"
       end
 
-      describe '#namespace' do
-        subject { super().namespace }
-        it { is_expected.to eq "http_request" }
+      it "sets the namespace to http_request" do
+        expect(transaction.namespace).to eq "http_request"
       end
 
-      describe '#request' do
-        subject { super().request }
-        it { is_expected.to_not be_nil }
+      it "sets the request" do
+        expect(transaction.request).to_not be_nil
       end
 
-      describe '#paused' do
-        subject { super().paused }
-        it { is_expected.to be_falsy }
+      it "sets the request not to paused" do
+        expect(transaction.paused).to be_falsy
       end
 
-      describe '#tags' do
-        subject { super().tags }
-        it { is_expected.to eq({}) }
+      it "sets no tags by default" do
+        expect(transaction.tags).to eq({})
       end
 
-      context "options" do
+      describe "#options" do
         subject { transaction.options }
 
-        describe '[:params_method]' do
-          subject { super()[:params_method] }
-          it { is_expected.to eq :params }
+        it "sets the default :params_method" do
+          expect(subject[:params_method]).to eq :params
         end
 
         context "with overridden options" do
           let(:options) { { :params_method => :filtered_params } }
 
-          describe '[:params_method]' do
-            subject { super()[:params_method] }
-            it { is_expected.to eq :filtered_params }
+          it "sets the overriden :params_method" do
+            expect(subject[:params_method]).to eq :filtered_params
           end
         end
       end
@@ -596,11 +586,11 @@ describe Appsignal::Transaction do
       let(:env) { {} }
       subject { Appsignal::Transaction::GenericRequest.new(env) }
 
-      it "should initialize with an empty env" do
+      it "initializes with an empty env" do
         expect(subject.env).to be_empty
       end
 
-      context "with a filled env" do
+      context "when given an env" do
         let(:env) do
           {
             :params => { :id => 1 },
@@ -608,14 +598,12 @@ describe Appsignal::Transaction do
           }
         end
 
-        describe '#env' do
-          subject { super().env }
-          it { is_expected.to eq env }
+        it "sets the given env" do
+          expect(subject.env).to eq env
         end
 
-        describe '#params' do
-          subject { super().params }
-          it { is_expected.to eq(:id => 1) }
+        it "sets the params present in the env" do
+          expect(subject.params).to eq(:id => 1)
         end
       end
     end
@@ -795,9 +783,7 @@ describe Appsignal::Transaction do
       context "when request is nil" do
         let(:request) { nil }
 
-        it "returns nil" do
-          expect(subject).to be_nil
-        end
+        it { is_expected.to be_nil }
       end
 
       context "when env is nil" do
@@ -815,9 +801,8 @@ describe Appsignal::Transaction do
           end
         end
 
-        describe '#keys' do
-          subject { super().keys }
-          it { is_expected.to match_array(whitelisted_keys[0, whitelisted_keys.length]) }
+        it "only sets whitelisted keys" do
+          expect(subject.keys).to match_array(whitelisted_keys)
         end
       end
     end
@@ -828,9 +813,7 @@ describe Appsignal::Transaction do
       context "when request is nil" do
         let(:request) { nil }
 
-        it "returns nil" do
-          expect(subject).to be_nil
-        end
+        it { is_expected.to be_nil }
       end
 
       context "when session is nil" do

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -425,7 +425,7 @@ describe Appsignal::Transaction do
       context "for a http request" do
         it "should set an error in the extension" do
           transaction.ext.should_receive(:set_error).with(
-            "RSpec::Mocks::Mock",
+            "RSpec::Mocks::Double",
             "test message",
             Appsignal::Utils.data_generate(["line 1"])
           )
@@ -443,7 +443,7 @@ describe Appsignal::Transaction do
 
         it "should set an error in the extension" do
           transaction.ext.should_receive(:set_error).with(
-            "RSpec::Mocks::Mock",
+            "RSpec::Mocks::Double",
             "",
             Appsignal::Utils.data_generate(["line 1"])
           )

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -7,7 +7,7 @@ class Smash < Hash
 end
 
 describe Appsignal::Transaction do
-  before :all do
+  before :context do
     start_agent
   end
 
@@ -837,8 +837,8 @@ describe Appsignal::Transaction do
       context "when there is a session" do
         before do
           expect(transaction).to respond_to(:request)
-          transaction.stub_chain(:request, :session => { :foo => :bar })
-          transaction.stub_chain(:request, :fullpath => :bar)
+          allow(transaction).to receive_message_chain(:request, :session => { :foo => :bar })
+          allow(transaction).to receive_message_chain(:request, :fullpath => :bar)
         end
 
         it "passes the session data into the params sanitizer" do
@@ -851,8 +851,8 @@ describe Appsignal::Transaction do
           context "with ActionDispatch::Request::Session" do
             before do
               expect(transaction).to respond_to(:request)
-              transaction.stub_chain(:request, :session => action_dispatch_session)
-              transaction.stub_chain(:request, :fullpath => :bar)
+              allow(transaction).to receive_message_chain(:request, :session => action_dispatch_session)
+              allow(transaction).to receive_message_chain(:request, :fullpath => :bar)
             end
 
             it "should return an session hash" do

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -585,9 +585,10 @@ describe Appsignal::Transaction do
           0
         )
 
-        expect(transaction.instrument "name", "title", "body" do
+        return_value = transaction.instrument "name", "title", "body" do
           stub.method_call
-        end).to eq "return value"
+        end
+        expect(return_value).to eq "return value"
       end
     end
 

--- a/spec/lib/appsignal/transmitter_spec.rb
+++ b/spec/lib/appsignal/transmitter_spec.rb
@@ -11,12 +11,12 @@ describe Appsignal::Transmitter do
   describe "#uri" do
     subject { instance.uri.to_s }
 
-    it { should include "https://push.appsignal.com/1/action?" }
-    it { should include "api_key=abc" }
-    it { should include "hostname=app1.local" }
-    it { should include "name=TestApp" }
-    it { should include "environment=production" }
-    it { should include "gem_version=#{Appsignal::VERSION}" }
+    it { is_expected.to include "https://push.appsignal.com/1/action?" }
+    it { is_expected.to include "api_key=abc" }
+    it { is_expected.to include "hostname=app1.local" }
+    it { is_expected.to include "name=TestApp" }
+    it { is_expected.to include "environment=production" }
+    it { is_expected.to include "gem_version=#{Appsignal::VERSION}" }
   end
 
   describe "#transmit" do
@@ -38,7 +38,7 @@ describe Appsignal::Transmitter do
     end
     subject { instance.transmit(:the => :payload) }
 
-    it { should eq "200" }
+    it { is_expected.to eq "200" }
 
     context "with ca_file_path config option set" do
       context "when not existing file" do
@@ -86,12 +86,19 @@ describe Appsignal::Transmitter do
   describe "#http_post" do
     subject { instance.send(:http_post, "the" => "payload") }
 
-    its(:body) { should eq Appsignal::Utils::Gzip.compress("{\"the\":\"payload\"}") }
-    its(:path) { should eq instance.uri.request_uri }
+    describe '#body' do
+      subject { super().body }
+      it { is_expected.to eq Appsignal::Utils::Gzip.compress("{\"the\":\"payload\"}") }
+    end
+
+    describe '#path' do
+      subject { super().path }
+      it { is_expected.to eq instance.uri.request_uri }
+    end
 
     it "should have the correct headers" do
-      subject["Content-Type"].should eq "application/json; charset=UTF-8"
-      subject["Content-Encoding"].should eq "gzip"
+      expect(subject["Content-Type"]).to eq "application/json; charset=UTF-8"
+      expect(subject["Content-Encoding"]).to eq "gzip"
     end
   end
 
@@ -101,27 +108,62 @@ describe Appsignal::Transmitter do
     context "with a http uri" do
       let(:config) { project_fixture_config("test") }
 
-      it { should be_instance_of(Net::HTTP) }
-      its(:proxy?) { should be_false }
-      its(:use_ssl?) { should be_false }
+      it { is_expected.to be_instance_of(Net::HTTP) }
+
+      describe '#proxy?' do
+        subject { super().proxy? }
+        it { is_expected.to be_falsy }
+      end
+
+      describe '#use_ssl?' do
+        subject { super().use_ssl? }
+        it { is_expected.to be_falsy }
+      end
     end
 
     context "with a https uri" do
       let(:config) { project_fixture_config("production") }
 
-      it { should be_instance_of(Net::HTTP) }
-      its(:proxy?) { should be_false }
-      its(:use_ssl?) { should be_true }
-      its(:verify_mode) { should eq OpenSSL::SSL::VERIFY_PEER }
-      its(:ca_file) { should eq config[:ca_file_path] }
+      it { is_expected.to be_instance_of(Net::HTTP) }
+
+      describe '#proxy?' do
+        subject { super().proxy? }
+        it { is_expected.to be_falsy }
+      end
+
+      describe '#use_ssl?' do
+        subject { super().use_ssl? }
+        it { is_expected.to be_truthy }
+      end
+
+      describe '#verify_mode' do
+        subject { super().verify_mode }
+        it { is_expected.to eq OpenSSL::SSL::VERIFY_PEER }
+      end
+
+      describe '#ca_file' do
+        subject { super().ca_file }
+        it { is_expected.to eq config[:ca_file_path] }
+      end
     end
 
     context "with a proxy" do
       let(:config) { project_fixture_config("production", :http_proxy => "http://localhost:8080") }
 
-      its(:proxy?) { should be_true }
-      its(:proxy_address) { should eq "localhost" }
-      its(:proxy_port) { should eq 8080 }
+      describe '#proxy?' do
+        subject { super().proxy? }
+        it { is_expected.to be_truthy }
+      end
+
+      describe '#proxy_address' do
+        subject { super().proxy_address }
+        it { is_expected.to eq "localhost" }
+      end
+
+      describe '#proxy_port' do
+        subject { super().proxy_port }
+        it { is_expected.to eq 8080 }
+      end
     end
   end
 end

--- a/spec/lib/appsignal/transmitter_spec.rb
+++ b/spec/lib/appsignal/transmitter_spec.rb
@@ -86,17 +86,15 @@ describe Appsignal::Transmitter do
   describe "#http_post" do
     subject { instance.send(:http_post, "the" => "payload") }
 
-    describe '#body' do
-      subject { super().body }
-      it { is_expected.to eq Appsignal::Utils::Gzip.compress("{\"the\":\"payload\"}") }
+    it "gzips the body" do
+      expect(subject.body).to eq Appsignal::Utils::Gzip.compress("{\"the\":\"payload\"}")
     end
 
-    describe '#path' do
-      subject { super().path }
-      it { is_expected.to eq instance.uri.request_uri }
+    it "sets the path" do
+      expect(subject.path).to eq instance.uri.request_uri
     end
 
-    it "should have the correct headers" do
+    it "sets the correct headers" do
       expect(subject["Content-Type"]).to eq "application/json; charset=UTF-8"
       expect(subject["Content-Encoding"]).to eq "gzip"
     end
@@ -108,62 +106,28 @@ describe Appsignal::Transmitter do
     context "with a http uri" do
       let(:config) { project_fixture_config("test") }
 
-      it { is_expected.to be_instance_of(Net::HTTP) }
-
-      describe '#proxy?' do
-        subject { super().proxy? }
-        it { is_expected.to be_falsy }
-      end
-
-      describe '#use_ssl?' do
-        subject { super().use_ssl? }
-        it { is_expected.to be_falsy }
-      end
+      it { expect(subject).to be_instance_of(Net::HTTP) }
+      it { expect(subject.proxy?).to be_falsy }
+      it { expect(subject.use_ssl?).to be_falsy }
     end
 
     context "with a https uri" do
       let(:config) { project_fixture_config("production") }
 
-      it { is_expected.to be_instance_of(Net::HTTP) }
-
-      describe '#proxy?' do
-        subject { super().proxy? }
-        it { is_expected.to be_falsy }
-      end
-
-      describe '#use_ssl?' do
-        subject { super().use_ssl? }
-        it { is_expected.to be_truthy }
-      end
-
-      describe '#verify_mode' do
-        subject { super().verify_mode }
-        it { is_expected.to eq OpenSSL::SSL::VERIFY_PEER }
-      end
-
-      describe '#ca_file' do
-        subject { super().ca_file }
-        it { is_expected.to eq config[:ca_file_path] }
-      end
+      it { expect(subject).to be_instance_of(Net::HTTP) }
+      it { expect(subject.proxy?).to be_falsy }
+      it { expect(subject.use_ssl?).to be_truthy }
+      it { expect(subject.verify_mode).to eq OpenSSL::SSL::VERIFY_PEER }
+      it { expect(subject.ca_file).to eq config[:ca_file_path] }
     end
 
     context "with a proxy" do
       let(:config) { project_fixture_config("production", :http_proxy => "http://localhost:8080") }
 
-      describe '#proxy?' do
-        subject { super().proxy? }
-        it { is_expected.to be_truthy }
-      end
-
-      describe '#proxy_address' do
-        subject { super().proxy_address }
-        it { is_expected.to eq "localhost" }
-      end
-
-      describe '#proxy_port' do
-        subject { super().proxy_port }
-        it { is_expected.to eq 8080 }
-      end
+      it { expect(subject).to be_instance_of(Net::HTTP) }
+      it { expect(subject.proxy?).to be_truthy }
+      it { expect(subject.proxy_address).to eq "localhost" }
+      it { expect(subject.proxy_port).to eq 8080 }
     end
   end
 end

--- a/spec/lib/appsignal/utils/params_sanitizer_spec.rb
+++ b/spec/lib/appsignal/utils/params_sanitizer_spec.rb
@@ -29,45 +29,113 @@ describe Appsignal::Utils::ParamsSanitizer do
     let(:sanitized_params) { described_class.sanitize(params) }
     subject { sanitized_params }
 
-    it { should be_instance_of Hash }
-    its([:text]) { should eq("string") }
-    its(["string"]) { should eq("string key value") }
-    its([:file]) { should be_instance_of String }
-    its([:file]) { should include "::UploadedFile" }
-    its([:float]) { should eq(0.0) }
-    its([:bool_true]) { should be(true) }
-    its([:bool_false]) { should be(false) }
-    its([:nil]) { should be_nil }
-    its([:int]) { should eq(1) }
+    it { is_expected.to be_instance_of Hash }
+
+    describe '[:text]' do
+      subject { super()[:text] }
+      it { is_expected.to eq("string") }
+    end
+
+    describe "[\"string\"]" do
+      subject { super()["string"] }
+      it { is_expected.to eq("string key value") }
+    end
+
+    describe '[:file]' do
+      subject { super()[:file] }
+      it { is_expected.to be_instance_of String }
+    end
+
+    describe '[:file]' do
+      subject { super()[:file] }
+      it { is_expected.to include "::UploadedFile" }
+    end
+
+    describe '[:float]' do
+      subject { super()[:float] }
+      it { is_expected.to eq(0.0) }
+    end
+
+    describe '[:bool_true]' do
+      subject { super()[:bool_true] }
+      it { is_expected.to be(true) }
+    end
+
+    describe '[:bool_false]' do
+      subject { super()[:bool_false] }
+      it { is_expected.to be(false) }
+    end
+
+    describe '[:nil]' do
+      subject { super()[:nil] }
+      it { is_expected.to be_nil }
+    end
+
+    describe '[:int]' do
+      subject { super()[:int] }
+      it { is_expected.to eq(1) }
+    end
 
     it "does not change the original params" do
       subject
-      params[:file].should eq(file)
-      params[:hash][:nested_array][2].should eq(file)
+      expect(params[:file]).to eq(file)
+      expect(params[:hash][:nested_array][2]).to eq(file)
     end
 
     describe ":hash" do
       subject { sanitized_params[:hash] }
 
-      it { should be_instance_of Hash }
-      its([:nested_text]) { should eq("string") }
+      it { is_expected.to be_instance_of Hash }
+
+      describe '[:nested_text]' do
+        subject { super()[:nested_text] }
+        it { is_expected.to eq("string") }
+      end
 
       describe ":nested_array" do
         subject { sanitized_params[:hash][:nested_array] }
 
-        it { should be_instance_of Array }
-        its([0]) { should eq("something") }
-        its([1]) { should eq("else") }
-        its([2]) { should be_instance_of String }
-        its([2]) { should include "::UploadedFile" }
+        it { is_expected.to be_instance_of Array }
+
+        describe '[0]' do
+          subject { super()[0] }
+          it { is_expected.to eq("something") }
+        end
+
+        describe '[1]' do
+          subject { super()[1] }
+          it { is_expected.to eq("else") }
+        end
+
+        describe '[2]' do
+          subject { super()[2] }
+          it { is_expected.to be_instance_of String }
+        end
+
+        describe '[2]' do
+          subject { super()[2] }
+          it { is_expected.to include "::UploadedFile" }
+        end
 
         describe ":nested_hash" do
           subject { sanitized_params[:hash][:nested_array][3] }
 
-          it { should be_instance_of Hash }
-          its([:key]) { should eq("value") }
-          its([:file]) { should be_instance_of String }
-          its([:file]) { should include "::UploadedFile" }
+          it { is_expected.to be_instance_of Hash }
+
+          describe '[:key]' do
+            subject { super()[:key] }
+            it { is_expected.to eq("value") }
+          end
+
+          describe '[:file]' do
+            subject { super()[:file] }
+            it { is_expected.to be_instance_of String }
+          end
+
+          describe '[:file]' do
+            subject { super()[:file] }
+            it { is_expected.to include "::UploadedFile" }
+          end
         end
       end
     end
@@ -78,22 +146,60 @@ describe Appsignal::Utils::ParamsSanitizer do
       end
       subject { sanitized_params }
 
-      its([:text]) { should eq(described_class::FILTERED) }
-      its([:hash]) { should eq(described_class::FILTERED) }
-      its([:file]) { should be_instance_of String }
-      its([:file]) { should include "::UploadedFile" }
-      its([:float]) { should eq(0.0) }
-      its([:bool_true]) { should be(true) }
-      its([:bool_false]) { should be(false) }
-      its([:nil]) { should be_nil }
-      its([:int]) { should eq(1) }
+      describe '[:text]' do
+        subject { super()[:text] }
+        it { is_expected.to eq(described_class::FILTERED) }
+      end
+
+      describe '[:hash]' do
+        subject { super()[:hash] }
+        it { is_expected.to eq(described_class::FILTERED) }
+      end
+
+      describe '[:file]' do
+        subject { super()[:file] }
+        it { is_expected.to be_instance_of String }
+      end
+
+      describe '[:file]' do
+        subject { super()[:file] }
+        it { is_expected.to include "::UploadedFile" }
+      end
+
+      describe '[:float]' do
+        subject { super()[:float] }
+        it { is_expected.to eq(0.0) }
+      end
+
+      describe '[:bool_true]' do
+        subject { super()[:bool_true] }
+        it { is_expected.to be(true) }
+      end
+
+      describe '[:bool_false]' do
+        subject { super()[:bool_false] }
+        it { is_expected.to be(false) }
+      end
+
+      describe '[:nil]' do
+        subject { super()[:nil] }
+        it { is_expected.to be_nil }
+      end
+
+      describe '[:int]' do
+        subject { super()[:int] }
+        it { is_expected.to eq(1) }
+      end
 
       context "with strings as key filter values" do
         let(:sanitized_params) do
           described_class.sanitize(params, :filter_parameters => %w(string))
         end
 
-        its(["string"]) { should eq("[FILTERED]") }
+        describe "[\"string\"]" do
+          subject { super()["string"] }
+          it { is_expected.to eq("[FILTERED]") }
+        end
       end
 
       describe ":hash" do
@@ -102,7 +208,10 @@ describe Appsignal::Utils::ParamsSanitizer do
         end
         subject { sanitized_params[:hash] }
 
-        its([:nested_text]) { should eq("[FILTERED]") }
+        describe '[:nested_text]' do
+          subject { super()[:nested_text] }
+          it { is_expected.to eq("[FILTERED]") }
+        end
 
         describe ":nested_array" do
           describe ":nested_hash" do
@@ -111,7 +220,10 @@ describe Appsignal::Utils::ParamsSanitizer do
             end
             subject { sanitized_params[:hash][:nested_array][3] }
 
-            its([:key]) { should eq("[FILTERED]") }
+            describe '[:key]' do
+              subject { super()[:key] }
+              it { is_expected.to eq("[FILTERED]") }
+            end
           end
         end
       end

--- a/spec/lib/appsignal/utils/params_sanitizer_spec.rb
+++ b/spec/lib/appsignal/utils/params_sanitizer_spec.rb
@@ -30,51 +30,17 @@ describe Appsignal::Utils::ParamsSanitizer do
     subject { sanitized_params }
 
     it { is_expected.to be_instance_of Hash }
-
-    describe '[:text]' do
-      subject { super()[:text] }
-      it { is_expected.to eq("string") }
+    it { expect(subject[:text]).to eq("string") }
+    it { expect(subject["string"]).to eq("string key value") }
+    it do
+      expect(subject[:file]).to be_instance_of String
+      expect(subject[:file]).to include "::UploadedFile"
     end
-
-    describe "[\"string\"]" do
-      subject { super()["string"] }
-      it { is_expected.to eq("string key value") }
-    end
-
-    describe '[:file]' do
-      subject { super()[:file] }
-      it { is_expected.to be_instance_of String }
-    end
-
-    describe '[:file]' do
-      subject { super()[:file] }
-      it { is_expected.to include "::UploadedFile" }
-    end
-
-    describe '[:float]' do
-      subject { super()[:float] }
-      it { is_expected.to eq(0.0) }
-    end
-
-    describe '[:bool_true]' do
-      subject { super()[:bool_true] }
-      it { is_expected.to be(true) }
-    end
-
-    describe '[:bool_false]' do
-      subject { super()[:bool_false] }
-      it { is_expected.to be(false) }
-    end
-
-    describe '[:nil]' do
-      subject { super()[:nil] }
-      it { is_expected.to be_nil }
-    end
-
-    describe '[:int]' do
-      subject { super()[:int] }
-      it { is_expected.to eq(1) }
-    end
+    it { expect(subject[:float]).to eq(0.0) }
+    it { expect(subject[:bool_true]).to be(true) }
+    it { expect(subject[:bool_false]).to be(false) }
+    it { expect(subject[:nil]).to be_nil }
+    it { expect(subject[:int]).to eq(1) }
 
     it "does not change the original params" do
       subject
@@ -86,55 +52,27 @@ describe Appsignal::Utils::ParamsSanitizer do
       subject { sanitized_params[:hash] }
 
       it { is_expected.to be_instance_of Hash }
-
-      describe '[:nested_text]' do
-        subject { super()[:nested_text] }
-        it { is_expected.to eq("string") }
-      end
+      it { expect(subject[:nested_text]).to eq("string") }
 
       describe ":nested_array" do
         subject { sanitized_params[:hash][:nested_array] }
 
         it { is_expected.to be_instance_of Array }
-
-        describe '[0]' do
-          subject { super()[0] }
-          it { is_expected.to eq("something") }
-        end
-
-        describe '[1]' do
-          subject { super()[1] }
-          it { is_expected.to eq("else") }
-        end
-
-        describe '[2]' do
-          subject { super()[2] }
-          it { is_expected.to be_instance_of String }
-        end
-
-        describe '[2]' do
-          subject { super()[2] }
-          it { is_expected.to include "::UploadedFile" }
+        it { expect(subject[0]).to eq("something") }
+        it { expect(subject[1]).to eq("else") }
+        it do
+          expect(subject[2]).to be_instance_of String
+          expect(subject[2]).to include "::UploadedFile"
         end
 
         describe ":nested_hash" do
           subject { sanitized_params[:hash][:nested_array][3] }
 
           it { is_expected.to be_instance_of Hash }
-
-          describe '[:key]' do
-            subject { super()[:key] }
-            it { is_expected.to eq("value") }
-          end
-
-          describe '[:file]' do
-            subject { super()[:file] }
-            it { is_expected.to be_instance_of String }
-          end
-
-          describe '[:file]' do
-            subject { super()[:file] }
-            it { is_expected.to include "::UploadedFile" }
+          it { expect(subject[:key]).to eq("value") }
+          it do
+            expect(subject[:file]).to be_instance_of String
+            expect(subject[:file]).to include "::UploadedFile"
           end
         end
       end
@@ -146,59 +84,25 @@ describe Appsignal::Utils::ParamsSanitizer do
       end
       subject { sanitized_params }
 
-      describe '[:text]' do
-        subject { super()[:text] }
-        it { is_expected.to eq(described_class::FILTERED) }
+      it { expect(subject[:text]).to eq(described_class::FILTERED) }
+      it { expect(subject[:hash]).to eq(described_class::FILTERED) }
+      it do
+        expect(subject[:file]).to be_instance_of String
+        expect(subject[:file]).to include "::UploadedFile"
       end
-
-      describe '[:hash]' do
-        subject { super()[:hash] }
-        it { is_expected.to eq(described_class::FILTERED) }
-      end
-
-      describe '[:file]' do
-        subject { super()[:file] }
-        it { is_expected.to be_instance_of String }
-      end
-
-      describe '[:file]' do
-        subject { super()[:file] }
-        it { is_expected.to include "::UploadedFile" }
-      end
-
-      describe '[:float]' do
-        subject { super()[:float] }
-        it { is_expected.to eq(0.0) }
-      end
-
-      describe '[:bool_true]' do
-        subject { super()[:bool_true] }
-        it { is_expected.to be(true) }
-      end
-
-      describe '[:bool_false]' do
-        subject { super()[:bool_false] }
-        it { is_expected.to be(false) }
-      end
-
-      describe '[:nil]' do
-        subject { super()[:nil] }
-        it { is_expected.to be_nil }
-      end
-
-      describe '[:int]' do
-        subject { super()[:int] }
-        it { is_expected.to eq(1) }
-      end
+      it { expect(subject[:float]).to eq(0.0) }
+      it { expect(subject[:bool_true]).to be(true) }
+      it { expect(subject[:bool_false]).to be(false) }
+      it { expect(subject[:nil]).to be_nil }
+      it { expect(subject[:int]).to eq(1) }
 
       context "with strings as key filter values" do
         let(:sanitized_params) do
           described_class.sanitize(params, :filter_parameters => %w(string))
         end
 
-        describe "[\"string\"]" do
-          subject { super()["string"] }
-          it { is_expected.to eq("[FILTERED]") }
+        it "sanitizes values" do
+          expect(subject["string"]).to eq("[FILTERED]")
         end
       end
 
@@ -208,9 +112,8 @@ describe Appsignal::Utils::ParamsSanitizer do
         end
         subject { sanitized_params[:hash] }
 
-        describe '[:nested_text]' do
-          subject { super()[:nested_text] }
-          it { is_expected.to eq("[FILTERED]") }
+        it "sanitizes values in nested hashes" do
+          expect(subject[:nested_text]).to eq("[FILTERED]")
         end
 
         describe ":nested_array" do
@@ -220,9 +123,8 @@ describe Appsignal::Utils::ParamsSanitizer do
             end
             subject { sanitized_params[:hash][:nested_array][3] }
 
-            describe '[:key]' do
-              subject { super()[:key] }
-              it { is_expected.to eq("[FILTERED]") }
+            it "sanitizes values in deeply nested hashes and arrays" do
+              expect(subject[:key]).to eq("[FILTERED]")
             end
           end
         end

--- a/spec/lib/appsignal/utils_spec.rb
+++ b/spec/lib/appsignal/utils_spec.rb
@@ -18,10 +18,14 @@ describe Appsignal::Utils do
         }
       end
 
-      it { should eq Appsignal::Utils.data_generate(body) }
-      it { should_not eq Appsignal::Utils.data_generate({}) }
-      it { should_not eq "a string" }
-      its(:to_s) { should eq %({"":"test","1":true,"bar":null,"baz":{"arr":[1,2],"foo":"bʊr"},"float":1.0,"foo":[1,2,"three",{"foo":"bar"}],"int":1,"the":"payload"}) }
+      it { is_expected.to eq Appsignal::Utils.data_generate(body) }
+      it { is_expected.to_not eq Appsignal::Utils.data_generate({}) }
+      it { is_expected.to_not eq "a string" }
+
+      describe '#to_s' do
+        subject { super().to_s }
+        it { is_expected.to eq %({"":"test","1":true,"bar":null,"baz":{"arr":[1,2],"foo":"bʊr"},"float":1.0,"foo":[1,2,"three",{"foo":"bar"}],"int":1,"the":"payload"}) }
+      end
     end
 
     context "with a valid array body" do
@@ -29,7 +33,10 @@ describe Appsignal::Utils do
         [1, "string", 10, { "foo" => "bʊr" }]
       end
 
-      its(:to_s) { should eq %([1,\"string\",10,{\"foo\":\"bʊr\"}]) }
+      describe '#to_s' do
+        subject { super().to_s }
+        it { is_expected.to eq %([1,\"string\",10,{\"foo\":\"bʊr\"}]) }
+      end
     end
 
     context "with a body that contains strings with invalid utf-8 content" do
@@ -47,7 +54,10 @@ describe Appsignal::Utils do
         }
       end
 
-      its(:to_s) { should eq %({"field_four":{"one":"aa�"},"field_one":"aa","field_three":["one","aa�"],"field_two":"aa�"}) }
+      describe '#to_s' do
+        subject { super().to_s }
+        it { is_expected.to eq %({"field_four":{"one":"aa�"},"field_one":"aa","field_three":["one","aa�"],"field_two":"aa�"}) }
+      end
     end
 
     context "with an invalid body" do
@@ -76,7 +86,7 @@ describe Appsignal::Utils do
         }
       end
 
-      it { should eq %({"the":"payload","1":true,"":"test","foo":[1,2,"three"],"bar":null,"baz":{"foo":"bar"}}) }
+      it { is_expected.to eq %({"the":"payload","1":true,"":"test","foo":[1,2,"three"],"bar":null,"baz":{"foo":"bar"}}) }
     end
 
     context "with a body that contains strings with invalid utf-8 content" do
@@ -94,7 +104,7 @@ describe Appsignal::Utils do
         }
       end
 
-      it { should eq %({"field_one":"aa","field_two":"aa�","field_three":["one","aa�"],"field_four":{"one":"aa�"}}) }
+      it { is_expected.to eq %({"field_one":"aa","field_two":"aa�","field_three":["one","aa�"],"field_four":{"one":"aa�"}}) }
     end
   end
 end

--- a/spec/lib/appsignal/utils_spec.rb
+++ b/spec/lib/appsignal/utils_spec.rb
@@ -22,9 +22,10 @@ describe Appsignal::Utils do
       it { is_expected.to_not eq Appsignal::Utils.data_generate({}) }
       it { is_expected.to_not eq "a string" }
 
-      describe '#to_s' do
-        subject { super().to_s }
-        it { is_expected.to eq %({"":"test","1":true,"bar":null,"baz":{"arr":[1,2],"foo":"bʊr"},"float":1.0,"foo":[1,2,"three",{"foo":"bar"}],"int":1,"the":"payload"}) }
+      describe "#to_s" do
+        it do
+          expect(subject.to_s).to eq %({"":"test","1":true,"bar":null,"baz":{"arr":[1,2],"foo":"bʊr"},"float":1.0,"foo":[1,2,"three",{"foo":"bar"}],"int":1,"the":"payload"})
+        end
       end
     end
 
@@ -33,10 +34,7 @@ describe Appsignal::Utils do
         [1, "string", 10, { "foo" => "bʊr" }]
       end
 
-      describe '#to_s' do
-        subject { super().to_s }
-        it { is_expected.to eq %([1,\"string\",10,{\"foo\":\"bʊr\"}]) }
-      end
+      it { expect(subject.to_s).to eq %([1,\"string\",10,{\"foo\":\"bʊr\"}]) }
     end
 
     context "with a body that contains strings with invalid utf-8 content" do
@@ -54,9 +52,8 @@ describe Appsignal::Utils do
         }
       end
 
-      describe '#to_s' do
-        subject { super().to_s }
-        it { is_expected.to eq %({"field_four":{"one":"aa�"},"field_one":"aa","field_three":["one","aa�"],"field_two":"aa�"}) }
+      describe "#to_s" do
+        it { expect(subject.to_s).to eq %({"field_four":{"one":"aa�"},"field_one":"aa","field_three":["one","aa�"],"field_two":"aa�"}) }
       end
     end
 

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -866,7 +866,7 @@ describe Appsignal do
       let(:err_stream) { std_stream }
       let(:stderr) { err_stream.read }
       before do
-        allow(Appsignal).to receive(:config).and_return({ :ignore_errors => ["StandardError"] })
+        allow(Appsignal).to receive(:config).and_return(:ignore_errors => ["StandardError"])
       end
 
       subject do
@@ -898,7 +898,7 @@ describe Appsignal do
       let(:err_stream) { std_stream }
       let(:stderr) { err_stream.read }
       before do
-        allow(Appsignal).to receive(:config).and_return({ :ignore_actions => "TestController#isup" })
+        allow(Appsignal).to receive(:config).and_return(:ignore_actions => "TestController#isup")
       end
 
       subject do

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -13,37 +13,37 @@ describe Appsignal do
   describe ".config=" do
     it "should set the config" do
       config = project_fixture_config
-      Appsignal.logger.should_not_receive(:level=)
+      expect(Appsignal.logger).to_not receive(:level=)
 
       Appsignal.config = config
-      Appsignal.config.should eq config
+      expect(Appsignal.config).to eq config
     end
   end
 
   describe ".extensions" do
     it "should keep a list of extensions" do
-      Appsignal.extensions.should be_empty
+      expect(Appsignal.extensions).to be_empty
       Appsignal.extensions << Appsignal::MockExtension
-      Appsignal.extensions.should have(1).item
+      expect(Appsignal.extensions.size).to eq(1)
     end
   end
 
   describe ".start" do
     context "with no config set beforehand" do
       it "should do nothing when config is not set and there is no valid config in the env" do
-        Appsignal.logger.should_receive(:error).with(
+        expect(Appsignal.logger).to receive(:error).with(
           "Push api key not set after loading config"
         ).once
-        Appsignal.logger.should_receive(:error).with(
+        expect(Appsignal.logger).to receive(:error).with(
           "Not starting, no valid config for this environment"
         ).once
-        Appsignal::Extension.should_not_receive(:start)
+        expect(Appsignal::Extension).to_not receive(:start)
         Appsignal.start
       end
 
       it "should create a config from the env" do
         ENV["APPSIGNAL_PUSH_API_KEY"] = "something"
-        Appsignal::Extension.should_receive(:start)
+        expect(Appsignal::Extension).to receive(:start)
         expect(Appsignal.logger).not_to receive(:error)
         silence { Appsignal.start }
         expect(Appsignal.config[:push_api_key]).to eq("something")
@@ -55,16 +55,16 @@ describe Appsignal do
 
       it "should initialize logging" do
         Appsignal.start
-        Appsignal.logger.level.should eq Logger::INFO
+        expect(Appsignal.logger.level).to eq Logger::INFO
       end
 
       it "should start native" do
-        Appsignal::Extension.should_receive(:start)
+        expect(Appsignal::Extension).to receive(:start)
         Appsignal.start
       end
 
       it "should initialize formatters" do
-        Appsignal::EventFormatter.should_receive(:initialize_formatters)
+        expect(Appsignal::EventFormatter).to receive(:initialize_formatters)
         Appsignal.start
       end
 
@@ -73,7 +73,7 @@ describe Appsignal do
 
         it "should do nothing" do
           Appsignal.start
-          Appsignal.agent.should be_nil
+          expect(Appsignal.agent).to be_nil
         end
       end
 
@@ -81,7 +81,7 @@ describe Appsignal do
         before { Appsignal.extensions << Appsignal::MockExtension }
 
         it "should call the extension's initializer" do
-          Appsignal::MockExtension.should_receive(:initializer)
+          expect(Appsignal::MockExtension).to receive(:initializer)
           Appsignal.start
         end
       end
@@ -137,7 +137,7 @@ describe Appsignal do
         end
 
         it "should start minutely" do
-          Appsignal::Minutely.should_receive(:start)
+          expect(Appsignal::Minutely).to receive(:start)
           Appsignal.start
         end
       end
@@ -148,7 +148,7 @@ describe Appsignal do
         end
 
         it "should not start minutely" do
-          Appsignal::Minutely.should_not_receive(:start)
+          expect(Appsignal::Minutely).to_not receive(:start)
           Appsignal.start
         end
       end
@@ -159,7 +159,7 @@ describe Appsignal do
 
       it "should change the log level" do
         Appsignal.start
-        Appsignal.logger.level.should eq Logger::DEBUG
+        expect(Appsignal.logger.level).to eq Logger::DEBUG
       end
     end
   end
@@ -167,7 +167,7 @@ describe Appsignal do
   describe ".forked" do
     context "when not active" do
       it "should should do nothing" do
-        Appsignal::Extension.should_not_receive(:start)
+        expect(Appsignal::Extension).to_not receive(:start)
 
         Appsignal.forked
       end
@@ -179,8 +179,8 @@ describe Appsignal do
       end
 
       it "should resubscribe and start the extension" do
-        Appsignal.should_receive(:start_logger)
-        Appsignal::Extension.should_receive(:start)
+        expect(Appsignal).to receive(:start_logger)
+        expect(Appsignal::Extension).to receive(:start)
 
         Appsignal.forked
       end
@@ -189,18 +189,18 @@ describe Appsignal do
 
   describe ".stop" do
     it "should call stop on the extension" do
-      Appsignal.logger.should_receive(:debug).with("Stopping appsignal")
-      Appsignal::Extension.should_receive(:stop)
+      expect(Appsignal.logger).to receive(:debug).with("Stopping appsignal")
+      expect(Appsignal::Extension).to receive(:stop)
       Appsignal.stop
-      Appsignal.active?.should be_false
+      expect(Appsignal.active?).to be_falsy
     end
 
     context "with context specified" do
       it "should log the context" do
-        Appsignal.logger.should_receive(:debug).with("Stopping appsignal (something)")
-        Appsignal::Extension.should_receive(:stop)
+        expect(Appsignal.logger).to receive(:debug).with("Stopping appsignal (something)")
+        expect(Appsignal::Extension).to receive(:stop)
         Appsignal.stop("something")
-        Appsignal.active?.should be_false
+        expect(Appsignal.active?).to be_falsy
       end
     end
   end
@@ -213,7 +213,7 @@ describe Appsignal do
         Appsignal.config = nil
       end
 
-      it { should be_false }
+      it { is_expected.to be_falsy }
     end
 
     context "with inactive config" do
@@ -221,7 +221,7 @@ describe Appsignal do
         Appsignal.config = project_fixture_config("nonsense")
       end
 
-      it { should be_false }
+      it { is_expected.to be_falsy }
     end
 
     context "with active config" do
@@ -229,89 +229,89 @@ describe Appsignal do
         Appsignal.config = project_fixture_config
       end
 
-      it { should be_true }
+      it { is_expected.to be_truthy }
     end
   end
 
   describe ".add_exception" do
     it "should alias this method" do
-      Appsignal.should respond_to(:add_exception)
+      expect(Appsignal).to respond_to(:add_exception)
     end
   end
 
   describe ".get_server_state" do
     it "should call server state on the extension" do
-      Appsignal::Extension.should_receive(:get_server_state).with("key")
+      expect(Appsignal::Extension).to receive(:get_server_state).with("key")
 
       Appsignal.get_server_state("key")
     end
 
     it "should get nil by default" do
-      Appsignal.get_server_state("key").should be_nil
+      expect(Appsignal.get_server_state("key")).to be_nil
     end
   end
 
   context "not active" do
     describe ".monitor_transaction" do
       it "should do nothing but still yield the block" do
-        Appsignal::Transaction.should_not_receive(:create)
-        Appsignal.should_not_receive(:instrument)
+        expect(Appsignal::Transaction).to_not receive(:create)
+        expect(Appsignal).to_not receive(:instrument)
         object = double
-        object.should_receive(:some_method).and_return(1)
+        expect(object).to receive(:some_method).and_return(1)
 
-        lambda do
-          Appsignal.monitor_transaction("perform_job.nothing") do
+        expect do
+          expect(Appsignal.monitor_transaction("perform_job.nothing") do
             object.some_method
-          end.should eq 1
-        end.should_not raise_error
+          end).to eq 1
+        end.to_not raise_error
       end
     end
 
     describe ".listen_for_error" do
       it "should do nothing" do
         error = RuntimeError.new("specific error")
-        lambda do
+        expect do
           Appsignal.listen_for_error do
             raise error
           end
-        end.should raise_error(error)
+        end.to raise_error(error)
       end
     end
 
     describe ".send_error" do
       it "should do nothing" do
-        lambda do
+        expect do
           Appsignal.send_error(RuntimeError.new)
-        end.should_not raise_error
+        end.to_not raise_error
       end
     end
 
     describe ".set_error" do
       it "should do nothing" do
-        lambda do
+        expect do
           Appsignal.set_error(RuntimeError.new)
-        end.should_not raise_error
+        end.to_not raise_error
       end
     end
 
     describe ".tag_request" do
       it "should do nothing" do
-        lambda do
+        expect do
           Appsignal.tag_request(:tag => "tag")
-        end.should_not raise_error
+        end.to_not raise_error
       end
     end
 
     describe ".instrument" do
       it "should not instrument, but still call the block" do
         stub = double
-        stub.should_receive(:method_call).and_return("return value")
+        expect(stub).to receive(:method_call).and_return("return value")
 
-        lambda do
-          Appsignal.instrument "name" do
+        expect do
+          expect(Appsignal.instrument "name" do
             stub.method_call
-          end.should eq "return value"
-        end.should_not raise_error
+          end).to eq "return value"
+        end.to_not raise_error
       end
     end
   end
@@ -325,39 +325,39 @@ describe Appsignal do
     describe ".monitor_transaction" do
       context "with a successful call" do
         it "should instrument and complete for a background job" do
-          Appsignal.should_receive(:instrument).with(
+          expect(Appsignal).to receive(:instrument).with(
             "perform_job.something"
           ).and_yield
-          Appsignal::Transaction.should_receive(:complete_current!)
+          expect(Appsignal::Transaction).to receive(:complete_current!)
           object = double
-          object.should_receive(:some_method).and_return(1)
+          expect(object).to receive(:some_method).and_return(1)
 
-          Appsignal.monitor_transaction(
+          expect(Appsignal.monitor_transaction(
             "perform_job.something",
             background_env_with_data
           ) do
             current = Appsignal::Transaction.current
-            current.namespace.should eq Appsignal::Transaction::BACKGROUND_JOB
-            current.request.should be_a(Appsignal::Transaction::GenericRequest)
+            expect(current.namespace).to eq Appsignal::Transaction::BACKGROUND_JOB
+            expect(current.request).to be_a(Appsignal::Transaction::GenericRequest)
             object.some_method
-          end.should eq 1
+          end).to eq 1
         end
 
         it "should instrument and complete for a http request" do
-          Appsignal.should_receive(:instrument).with(
+          expect(Appsignal).to receive(:instrument).with(
             "process_action.something"
           ).and_yield
-          Appsignal::Transaction.should_receive(:complete_current!)
+          expect(Appsignal::Transaction).to receive(:complete_current!)
           object = double
-          object.should_receive(:some_method)
+          expect(object).to receive(:some_method)
 
           Appsignal.monitor_transaction(
             "process_action.something",
             http_request_env_with_data
           ) do
             current = Appsignal::Transaction.current
-            current.namespace.should eq Appsignal::Transaction::HTTP_REQUEST
-            current.request.should be_a(::Rack::Request)
+            expect(current.namespace).to eq Appsignal::Transaction::HTTP_REQUEST
+            expect(current.request).to be_a(::Rack::Request)
             object.some_method
           end
         end
@@ -367,14 +367,14 @@ describe Appsignal do
         let(:error) { VerySpecificError.new }
 
         it "should add the error to the current transaction and complete" do
-          Appsignal::Transaction.any_instance.should_receive(:set_error).with(error)
-          Appsignal::Transaction.should_receive(:complete_current!)
+          expect_any_instance_of(Appsignal::Transaction).to receive(:set_error).with(error)
+          expect(Appsignal::Transaction).to receive(:complete_current!)
 
-          lambda do
+          expect do
             Appsignal.monitor_transaction("perform_job.something") do
               raise error
             end
-          end.should raise_error(error)
+          end.to raise_error(error)
         end
       end
     end
@@ -382,11 +382,11 @@ describe Appsignal do
     describe ".monitor_single_transaction" do
       context "with a successful call" do
         it "should call monitor_transaction and stop" do
-          Appsignal.should_receive(:monitor_transaction).with(
+          expect(Appsignal).to receive(:monitor_transaction).with(
             "perform_job.something",
             :key => :value
           ).and_yield
-          Appsignal.should_receive(:stop)
+          expect(Appsignal).to receive(:stop)
 
           Appsignal.monitor_single_transaction("perform_job.something", :key => :value) do
             # nothing
@@ -398,28 +398,28 @@ describe Appsignal do
         let(:error) { VerySpecificError.new }
 
         it "should call monitor_transaction and stop and then raise the error" do
-          Appsignal.should_receive(:monitor_transaction).with(
+          expect(Appsignal).to receive(:monitor_transaction).with(
             "perform_job.something",
             :key => :value
           ).and_yield
-          Appsignal.should_receive(:stop)
+          expect(Appsignal).to receive(:stop)
 
-          lambda do
+          expect do
             Appsignal.monitor_single_transaction("perform_job.something", :key => :value) do
               raise error
             end
-          end.should raise_error(error)
+          end.to raise_error(error)
         end
       end
     end
 
     describe ".tag_request" do
-      before { Appsignal::Transaction.stub(:current => transaction) }
+      before { allow(Appsignal::Transaction).to receive(:current).and_return(transaction) }
 
       context "with transaction" do
         let(:transaction) { double }
         it "should call set_tags on transaction" do
-          transaction.should_receive(:set_tags).with("a" => "b")
+          expect(transaction).to receive(:set_tags).with("a" => "b")
         end
 
         after { Appsignal.tag_request("a" => "b") }
@@ -429,118 +429,118 @@ describe Appsignal do
         let(:transaction) { nil }
 
         it "should call set_tags on transaction" do
-          Appsignal.tag_request.should be_false
+          expect(Appsignal.tag_request).to be_falsy
         end
       end
 
       it "should also listen to tag_job" do
-        Appsignal.should respond_to(:tag_job)
+        expect(Appsignal).to respond_to(:tag_job)
       end
     end
 
     describe "custom stats" do
       describe ".set_gauge" do
         it "should call set_gauge on the extension with a string key and float" do
-          Appsignal::Extension.should_receive(:set_gauge).with("key", 0.1)
+          expect(Appsignal::Extension).to receive(:set_gauge).with("key", 0.1)
           Appsignal.set_gauge("key", 0.1)
         end
 
         it "should call set_gauge on the extension with a symbol key and int" do
-          Appsignal::Extension.should_receive(:set_gauge).with("key", 1.0)
+          expect(Appsignal::Extension).to receive(:set_gauge).with("key", 1.0)
           Appsignal.set_gauge(:key, 1)
         end
 
         it "should not raise an exception when out of range" do
-          Appsignal::Extension.should_receive(:set_gauge).with("key", 10).and_raise(RangeError)
-          Appsignal.logger.should_receive(:warn).with("Gauge value 10 for key 'key' is too big")
-          lambda do
+          expect(Appsignal::Extension).to receive(:set_gauge).with("key", 10).and_raise(RangeError)
+          expect(Appsignal.logger).to receive(:warn).with("Gauge value 10 for key 'key' is too big")
+          expect do
             Appsignal.set_gauge("key", 10)
-          end.should_not raise_error
+          end.to_not raise_error
         end
       end
 
       describe ".set_host_gauge" do
         it "should call set_host_gauge on the extension with a string key and float" do
-          Appsignal::Extension.should_receive(:set_host_gauge).with("key", 0.1)
+          expect(Appsignal::Extension).to receive(:set_host_gauge).with("key", 0.1)
           Appsignal.set_host_gauge("key", 0.1)
         end
 
         it "should call set_host_gauge on the extension with a symbol key and int" do
-          Appsignal::Extension.should_receive(:set_host_gauge).with("key", 1.0)
+          expect(Appsignal::Extension).to receive(:set_host_gauge).with("key", 1.0)
           Appsignal.set_host_gauge(:key, 1)
         end
 
         it "should not raise an exception when out of range" do
-          Appsignal::Extension.should_receive(:set_host_gauge).with("key", 10).and_raise(RangeError)
-          Appsignal.logger.should_receive(:warn).with("Host gauge value 10 for key 'key' is too big")
-          lambda do
+          expect(Appsignal::Extension).to receive(:set_host_gauge).with("key", 10).and_raise(RangeError)
+          expect(Appsignal.logger).to receive(:warn).with("Host gauge value 10 for key 'key' is too big")
+          expect do
             Appsignal.set_host_gauge("key", 10)
-          end.should_not raise_error
+          end.to_not raise_error
         end
       end
 
       describe ".set_process_gauge" do
         it "should call set_process_gauge on the extension with a string key and float" do
-          Appsignal::Extension.should_receive(:set_process_gauge).with("key", 0.1)
+          expect(Appsignal::Extension).to receive(:set_process_gauge).with("key", 0.1)
           Appsignal.set_process_gauge("key", 0.1)
         end
 
         it "should call set_process_gauge on the extension with a symbol key and int" do
-          Appsignal::Extension.should_receive(:set_process_gauge).with("key", 1.0)
+          expect(Appsignal::Extension).to receive(:set_process_gauge).with("key", 1.0)
           Appsignal.set_process_gauge(:key, 1)
         end
 
         it "should not raise an exception when out of range" do
-          Appsignal::Extension.should_receive(:set_process_gauge).with("key", 10).and_raise(RangeError)
-          Appsignal.logger.should_receive(:warn).with("Process gauge value 10 for key 'key' is too big")
-          lambda do
+          expect(Appsignal::Extension).to receive(:set_process_gauge).with("key", 10).and_raise(RangeError)
+          expect(Appsignal.logger).to receive(:warn).with("Process gauge value 10 for key 'key' is too big")
+          expect do
             Appsignal.set_process_gauge("key", 10)
-          end.should_not raise_error
+          end.to_not raise_error
         end
       end
 
       describe ".increment_counter" do
         it "should call increment_counter on the extension with a string key" do
-          Appsignal::Extension.should_receive(:increment_counter).with("key", 1)
+          expect(Appsignal::Extension).to receive(:increment_counter).with("key", 1)
           Appsignal.increment_counter("key")
         end
 
         it "should call increment_counter on the extension with a symbol key" do
-          Appsignal::Extension.should_receive(:increment_counter).with("key", 1)
+          expect(Appsignal::Extension).to receive(:increment_counter).with("key", 1)
           Appsignal.increment_counter(:key)
         end
 
         it "should call increment_counter on the extension with a count" do
-          Appsignal::Extension.should_receive(:increment_counter).with("key", 5)
+          expect(Appsignal::Extension).to receive(:increment_counter).with("key", 5)
           Appsignal.increment_counter("key", 5)
         end
 
         it "should not raise an exception when out of range" do
-          Appsignal::Extension.should_receive(:increment_counter).with("key", 10).and_raise(RangeError)
-          Appsignal.logger.should_receive(:warn).with("Counter value 10 for key 'key' is too big")
-          lambda do
+          expect(Appsignal::Extension).to receive(:increment_counter).with("key", 10).and_raise(RangeError)
+          expect(Appsignal.logger).to receive(:warn).with("Counter value 10 for key 'key' is too big")
+          expect do
             Appsignal.increment_counter("key", 10)
-          end.should_not raise_error
+          end.to_not raise_error
         end
       end
 
       describe ".add_distribution_value" do
         it "should call add_distribution_value on the extension with a string key and float" do
-          Appsignal::Extension.should_receive(:add_distribution_value).with("key", 0.1)
+          expect(Appsignal::Extension).to receive(:add_distribution_value).with("key", 0.1)
           Appsignal.add_distribution_value("key", 0.1)
         end
 
         it "should call add_distribution_value on the extension with a symbol key and int" do
-          Appsignal::Extension.should_receive(:add_distribution_value).with("key", 1.0)
+          expect(Appsignal::Extension).to receive(:add_distribution_value).with("key", 1.0)
           Appsignal.add_distribution_value(:key, 1)
         end
 
         it "should not raise an exception when out of range" do
-          Appsignal::Extension.should_receive(:add_distribution_value).with("key", 10).and_raise(RangeError)
-          Appsignal.logger.should_receive(:warn).with("Distribution value 10 for key 'key' is too big")
-          lambda do
+          expect(Appsignal::Extension).to receive(:add_distribution_value).with("key", 10).and_raise(RangeError)
+          expect(Appsignal.logger).to receive(:warn).with("Distribution value 10 for key 'key' is too big")
+          expect do
             Appsignal.add_distribution_value("key", 10)
-          end.should_not raise_error
+          end.to_not raise_error
         end
       end
     end
@@ -548,7 +548,7 @@ describe Appsignal do
     describe ".logger" do
       subject { Appsignal.logger }
 
-      it { should be_a Logger }
+      it { is_expected.to be_a Logger }
     end
 
     describe ".start_logger" do
@@ -581,7 +581,7 @@ describe Appsignal do
           end
 
           it "logs to file" do
-            expect(File.exist?(log_file)).to be_true
+            expect(File.exist?(log_file)).to be_truthy
             expect(log_file_contents).to include "[ERROR] Log to file"
             expect(output).to be_empty
           end
@@ -603,7 +603,7 @@ describe Appsignal do
           end
 
           it "logs to stdout" do
-            expect(File.writable?(log_file)).to be_false
+            expect(File.writable?(log_file)).to be_falsy
             expect(output).to include "[ERROR] appsignal: Log to not writable log file"
           end
 
@@ -634,7 +634,7 @@ describe Appsignal do
         end
 
         it "logs to stdout" do
-          expect(File.writable?(log_path)).to be_false
+          expect(File.writable?(log_path)).to be_falsy
           expect(output).to include "[ERROR] appsignal: Log to not writable log path"
         end
 
@@ -722,9 +722,9 @@ describe Appsignal do
     describe ".config" do
       subject { Appsignal.config }
 
-      it { should be_a Appsignal::Config }
+      it { is_expected.to be_a Appsignal::Config }
       it "should return configuration" do
-        subject[:endpoint].should eq "https://push.appsignal.com"
+        expect(subject[:endpoint]).to eq "https://push.appsignal.com"
       end
     end
 
@@ -733,7 +733,7 @@ describe Appsignal do
       let(:error) { VerySpecificError.new }
 
       it "should send the error to AppSignal" do
-        Appsignal::Transaction.should_receive(:new).and_call_original
+        expect(Appsignal::Transaction).to receive(:new).and_call_original
       end
 
       context "with tags" do
@@ -745,9 +745,9 @@ describe Appsignal do
             Appsignal::Transaction::HTTP_REQUEST,
             Appsignal::Transaction::GenericRequest.new({})
           )
-          Appsignal::Transaction.stub(:new => transaction)
-          transaction.should_receive(:set_tags).with(tags)
-          transaction.should_receive(:complete)
+          allow(Appsignal::Transaction).to receive(:new).and_return(transaction)
+          expect(transaction).to receive(:set_tags).with(tags)
+          expect(transaction).to receive(:complete)
         end
       end
 
@@ -770,35 +770,35 @@ describe Appsignal do
 
     describe ".listen_for_error" do
       it "should call send_error and re-raise" do
-        Appsignal.should_receive(:send_error).with(kind_of(Exception))
-        lambda do
+        expect(Appsignal).to receive(:send_error).with(kind_of(Exception))
+        expect do
           Appsignal.listen_for_error do
             raise "I am an exception"
           end
-        end.should raise_error(RuntimeError, "I am an exception")
+        end.to raise_error(RuntimeError, "I am an exception")
       end
     end
 
     describe ".set_error" do
-      before { Appsignal::Transaction.stub(:current => transaction) }
+      before { allow(Appsignal::Transaction).to receive(:current).and_return(transaction) }
       let(:error) { RuntimeError.new("I am an exception") }
 
       it "should add the error to the current transaction" do
-        transaction.should_receive(:set_error).with(error)
+        expect(transaction).to receive(:set_error).with(error)
 
         Appsignal.set_error(error)
       end
 
       it "should do nothing if there is no current transaction" do
-        Appsignal::Transaction.stub(:current => nil)
+        allow(Appsignal::Transaction).to receive(:current).and_return(nil)
 
-        transaction.should_not_receive(:set_error)
+        expect(transaction).to_not receive(:set_error)
 
         Appsignal.set_error(error)
       end
 
       it "should do nothing if the error is nil" do
-        transaction.should_not_receive(:set_error)
+        expect(transaction).to_not receive(:set_error)
 
         Appsignal.set_error(nil)
       end
@@ -840,11 +840,11 @@ describe Appsignal do
 
     describe ".without_instrumentation" do
       let(:transaction) { double }
-      before { Appsignal::Transaction.stub(:current => transaction) }
+      before { allow(Appsignal::Transaction).to receive(:current).and_return(transaction) }
 
       it "should pause and unpause the transaction around the block" do
-        transaction.should_receive(:pause!)
-        transaction.should_receive(:resume!)
+        expect(transaction).to receive(:pause!)
+        expect(transaction).to receive(:resume!)
       end
 
       context "without transaction" do
@@ -867,9 +867,7 @@ describe Appsignal do
       let(:err_stream) { std_stream }
       let(:stderr) { err_stream.read }
       before do
-        Appsignal.stub(
-          :config => { :ignore_errors => ["StandardError"] }
-        )
+        allow(Appsignal).to receive(:config).and_return({ :ignore_errors => ["StandardError"] })
       end
 
       subject do
@@ -879,7 +877,7 @@ describe Appsignal do
       end
 
       it "should return true if it's in the ignored list" do
-        should be_true
+        is_expected.to be_truthy
       end
 
       it "outputs deprecated warning" do
@@ -891,7 +889,7 @@ describe Appsignal do
         let(:error) { Object.new }
 
         it "should return false" do
-          should be_false
+          is_expected.to be_falsy
         end
       end
     end
@@ -901,9 +899,7 @@ describe Appsignal do
       let(:err_stream) { std_stream }
       let(:stderr) { err_stream.read }
       before do
-        Appsignal.stub(
-          :config => { :ignore_actions => "TestController#isup" }
-        )
+        allow(Appsignal).to receive(:config).and_return({ :ignore_actions => "TestController#isup" })
       end
 
       subject do
@@ -913,7 +909,7 @@ describe Appsignal do
       end
 
       it "should return true if it's in the ignored list" do
-        should be_true
+        is_expected.to be_truthy
       end
 
       it "outputs deprecated warning" do
@@ -925,7 +921,7 @@ describe Appsignal do
         let(:action) { "TestController#other_action" }
 
         it "should return false" do
-          should be_false
+          is_expected.to be_falsy
         end
       end
     end

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -307,11 +307,10 @@ describe Appsignal do
         stub = double
         expect(stub).to receive(:method_call).and_return("return value")
 
-        expect do
-          expect(Appsignal.instrument "name" do
-            stub.method_call
-          end).to eq "return value"
-        end.to_not raise_error
+        return_value = Appsignal.instrument "name" do
+          stub.method_call
+        end
+        expect(return_value).to eq "return value"
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,7 +47,7 @@ RSpec.configure do |config|
   config.include SystemHelpers
   config.extend DependencyHelper
 
-  config.before :all do
+  config.before :context do
     # Use modified SYSTEM_TMP_DIR
     Appsignal::Config.send :remove_const, :SYSTEM_TMP_DIR
     Appsignal::Config.send :const_set, :SYSTEM_TMP_DIR,
@@ -72,7 +72,7 @@ RSpec.configure do |config|
     Thread.current[:appsignal_transaction] = nil
   end
 
-  config.after :all do
+  config.after :context do
     FileUtils.rm_f(File.join(project_fixture_path, "log/appsignal.log"))
     Appsignal.config = nil
     Appsignal.logger = nil


### PR DESCRIPTION
Upgrade to RSpec version 3.5. Previously version 2.14

This guide was followed: http://rspec.info/upgrading-from-rspec-2/

Conversion of outdated syntax was done with [Transpec](https://github.com/yujinakayama/transpec#transpec), using this command:

```
transpec --boolean-matcher truthy,falsy --convert hook_scope,stub_with_hash --negative-form to_not
```

Some examples using the `its(:method)` were updated by hand to avoid the `subject { super().method }` syntax.