### PR TITLE
Fix transaction record_event and update specs

### DIFF
--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -213,7 +213,8 @@ module Appsignal
         title || BLANK,
         body || BLANK,
         duration,
-        body_format || Appsignal::EventFormatter::DEFAULT
+        body_format || Appsignal::EventFormatter::DEFAULT,
+        self.class.garbage_collection_profiler.total_time
       )
     end
 

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -466,7 +466,11 @@ describe Appsignal::Transaction do
 
     describe "#start_event" do
       it "should start the event in the extension" do
-        transaction.ext.should_receive(:start_event)
+        expect {
+          transaction.start_event
+        }.to_not raise_error
+
+        transaction.ext.should_receive(:start_event).with(0);
 
         transaction.start_event
       end
@@ -474,6 +478,10 @@ describe Appsignal::Transaction do
 
     describe "#finish_event" do
       it "should finish the event in the extension" do
+        expect {
+          transaction.finish_event('name', 'title', 'body', 1)
+        }.to_not raise_error
+
         transaction.ext.should_receive(:finish_event).with(
           'name',
           'title',
@@ -491,6 +499,11 @@ describe Appsignal::Transaction do
       end
 
       it "should finish the event in the extension with nil arguments" do
+        expect {
+          transaction.finish_event('name', nil, nil, nil)
+        }.to_not raise_error
+
+
         transaction.ext.should_receive(:finish_event).with(
           'name',
           '',
@@ -518,12 +531,17 @@ describe Appsignal::Transaction do
 
     describe "#record_event" do
       it "should record the event in the extension" do
+        expect {
+          transaction.record_event('name', 'title', 'body', 1000, 1)
+        }.to_not raise_error
+
         transaction.ext.should_receive(:record_event).with(
           'name',
           'title',
           'body',
           1000,
-          1
+          1,
+          0
         )
 
         transaction.record_event(
@@ -536,11 +554,16 @@ describe Appsignal::Transaction do
       end
 
       it "should finish the event in the extension with nil arguments" do
+        expect {
+          transaction.record_event('name', nil, nil, 1000, nil)
+        }.to_not raise_error
+
         transaction.ext.should_receive(:record_event).with(
           'name',
           '',
           '',
           1000,
+          0,
           0
         )
 


### PR DESCRIPTION
Add missing argument to @ext.record_event, as per changes from #134.

This was detected when using the DataMapper integration, which calls #record_event (https://github.com/appsignal/appsignal-ruby/blob/master/lib/appsignal/integrations/data_mapper.rb#L22)

Also noticed that the spec for garbage collection was leaking, once #record_event was updated.

I'm not sure if my changes to the spec are appropriate, although valid :)