### PR TITLE
Update transaction `#record_event` method call

### DIFF
--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -213,7 +213,8 @@ module Appsignal
         title || BLANK,
         body || BLANK,
         duration,
-        body_format || Appsignal::EventFormatter::DEFAULT
+        body_format || Appsignal::EventFormatter::DEFAULT,
+        self.class.garbage_collection_profiler.total_time
       )
     end
 


### PR DESCRIPTION
Add missing argument to `@ext.record_event`, as per changes
from https://github.com/appsignal/appsignal-ruby/pull/134

Update transaction spec so that argument changes to
`ext/appsignal_extension.c` are caught upon transaction's use of
`Appsignal::Extension.`

This was detected when using the DataMapper integration, which calls
`#record_event`.

Written by @jsmpereira, modified by @tombruijn

Reworked version of from #239