### PR TITLE
Add inline code documentation

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,8 @@
+--protected
+--no-private
+--output-dir doc
+--markup markdown
+-
+CHANGELOG.md
+LICENSE
+README.md

--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'timecop'
   gem.add_development_dependency 'webmock'
   gem.add_development_dependency 'rubocop', '0.46.0'
+  gem.add_development_dependency 'yard'
 end

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -2,6 +2,11 @@ require "json"
 require "logger"
 require "securerandom"
 
+# AppSignal gem's main module.
+#
+# Provides method to control the AppSignal instrumentation and the system agent.
+#
+# Also provides instrumentation helpers for ease of use.
 module Appsignal
   class << self
     extend Gem::Deprecate

--- a/lib/appsignal/auth_check.rb
+++ b/lib/appsignal/auth_check.rb
@@ -1,5 +1,21 @@
 module Appsignal
+  # Class used to perform a Push API validation / authentication check against
+  # the AppSignal Push API.
+  #
+  # @example
+  #   config = Appsignal::Config.new(Dir.pwd, "production")
+  #   auth_check = Appsignal::AuthCheck.new(config)
+  #   # Valid push_api_key
+  #   auth_check.perform # => "200"
+  #   # Invalid push_api_key
+  #   auth_check.perform # => "401"
+  #
+  # @!attribute [r] config
+  #   @return [Appsignal::Config] config to use in the authentication request.
+  # @api private
   class AuthCheck
+    # Path used on the AppSignal Push API
+    # https://push.appsignal.com/1/auth
     ACTION = "auth".freeze
 
     attr_reader :config, :logger
@@ -12,10 +28,21 @@ module Appsignal
       end
     end
 
+    # Perform push api validation request and return response status code.
+    #
+    # @return [String] response status code.
+    # @raise [StandardError] see {Appsignal::Transmitter#transmit}.
     def perform
       Appsignal::Transmitter.new(ACTION, config).transmit({})
     end
 
+    # Perform push api validation request and return a descriptive response
+    # tuple.
+    #
+    # @return [Array<String/nil, String>] response tuple.
+    #   - First value is the response status code.
+    #   - Second value is a description of the response and the exception error
+    #     message if an exception occured.
     def perform_with_result
       status = perform
       result =

--- a/lib/appsignal/cli.rb
+++ b/lib/appsignal/cli.rb
@@ -9,6 +9,7 @@ require "appsignal/cli/install"
 require "appsignal/cli/notify_of_deploy"
 
 module Appsignal
+  # @api private
   class CLI
     AVAILABLE_COMMANDS = %w(demo diagnose install notify_of_deploy).freeze
 

--- a/lib/appsignal/cli/demo.rb
+++ b/lib/appsignal/cli/demo.rb
@@ -2,8 +2,46 @@ require "appsignal/demo"
 
 module Appsignal
   class CLI
+    # Command line tool for sending demonstration samples to AppSignal.com
+    #
+    # This command line tool is useful when testing AppSignal on a system and
+    # validating the local configuration. It tests if the installation of
+    # AppSignal has succeeded and if the AppSignal agent is able to run on the
+    # machine's architecture and communicate with the AppSignal servers.
+    #
+    # The same test is also run during installation with
+    # {Appsignal::CLI::Install}.
+    #
+    # ## Exit codes
+    #
+    # - Exits with status code `0` if the demo command has finished.
+    # - Exits with status code `1` if the demo command failed to finished.
+    #
+    # @example On the command line in your project
+    #   appsignal demo
+    #
+    # @example With a specific environment
+    #   appsignal demo --environment=production
+    #
+    # @example Standalone run
+    #   gem install appsignal
+    #   export APPSIGNAL_APP_NAME="My test app"
+    #   export APPSIGNAL_APP_ENV="test"
+    #   export APPSIGNAL_PUSH_API_KEY="xxxx-xxxx-xxxx-xxxx"
+    #   appsignal demo
+    #
+    # @since 2.0.0
+    # @see Appsignal::Demo
+    # @see Appsignal::CLI::Install
+    # @see http://docs.appsignal.com/support/debugging.html
+    #   Debugging AppSignal guide
+    # @api private
     class Demo
       class << self
+        # @param options [Hash]
+        # @option options :environment [String] environment to load
+        #   configuration for.
+        # @return [void]
         def run(options = {})
           ENV["APPSIGNAL_APP_ENV"] = options[:environment] if options[:environment]
 

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -5,8 +5,44 @@ require "etc"
 
 module Appsignal
   class CLI
+    # Command line tool to run diagnostics on your project.
+    #
+    # This command line tool is useful when testing AppSignal on a system and
+    # validating the local configuration. It outputs useful information to
+    # debug issues and it checks if AppSignal agent is able to run on the
+    # machine's architecture and communicate with the AppSignal servers.
+    #
+    # This diagnostic tool outputs the following:
+    # - if AppSignal can run on the host system.
+    # - if the configuration is valid and active.
+    # - if the Push API key is present and valid (internet connection required).
+    # - if the required system paths exist and are writable.
+    # - outputs AppSignal version information.
+    # - outputs information about the host system and Ruby.
+    # - outputs last lines from the available log files.
+    #
+    # ## Exit codes
+    #
+    # - Exits with status code `0` if the diagnose command has finished.
+    # - Exits with status code `1` if the diagnose command failed to finished.
+    #
+    # @example On the command line in your project
+    #   appsignal diagnose
+    #
+    # @example With a specific environment
+    #   appsignal diagnose --environment=production
+    #
+    # @see http://docs.appsignal.com/support/debugging.html Debugging AppSignal
+    # @see http://docs.appsignal.com/ruby/command-line/diagnose.html
+    #   AppSignal diagnose documentation
+    # @since 1.1.0
     class Diagnose
       class << self
+        # @param options [Hash]
+        # @option options :environment [String] environment to load
+        #   configuration for.
+        # @return [void]
+        # @api private
         def run(options = {})
           header
           empty_line

--- a/lib/appsignal/cli/notify_of_deploy.rb
+++ b/lib/appsignal/cli/notify_of_deploy.rb
@@ -1,7 +1,58 @@
 module Appsignal
   class CLI
+    # Command line tool to send a "Deploy Marker" for an application to
+    # AppSignal.
+    #
+    # Deploy markers are used on AppSignal.com to indicate changes in an
+    # application, "Deploy markers" indicate a deploy of an application.
+    #
+    # Incidents for exceptions and performance issues will be closed and
+    # reopened if they occur again in the new deploy.
+    #
+    # ## Required options
+    #
+    # - `--environment` required
+    # - `--user` required
+    # - `--revision` required
+    # - `--name` If no name config can be found in a `config/appsignal.yml`
+    #   file or based on the `APPSIGNAL_APP_NAME` environment variable this
+    #   option is required.
+    #
+    # ## Exit codes
+    #
+    # - Exits with status code `0` if the deploy marker is sent.
+    # - Exits with status code `1` if the configuration is not valid and active.
+    # - Exits with status code `1` if the required options aren't present.
+    #
+    # @example command line
+    #   appsignal notify_of_deploy \
+    #     --user=tom \
+    #     --environment=production \
+    #     --revision=abc1234
+    #
+    # @example command line with a custom name
+    #   appsignal notify_of_deploy \
+    #     --user=tom \
+    #     --environment=production \
+    #     --revision=abc1234 \
+    #     --name="My app"
+    #
+    # @example help command
+    #   appsignal notify_of_deploy --help
+    #
+    # @see Appsignal::Marker Appsignal::Marker
+    # @see http://docs.appsignal.com/appsignal/terminology.html#markers
+    #   Terminology: Deploy marker
     class NotifyOfDeploy
       class << self
+        # @param options [Hash]
+        # @option options :environment [String] environment to load
+        #   configuration for.
+        # @option options :name [String] custom name of the application.
+        # @option options :user [String] user who triggered the deploy.
+        # @option options :revision [String] the revision that has been
+        #   deployed. E.g. a git commit SHA.
+        # @return [void]
         def run(options)
           config = config_for(options[:environment])
           config[:name] = options[:name] if options[:name]

--- a/lib/appsignal/demo.rb
+++ b/lib/appsignal/demo.rb
@@ -1,10 +1,30 @@
 require "rack/mock"
 
 module Appsignal
+  # {Appsignal::Demo} is a way to send demonstration / test samples for a
+  # exception and a performance issue.
+  #
+  # @example Loading config automatically
+  #   Appsignal::Demo.transmit
+  #
+  # @example With custom config
+  #   # If another configuration should be used, set it beforehand.
+  #   Appsignal.config = Appsignal::Config.new(Dir.pwd, "production")
+  #   Appsignal::Demo.transmit
+  #
+  # @since 2.0.0
+  # @see Appsignal::CLI::Demo
+  # @api private
   class Demo
+    # Error type used to create demonstration exception.
     class TestError < StandardError; end
 
     class << self
+      # Starts AppSignal and transmits the demonstration samples to AppSignal
+      # using the loaded configuration.
+      #
+      # @return [Boolean]
+      #   - returns `false` if Appsignal is not active.
       def transmit
         Appsignal.start
         Appsignal.start_logger

--- a/lib/appsignal/event_formatter.rb
+++ b/lib/appsignal/event_formatter.rb
@@ -8,6 +8,8 @@ module Appsignal
   # event, the same object will be called intermittently in a threaded environment.
   # So only keep global configuration as state and pass the payload around as an
   # argument if you need to use helper methods.
+  #
+  # @api private
   class EventFormatter
     class << self
       def formatters

--- a/lib/appsignal/event_formatter/action_view/render_formatter.rb
+++ b/lib/appsignal/event_formatter/action_view/render_formatter.rb
@@ -1,5 +1,6 @@
 module Appsignal
   class EventFormatter
+    # @api private
     module ActionView
       class RenderFormatter < Appsignal::EventFormatter
         register "render_partial.action_view"

--- a/lib/appsignal/event_formatter/active_record/instantiation_formatter.rb
+++ b/lib/appsignal/event_formatter/active_record/instantiation_formatter.rb
@@ -1,5 +1,6 @@
 module Appsignal
   class EventFormatter
+    # @api private
     module ActiveRecord
       class InstantiationFormatter < Appsignal::EventFormatter
         register "instantiation.active_record"

--- a/lib/appsignal/event_formatter/active_record/sql_formatter.rb
+++ b/lib/appsignal/event_formatter/active_record/sql_formatter.rb
@@ -1,5 +1,6 @@
 module Appsignal
   class EventFormatter
+    # @api private
     module ActiveRecord
       class SqlFormatter < Appsignal::EventFormatter
         register "sql.active_record"

--- a/lib/appsignal/event_formatter/elastic_search/search_formatter.rb
+++ b/lib/appsignal/event_formatter/elastic_search/search_formatter.rb
@@ -1,5 +1,6 @@
 module Appsignal
   class EventFormatter
+    # @api private
     module ElasticSearch
       class SearchFormatter < Appsignal::EventFormatter
         register "search.elasticsearch"

--- a/lib/appsignal/event_formatter/faraday/request_formatter.rb
+++ b/lib/appsignal/event_formatter/faraday/request_formatter.rb
@@ -1,5 +1,6 @@
 module Appsignal
   class EventFormatter
+    # @api private
     module Faraday
       class RequestFormatter < Appsignal::EventFormatter
         register "request.faraday"

--- a/lib/appsignal/event_formatter/mongo_ruby_driver/query_formatter.rb
+++ b/lib/appsignal/event_formatter/mongo_ruby_driver/query_formatter.rb
@@ -1,5 +1,6 @@
 module Appsignal
   class EventFormatter
+    # @api private
     module MongoRubyDriver
       class QueryFormatter
         ALLOWED = {

--- a/lib/appsignal/event_formatter/moped/query_formatter.rb
+++ b/lib/appsignal/event_formatter/moped/query_formatter.rb
@@ -1,5 +1,6 @@
 module Appsignal
   class EventFormatter
+    # @api private
     module Moped
       class QueryFormatter < Appsignal::EventFormatter
         register "query.moped"

--- a/lib/appsignal/extension.rb
+++ b/lib/appsignal/extension.rb
@@ -12,6 +12,7 @@ rescue LoadError => err
 end
 
 module Appsignal
+  # @api private
   class Extension
     class << self
       def agent_config

--- a/lib/appsignal/garbage_collection_profiler.rb
+++ b/lib/appsignal/garbage_collection_profiler.rb
@@ -1,22 +1,25 @@
 module Appsignal
-  # Appsignal::GarbageCollectionProfiler wraps Ruby's GC::Profiler to be able
-  # to track garbage collection time for multiple transactions, while
-  # constantly clearing GC::Profiler's total_time to make sure it doesn't leak
-  # memory by keeping garbage collection run samples in memory.
-
+  # {Appsignal::GarbageCollectionProfiler} wraps Ruby's `GC::Profiler` to be
+  # able to track garbage collection time for multiple transactions, while
+  # constantly clearing `GC::Profiler`'s total_time to make sure it doesn't
+  # leak memory by keeping garbage collection run samples in memory.
+  #
+  # @api private
   class GarbageCollectionProfiler
     def initialize
       @total_time = 0
     end
 
-    # Whenever #total_time is called, the current GC::Profiler.total_time gets
-    # added to @total_time, after which GC::Profiler.clear is called to prevent
-    # it from leaking memory. A class-level lock is used to make sure garbage
-    # collection time is never counted more than once.
+    # Whenever {#total_time} is called, the current `GC::Profiler#total_time`
+    # gets added to `@total_time`, after which `GC::Profiler.clear` is called
+    # to prevent it from leaking memory. A class-level lock is used to make
+    # sure garbage collection time is never counted more than once.
     #
-    # Whenever @total_time gets above two billion milliseconds (about 23 days),
-    # it's reset to make sure the result fits in a signed 32-bit integer.
-
+    # Whenever `@total_time` gets above two billion milliseconds (about 23
+    # days), it's reset to make sure the result fits in a signed 32-bit
+    # integer.
+    #
+    # @return [Integer]
     def total_time
       lock.synchronize do
         @total_time += (internal_profiler.total_time * 1000).round

--- a/lib/appsignal/hooks.rb
+++ b/lib/appsignal/hooks.rb
@@ -1,4 +1,5 @@
 module Appsignal
+  # @api private
   class Hooks
     class << self
       def register(name, hook)

--- a/lib/appsignal/hooks/active_support_notifications.rb
+++ b/lib/appsignal/hooks/active_support_notifications.rb
@@ -1,5 +1,6 @@
 module Appsignal
   class Hooks
+    # @api private
     class ActiveSupportNotificationsHook < Appsignal::Hooks::Hook
       register :active_support_notifications
 

--- a/lib/appsignal/hooks/celluloid.rb
+++ b/lib/appsignal/hooks/celluloid.rb
@@ -1,5 +1,6 @@
 module Appsignal
   class Hooks
+    # @api private
     class CelluloidHook < Appsignal::Hooks::Hook
       register :celluloid
 

--- a/lib/appsignal/hooks/data_mapper.rb
+++ b/lib/appsignal/hooks/data_mapper.rb
@@ -1,5 +1,6 @@
 module Appsignal
   class Hooks
+    # @api private
     class DataMapperHook < Appsignal::Hooks::Hook
       register :data_mapper
 

--- a/lib/appsignal/hooks/delayed_job.rb
+++ b/lib/appsignal/hooks/delayed_job.rb
@@ -1,5 +1,6 @@
 module Appsignal
   class Hooks
+    # @api private
     class DelayedJobHook < Appsignal::Hooks::Hook
       register :delayed_job
 

--- a/lib/appsignal/hooks/mongo_ruby_driver.rb
+++ b/lib/appsignal/hooks/mongo_ruby_driver.rb
@@ -1,5 +1,6 @@
 module Appsignal
   class Hooks
+    # @api private
     class MongoRubyDriverHook < Appsignal::Hooks::Hook
       register :mongo_ruby_driver
 

--- a/lib/appsignal/hooks/net_http.rb
+++ b/lib/appsignal/hooks/net_http.rb
@@ -2,6 +2,7 @@ require "net/http"
 
 module Appsignal
   class Hooks
+    # @api private
     class NetHttpHook < Appsignal::Hooks::Hook
       register :net_http
 

--- a/lib/appsignal/hooks/passenger.rb
+++ b/lib/appsignal/hooks/passenger.rb
@@ -1,5 +1,6 @@
 module Appsignal
   class Hooks
+    # @api private
     class PassengerHook < Appsignal::Hooks::Hook
       register :passenger
 

--- a/lib/appsignal/hooks/puma.rb
+++ b/lib/appsignal/hooks/puma.rb
@@ -1,5 +1,6 @@
 module Appsignal
   class Hooks
+    # @api private
     class PumaHook < Appsignal::Hooks::Hook
       register :puma
 

--- a/lib/appsignal/hooks/rake.rb
+++ b/lib/appsignal/hooks/rake.rb
@@ -1,5 +1,6 @@
 module Appsignal
   class Hooks
+    # @api private
     class RakeHook < Appsignal::Hooks::Hook
       register :rake
 

--- a/lib/appsignal/hooks/redis.rb
+++ b/lib/appsignal/hooks/redis.rb
@@ -1,5 +1,6 @@
 module Appsignal
   class Hooks
+    # @api private
     class RedisHook < Appsignal::Hooks::Hook
       register :redis
 

--- a/lib/appsignal/hooks/sequel.rb
+++ b/lib/appsignal/hooks/sequel.rb
@@ -1,5 +1,6 @@
 module Appsignal
   class Hooks
+    # @api private
     module SequelLogExtension
       # Add query instrumentation
       def log_yield(sql, args = nil)

--- a/lib/appsignal/hooks/shoryuken.rb
+++ b/lib/appsignal/hooks/shoryuken.rb
@@ -1,5 +1,6 @@
 module Appsignal
   class Hooks
+    # @api private
     class ShoryukenMiddleware
       def call(_worker_instance, queue, sqs_msg, body)
         metadata = {

--- a/lib/appsignal/hooks/sidekiq.rb
+++ b/lib/appsignal/hooks/sidekiq.rb
@@ -1,5 +1,6 @@
 module Appsignal
   class Hooks
+    # @api private
     class SidekiqPlugin
       include Appsignal::Hooks::Helpers
 

--- a/lib/appsignal/hooks/unicorn.rb
+++ b/lib/appsignal/hooks/unicorn.rb
@@ -1,5 +1,6 @@
 module Appsignal
   class Hooks
+    # @api private
     class UnicornHook < Appsignal::Hooks::Hook
       register :unicorn
 

--- a/lib/appsignal/hooks/webmachine.rb
+++ b/lib/appsignal/hooks/webmachine.rb
@@ -1,5 +1,6 @@
 module Appsignal
   class Hooks
+    # @api private
     class WebmachineHook < Appsignal::Hooks::Hook
       register :webmachine
 

--- a/lib/appsignal/integrations/capistrano/capistrano_2_tasks.rb
+++ b/lib/appsignal/integrations/capistrano/capistrano_2_tasks.rb
@@ -1,4 +1,6 @@
 module Appsignal
+  # @todo Move to sub-namespace
+  # @api private
   class Capistrano
     def self.tasks(config)
       config.load do

--- a/lib/appsignal/integrations/delayed_job_plugin.rb
+++ b/lib/appsignal/integrations/delayed_job_plugin.rb
@@ -1,5 +1,6 @@
 module Appsignal
   class Hooks
+    # @api private
     class DelayedJobPlugin < ::Delayed::Plugin
       extend Appsignal::Hooks::Helpers
 

--- a/lib/appsignal/integrations/grape.rb
+++ b/lib/appsignal/integrations/grape.rb
@@ -1,4 +1,6 @@
 module Appsignal
+  # @todo Move to sub-namespace
+  # @api private
   module Grape
     class Middleware < ::Grape::Middleware::Base
       def call(env)

--- a/lib/appsignal/integrations/mongo_ruby_driver.rb
+++ b/lib/appsignal/integrations/mongo_ruby_driver.rb
@@ -1,5 +1,6 @@
 module Appsignal
   class Hooks
+    # @api private
     class MongoMonitorSubscriber
       # Called by Mongo::Monitor when query starts
       def started(event)

--- a/lib/appsignal/integrations/padrino.rb
+++ b/lib/appsignal/integrations/padrino.rb
@@ -1,19 +1,22 @@
 require "appsignal"
 
-module Appsignal::Integrations
-  module PadrinoPlugin
-    def self.init
-      Appsignal.logger.info("Loading Padrino (#{Padrino::VERSION}) integration")
+module Appsignal
+  module Integrations
+    # @api private
+    module PadrinoPlugin
+      def self.init
+        Appsignal.logger.info("Loading Padrino (#{Padrino::VERSION}) integration")
 
-      root             = Padrino.mounted_root
-      Appsignal.config = Appsignal::Config.new(
-        root,
-        Padrino.env,
-        :log_path => File.join(root, "log")
-      )
+        root             = Padrino.mounted_root
+        Appsignal.config = Appsignal::Config.new(
+          root,
+          Padrino.env,
+          :log_path => File.join(root, "log")
+        )
 
-      Appsignal.start_logger
-      Appsignal.start
+        Appsignal.start_logger
+        Appsignal.start
+      end
     end
   end
 end

--- a/lib/appsignal/integrations/railtie.rb
+++ b/lib/appsignal/integrations/railtie.rb
@@ -4,6 +4,7 @@ require "appsignal/rack/rails_instrumentation"
 
 module Appsignal
   module Integrations
+    # @api private
     class Railtie < ::Rails::Railtie
       initializer "appsignal.configure_rails_initialization" do |app|
         Appsignal::Integrations::Railtie.initialize_appsignal(app)

--- a/lib/appsignal/integrations/resque.rb
+++ b/lib/appsignal/integrations/resque.rb
@@ -1,5 +1,6 @@
 module Appsignal
   module Integrations
+    # @api private
     module ResquePlugin
       # Do not use this file as a template for your own background processor
       # Resque is an exception to the rule and the code below causes the

--- a/lib/appsignal/integrations/resque_active_job.rb
+++ b/lib/appsignal/integrations/resque_active_job.rb
@@ -1,5 +1,6 @@
 module Appsignal
   module Integrations
+    # @api private
     module ResqueActiveJobPlugin
       include Appsignal::Hooks::Helpers
 

--- a/lib/appsignal/integrations/webmachine.rb
+++ b/lib/appsignal/integrations/webmachine.rb
@@ -1,32 +1,35 @@
-module Appsignal::Integrations
-  module WebmachinePlugin
-    module FSM
-      def run_with_appsignal
-        transaction = Appsignal::Transaction.create(
-          SecureRandom.uuid,
-          Appsignal::Transaction::HTTP_REQUEST,
-          request,
-          :params_method => :query
-        )
+module Appsignal
+  module Integrations
+    # @api private
+    module WebmachinePlugin
+      module FSM
+        def run_with_appsignal
+          transaction = Appsignal::Transaction.create(
+            SecureRandom.uuid,
+            Appsignal::Transaction::HTTP_REQUEST,
+            request,
+            :params_method => :query
+          )
 
-        transaction.set_action("#{resource.class.name}##{request.method}")
+          transaction.set_action("#{resource.class.name}##{request.method}")
 
-        Appsignal.instrument("process_action.webmachine") do
-          run_without_appsignal
+          Appsignal.instrument("process_action.webmachine") do
+            run_without_appsignal
+          end
+
+          Appsignal::Transaction.complete_current!
         end
 
-        Appsignal::Transaction.complete_current!
-      end
+        private
 
-      private
-
-      def handle_exceptions_with_appsignal
-        handle_exceptions_without_appsignal do
-          begin
-            yield
-          rescue => e
-            Appsignal.set_error(e)
-            raise e
+        def handle_exceptions_with_appsignal
+          handle_exceptions_without_appsignal do
+            begin
+              yield
+            rescue => e
+              Appsignal.set_error(e)
+              raise e
+            end
           end
         end
       end

--- a/lib/appsignal/marker.rb
+++ b/lib/appsignal/marker.rb
@@ -1,14 +1,50 @@
 module Appsignal
+  # Deploy markers are used on AppSignal.com to indicate changes in an
+  # application, "Deploy markers" indicate a deploy of an application.
+  #
+  # Incidents for exceptions and performance issues will be closed and
+  # reopened if they occur again in the new deploy.
+  #
+  # This class will help send a request to the AppSignal Push API to create a
+  # Deploy marker for the application on AppSignal.com.
+  #
+  # @!attribute [r] marker_data
+  #   @return [Hash] marker data to send.
+  #
+  # @!attribute [r] config
+  #   @return [Appsignal::Config] config to use in the authentication request.
+  #     Set config does not override data set in {#marker_data}.
+  #
+  # @see Appsignal::CLI::NotifyOfDeploy
+  # @see http://docs.appsignal.com/appsignal/terminology.html#markers
+  #   Terminology: Deploy marker
   # @api private
   class Marker
-    attr_reader :marker_data, :config
+    # Path used on the AppSignal Push API
+    # https://push.appsignal.com/1/markers
     ACTION = "markers"
 
+    attr_reader :marker_data, :config
+
+    # @param marker_data [Hash] see {#marker_data}
+    # @option marker_data :environment [String] environment to load
+    #   configuration for.
+    # @option marker_data :name [String] name of the application.
+    # @option marker_data :user [String] name of the user that is creating the
+    #   marker.
+    # @option marker_data :revision [String] the revision that has been
+    #   deployed. E.g. a git commit SHA.
+    # @param config [Appsignal::Config]
     def initialize(marker_data, config)
       @marker_data = marker_data
       @config = config
     end
 
+    # Send a request to create the marker.
+    #
+    # Prints output to STDOUT.
+    #
+    # @return [void]
     def transmit
       transmitter = Transmitter.new(ACTION, config)
       puts "Notifying AppSignal of deploy with: "\

--- a/lib/appsignal/marker.rb
+++ b/lib/appsignal/marker.rb
@@ -1,4 +1,5 @@
 module Appsignal
+  # @api private
   class Marker
     attr_reader :marker_data, :config
     ACTION = "markers"

--- a/lib/appsignal/minutely.rb
+++ b/lib/appsignal/minutely.rb
@@ -1,4 +1,5 @@
 module Appsignal
+  # @api private
   class Minutely
     class << self
       # List of probes. Probes can be lamdba's or objects that

--- a/lib/appsignal/rack/generic_instrumentation.rb
+++ b/lib/appsignal/rack/generic_instrumentation.rb
@@ -1,6 +1,7 @@
 require "rack"
 
 module Appsignal
+  # @api private
   module Rack
     class GenericInstrumentation
       def initialize(app, options = {})

--- a/lib/appsignal/rack/js_exception_catcher.rb
+++ b/lib/appsignal/rack/js_exception_catcher.rb
@@ -1,4 +1,5 @@
 module Appsignal
+  # @api private
   module Rack
     class JSExceptionCatcher
       def initialize(app, options = {})

--- a/lib/appsignal/rack/rails_instrumentation.rb
+++ b/lib/appsignal/rack/rails_instrumentation.rb
@@ -1,6 +1,7 @@
 require "rack"
 
 module Appsignal
+  # @api private
   module Rack
     class RailsInstrumentation
       def initialize(app, options = {})

--- a/lib/appsignal/rack/sinatra_instrumentation.rb
+++ b/lib/appsignal/rack/sinatra_instrumentation.rb
@@ -7,6 +7,8 @@ module Appsignal
     # `use Appsignal::Rack::SinatraInstrumentation` in their modular Sinatra
     # applications. This is no longer needed. Instead Appsignal now includes
     # `use Appsignal::Rack::SinatraBaseInstrumentation` automatically.
+    #
+    # @api private
     class SinatraInstrumentation
       def initialize(app, options = {})
         @app = app

--- a/lib/appsignal/rack/streaming_listener.rb
+++ b/lib/appsignal/rack/streaming_listener.rb
@@ -1,6 +1,8 @@
-# Appsignal module that tracks exceptions in Streaming rack responses.
 module Appsignal
   module Rack
+    # Appsignal module that tracks exceptions in Streaming rack responses.
+    #
+    # @api private
     class StreamingListener
       def initialize(app, options = {})
         Appsignal.logger.debug "Initializing Appsignal::Rack::StreamingListener"

--- a/lib/appsignal/system.rb
+++ b/lib/appsignal/system.rb
@@ -1,17 +1,35 @@
 module Appsignal
+  # System environment detection module.
+  #
+  # Provides useful methods to find out more about the host system.
+  #
+  # @api private
   module System
+    # @return [Boolean]
     def self.container?
       heroku? || Container.id
     end
 
+    # Returns `true` if AppSignal detects it's running on a Heroku dyno.
+    # @see http://heroku.com Heroku
+    # @return [Boolean]
     def self.heroku?
       ENV.key? "DYNO".freeze
     end
 
+    # Container detection helper.
+    #
+    # Reads and parses the system's cgroup file and tries to find signs of a
+    # containerized system.
     module Container
+      # Location of the cgropu file used to detect container systems.
       CGROUP_FILE = "/proc/self/cgroup".freeze
 
       class << self
+        # Returns container id if a container is detected.
+        #
+        # @return [String]
+        # @return [nil] no container id found.
         def id
           case cgroups
           when %r{docker[-|/]([0-9a-f]+)}

--- a/lib/appsignal/transmitter.rb
+++ b/lib/appsignal/transmitter.rb
@@ -5,6 +5,7 @@ require "rack/utils"
 require "json"
 
 module Appsignal
+  # @api private
   class Transmitter
     CONTENT_TYPE = "application/json; charset=UTF-8".freeze
     CONTENT_ENCODING = "gzip".freeze

--- a/lib/appsignal/utils.rb
+++ b/lib/appsignal/utils.rb
@@ -2,6 +2,7 @@ require "appsignal/utils/params_sanitizer"
 require "appsignal/utils/query_params_sanitizer"
 
 module Appsignal
+  # @api private
   module Utils
     def self.data_generate(body)
       Data.generate(body)

--- a/lib/appsignal/utils/params_sanitizer.rb
+++ b/lib/appsignal/utils/params_sanitizer.rb
@@ -1,5 +1,6 @@
 module Appsignal
   module Utils
+    # @api private
     class ParamsSanitizer
       FILTERED = "[FILTERED]".freeze
 

--- a/lib/appsignal/utils/query_params_sanitizer.rb
+++ b/lib/appsignal/utils/query_params_sanitizer.rb
@@ -1,5 +1,6 @@
 module Appsignal
   module Utils
+    # @api private
     class QueryParamsSanitizer
       REPLACEMENT_KEY = "?".freeze
 

--- a/spec/lib/appsignal/demo_spec.rb
+++ b/spec/lib/appsignal/demo_spec.rb
@@ -11,7 +11,7 @@ describe Appsignal::Demo do
 
     context "without config" do
       it "returns false" do
-        expect(silence { subject }).to be_falsy
+        expect(silence { subject }).to eq(false)
       end
     end
 
@@ -20,7 +20,7 @@ describe Appsignal::Demo do
       before { Appsignal.config = config }
 
       it "returns true" do
-        expect(subject).to be_truthy
+        expect(subject).to eq(true)
       end
 
       it "creates demonstration samples" do

--- a/spec/lib/appsignal/garbage_collection_profiler_spec.rb
+++ b/spec/lib/appsignal/garbage_collection_profiler_spec.rb
@@ -1,44 +1,41 @@
 describe Appsignal::GarbageCollectionProfiler do
   let(:internal_profiler) { FakeGCProfiler.new }
+  let(:profiler) { described_class.new }
 
   before do
-    allow_any_instance_of(Appsignal::GarbageCollectionProfiler)
+    allow_any_instance_of(described_class)
       .to receive(:internal_profiler)
       .and_return(internal_profiler)
   end
 
-  it "should have a total time of 0" do
-    expect(Appsignal::GarbageCollectionProfiler.new.total_time).to eq(0)
+  context "on initialization" do
+    it "has a total time of 0" do
+      expect(profiler.total_time).to eq(0)
+    end
   end
 
-  describe "after a GC run" do
-    before do
-      internal_profiler.total_time = 0.12345
-      @profiler = Appsignal::GarbageCollectionProfiler.new
+  context "when the GC has run" do
+    before { internal_profiler.total_time = 0.12345 }
+
+    it "fetches the total time from Ruby's GC::Profiler" do
+      expect(profiler.total_time).to eq(123)
     end
 
-    it "should take the total time from Ruby's GC::Profiler" do
-      expect(@profiler.total_time).to eq(123)
-    end
-
-    it "should clear Ruby's GC::Profiler" do
+    it "clears Ruby's GC::Profiler afterward" do
       expect(internal_profiler).to receive(:clear)
-      @profiler.total_time
+      profiler.total_time
     end
   end
 
-  describe "when the total GC time becomes too high" do
-    it "should reset" do
-      profiler = Appsignal::GarbageCollectionProfiler.new
+  context "when the total GC time becomes too high" do
+    it "resets the total time" do
       internal_profiler.total_time = 2_147_483_647
       expect(profiler.total_time).to eq(0)
     end
   end
 
-  describe "after multiple GC runs" do
-    it "should add all times from Ruby's GC::Profiler together" do
-      profiler = Appsignal::GarbageCollectionProfiler.new
-
+  context "when the GC has run multiple times" do
+    it "adds all times from Ruby's GC::Profiler together" do
       2.times do
         internal_profiler.total_time = 0.12345
         profiler.total_time
@@ -48,8 +45,8 @@ describe Appsignal::GarbageCollectionProfiler do
     end
   end
 
-  describe "in multiple threads, with a slow GC::Profiler" do
-    it "should not count garbage collection times twice" do
+  context "when in multiple threads and with a slow GC::Profiler" do
+    it "does not count garbage collection times twice" do
       threads = []
       results = []
       internal_profiler.clear_delay = 0.001

--- a/spec/lib/appsignal/system_spec.rb
+++ b/spec/lib/appsignal/system_spec.rb
@@ -6,7 +6,7 @@ describe Appsignal::System do
       around { |example| recognize_as_heroku { example.run } }
 
       it "returns true" do
-        expect(subject).to be_truthy
+        is_expected.to eq(true)
       end
     end
 
@@ -14,7 +14,7 @@ describe Appsignal::System do
       around { |example| recognize_as_container(:docker) { example.run } }
 
       it "returns true" do
-        expect(subject).to be_truthy
+        is_expected.to be_truthy
       end
     end
 
@@ -22,7 +22,7 @@ describe Appsignal::System do
       around { |example| recognize_as_container(:none) { example.run } }
 
       it "returns false" do
-        expect(subject).to be_falsy
+        is_expected.to be_falsy
       end
     end
   end
@@ -34,7 +34,7 @@ describe Appsignal::System do
       around { |example| recognize_as_heroku { example.run } }
 
       it "returns true" do
-        expect(subject).to be_truthy
+        is_expected.to eq(true)
       end
     end
 
@@ -42,7 +42,7 @@ describe Appsignal::System do
       around { |example| recognize_as_container(:none) { example.run } }
 
       it "returns false" do
-        expect(subject).to be_falsy
+        is_expected.to eq(false)
       end
     end
   end


### PR DESCRIPTION
Add yard to document the gem.

Document select classes in the gem. Mark private classes as such so that people won't start using them, or at least they know they're private and the behavior can change at any time.

This PR doesn't document all classes yet, but introduces the method of documentation and allows for easier documentation of other classes after this PR is merged. 