### PR TITLE
Deprecate unused AuthCheck logger argument

### DIFF
--- a/lib/appsignal/auth_check.rb
+++ b/lib/appsignal/auth_check.rb
@@ -4,9 +4,12 @@ module Appsignal
 
     attr_reader :config, :logger
 
-    def initialize(config, logger = Appsignal.logger)
+    def initialize(config, logger = nil)
       @config = config
-      @logger = logger
+      if logger # rubocop:disable Style/GuardClause
+        warn "Deprecated: `logger` argument will be removed in the next " \
+          "major version."
+      end
     end
 
     def perform

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -159,7 +159,7 @@ module Appsignal
         end
 
         def check_api_key
-          auth_check = ::Appsignal::AuthCheck.new(Appsignal.config, Appsignal.logger)
+          auth_check = ::Appsignal::AuthCheck.new(Appsignal.config)
           print "Validating API key: "
           status, error = auth_check.perform_with_result
           case status

--- a/spec/lib/appsignal/auth_check_spec.rb
+++ b/spec/lib/appsignal/auth_check_spec.rb
@@ -1,7 +1,6 @@
 describe Appsignal::AuthCheck do
   let(:config) { project_fixture_config }
-  let(:logger) { Logger.new(StringIO.new) }
-  let(:auth_check) { Appsignal::AuthCheck.new(config, logger) }
+  let(:auth_check) { Appsignal::AuthCheck.new(config) }
 
   describe "#perform_with_result" do
     it "should give success message" do


### PR DESCRIPTION
Deprecated to avoid breaking existing code.