### PR TITLE
Benchmark update

### DIFF
--- a/benchmark.rake
+++ b/benchmark.rake
@@ -6,8 +6,7 @@ GC.disable
 task :default => :'benchmark:all'
 
 namespace :benchmark do
-  task :all => [:run_inactive, :run_active] do
-  end
+  task :all => [:run_inactive, :run_active]
 
   task :run_inactive do
     puts 'Running with appsignal off'
@@ -23,8 +22,8 @@ namespace :benchmark do
 end
 
 def run_benchmark
-  no_transactions = (ENV['NO_TRANSACTIONS'] || '100000').to_i
-  no_threads = (ENV['NO_THREADS'] || '1').to_i
+  no_transactions = (ENV['NO_TRANSACTIONS'] || 100_000).to_i
+  no_threads = (ENV['NO_THREADS'] || 1).to_i
 
   total_objects = ObjectSpace.count_objects[:TOTAL]
   puts "Initializing, currently #{total_objects} objects"
@@ -47,9 +46,9 @@ def run_benchmark
           Appsignal::Transaction.create("transaction_#{i}", Appsignal::Transaction::HTTP_REQUEST, request)
 
           Appsignal.instrument('process_action.action_controller') do
-            Appsignal.instrument('sql.active_record', nil, 'SELECT `users`.* FROM `users` WHERE `users`.`id` = ?', Appsignal::EventFormatter::SQL_BODY_FORMAT)
+            Appsignal.instrument_sql('sql.active_record', nil, 'SELECT `users`.* FROM `users` WHERE `users`.`id` = ?')
             10.times do
-              Appsignal.instrument('sql.active_record', nil, 'SELECT `todos`.* FROM `todos` WHERE `todos`.`id` = ?', Appsignal::EventFormatter::SQL_BODY_FORMAT)
+              Appsignal.instrument_sql('sql.active_record', nil, 'SELECT `todos`.* FROM `todos` WHERE `todos`.`id` = ?')
             end
 
             Appsignal.instrument('render_template.action_view', 'app/views/home/show.html.erb') do

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -186,7 +186,11 @@ module Appsignal
 
     def instrument(name, title = nil, body = nil, body_format = Appsignal::EventFormatter::DEFAULT)
       Appsignal::Transaction.current.start_event
-      return_value = yield
+      return_value = if block_given?
+                       yield
+                     else
+                       nil
+                     end
       Appsignal::Transaction.current.finish_event(name, title, body, body_format)
       return_value
     end

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -186,11 +186,7 @@ module Appsignal
 
     def instrument(name, title = nil, body = nil, body_format = Appsignal::EventFormatter::DEFAULT)
       Appsignal::Transaction.current.start_event
-      return_value = if block_given?
-                       yield
-                     else
-                       nil
-                     end
+      return_value = yield if block_given?
       Appsignal::Transaction.current.finish_event(name, title, body, body_format)
       return_value
     end

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -807,6 +807,15 @@ describe Appsignal do
         end
         expect(result).to eq "return value"
       end
+
+      it "should instrument without a block given" do
+        expect(transaction).to receive(:start_event)
+        expect(transaction).to receive(:finish_event)
+          .with("name", "title", "body", Appsignal::EventFormatter::DEFAULT)
+
+        result = Appsignal.instrument "name", "title", "body"
+        expect(result).to be_nil
+      end
     end
 
     describe ".instrument_sql" do


### PR DESCRIPTION
Make the benchmark usable as a simple load test. AS notifications supports calling instrument without a block, add that support too.