### PR TITLE
Allow overriding of action and namespace

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -51,7 +51,11 @@ Metrics/BlockLength:
 # Offense count: 4
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 263
+  Exclude:
+    - "lib/appsignal/cli/diagnose.rb"
+    - "lib/appsignal/cli/install.rb"
+    - "lib/appsignal/config.rb"
+    - "lib/appsignal/transaction.rb"
 
 # Offense count: 14
 Metrics/CyclomaticComplexity:

--- a/ext/appsignal_extension.c
+++ b/ext/appsignal_extension.c
@@ -211,6 +211,19 @@ static VALUE set_transaction_action(VALUE self, VALUE action) {
   return Qnil;
 }
 
+static VALUE set_transaction_namespace(VALUE self, VALUE namespace) {
+  appsignal_transaction_t* transaction;
+
+  Check_Type(namespace, T_STRING);
+  Data_Get_Struct(self, appsignal_transaction_t, transaction);
+
+  appsignal_set_transaction_namespace(
+      transaction,
+      make_appsignal_string(namespace)
+  );
+  return Qnil;
+}
+
 static VALUE set_transaction_queue_start(VALUE self, VALUE queue_start) {
   appsignal_transaction_t* transaction;
   int queue_start_type;
@@ -608,6 +621,7 @@ void Init_appsignal_extension(void) {
   rb_define_method(Transaction, "set_error",       set_transaction_error,       3);
   rb_define_method(Transaction, "set_sample_data", set_transaction_sample_data, 2);
   rb_define_method(Transaction, "set_action",      set_transaction_action,      1);
+  rb_define_method(Transaction, "set_namespace",   set_transaction_namespace,   1);
   rb_define_method(Transaction, "set_queue_start", set_transaction_queue_start, 1);
   rb_define_method(Transaction, "set_metadata",    set_transaction_metadata,    2);
   rb_define_method(Transaction, "finish",          finish_transaction,          1);

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -181,6 +181,13 @@ module Appsignal
     alias :set_exception :set_error
     alias :add_exception :set_error
 
+    def set_action(action)
+      return if !active? ||
+          Appsignal::Transaction.current.nil? ||
+          action.nil?
+      Appsignal::Transaction.current.set_action(action)
+    end
+
     def set_namespace(namespace)
       return if !active? ||
           Appsignal::Transaction.current.nil? ||

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -181,6 +181,10 @@ module Appsignal
     alias :set_exception :set_error
     alias :add_exception :set_error
 
+    # Helper method for {Transaction#set_action}.
+    #
+    # @param action [String]
+    # @see Transaction#set_action
     def set_action(action)
       return if !active? ||
           Appsignal::Transaction.current.nil? ||
@@ -188,6 +192,10 @@ module Appsignal
       Appsignal::Transaction.current.set_action(action)
     end
 
+    # Helper method for {Transaction#set_namespace}.
+    #
+    # @param namespace [String]
+    # @see Transaction#set_namespace
     def set_namespace(namespace)
       return if !active? ||
           Appsignal::Transaction.current.nil? ||

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -181,6 +181,13 @@ module Appsignal
     alias :set_exception :set_error
     alias :add_exception :set_error
 
+    def set_namespace(namespace)
+      return if !active? ||
+          Appsignal::Transaction.current.nil? ||
+          namespace.nil?
+      Appsignal::Transaction.current.set_namespace(namespace)
+    end
+
     def tag_request(params = {})
       return unless active?
       transaction = Appsignal::Transaction.current

--- a/lib/appsignal/integrations/grape.rb
+++ b/lib/appsignal/integrations/grape.rb
@@ -39,7 +39,7 @@ module Appsignal
             path = "/#{path}" if path[0] != "/"
             path = "#{namespace}#{path}"
 
-            transaction.set_action("#{request_method}::#{klass}##{path}")
+            transaction.set_action_if_nil("#{request_method}::#{klass}##{path}")
           end
 
           transaction.set_http_or_background_queue_start

--- a/lib/appsignal/integrations/padrino.rb
+++ b/lib/appsignal/integrations/padrino.rb
@@ -43,7 +43,7 @@ module Padrino::Routing::InstanceMethods
       transaction.set_error(error)
       raise error
     ensure
-      transaction.set_action(get_payload_action(request))
+      transaction.set_action_if_nil(get_payload_action(request))
       transaction.set_metadata("path", request.path)
       transaction.set_metadata("method", request.request_method)
       transaction.set_http_or_background_queue_start

--- a/lib/appsignal/integrations/webmachine.rb
+++ b/lib/appsignal/integrations/webmachine.rb
@@ -11,7 +11,7 @@ module Appsignal
             :params_method => :query
           )
 
-          transaction.set_action("#{resource.class.name}##{request.method}")
+          transaction.set_action_if_nil("#{resource.class.name}##{request.method}")
 
           Appsignal.instrument("process_action.webmachine") do
             run_without_appsignal

--- a/lib/appsignal/rack/generic_instrumentation.rb
+++ b/lib/appsignal/rack/generic_instrumentation.rb
@@ -34,9 +34,9 @@ module Appsignal
           raise error
         ensure
           if env["appsignal.route"]
-            transaction.set_action(env["appsignal.route"])
+            transaction.set_action_if_nil(env["appsignal.route"])
           else
-            transaction.set_action("unknown")
+            transaction.set_action_if_nil("unknown")
           end
           transaction.set_metadata("path", request.path)
           transaction.set_metadata("method", request.request_method)

--- a/lib/appsignal/rack/rails_instrumentation.rb
+++ b/lib/appsignal/rack/rails_instrumentation.rb
@@ -34,7 +34,7 @@ module Appsignal
         ensure
           controller = env["action_controller.instance"]
           if controller
-            transaction.set_action("#{controller.class}##{controller.action_name}")
+            transaction.set_action_if_nil("#{controller.class}##{controller.action_name}")
           end
           transaction.set_http_or_background_queue_start
           transaction.set_metadata("path", request.path)

--- a/lib/appsignal/rack/sinatra_instrumentation.rb
+++ b/lib/appsignal/rack/sinatra_instrumentation.rb
@@ -68,7 +68,7 @@ module Appsignal
           if !@raise_errors_on && env["sinatra.error"] && !env["sinatra.skip_appsignal_error"]
             transaction.set_error(env["sinatra.error"])
           end
-          transaction.set_action(action_name(env))
+          transaction.set_action_if_nil(action_name(env))
           transaction.set_metadata("path", request.path)
           transaction.set_metadata("method", request.request_method)
           transaction.set_http_or_background_queue_start

--- a/lib/appsignal/rack/streaming_listener.rb
+++ b/lib/appsignal/rack/streaming_listener.rb
@@ -35,7 +35,7 @@ module Appsignal
               transaction.set_error(e)
               raise e
             ensure
-              transaction.set_action(env["appsignal.action"])
+              transaction.set_action_if_nil(env["appsignal.action"])
               transaction.set_metadata("path", request.path)
               transaction.set_metadata("method", request.request_method)
               transaction.set_http_or_background_queue_start

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -127,19 +127,82 @@ module Appsignal
       @tags.merge!(given_tags)
     end
 
+    # Set a custom action name for this transaction.
+    #
+    # When using an integration such as the Rails or Sinatra AppSignal will try
+    # to find the action name from the controller or endpoint for you.
+    #
+    # If you want to customize the action name as it appears on AppSignal.com
+    # you can use this method. This overrides the action name AppSignal
+    # generates in an integration.
+    #
+    # @example in a Rails controller
+    #   class SomeController < ApplicationController
+    #     before_action :set_appsignal_action
+    #
+    #     def set_appsignal_action
+    #       Appsignal.set_action("DynamicController#dynamic_method")
+    #     end
+    #   end
+    #
+    # @param action [String] the action name to set.
+    # @return [void]
     def set_action(action)
-      return if action.nil?
+      return unless action
       @action = action
       @ext.set_action(action)
     end
 
+    # Set an action name only if there is no current action set.
+    #
+    # Commonly used by AppSignal integrations so that they don't override
+    # custom action names.
+    #
+    # @example
+    #   Appsignal.set_action("foo")
+    #   Appsignal.set_action_if_nil("bar")
+    #   # Transaction action will be "foo"
+    #
+    # @param action [String]
+    # @return [void]
+    # @see #set_action
     def set_action_if_nil(action)
-      return unless @action.nil?
+      return if @action
       set_action(action)
     end
 
+    # Set a custom namespace for this transaction.
+    #
+    # When using an integration such as Rails or Sidekiq AppSignal will try to
+    # find a appropriate namespace for the transaction.
+    #
+    # A Rails controller will be automatically put in the "http_request"
+    # namespace, while a Sidekiq background job is put in the "background_job"
+    # namespace.
+    #
+    # Note: The "http_request" namespace gets transformed on AppSignal.com to
+    # "Web" and "background_job" gets transformed to "Background".
+    #
+    # If you want to customize the namespace in which transactions appear you
+    # can use this method. This overrides the namespace AppSignal uses by
+    # default.
+    #
+    # A common request we've seen is to split the administration panel from the
+    # main application.
+    #
+    # @example create a custom admin namespace
+    #   class AdminController < ApplicationController
+    #     before_action :set_appsignal_namespace
+    #
+    #     def set_appsignal_namespace
+    #       Appsignal.set_namespace("admin")
+    #     end
+    #   end
+    #
+    # @param namespace [String] namespace name to use for this transaction.
+    # @return [void]
     def set_namespace(namespace)
-      return if namespace.nil?
+      return unless namespace
       @namespace = namespace
       @ext.set_namespace(namespace)
     end

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -131,6 +131,12 @@ module Appsignal
       @ext.set_action(action)
     end
 
+    def set_namespace(namespace)
+      return unless namespace
+      @namespace = namespace
+      @ext.set_namespace(namespace)
+    end
+
     def set_http_or_background_action(from = request.params)
       return unless from
       group_and_action = [

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -59,10 +59,11 @@ module Appsignal
       end
     end
 
-    attr_reader :ext, :transaction_id, :namespace, :request, :paused, :tags, :options, :discarded
+    attr_reader :ext, :transaction_id, :action, :namespace, :request, :paused, :tags, :options, :discarded
 
     def initialize(transaction_id, namespace, request, options = {})
       @transaction_id = transaction_id
+      @action = nil
       @namespace = namespace
       @request = request
       @paused = false
@@ -127,12 +128,18 @@ module Appsignal
     end
 
     def set_action(action)
-      return unless action
+      return if action.nil?
+      @action = action
       @ext.set_action(action)
     end
 
+    def set_action_if_nil(action)
+      return unless @action.nil?
+      set_action(action)
+    end
+
     def set_namespace(namespace)
-      return unless namespace
+      return if namespace.nil?
       @namespace = namespace
       @ext.set_namespace(namespace)
     end

--- a/spec/lib/appsignal/extension_spec.rb
+++ b/spec/lib/appsignal/extension_spec.rb
@@ -63,6 +63,10 @@ describe "extension loading and operation" do
           subject.set_action("value")
         end
 
+        it "should have a set_namespace method" do
+          subject.set_namespace("value")
+        end
+
         it "should have a set_queue_start method" do
           subject.set_queue_start(10)
         end

--- a/spec/lib/appsignal/integrations/grape_spec.rb
+++ b/spec/lib/appsignal/integrations/grape_spec.rb
@@ -64,7 +64,7 @@ if DependencyHelper.grape_present?
 
           it "sets metadata" do
             expect(transaction).to receive(:set_http_or_background_queue_start)
-            expect(transaction).to receive(:set_action).with("POST::GrapeExample::Api#/ping")
+            expect(transaction).to receive(:set_action_if_nil).with("POST::GrapeExample::Api#/ping")
             expect(transaction).to receive(:set_metadata).with("path", "/ping")
             expect(transaction).to receive(:set_metadata).with("method", "POST")
           end
@@ -84,7 +84,7 @@ if DependencyHelper.grape_present?
 
           it "sets metadata" do
             expect(transaction).to receive(:set_http_or_background_queue_start)
-            expect(transaction).to receive(:set_action).with("POST::GrapeExample::Api#/ping")
+            expect(transaction).to receive(:set_action_if_nil).with("POST::GrapeExample::Api#/ping")
             expect(transaction).to receive(:set_metadata).with("path", "/ping")
             expect(transaction).to receive(:set_metadata).with("method", "POST")
           end
@@ -119,7 +119,7 @@ if DependencyHelper.grape_present?
           end
 
           it "sets non-unique route_param path" do
-            expect(transaction).to receive(:set_action).with("GET::GrapeExample::Api#/users/:id/")
+            expect(transaction).to receive(:set_action_if_nil).with("GET::GrapeExample::Api#/users/:id/")
             expect(transaction).to receive(:set_metadata).with("path", "/users/:id/")
             expect(transaction).to receive(:set_metadata).with("method", "GET")
           end
@@ -143,7 +143,7 @@ if DependencyHelper.grape_present?
             end
 
             it "sets namespaced path" do
-              expect(transaction).to receive(:set_action).with("POST::GrapeExample::Api#/v1/beta/ping")
+              expect(transaction).to receive(:set_action_if_nil).with("POST::GrapeExample::Api#/v1/beta/ping")
               expect(transaction).to receive(:set_metadata).with("path", "/v1/beta/ping")
               expect(transaction).to receive(:set_metadata).with("method", "POST")
             end
@@ -165,7 +165,7 @@ if DependencyHelper.grape_present?
               end
 
               it "sets namespaced path" do
-                expect(transaction).to receive(:set_action).with("POST::GrapeExample::Api#/v1/beta/ping")
+                expect(transaction).to receive(:set_action_if_nil).with("POST::GrapeExample::Api#/v1/beta/ping")
                 expect(transaction).to receive(:set_metadata).with("path", "/v1/beta/ping")
                 expect(transaction).to receive(:set_metadata).with("method", "POST")
               end
@@ -186,7 +186,7 @@ if DependencyHelper.grape_present?
               end
 
               it "sets namespaced path" do
-                expect(transaction).to receive(:set_action).with("POST::GrapeExample::Api#/v1/beta/ping")
+                expect(transaction).to receive(:set_action_if_nil).with("POST::GrapeExample::Api#/v1/beta/ping")
                 expect(transaction).to receive(:set_metadata).with("path", "/v1/beta/ping")
                 expect(transaction).to receive(:set_metadata).with("method", "POST")
               end

--- a/spec/lib/appsignal/integrations/padrino_spec.rb
+++ b/spec/lib/appsignal/integrations/padrino_spec.rb
@@ -143,7 +143,7 @@ if DependencyHelper.padrino_present?
             end
 
             it "should set the action on the transaction" do
-              expect(transaction).to receive(:set_action).with("controller#action")
+              expect(transaction).to receive(:set_action_if_nil).with("controller#action")
             end
 
             after { router.route!(base) }

--- a/spec/lib/appsignal/integrations/padrino_spec.rb
+++ b/spec/lib/appsignal/integrations/padrino_spec.rb
@@ -111,13 +111,13 @@ if DependencyHelper.padrino_present?
 
         context "with a dynamic request" do
           let(:transaction) do
-            double(
+            instance_double "Appsignal::Transaction",
               :set_http_or_background_action => nil,
               :set_http_or_background_queue_start => nil,
               :set_metadata => nil,
               :set_action => nil,
+              :set_action_if_nil => nil,
               :set_error => nil
-            )
           end
           before { allow(Appsignal::Transaction).to receive(:create).and_return(transaction) }
 

--- a/spec/lib/appsignal/integrations/webmachine_spec.rb
+++ b/spec/lib/appsignal/integrations/webmachine_spec.rb
@@ -7,7 +7,7 @@ if DependencyHelper.webmachine_present?
     end
     let(:resource)    { double(:trace? => false, :handle_exception => true) }
     let(:response)    { double }
-    let(:transaction) { double(:set_action => true) }
+    let(:transaction) { double(:set_action_if_nil => true) }
     let(:fsm) { Webmachine::Decision::FSM.new(resource, request, response) }
     before(:context) { start_agent }
 
@@ -36,7 +36,7 @@ if DependencyHelper.webmachine_present?
       end
 
       it "should set the action" do
-        expect(transaction).to receive(:set_action).with("RSpec::Mocks::Mock#GET")
+        expect(transaction).to receive(:set_action_if_nil).with("RSpec::Mocks::Mock#GET")
       end
 
       it "should call the original method" do

--- a/spec/lib/appsignal/rack/generic_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/generic_instrumentation_spec.rb
@@ -42,7 +42,7 @@ describe Appsignal::Rack::GenericInstrumentation do
         kind_of(String),
         Appsignal::Transaction::HTTP_REQUEST,
         kind_of(Rack::Request)
-      ).and_return(double(:set_action => nil, :set_http_or_background_queue_start => nil, :set_metadata => nil))
+      ).and_return(double(:set_action_if_nil => nil, :set_http_or_background_queue_start => nil, :set_metadata => nil))
     end
 
     it "should call the app" do
@@ -63,7 +63,7 @@ describe Appsignal::Rack::GenericInstrumentation do
     end
 
     it "should set the action to unknown" do
-      expect_any_instance_of(Appsignal::Transaction).to receive(:set_action).with("unknown")
+      expect_any_instance_of(Appsignal::Transaction).to receive(:set_action_if_nil).with("unknown")
     end
 
     context "with a route specified in the env" do
@@ -72,7 +72,7 @@ describe Appsignal::Rack::GenericInstrumentation do
       end
 
       it "should set the action" do
-        expect_any_instance_of(Appsignal::Transaction).to receive(:set_action).with("GET /")
+        expect_any_instance_of(Appsignal::Transaction).to receive(:set_action_if_nil).with("GET /")
       end
     end
 

--- a/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
@@ -54,8 +54,10 @@ if DependencyHelper.rails_present?
           kind_of(ActionDispatch::Request),
           :params_method => :filtered_parameters
         ).and_return(
-          double(
+          instance_double(
+            "Appsignal::Transaction",
             :set_action => nil,
+            :set_action_if_nil => nil,
             :set_http_or_background_queue_start => nil,
             :set_metadata => nil
           )

--- a/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
@@ -84,7 +84,7 @@ if DependencyHelper.rails_present?
       end
 
       it "should set the action and queue start" do
-        expect_any_instance_of(Appsignal::Transaction).to receive(:set_action).with("MockController#index")
+        expect_any_instance_of(Appsignal::Transaction).to receive(:set_action_if_nil).with("MockController#index")
         expect_any_instance_of(Appsignal::Transaction).to receive(:set_http_or_background_queue_start)
       end
 

--- a/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
@@ -110,7 +110,7 @@ if DependencyHelper.sinatra_present?
           Appsignal::Transaction::HTTP_REQUEST,
           kind_of(Sinatra::Request),
           kind_of(Hash)
-        ).and_return(double(:set_action => nil, :set_http_or_background_queue_start => nil, :set_metadata => nil))
+        ).and_return(double(:set_action_if_nil => nil, :set_http_or_background_queue_start => nil, :set_metadata => nil))
       end
 
       it "should call the app" do
@@ -158,14 +158,14 @@ if DependencyHelper.sinatra_present?
 
       describe "action name" do
         it "should set the action" do
-          expect_any_instance_of(Appsignal::Transaction).to receive(:set_action).with("GET /")
+          expect_any_instance_of(Appsignal::Transaction).to receive(:set_action_if_nil).with("GET /")
         end
 
         context "without 'sinatra.route' env" do
           let(:env) { { :path => "/", :method => "GET" } }
 
           it "returns nil" do
-            expect_any_instance_of(Appsignal::Transaction).to receive(:set_action).with(nil)
+            expect_any_instance_of(Appsignal::Transaction).to receive(:set_action_if_nil).with(nil)
           end
         end
 
@@ -173,14 +173,14 @@ if DependencyHelper.sinatra_present?
           before { env["SCRIPT_NAME"] = "/api" }
 
           it "should call set_action with an application prefix path" do
-            expect_any_instance_of(Appsignal::Transaction).to receive(:set_action).with("GET /api/")
+            expect_any_instance_of(Appsignal::Transaction).to receive(:set_action_if_nil).with("GET /api/")
           end
 
           context "without 'sinatra.route' env" do
             let(:env) { { :path => "/", :method => "GET" } }
 
             it "returns nil" do
-              expect_any_instance_of(Appsignal::Transaction).to receive(:set_action).with(nil)
+              expect_any_instance_of(Appsignal::Transaction).to receive(:set_action_if_nil).with(nil)
             end
           end
         end

--- a/spec/lib/appsignal/rack/streaming_listener_spec.rb
+++ b/spec/lib/appsignal/rack/streaming_listener_spec.rb
@@ -71,7 +71,7 @@ describe Appsignal::Rack::StreamingListener do
 
       env["appsignal.action"] = "Action"
 
-      expect(transaction).to receive(:set_action).with("Action")
+      expect(transaction).to receive(:set_action_if_nil).with("Action")
 
       listener.call_with_appsignal_monitoring(env)
     end

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -259,7 +259,25 @@ describe Appsignal::Transaction do
       end
 
       it "should not set the action in extension when value is nil" do
-        expect(Appsignal::Extension).to_not receive(:set_transaction_action)
+        expect(Appsignal::Extension).to_not receive(:set_action)
+
+        transaction.set_action(nil)
+      end
+    end
+
+    describe "set_namespace" do
+      it "should set the action in extension" do
+        expect(transaction.ext).to receive(:set_namespace).with(
+          "custom"
+        ).once
+
+        transaction.set_namespace("custom")
+
+        expect(transaction.namespace).to eq "custom"
+      end
+
+      it "should not set the action in extension when value is nil" do
+        expect(Appsignal::Extension).to_not receive(:set_namespace)
 
         transaction.set_action(nil)
       end

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -256,12 +256,36 @@ describe Appsignal::Transaction do
         ).once
 
         transaction.set_action("PagesController#show")
+
+        expect(transaction.action).to eq "PagesController#show"
       end
 
       it "should not set the action in extension when value is nil" do
         expect(Appsignal::Extension).to_not receive(:set_action)
 
         transaction.set_action(nil)
+      end
+    end
+
+    describe "set_action_if_nil" do
+      context "if action is currently nil" do
+        it "should set the action" do
+          expect(transaction.ext).to receive(:set_action).with(
+            "PagesController#show"
+          ).once
+
+          transaction.set_action_if_nil("PagesController#show")
+        end
+      end
+
+      context "if action is currently set" do
+        it "should not set the action" do
+          transaction.set_action("something")
+
+          expect(transaction.ext).not_to receive(:set_action)
+
+          transaction.set_action_if_nil("PagesController#show")
+        end
       end
     end
 

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -286,7 +286,7 @@ describe Appsignal do
     describe ".set_namespace" do
       it "should do nothing" do
         expect do
-          Appsignal.set_namespace('custom')
+          Appsignal.set_namespace("custom")
         end.to_not raise_error
       end
     end
@@ -804,9 +804,9 @@ describe Appsignal do
       before { allow(Appsignal::Transaction).to receive(:current).and_return(transaction) }
 
       it "should set the namespace to the current transaction" do
-        expect(transaction).to receive(:set_action).with('custom')
+        expect(transaction).to receive(:set_action).with("custom")
 
-        Appsignal.set_action('custom')
+        Appsignal.set_action("custom")
       end
 
       it "should do nothing if there is no current transaction" do
@@ -814,7 +814,7 @@ describe Appsignal do
 
         expect(transaction).to_not receive(:set_action)
 
-        Appsignal.set_action('custom')
+        Appsignal.set_action("custom")
       end
 
       it "should do nothing if the error is nil" do
@@ -828,9 +828,9 @@ describe Appsignal do
       before { allow(Appsignal::Transaction).to receive(:current).and_return(transaction) }
 
       it "should set the namespace to the current transaction" do
-        expect(transaction).to receive(:set_namespace).with('custom')
+        expect(transaction).to receive(:set_namespace).with("custom")
 
-        Appsignal.set_namespace('custom')
+        Appsignal.set_namespace("custom")
       end
 
       it "should do nothing if there is no current transaction" do
@@ -838,7 +838,7 @@ describe Appsignal do
 
         expect(transaction).to_not receive(:set_namespace)
 
-        Appsignal.set_namespace('custom')
+        Appsignal.set_namespace("custom")
       end
 
       it "should do nothing if the error is nil" do

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -283,6 +283,14 @@ describe Appsignal do
       end
     end
 
+    describe ".set_namespace" do
+      it "should do nothing" do
+        expect do
+          Appsignal.set_namespace('custom')
+        end.to_not raise_error
+      end
+    end
+
     describe ".tag_request" do
       it "should do nothing" do
         expect do
@@ -789,6 +797,30 @@ describe Appsignal do
         expect(transaction).to_not receive(:set_error)
 
         Appsignal.set_error(nil)
+      end
+    end
+
+    describe ".set_namespace" do
+      before { allow(Appsignal::Transaction).to receive(:current).and_return(transaction) }
+
+      it "should set the namespace to the current transaction" do
+        expect(transaction).to receive(:set_namespace).with('custom')
+
+        Appsignal.set_namespace('custom')
+      end
+
+      it "should do nothing if there is no current transaction" do
+        allow(Appsignal::Transaction).to receive(:current).and_return(nil)
+
+        expect(transaction).to_not receive(:set_namespace)
+
+        Appsignal.set_namespace('custom')
+      end
+
+      it "should do nothing if the error is nil" do
+        expect(transaction).to_not receive(:set_namespace)
+
+        Appsignal.set_namespace(nil)
       end
     end
 

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -800,6 +800,30 @@ describe Appsignal do
       end
     end
 
+    describe ".set_action" do
+      before { allow(Appsignal::Transaction).to receive(:current).and_return(transaction) }
+
+      it "should set the namespace to the current transaction" do
+        expect(transaction).to receive(:set_action).with('custom')
+
+        Appsignal.set_action('custom')
+      end
+
+      it "should do nothing if there is no current transaction" do
+        allow(Appsignal::Transaction).to receive(:current).and_return(nil)
+
+        expect(transaction).to_not receive(:set_action)
+
+        Appsignal.set_action('custom')
+      end
+
+      it "should do nothing if the error is nil" do
+        expect(transaction).to_not receive(:set_action)
+
+        Appsignal.set_action(nil)
+      end
+    end
+
     describe ".set_namespace" do
       before { allow(Appsignal::Transaction).to receive(:current).and_return(transaction) }
 


### PR DESCRIPTION
This pull enables you to have control over both the action and namespace. You can do this in a `before_action` in Rails for example:

```ruby
Appsignal.set_namespace("admin")
```

All information for admin controllers then automatically ends up a in a separate namespace in AppSignal. You can also do this with an action:

```ruby
Appsignal.set_namespace("special_api")
Appsignal.set_action("endpoint_#{name}")
```

This works with any integration. This is achieved by adding a method `set_action_if_nil` that's used in the standard integrations. This method checks if the action has already been set and skips the default action if that is the case.

If you do not override anything the behaviour stays the same.

Fixes #232