### PR TITLE
Fix Redis spec

### DIFF
--- a/spec/lib/appsignal/hooks/redis_spec.rb
+++ b/spec/lib/appsignal/hooks/redis_spec.rb
@@ -1,6 +1,6 @@
 describe Appsignal::Hooks::RedisHook do
-  before :context do
-    start_agent
+  before do
+    Appsignal.config = project_fixture_config
   end
 
   context "with redis" do
@@ -14,13 +14,13 @@ describe Appsignal::Hooks::RedisHook do
         VERSION = "1.0"
       end
     end
+    after(:context) { Object.send(:remove_const, :Redis) }
 
     context "with instrumentation enabled" do
-      before :context do
+      before do
         Appsignal.config.config_hash[:instrument_redis] = true
         Appsignal::Hooks::RedisHook.new.install
       end
-      after(:context) { Object.send(:remove_const, :Redis) }
 
       describe "#dependencies_present?" do
         subject { described_class.new.dependencies_present? }
@@ -43,8 +43,8 @@ describe Appsignal::Hooks::RedisHook do
     end
 
     context "with instrumentation disabled" do
-      before :context do
-        Appsignal.config.config_hash[:instrument_net_http] = false
+      before do
+        Appsignal.config.config_hash[:instrument_redis] = false
       end
 
       describe "#dependencies_present?" do

--- a/spec/lib/appsignal/hooks/redis_spec.rb
+++ b/spec/lib/appsignal/hooks/redis_spec.rb
@@ -1,65 +1,55 @@
 describe Appsignal::Hooks::RedisHook do
   before do
     Appsignal.config = project_fixture_config
+    Appsignal::Hooks.load_hooks
   end
 
-  context "with redis" do
-    before :context do
-      class Redis
-        class Client
-          def process(_commands)
-            1
-          end
+  if DependencyHelper.redis_present?
+    context "with redis" do
+      context "with instrumentation enabled" do
+        before do
+          Appsignal.config.config_hash[:instrument_redis] = true
+          allow_any_instance_of(Redis::Client).to receive(:process_without_appsignal).and_return(1)
         end
-        VERSION = "1.0"
+
+        describe "#dependencies_present?" do
+          subject { described_class.new.dependencies_present? }
+
+          it { is_expected.to be_truthy }
+        end
+
+        it "should instrument a redis call" do
+          Appsignal::Transaction.create("uuid", Appsignal::Transaction::HTTP_REQUEST, "test")
+          expect(Appsignal::Transaction.current).to receive(:start_event)
+            .at_least(:once)
+          expect(Appsignal::Transaction.current).to receive(:finish_event)
+            .at_least(:once)
+            .with("query.redis", nil, nil, 0)
+
+          client = Redis::Client.new
+          expect(client.process([])).to eq 1
+        end
+      end
+
+      context "with instrumentation disabled" do
+        before do
+          Appsignal.config.config_hash[:instrument_redis] = false
+        end
+
+        describe "#dependencies_present?" do
+          subject { described_class.new.dependencies_present? }
+
+          it { is_expected.to be_falsy }
+        end
       end
     end
-    after(:context) { Object.send(:remove_const, :Redis) }
-
-    context "with instrumentation enabled" do
-      before do
-        Appsignal.config.config_hash[:instrument_redis] = true
-        Appsignal::Hooks::RedisHook.new.install
-      end
-
-      describe "#dependencies_present?" do
-        subject { described_class.new.dependencies_present? }
-
-        it { is_expected.to be_truthy }
-      end
-
-      it "should instrument a redis call" do
-        Appsignal::Transaction.create("uuid", Appsignal::Transaction::HTTP_REQUEST, "test")
-        expect(Appsignal::Transaction.current).to receive(:start_event)
-          .at_least(:once)
-        expect(Appsignal::Transaction.current).to receive(:finish_event)
-          .at_least(:once)
-          .with("query.redis", nil, nil, 0)
-
-        client = Redis::Client.new
-
-        expect(client.process([])).to eq 1
-      end
-    end
-
-    context "with instrumentation disabled" do
-      before do
-        Appsignal.config.config_hash[:instrument_redis] = false
-      end
-
+  else
+    context "without redis" do
       describe "#dependencies_present?" do
         subject { described_class.new.dependencies_present? }
 
         it { is_expected.to be_falsy }
       end
-    end
-  end
-
-  context "without redis" do
-    describe "#dependencies_present?" do
-      subject { described_class.new.dependencies_present? }
-
-      it { is_expected.to be_falsy }
     end
   end
 end

--- a/spec/support/helpers/dependency_helper.rb
+++ b/spec/support/helpers/dependency_helper.rb
@@ -17,6 +17,10 @@ module DependencyHelper
     dependency_present? "resque"
   end
 
+  def redis_present?
+    dependency_present? "redis"
+  end
+
   def active_job_present?
     dependency_present? "activejob"
   end


### PR DESCRIPTION
Not sure how this could have worked, but removing the setup from the
`before :context/:all` blocks highlighted that the setting being changed
was not in fact the correct setting. Should be `:instrument_redis`, was
`:instrument_net_http`.

Fix spec and moved more setup to `before` blocks, rather than `before
:context`.

This problem was highlighted by running the test suite in RSpec's
`config.order = :random`.