### PR TITLE
Configure agent with underscored config env vars

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,7 +22,7 @@ Lint/RescueException:
 
 # Offense count: 37
 Metrics/AbcSize:
-  Max: 59
+  Max: 61
 
 # Offense count: 2
 # Configuration parameters: CountComments.

--- a/ext/agent.yml
+++ b/ext/agent.yml
@@ -1,18 +1,18 @@
 ---
-version: 557cdf6
+version: 413c222
 triples:
   x86_64-linux:
-    checksum: ebf3da9dfd753596295db62af5e786cc2d39fd75d23bf2b3b986763e853db87a
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/557cdf6/appsignal-x86_64-linux-all-static.tar.gz
+    checksum: 0154d797bf3873b40e2499140284e05c91070a13f25ec54a0df6d60c2e0f7c36
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/413c222/appsignal-x86_64-linux-all-static.tar.gz
   i686-linux:
-    checksum: 853c7d58b6c84f702351cf5690c606b8d51ab686494f989133dde42171ea691e
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/557cdf6/appsignal-i686-linux-all-static.tar.gz
+    checksum: f7773d34618b742edeac39bf41ee6588ac0d5c8d182a459a86dc12c26020f188
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/413c222/appsignal-i686-linux-all-static.tar.gz
   x86-linux:
-    checksum: 853c7d58b6c84f702351cf5690c606b8d51ab686494f989133dde42171ea691e
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/557cdf6/appsignal-i686-linux-all-static.tar.gz
+    checksum: f7773d34618b742edeac39bf41ee6588ac0d5c8d182a459a86dc12c26020f188
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/413c222/appsignal-i686-linux-all-static.tar.gz
   x86_64-darwin:
-    checksum: 80815cf70a783cf0bcef586361fcbd4460b379ac4876cb824388345cd1cbecbb
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/557cdf6/appsignal-x86_64-darwin-all-static.tar.gz
+    checksum: dafa8467812ceaeecb96c8ca2768f4b667fc404935c7ef53e6d7c758dc6259c0
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/413c222/appsignal-x86_64-darwin-all-static.tar.gz
   universal-darwin:
-    checksum: 80815cf70a783cf0bcef586361fcbd4460b379ac4876cb824388345cd1cbecbb
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/557cdf6/appsignal-x86_64-darwin-all-static.tar.gz
+    checksum: dafa8467812ceaeecb96c8ca2768f4b667fc404935c7ef53e6d7c758dc6259c0
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/413c222/appsignal-x86_64-darwin-all-static.tar.gz

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -78,7 +78,7 @@ module Appsignal
             initial_config[:log_path] = Rails.root.join("log")
           end
 
-          ENV["APPSIGNAL_DIAGNOSE"] = "true"
+          ENV["_APPSIGNAL_DIAGNOSE"] = "true"
           Appsignal.config = Appsignal::Config.new(
             current_path,
             options[:environment],

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -122,6 +122,7 @@ module Appsignal
       ENV["_APPSIGNAL_AGENT_VERSION"]                = Appsignal::Extension.agent_version
       ENV["_APPSIGNAL_LANGUAGE_INTEGRATION_VERSION"] = "ruby-#{Appsignal::VERSION}"
       ENV["_APPSIGNAL_DEBUG_LOGGING"]                = config_hash[:debug].to_s
+      ENV["_APPSIGNAL_LOG"]                          = config_hash[:log]
       ENV["_APPSIGNAL_LOG_FILE_PATH"]                = log_file_path.to_s if log_file_path
       ENV["_APPSIGNAL_PUSH_API_ENDPOINT"]            = config_hash[:endpoint]
       ENV["_APPSIGNAL_PUSH_API_KEY"]                 = config_hash[:push_api_key]

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -115,29 +115,29 @@ module Appsignal
     end
 
     def write_to_environment
-      ENV["APPSIGNAL_ACTIVE"]                       = active?.to_s
-      ENV["APPSIGNAL_APP_PATH"]                     = root_path.to_s
-      ENV["APPSIGNAL_AGENT_PATH"]                   = File.expand_path("../../../ext", __FILE__).to_s
-      ENV["APPSIGNAL_ENVIRONMENT"]                  = env
-      ENV["APPSIGNAL_AGENT_VERSION"]                = Appsignal::Extension.agent_version
-      ENV["APPSIGNAL_LANGUAGE_INTEGRATION_VERSION"] = "ruby-#{Appsignal::VERSION}"
-      ENV["APPSIGNAL_DEBUG_LOGGING"]                = config_hash[:debug].to_s
-      ENV["APPSIGNAL_LOG_FILE_PATH"]                = log_file_path.to_s if log_file_path
-      ENV["APPSIGNAL_PUSH_API_ENDPOINT"]            = config_hash[:endpoint]
-      ENV["APPSIGNAL_PUSH_API_KEY"]                 = config_hash[:push_api_key]
-      ENV["APPSIGNAL_APP_NAME"]                     = config_hash[:name]
-      ENV["APPSIGNAL_HTTP_PROXY"]                   = config_hash[:http_proxy]
-      ENV["APPSIGNAL_IGNORE_ACTIONS"]               = config_hash[:ignore_actions].join(",")
-      ENV["APPSIGNAL_IGNORE_ERRORS"]                = config_hash[:ignore_errors].join(",")
-      ENV["APPSIGNAL_FILTER_PARAMETERS"]            = config_hash[:filter_parameters].join(",")
-      ENV["APPSIGNAL_SEND_PARAMS"]                  = config_hash[:send_params].to_s
-      ENV["APPSIGNAL_RUNNING_IN_CONTAINER"]         = config_hash[:running_in_container].to_s
-      ENV["APPSIGNAL_WORKING_DIR_PATH"]             = config_hash[:working_dir_path] if config_hash[:working_dir_path]
-      ENV["APPSIGNAL_ENABLE_HOST_METRICS"]          = config_hash[:enable_host_metrics].to_s
-      ENV["APPSIGNAL_ENABLE_MINUTELY_PROBES"]       = config_hash[:enable_minutely_probes].to_s
-      ENV["APPSIGNAL_HOSTNAME"]                     = config_hash[:hostname].to_s
-      ENV["APPSIGNAL_PROCESS_NAME"]                 = $PROGRAM_NAME
-      ENV["APPSIGNAL_CA_FILE_PATH"]                 = config_hash[:ca_file_path].to_s
+      ENV["_APPSIGNAL_ACTIVE"]                       = active?.to_s
+      ENV["_APPSIGNAL_APP_PATH"]                     = root_path.to_s
+      ENV["_APPSIGNAL_AGENT_PATH"]                   = File.expand_path("../../../ext", __FILE__).to_s
+      ENV["_APPSIGNAL_ENVIRONMENT"]                  = env
+      ENV["_APPSIGNAL_AGENT_VERSION"]                = Appsignal::Extension.agent_version
+      ENV["_APPSIGNAL_LANGUAGE_INTEGRATION_VERSION"] = "ruby-#{Appsignal::VERSION}"
+      ENV["_APPSIGNAL_DEBUG_LOGGING"]                = config_hash[:debug].to_s
+      ENV["_APPSIGNAL_LOG_FILE_PATH"]                = log_file_path.to_s if log_file_path
+      ENV["_APPSIGNAL_PUSH_API_ENDPOINT"]            = config_hash[:endpoint]
+      ENV["_APPSIGNAL_PUSH_API_KEY"]                 = config_hash[:push_api_key]
+      ENV["_APPSIGNAL_APP_NAME"]                     = config_hash[:name]
+      ENV["_APPSIGNAL_HTTP_PROXY"]                   = config_hash[:http_proxy]
+      ENV["_APPSIGNAL_IGNORE_ACTIONS"]               = config_hash[:ignore_actions].join(",")
+      ENV["_APPSIGNAL_IGNORE_ERRORS"]                = config_hash[:ignore_errors].join(",")
+      ENV["_APPSIGNAL_FILTER_PARAMETERS"]            = config_hash[:filter_parameters].join(",")
+      ENV["_APPSIGNAL_SEND_PARAMS"]                  = config_hash[:send_params].to_s
+      ENV["_APPSIGNAL_RUNNING_IN_CONTAINER"]         = config_hash[:running_in_container].to_s
+      ENV["_APPSIGNAL_WORKING_DIR_PATH"]             = config_hash[:working_dir_path] if config_hash[:working_dir_path]
+      ENV["_APPSIGNAL_ENABLE_HOST_METRICS"]          = config_hash[:enable_host_metrics].to_s
+      ENV["_APPSIGNAL_ENABLE_MINUTELY_PROBES"]       = config_hash[:enable_minutely_probes].to_s
+      ENV["_APPSIGNAL_HOSTNAME"]                     = config_hash[:hostname].to_s
+      ENV["_APPSIGNAL_PROCESS_NAME"]                 = $PROGRAM_NAME
+      ENV["_APPSIGNAL_CA_FILE_PATH"]                 = config_hash[:ca_file_path].to_s
     end
 
     private

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -391,7 +391,7 @@ describe Appsignal::Config do
       expect(ENV["_APPSIGNAL_HOSTNAME"]).to                     eq "app1.local"
       expect(ENV["_APPSIGNAL_PROCESS_NAME"]).to                 include "rspec"
       expect(ENV["_APPSIGNAL_CA_FILE_PATH"]).to                 eq File.join(resources_dir, "cacert.pem")
-      expect(ENV).to_not                                       have_key("APPSIGNAL_WORKING_DIR_PATH")
+      expect(ENV).to_not                                        have_key("APPSIGNAL_WORKING_DIR_PATH")
     end
 
     context "with :working_dir_path" do

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -367,28 +367,28 @@ describe Appsignal::Config do
     end
 
     it "writes the current config to environment variables" do
-      expect(ENV["APPSIGNAL_ACTIVE"]).to                       eq "true"
-      expect(ENV["APPSIGNAL_APP_PATH"]).to                     end_with("spec/support/project_fixture")
-      expect(ENV["APPSIGNAL_AGENT_PATH"]).to                   end_with("/ext")
-      expect(ENV["APPSIGNAL_DEBUG_LOGGING"]).to                eq "false"
-      expect(ENV["APPSIGNAL_LOG_FILE_PATH"]).to                end_with("/tmp/appsignal.log")
-      expect(ENV["APPSIGNAL_PUSH_API_ENDPOINT"]).to            eq "https://push.appsignal.com"
-      expect(ENV["APPSIGNAL_PUSH_API_KEY"]).to                 eq "abc"
-      expect(ENV["APPSIGNAL_APP_NAME"]).to                     eq "TestApp"
-      expect(ENV["APPSIGNAL_ENVIRONMENT"]).to                  eq "production"
-      expect(ENV["APPSIGNAL_AGENT_VERSION"]).to                eq Appsignal::Extension.agent_version
-      expect(ENV["APPSIGNAL_LANGUAGE_INTEGRATION_VERSION"]).to eq "ruby-#{Appsignal::VERSION}"
-      expect(ENV["APPSIGNAL_HTTP_PROXY"]).to                   eq "http://localhost"
-      expect(ENV["APPSIGNAL_IGNORE_ACTIONS"]).to               eq "action1,action2"
-      expect(ENV["APPSIGNAL_IGNORE_ERRORS"]).to                eq "VerySpecificError,AnotherError"
-      expect(ENV["APPSIGNAL_FILTER_PARAMETERS"]).to            eq "password,confirm_password"
-      expect(ENV["APPSIGNAL_SEND_PARAMS"]).to                  eq "true"
-      expect(ENV["APPSIGNAL_RUNNING_IN_CONTAINER"]).to         eq "false"
-      expect(ENV["APPSIGNAL_ENABLE_HOST_METRICS"]).to          eq "true"
-      expect(ENV["APPSIGNAL_ENABLE_MINUTELY_PROBES"]).to       eq "false"
-      expect(ENV["APPSIGNAL_HOSTNAME"]).to                     eq "app1.local"
-      expect(ENV["APPSIGNAL_PROCESS_NAME"]).to                 include "rspec"
-      expect(ENV["APPSIGNAL_CA_FILE_PATH"]).to                 eq File.join(resources_dir, "cacert.pem")
+      expect(ENV["_APPSIGNAL_ACTIVE"]).to                       eq "true"
+      expect(ENV["_APPSIGNAL_APP_PATH"]).to                     end_with("spec/support/project_fixture")
+      expect(ENV["_APPSIGNAL_AGENT_PATH"]).to                   end_with("/ext")
+      expect(ENV["_APPSIGNAL_DEBUG_LOGGING"]).to                eq "false"
+      expect(ENV["_APPSIGNAL_LOG_FILE_PATH"]).to                end_with("/tmp/appsignal.log")
+      expect(ENV["_APPSIGNAL_PUSH_API_ENDPOINT"]).to            eq "https://push.appsignal.com"
+      expect(ENV["_APPSIGNAL_PUSH_API_KEY"]).to                 eq "abc"
+      expect(ENV["_APPSIGNAL_APP_NAME"]).to                     eq "TestApp"
+      expect(ENV["_APPSIGNAL_ENVIRONMENT"]).to                  eq "production"
+      expect(ENV["_APPSIGNAL_AGENT_VERSION"]).to                eq Appsignal::Extension.agent_version
+      expect(ENV["_APPSIGNAL_LANGUAGE_INTEGRATION_VERSION"]).to eq "ruby-#{Appsignal::VERSION}"
+      expect(ENV["_APPSIGNAL_HTTP_PROXY"]).to                   eq "http://localhost"
+      expect(ENV["_APPSIGNAL_IGNORE_ACTIONS"]).to               eq "action1,action2"
+      expect(ENV["_APPSIGNAL_IGNORE_ERRORS"]).to                eq "VerySpecificError,AnotherError"
+      expect(ENV["_APPSIGNAL_FILTER_PARAMETERS"]).to            eq "password,confirm_password"
+      expect(ENV["_APPSIGNAL_SEND_PARAMS"]).to                  eq "true"
+      expect(ENV["_APPSIGNAL_RUNNING_IN_CONTAINER"]).to         eq "false"
+      expect(ENV["_APPSIGNAL_ENABLE_HOST_METRICS"]).to          eq "true"
+      expect(ENV["_APPSIGNAL_ENABLE_MINUTELY_PROBES"]).to       eq "false"
+      expect(ENV["_APPSIGNAL_HOSTNAME"]).to                     eq "app1.local"
+      expect(ENV["_APPSIGNAL_PROCESS_NAME"]).to                 include "rspec"
+      expect(ENV["_APPSIGNAL_CA_FILE_PATH"]).to                 eq File.join(resources_dir, "cacert.pem")
       expect(ENV).to_not                                       have_key("APPSIGNAL_WORKING_DIR_PATH")
     end
 
@@ -399,7 +399,7 @@ describe Appsignal::Config do
       end
 
       it "sets the modified :working_dir_path" do
-        expect(ENV["APPSIGNAL_WORKING_DIR_PATH"]).to eq "/tmp/appsignal2"
+        expect(ENV["_APPSIGNAL_WORKING_DIR_PATH"]).to eq "/tmp/appsignal2"
       end
     end
   end

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -359,6 +359,7 @@ describe Appsignal::Config do
       config[:http_proxy] = "http://localhost"
       config[:ignore_actions] = ["action1", "action2"]
       config[:ignore_errors] = ["VerySpecificError", "AnotherError"]
+      config[:log] = "stdout"
       config[:log_path] = "/tmp"
       config[:hostname] = "app1.local"
       config[:filter_parameters] = %w(password confirm_password)
@@ -371,6 +372,7 @@ describe Appsignal::Config do
       expect(ENV["_APPSIGNAL_APP_PATH"]).to                     end_with("spec/support/project_fixture")
       expect(ENV["_APPSIGNAL_AGENT_PATH"]).to                   end_with("/ext")
       expect(ENV["_APPSIGNAL_DEBUG_LOGGING"]).to                eq "false"
+      expect(ENV["_APPSIGNAL_LOG"]).to                          eq "stdout"
       expect(ENV["_APPSIGNAL_LOG_FILE_PATH"]).to                end_with("/tmp/appsignal.log")
       expect(ENV["_APPSIGNAL_PUSH_API_ENDPOINT"]).to            eq "https://push.appsignal.com"
       expect(ENV["_APPSIGNAL_PUSH_API_KEY"]).to                 eq "abc"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,9 +66,9 @@ RSpec.configure do |config|
     ENV["PADRINO_ENV"] ||= "test"
 
     # Clean environment
-    ENV.keys.select { |key| key.start_with?("APPSIGNAL_") }.each do |key|
-      ENV.delete(key)
-    end
+    appsignal_key_prefixes = %w(APPSIGNAL_ _APPSIGNAL_)
+    env_keys = ENV.keys.select { |key| key.start_with?(*appsignal_key_prefixes) }
+    env_keys.each { |key| ENV.delete(key) }
   end
 
   config.after do


### PR DESCRIPTION
A problem that occurred in Elixir as described below and found in PR
https://github.com/appsignal/appsignal-elixir/pull/151

Gave us the idea of separating the logic between the two env vars
usages. Now they can't accidentally conflict with one another, override
settings unexpectedly and cause all kinds of problems.

> During a hot reload the AppSignal process is not
> reset/cleared/reloaded in any way to flush the previously set config
> env vars. When the AppSignal process starts it writes the current
> config to the environment so that the agent can read from this and be
> initialized with the same config.

> During a hot reload the AppSignal process tries to initialize the
> config again, but because the system env still contains the config for
> the agent from the last time it initialized the config it reads the
> previous config. The env vars are loading in initializing the config,
> as described here:
> http://docs.appsignal.com/elixir/configuration/load-order.html

> The fix? Underscore all the config sent to the agent process so that
> it doesn't conflict with the application's config.

**Note:** Requires the agent to be updated first!