### PR TITLE
Ensure Grape request method is always passed to metadata as a string

### DIFF
--- a/lib/appsignal/integrations/grape.rb
+++ b/lib/appsignal/integrations/grape.rb
@@ -22,13 +22,13 @@ module Appsignal
           transaction.set_error(error)
           raise error
         ensure
-          request_method = request.request_method
+          request_method = request.request_method.to_s.upcase
           path = request.path # Path without namespaces
           endpoint = env["api.endpoint"]
 
           if endpoint && endpoint.options
             options = endpoint.options
-            request_method = options[:method].first
+            request_method = options[:method].first.to_s.upcase
             klass = options[:for]
             namespace = endpoint.namespace
             namespace = "" if namespace == "/"

--- a/spec/lib/appsignal/integrations/grape_spec.rb
+++ b/spec/lib/appsignal/integrations/grape_spec.rb
@@ -98,6 +98,30 @@ if DependencyHelper.grape_present?
           end
         end
 
+        context "with route" do
+          let(:app) do
+            Class.new(::Grape::API) do
+              route [:get, :post], "hello" do
+                "Hello!"
+              end
+            end
+          end
+          let(:env) do
+            http_request_env_with_data \
+              "api.endpoint" => api_endpoint,
+              "REQUEST_METHOD" => "GET",
+              :path => ""
+          end
+
+          it "sets non-unique route path" do
+            expect(transaction).to receive(:set_action).with("GET::GrapeExample::Api#/hello")
+            expect(transaction).to receive(:set_metadata).with("path", "/hello")
+            expect(transaction).to receive(:set_metadata).with("method", "GET")
+          end
+
+          after { middleware.call(env) }
+        end
+
         context "with route_param" do
           let(:app) do
             Class.new(::Grape::API) do


### PR DESCRIPTION
Grape request methods are represented by strings when using the `get` and `post` DSL
methods. If you use the `route` DSL method, it is possible, and valid, to set the
request method as a symbol. This causes appsignal to fail on the request.

For example

```ruby
class API < Grape::API
  use Appsignal::Grape::Middleware

  route [:get, :post], 'hello' do
    'hello'
  end
end
```

will cause appsignal to give the following error on request

```
Exception: TypeError: wrong argument type Symbol (expected String)
.../lib/appsignal/transaction.rb:157:in `set_metadata'
.../lib/appsignal/integrations/grape.rb:45:in `ensure in call_with_appsignal_monitoring'
```