### PR TITLE
Force agent diagnostics in diagnose cli command

### DIFF
--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -84,7 +84,14 @@ module Appsignal
             options[:environment],
             initial_config
           )
+          # Force agent to run in diagnostics mode regardless if the user's
+          # config has AppSignal.active? => true
+          # But reset it later so it doesn't interfere with the user's config
+          # that's printed.
+          previous_active_state = Appsignal.config[:active]
+          Appsignal.config[:active] = true
           Appsignal.start
+          Appsignal.config[:active] = previous_active_state
         end
 
         def header

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -55,12 +55,31 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
         it "starts the agent in diagnose mode and outputs a log" do
           run
           expect(output).to include \
-            "Agent diagnostics:",
+            "Agent diagnostics",
             "Running agent in diagnose mode",
             "Valid config present",
             "Logger initialized successfully",
             "Lock path is writable",
             "Agent diagnose finished"
+        end
+
+        context "when user config has active: false" do
+          before do
+            # ENV is leading so easiest to set in test to force user config with active: false
+            ENV["APPSIGNAL_ACTIVE"] = "false"
+          end
+
+          it "force starts the agent in diagnose mode and outputs a log" do
+            run
+            expect(output).to include("active: false")
+            expect(output).to include \
+              "Agent diagnostics",
+              "Running agent in diagnose mode",
+              "Valid config present",
+              "Logger initialized successfully",
+              "Lock path is writable",
+              "Agent diagnose finished"
+          end
         end
       end
 


### PR DESCRIPTION
Allows us to test the diagnostics of the agent without the user having
to set `active: true` in their environment.

Follow up from https://github.com/appsignal/appsignal-elixir/pull/132 and discussion in slack