### PR TITLE
fix undefined method `[]' for nil:NilClass

### DIFF
--- a/lib/appsignal/rack/js_exception_catcher.rb
+++ b/lib/appsignal/rack/js_exception_catcher.rb
@@ -9,7 +9,7 @@ module Appsignal
 
       def call(env)
         if env["PATH_INFO"] == Appsignal.config[:frontend_error_catching_path]
-          body = JSON.parse(env["rack.input"].read)
+          body = JSON.parse(env["rack.input"].read) || {}
 
           if body["name"].is_a?(String) && !body["name"].empty?
             transaction = JSExceptionTransaction.new(body)


### PR DESCRIPTION
In case when `env["rack.input"].read` returns `""`, `JSON.parse("")` resolves to `nil`.
We get `[]` method calling on `nil`.

It is happening when someone open the `/appsignal_error_catcher` page.