### PR TITLE
Stub JS error catching endpoint when not active

### DIFF
--- a/lib/appsignal/integrations/railtie.rb
+++ b/lib/appsignal/integrations/railtie.rb
@@ -27,8 +27,7 @@ module Appsignal
           Appsignal::Rack::RailsInstrumentation
         )
 
-        if Appsignal.config.active? &&
-            Appsignal.config[:enable_frontend_error_catching] == true
+        if Appsignal.config[:enable_frontend_error_catching]
           app.middleware.insert_before(
             Appsignal::Rack::RailsInstrumentation,
             Appsignal::Rack::JSExceptionCatcher

--- a/lib/appsignal/rack/js_exception_catcher.rb
+++ b/lib/appsignal/rack/js_exception_catcher.rb
@@ -1,30 +1,64 @@
 module Appsignal
   # @api private
   module Rack
+    # JavaScript error catching middleware.
+    #
+    # Listens to the endpoint specified in the `frontend_error_catching_path`
+    # configuration option.
+    #
+    # This is automatically included middleware in Rails apps if the
+    # `frontend_error_catching_path` configuration option is active.
+    #
+    # If AppSignal is not active in the current environment, but does have
+    # JavaScript error catching turned on, we assume that a JavaScript script
+    # still sends errors to this endpoint. When AppSignal is not active in this
+    # scenario this middleware still listens to the endpoint, but won't record
+    # the error. It will return HTTP status code 202.
+    #
+    # @example with a Sinatra app
+    #   Sinatra::Application.use(Appsignal::Rack::JSExceptionCatcher)
+    #
+    # @see http://docs.appsignal.com/front-end/error-handling.html
+    # @api private
     class JSExceptionCatcher
-      def initialize(app, options = {})
-        Appsignal.logger.debug "Initializing Appsignal::Rack::JSExceptionCatcher"
+      def initialize(app, _options = nil)
+        Appsignal.logger.debug \
+          "Initializing Appsignal::Rack::JSExceptionCatcher"
         @app = app
-        @options = options
       end
 
       def call(env)
-        if env["PATH_INFO"] == Appsignal.config[:frontend_error_catching_path]
-          body = JSON.parse(env["rack.input"].read)
+        # Ignore other paths than the error catching path.
+        return @app.call(env) unless error_cathing_endpoint?(env)
 
-          if body["name"].is_a?(String) && !body["name"].empty?
-            transaction = JSExceptionTransaction.new(body)
-            transaction.complete!
-            code = 200
-          else
-            Appsignal.logger.debug "JSExceptionCatcher: Could not send exception, 'name' is empty."
-            code = 422
-          end
-
-          [code, {}, []]
-        else
-          @app.call(env)
+        # Prevent raising a 404 not found when a non-active environment posts
+        # to this endpoint.
+        unless Appsignal.active?
+          return [
+            202,
+            {},
+            ["AppSignal JavaScript error catching endpoint is not active."]
+          ]
         end
+
+        body = JSON.parse(env["rack.input"].read)
+        if body["name"].is_a?(String) && !body["name"].empty?
+          transaction = JSExceptionTransaction.new(body)
+          transaction.complete!
+          code = 200
+        else
+          Appsignal.logger.debug \
+            "JSExceptionCatcher: Could not send exception, 'name' is empty."
+          code = 422
+        end
+
+        [code, {}, []]
+      end
+
+      private
+
+      def error_cathing_endpoint?(env)
+        env["PATH_INFO"] == Appsignal.config[:frontend_error_catching_path]
       end
     end
   end

--- a/spec/lib/appsignal/rack/js_exception_catcher_spec.rb
+++ b/spec/lib/appsignal/rack/js_exception_catcher_spec.rb
@@ -1,17 +1,12 @@
 describe Appsignal::Rack::JSExceptionCatcher do
   let(:app)            { double(:call => true) }
-  let(:options)        { double }
-  let(:active)         { true }
+  let(:options)        { nil }
   let(:config_options) { { :enable_frontend_error_catching => true } }
   let(:config)         { project_fixture_config("production", config_options) }
-
-  before do
-    allow(Appsignal).to receive(:config).and_return(config)
-    allow(config).to receive(:active?).and_return(active)
-  end
+  before { Appsignal.config = config }
 
   describe "#initialize" do
-    it "should log to the logger" do
+    it "logs to the logger" do
       expect(Appsignal.logger).to receive(:debug)
         .with("Initializing Appsignal::Rack::JSExceptionCatcher")
 
@@ -21,16 +16,29 @@ describe Appsignal::Rack::JSExceptionCatcher do
 
   describe "#call" do
     let(:catcher) { Appsignal::Rack::JSExceptionCatcher.new(app, options) }
+    after { catcher.call(env) }
 
-    context "when path is not `/appsignal_error_catcher`" do
+    context "when path is not frontend_error_catching_path" do
       let(:env) { { "PATH_INFO" => "/foo" } }
 
-      it "should call the next middleware" do
-        expect(app).to receive(:call).with(env)
+      context "when AppSignal is not active" do
+        before { config[:active] = false }
+
+        it "calls the next middleware" do
+          expect(app).to receive(:call).with(env)
+        end
+      end
+
+      context "when AppSignal is active" do
+        before { config[:active] = true }
+
+        it "calls the next middleware" do
+          expect(app).to receive(:call).with(env)
+        end
       end
     end
 
-    context "when path is `/appsignal_error_catcher`" do
+    context "when path is frontend_error_catching_path" do
       let(:transaction) { double(:complete! => true) }
       let(:env) do
         {
@@ -39,72 +47,84 @@ describe Appsignal::Rack::JSExceptionCatcher do
         }
       end
 
-      it "should create a JSExceptionTransaction" do
-        expect(Appsignal::JSExceptionTransaction).to receive(:new)
-          .with("name" => "error")
-          .and_return(transaction)
+      context "when AppSignal is not active" do
+        before { config[:active] = false }
 
-        expect(transaction).to receive(:complete!)
-      end
-
-      it "should return 200" do
-        allow(Appsignal::JSExceptionTransaction).to receive(:new)
-          .and_return(transaction)
-
-        expect(catcher.call(env)).to eql([200, {}, []])
-      end
-
-      context "when `frontend_error_catching_path` is different" do
-        let(:config_options) do
-          {
-            :frontend_error_catching_path => "/foo"
-          }
-        end
-
-        it "should not create a transaction" do
+        it "doesn't create an AppSignal transaction" do
           expect(Appsignal::JSExceptionTransaction).to_not receive(:new)
         end
 
-        it "should call the next middleware" do
-          expect(app).to receive(:call).with(env)
+        it "returns a 202 status" do
+          expect(catcher.call(env)).to eq(
+            [202, {}, ["AppSignal JavaScript error catching endpoint is not active."]]
+          )
         end
       end
 
-      context "when `name` is empty" do
-        let(:env) do
-          {
-            "PATH_INFO"  => "/appsignal_error_catcher",
-            "rack.input" => double(:read => '{"name": ""}')
-          }
+      context "when AppSignal is active" do
+        before { config[:active] = true }
+
+        it "creates a JSExceptionTransaction" do
+          expect(Appsignal::JSExceptionTransaction).to receive(:new)
+            .with("name" => "error")
+            .and_return(transaction)
+
+          expect(transaction).to receive(:complete!)
         end
 
-        it "should not create a transaction" do
-          expect(Appsignal::JSExceptionTransaction).to_not receive(:new)
+        it "returns 200" do
+          allow(Appsignal::JSExceptionTransaction).to receive(:new)
+            .and_return(transaction)
+
+          expect(catcher.call(env)).to eq([200, {}, []])
         end
 
-        it "should return 422" do
-          expect(catcher.call(env)).to eql([422, {}, []])
-        end
-      end
+        context "when `frontend_error_catching_path` is different" do
+          let(:config_options) { { :frontend_error_catching_path => "/foo" } }
 
-      context "when `name` doesn't exist" do
-        let(:env) do
-          {
-            "PATH_INFO"  => "/appsignal_error_catcher",
-            "rack.input" => double(:read => '{"foo": ""}')
-          }
-        end
+          it "does not create a transaction" do
+            expect(Appsignal::JSExceptionTransaction).to_not receive(:new)
+          end
 
-        it "should not create a transaction" do
-          expect(Appsignal::JSExceptionTransaction).to_not receive(:new)
+          it "calls the next middleware" do
+            expect(app).to receive(:call).with(env)
+          end
         end
 
-        it "should return 422" do
-          expect(catcher.call(env)).to eql([422, {}, []])
+        context "when `name` is empty" do
+          let(:env) do
+            {
+              "PATH_INFO"  => "/appsignal_error_catcher",
+              "rack.input" => double(:read => '{"name": ""}')
+            }
+          end
+
+          it "does not create a transaction" do
+            expect(Appsignal::JSExceptionTransaction).to_not receive(:new)
+          end
+
+          it "returns 422" do
+            expect(catcher.call(env)).to eq([422, {}, []])
+          end
+        end
+
+        context "when `name` doesn't exist" do
+          let(:env) do
+            {
+              "PATH_INFO"  => "/appsignal_error_catcher",
+              "rack.input" => double(:read => '{"foo": ""}')
+            }
+          end
+
+          it "does not create a transaction" do
+            expect(Appsignal::JSExceptionTransaction).to_not receive(:new)
+          end
+
+          it "returns 422" do
+            expect(catcher.call(env)).to eq([422, {}, []])
+          end
         end
       end
     end
-
-    after { catcher.call(env) }
   end
 end


### PR DESCRIPTION
Fixes https://github.com/appsignal/appsignal-ruby/issues/247

When AppSignal is not active, but does have frontend_error_catching
turned on, most applications will still send errors to this endpoint
because the JS environment doesn't know what env it is running in.

To prevent spamming the server logs with 404 errors in such a scenario,
stub the frontend error catching endpoint and return the 202 status code
with a message explaining it's not active.