### PR TITLE
Use better Padrino action names 

### DIFF
--- a/gemfiles/padrino.gemfile
+++ b/gemfiles/padrino.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'padrino', '~> 0.12.0'
+gem 'padrino', '~> 0.13.0'
 gem 'rack', '~> 1.6'
 gem 'activesupport', '~> 4.2'
 

--- a/lib/appsignal/integrations/padrino.rb
+++ b/lib/appsignal/integrations/padrino.rb
@@ -22,8 +22,7 @@ module Padrino::Routing::InstanceMethods
 
   def route!(base = settings, pass_block = nil)
     if !Appsignal.active? || env["sinatra.static_file"]
-      route_without_appsignal(base, pass_block)
-      return
+      return route_without_appsignal(base, pass_block)
     end
 
     transaction = Appsignal::Transaction.create(

--- a/lib/appsignal/integrations/padrino.rb
+++ b/lib/appsignal/integrations/padrino.rb
@@ -46,19 +46,36 @@ module Padrino::Routing::InstanceMethods
     end
   end
 
+  private
+
   def get_payload_action(request)
     # Short-circut is there's no request object to obtain information from
-    return settings.name.to_s if request.nil?
+    return settings.name.to_s unless request
+
+    # Newer versions expose the action / controller on the request class.
+    # Newer versions also still expose a route_obj so we must prioritize the
+    # action/fullpath methods.
+    # The `request.action` and `request.controller` values are `nil` when a
+    # endpoint is not found, `""` if not specified by the user.
+    controller_name = request.controller if request.respond_to?(:controller)
+    action_name = request.action if request.respond_to?(:action)
+    action_name ||= ""
+    if action_name.empty? && request.respond_to?(:fullpath)
+      action_name = request.fullpath
+    end
+
+    unless action_name.empty?
+      return "#{settings.name}:#{controller_name}##{action_name}"
+    end
 
     # Older versions of Padrino work with a route object
-    route_obj = defined?(request.route_obj) && request.route_obj
-    if route_obj && route_obj.respond_to?(:original_path)
+    if request.respond_to?(:route_obj) && request.route_obj
       return "#{settings.name}:#{request.route_obj.original_path}"
     end
 
-    # Newer versions expose the action / controller on the request class
-    request_data = request.respond_to?(:action) ? request.action : request.fullpath
-    "#{settings.name}:#{request.controller}##{request_data}"
+    # Fall back to the application name if we haven't found an action name in
+    # any previous methods.
+    settings.name.to_s
   end
 end
 

--- a/lib/appsignal/integrations/padrino.rb
+++ b/lib/appsignal/integrations/padrino.rb
@@ -7,12 +7,8 @@ module Appsignal
       def self.init
         Appsignal.logger.info("Loading Padrino (#{Padrino::VERSION}) integration")
 
-        root             = Padrino.mounted_root
-        Appsignal.config = Appsignal::Config.new(
-          root,
-          Padrino.env,
-          :log_path => File.join(root, "log")
-        )
+        root = Padrino.mounted_root
+        Appsignal.config = Appsignal::Config.new(root, Padrino.env)
 
         Appsignal.start_logger
         Appsignal.start

--- a/spec/lib/appsignal/integrations/padrino_spec.rb
+++ b/spec/lib/appsignal/integrations/padrino_spec.rb
@@ -1,10 +1,6 @@
 if DependencyHelper.padrino_present?
   describe "Padrino integration" do
-    require File.expand_path("lib/appsignal/integrations/padrino.rb")
-
-    class ClassWithRouter
-      include Padrino::Routing
-    end
+    require "appsignal/integrations/padrino"
 
     before do
       allow(Appsignal).to receive(:active?).and_return(true)
@@ -12,188 +8,311 @@ if DependencyHelper.padrino_present?
       allow(Appsignal).to receive(:start_logger).and_return(true)
     end
 
-    describe "Appsignal::Integrations::PadrinoPlugin" do
-      it "should start the logger on init" do
-        expect(Appsignal).to receive(:start_logger)
+    describe Appsignal::Integrations::PadrinoPlugin do
+      it "starts AppSignal on init" do
+        expect(Appsignal).to receive(:start)
       end
 
-      it "should start appsignal on init" do
-        expect(Appsignal).to receive(:start)
+      it "starts the logger on init" do
+        expect(Appsignal).to receive(:start_logger)
       end
 
       context "when not active" do
         before { allow(Appsignal).to receive(:active?).and_return(false) }
 
-        it "should not add the Listener middleware to the stack" do
+        it "does not add the listener middleware to the stack" do
           expect(Padrino).to_not receive(:use)
         end
       end
 
       context "when APPSIGNAL_APP_ENV ENV var is provided" do
-        it "should use this as the environment" do
+        it "uses this as the environment" do
           ENV["APPSIGNAL_APP_ENV"] = "custom"
 
           # Reset the plugin to pull down the latest data
           Appsignal::Integrations::PadrinoPlugin.init
 
-          expect(Appsignal.config.env).to eq "custom"
+          expect(Appsignal.config.env).to eq("custom")
         end
       end
 
       context "when APPSIGNAL_APP_ENV ENV var is not provided" do
-        it "should use the Padrino environment" do
-          ENV["APPSIGNAL_APP_ENV"] = nil
-
+        it "uses the Padrino environment" do
           # Reset the plugin to pull down the latest data
           Appsignal::Integrations::PadrinoPlugin.init
 
-          expect(Appsignal.config.env).to eq Padrino.env.to_s
+          expect(Padrino.env.to_s).to eq("test")
+          expect(Appsignal.config.env).to eq(Padrino.env.to_s)
         end
       end
 
       after { Appsignal::Integrations::PadrinoPlugin.init }
     end
 
-    describe "Padrino::Routing::InstanceMethods" do
+    describe Padrino::Routing::InstanceMethods do
+      class PadrinoClassWithRouter
+        include Padrino::Routing
+      end
+
       let(:base)     { double }
-      let(:router)   { ClassWithRouter.new }
+      let(:router)   { PadrinoClassWithRouter.new }
       let(:env)      { {} }
       let(:settings) { double(:name => "TestApp") }
 
-      describe "#route!" do
-        let(:request) do
-          double(
-            :params          => { "id" => 1 },
-            :session         => { "user_id" => 123 },
-            :request_method  => "GET",
-            :path            => "/users/1",
-            :controller      => "users",
-            :action          => "show",
-            :env             => {}
-          )
+      describe "routes" do
+        let(:transaction) do
+          instance_double "Appsignal::Transaction",
+            :set_http_or_background_action => nil,
+            :set_http_or_background_queue_start => nil,
+            :set_metadata => nil,
+            :set_action => nil,
+            :set_action_if_nil => nil,
+            :set_error => nil,
+            :start_event => nil,
+            :finish_event => nil,
+            :complete => nil
         end
-
+        let(:request_kind) { kind_of(Sinatra::Request) }
+        let(:env) do
+          {
+            "REQUEST_METHOD" => "GET",
+            "PATH_INFO" => path,
+            "REQUEST_PATH" => path,
+            "rack.input" => StringIO.new
+          }
+        end
+        let(:app) do
+          Class.new(Padrino::Application) do
+            def self.name
+              "PadrinoTestApp"
+            end
+          end
+        end
+        let(:response) { app.call(env) }
         before do
-          allow(router).to receive(:route_without_appsignal).and_return(true)
-          allow(router).to receive(:request).and_return(request)
-          allow(router).to receive(:env).and_return(env)
-          allow(router).to receive(:settings).and_return(settings)
-          allow(router).to receive(:get_payload_action).and_return("controller#action")
+          allow(Appsignal::Transaction).to receive(:create).and_return(transaction)
+          allow(Appsignal::Transaction).to receive(:current).and_return(transaction)
         end
 
-        context "when Sinatra tells us it's a static file" do
-          let(:env) { { "sinatra.static_file" => true } }
-
-          it "should call the original method" do
-            expect(router).to receive(:route_without_appsignal)
+        RSpec::Matchers.define :match_response do |expected_status, expected_content|
+          match do |response|
+            status, _headers, content = response
+            status == expected_status && content == [expected_content].compact
           end
-
-          it "should not instrument the request" do
-            expect(Appsignal).to_not receive(:instrument)
-          end
-
-          after { router.route!(base) }
         end
 
-        context "when appsignal is not active" do
+        def expect_a_transaction_to_be_created
+          expect(Appsignal::Transaction).to receive(:create).with(
+            kind_of(String),
+            Appsignal::Transaction::HTTP_REQUEST,
+            request_kind
+          ).and_return(transaction)
+          expect(Appsignal).to receive(:instrument)
+            .at_least(:once)
+            .with("process_action.padrino")
+            .and_call_original
+          expect(transaction).to receive(:set_metadata).with("path", path)
+          expect(transaction).to receive(:set_metadata).with("method", "GET")
+          expect(transaction).to receive(:complete)
+        end
+
+        def expect_no_transaction_to_be_created
+          expect(Appsignal::Transaction).to_not receive(:create)
+          expect(Appsignal).to_not receive(:instrument)
+        end
+
+        context "when AppSignal is not active" do
           before { allow(Appsignal).to receive(:active?).and_return(false) }
+          let(:path) { "/foo" }
+          before { app.controllers { get(:foo) { "content" } } }
+          after { expect(response).to match_response(200, "content") }
 
-          it "should call the original method" do
-            expect(router).to receive(:route_without_appsignal)
-          end
-
-          it "should not instrument the request" do
-            expect(Appsignal).to_not receive(:instrument)
-          end
-
-          after { router.route!(base) }
-        end
-
-        context "with a dynamic request" do
-          let(:transaction) do
-            instance_double "Appsignal::Transaction",
-              :set_http_or_background_action => nil,
-              :set_http_or_background_queue_start => nil,
-              :set_metadata => nil,
-              :set_action => nil,
-              :set_action_if_nil => nil,
-              :set_error => nil
-          end
-          before { allow(Appsignal::Transaction).to receive(:create).and_return(transaction) }
-
-          context "without an error" do
-            it "should create a transaction" do
-              expect(Appsignal::Transaction).to receive(:create).with(
-                kind_of(String),
-                Appsignal::Transaction::HTTP_REQUEST,
-                request
-              ).and_return(transaction)
-            end
-
-            it "should call the original routing method" do
-              expect(router).to receive(:route_without_appsignal)
-            end
-
-            it "should instrument the action" do
-              expect(Appsignal).to receive(:instrument).with("process_action.padrino")
-            end
-
-            it "should set metadata" do
-              expect(transaction).to receive(:set_metadata).twice
-            end
-
-            it "should set the action on the transaction" do
-              expect(transaction).to receive(:set_action_if_nil).with("controller#action")
-            end
-
-            after { router.route!(base) }
-          end
-
-          context "with an error" do
-            let(:error) { VerySpecificError.new }
-            before { allow(router).to receive(:route_without_appsignal).and_raise(error) }
-
-            it "should add the exception to the current transaction" do
-              expect(transaction).to receive(:set_error).with(error)
-
-              router.route!(base) rescue VerySpecificError
-            end
-          end
-        end
-      end
-
-      describe "#get_payload_action" do
-        before { allow(router).to receive(:settings).and_return(settings) }
-
-        context "when request is nil" do
-          it "should return the site" do
-            expect(router.get_payload_action(nil)).to eql("TestApp")
+          it "does not instrument the request" do
+            expect_no_transaction_to_be_created
           end
         end
 
-        context "when there's no route object" do
-          let(:request) { double(:controller => "Controller", :action => "action") }
+        context "when AppSignal is active" do
+          context "with not existing route" do
+            let(:path) { "/404" }
 
-          it "should return the site name, controller and action" do
-            expect(router.get_payload_action(request)).to eql("TestApp:Controller#action")
-          end
-
-          context "when there's no action" do
-            let(:request) { double(:controller => "Controller", :fullpath => "/action") }
-
-            it "should return the site name, controller and fullpath" do
-              expect(router.get_payload_action(request)).to eql("TestApp:Controller#/action")
+            it "instruments the request" do
+              expect_a_transaction_to_be_created
+              # Uses path for action name
+              expect(transaction).to receive(:set_action_if_nil).with("PadrinoTestApp:#/404")
+              expect(response).to match_response(404, "<h1>Not Found</h1>")
             end
           end
-        end
 
-        context "when request has a route object" do
-          let(:request)      { double }
-          let(:route_object) { double(:original_path => "/accounts/edit/:id") }
-          before             { allow(request).to receive(:route_obj).and_return(route_object) }
+          context "when Sinatra tells us it's a static file" do
+            let(:path) { "/static" }
+            before do
+              env["sinatra.static_file"] = true
+              expect_any_instance_of(app)
+                .to receive(:route_without_appsignal).and_return([200, {}, ["foo"]])
+            end
+            after { expect(response).to match_response(200, "foo") }
 
-          it "should return the original path" do
-            expect(router.get_payload_action(request)).to eql("TestApp:/accounts/edit/:id")
+            it "does not instrument the request" do
+              expect_no_transaction_to_be_created
+            end
+          end
+
+          # Older Padrino versions don't support `action` (v11.0+)
+          context "without #action on Sinatra::Request" do
+            let(:path) { "/my_original_path" }
+            let(:request_kind) do
+              double(
+                :params => {},
+                :path => path,
+                :path_info => path,
+                :request_method => "GET",
+                :head? => false,
+                :route_obj => double(:original_path => "original_path method"),
+                :route_obj= => nil # Make sure route_obj doesn't get overwritten
+              )
+            end
+            before do
+              expect(Sinatra::Request).to receive(:new).and_return(request_kind)
+              app.controllers { get(:my_original_path) { "content" } }
+            end
+            after { expect(response).to match_response(200, "content") }
+
+            it "falls back on Sinatra::Request#route_obj.original_path" do
+              expect_a_transaction_to_be_created
+              expect(transaction)
+                .to receive(:set_action_if_nil).with("PadrinoTestApp:original_path method")
+            end
+          end
+
+          context "without Sinatra::Request#route_obj.original_path" do
+            let(:path) { "/my_original_path" }
+            let(:request_kind) do
+              double(
+                :params => {},
+                :path => path,
+                :path_info => path,
+                :request_method => "GET",
+                :head? => false,
+                :route_obj= => nil # Make sure route_obj doesn't get overwritten
+              )
+            end
+            before do
+              expect(Sinatra::Request).to receive(:new).and_return(request_kind)
+              app.controllers { get(:my_original_path) { "content" } }
+            end
+            after { expect(response).to match_response(200, "content") }
+
+            it "falls back on app name" do
+              expect_a_transaction_to_be_created
+              expect(transaction).to receive(:set_action_if_nil).with("PadrinoTestApp")
+            end
+          end
+
+          context "with existing route" do
+            context "with an exception in the controller" do
+              let(:path) { "/exception" }
+              before do
+                app.controllers { get(:exception) { raise VerySpecificError } }
+                expect_a_transaction_to_be_created
+              end
+              after do
+                expect { response }.to raise_error(VerySpecificError)
+              end
+
+              it "sets the action name based on the app name and action name" do
+                expect(transaction).to receive(:set_action_if_nil).with("PadrinoTestApp:#exception")
+              end
+
+              it "sets the error on the transaction" do
+                expect(transaction).to receive(:set_error).with(VerySpecificError)
+              end
+            end
+
+            context "without an exception in the controller" do
+              let(:path) { "/" }
+              after { expect(response).to match_response(200, "content") }
+
+              context "with action name as symbol" do
+                context "with :index helper" do
+                  before do
+                    # :index == "/"
+                    app.controllers { get(:index) { "content" } }
+                  end
+
+                  it "sets the action with the app name and action name" do
+                    expect_a_transaction_to_be_created
+                    expect(transaction).to receive(:set_action_if_nil).with("PadrinoTestApp:#index")
+                  end
+                end
+
+                context "with custom action name" do
+                  let(:path) { "/foo" }
+                  before do
+                    app.controllers { get(:foo) { "content" } }
+                  end
+
+                  it "sets the action with the app name and action name" do
+                    expect_a_transaction_to_be_created
+                    expect(transaction).to receive(:set_action_if_nil).with("PadrinoTestApp:#foo")
+                  end
+                end
+              end
+
+              context "with an action defined with a path" do
+                context "with root path" do
+                  before do
+                    # :index == "/"
+                    app.controllers { get("/") { "content" } }
+                  end
+
+                  it "sets the action with the app name and action path" do
+                    expect_a_transaction_to_be_created
+                    expect(transaction).to receive(:set_action_if_nil).with("PadrinoTestApp:#/")
+                  end
+                end
+
+                context "with custom path" do
+                  let(:path) { "/foo" }
+                  before do
+                    app.controllers { get("/foo") { "content" } }
+                  end
+
+                  it "sets the action with the app name and action path" do
+                    expect_a_transaction_to_be_created
+                    expect(transaction).to receive(:set_action_if_nil).with("PadrinoTestApp:#/foo")
+                  end
+                end
+              end
+
+              context "with controller" do
+                let(:path) { "/my_controller" }
+
+                context "with controller as name" do
+                  before do
+                    # :index == "/"
+                    app.controllers(:my_controller) { get(:index) { "content" } }
+                  end
+
+                  it "sets the action with the app name, controller name and action name" do
+                    expect_a_transaction_to_be_created
+                    expect(transaction).to receive(:set_action_if_nil).with("PadrinoTestApp:my_controller#index")
+                  end
+                end
+
+                context "with controller as path" do
+                  before do
+                    # :index == "/"
+                    app.controllers("/my_controller") { get(:index) { "content" } }
+                  end
+
+                  it "sets the action with the app name, controller name and action path" do
+                    expect_a_transaction_to_be_created
+                    expect(transaction).to receive(:set_action_if_nil).with("PadrinoTestApp:/my_controller#index")
+                  end
+                end
+              end
+            end
           end
         end
       end

--- a/spec/lib/appsignal/integrations/sinatra_spec.rb
+++ b/spec/lib/appsignal/integrations/sinatra_spec.rb
@@ -1,19 +1,49 @@
 if DependencyHelper.sinatra_present?
-  ENV["APPSIGNAL_PUSH_API_KEY"] = "key"
   require "appsignal/integrations/sinatra"
 
+  def install_sinatra_integration
+    load File.expand_path("lib/appsignal/integrations/sinatra.rb", project_dir)
+  end
+
+  # "Uninstall" the AppSignal integration
+  def uninstall_sinatra_integration
+    Sinatra::Base.instance_variable_get(:@middleware).delete_if do |middleware|
+      middleware.first == Appsignal::Rack::SinatraBaseInstrumentation
+    end
+  end
+
   describe "Sinatra integration" do
+    before { allow(Appsignal).to receive(:active?).and_return(true) }
+    after { uninstall_sinatra_integration }
+
     context "Appsignal.logger" do
       subject { Appsignal.logger }
 
-      it { is_expected.to be_a Logger }
+      it "sets a logger" do
+        install_sinatra_integration
+        is_expected.to be_a Logger
+      end
     end
 
     describe "middleware" do
-      it "adds the instrumentation middleware to Sinatra::Base" do
-        expect(Sinatra::Base.middleware.to_a).to include(
-          [Appsignal::Rack::SinatraBaseInstrumentation, [], nil]
-        )
+      context "when AppSignal is not active" do
+        before { allow(Appsignal).to receive(:active?).and_return(false) }
+
+        it "does not add the instrumentation middleware to Sinatra::Base" do
+          install_sinatra_integration
+          expect(Sinatra::Base.middleware.to_a).to_not include(
+            [Appsignal::Rack::SinatraBaseInstrumentation, [], nil]
+          )
+        end
+      end
+
+      context "when AppSignal is active" do
+        it "adds the instrumentation middleware to Sinatra::Base" do
+          install_sinatra_integration
+          expect(Sinatra::Base.middleware.to_a).to include(
+            [Appsignal::Rack::SinatraBaseInstrumentation, [], nil]
+          )
+        end
       end
     end
 
@@ -21,9 +51,7 @@ if DependencyHelper.sinatra_present?
       subject { Appsignal.config.env }
 
       context "without APPSIGNAL_APP_ENV" do
-        before do
-          load File.expand_path("lib/appsignal/integrations/sinatra.rb", project_dir)
-        end
+        before { install_sinatra_integration }
 
         it "uses the app environment" do
           expect(subject).to eq("test")
@@ -33,7 +61,7 @@ if DependencyHelper.sinatra_present?
       context "with APPSIGNAL_APP_ENV" do
         before do
           ENV["APPSIGNAL_APP_ENV"] = "env-staging"
-          load File.expand_path("lib/appsignal/integrations/sinatra.rb", project_dir)
+          install_sinatra_integration
         end
 
         it "uses the environment variable" do


### PR DESCRIPTION
The main fix in this change is the order in which the action name is
found. It now prefers the `Sinatra::Request#controller` and
`Sinatra::Request#action` rather than
`Sinatra::Request#route_obj#original_path` which is from older Padrino
versions.

Fixes #253 

## Other fixes include

### Refactor Padrino tests

Refactor specs to use a real Padrino app and not just test the
middleware. This way we will find out sooner if we break the integration
with Padrino itself.

### Make sure to return the intended `route!` value

Could potentially break something with our
integration if we don't return the
`Padrino::Routing#route!` return value.

### Remove log path config for Padrino.

It's not necessary to set anymore since it's the
AppSignal default since PR #222.

### Test with a newer Padrino version.

So we can be sure we're still compatible.

### Uninstall AppSignal middleware after Sinatra tests

"Uninstall" the Sinatra middleware after testing Sinatra so it
doesn't interfere with the Padrino specs. Padrino is based on
Sinatra, and we don't want to capture Sinatra events for Padrino.
