### PR TITLE
Shoryuken instrumentation body arg can be a string

### DIFF
--- a/lib/appsignal/hooks/shoryuken.rb
+++ b/lib/appsignal/hooks/shoryuken.rb
@@ -10,7 +10,9 @@ module Appsignal
           :metadata => metadata
         }
 
-        options[:params] = body.is_a?(Hash) ? body : { :params => body }
+        params = body.is_a?(Hash) ? body : { :params => body }
+        truncated_params = format_args(params)
+        options[:param] = truncated_params
 
         if sqs_msg.attributes.key?("SentTimestamp")
           options[:queue_start] = Time.at(sqs_msg.attributes["SentTimestamp"].to_i / 1000)

--- a/lib/appsignal/hooks/shoryuken.rb
+++ b/lib/appsignal/hooks/shoryuken.rb
@@ -11,8 +11,9 @@ module Appsignal
         }
 
         params = body.is_a?(Hash) ? body : { :params => body }
-        truncated_params = format_args(params)
-        options[:param] = truncated_params
+        config = { filter_parameters: Appsignal.config[:filter_parameters] }
+        truncated_params = Appsignal::Utils::ParamsSanitizer.sanitize(params, config)
+        options[:params] = truncated_params
 
         if sqs_msg.attributes.key?("SentTimestamp")
           options[:queue_start] = Time.at(sqs_msg.attributes["SentTimestamp"].to_i / 1000)

--- a/lib/appsignal/hooks/shoryuken.rb
+++ b/lib/appsignal/hooks/shoryuken.rb
@@ -6,8 +6,14 @@ module Appsignal
         metadata = {
           :queue => queue
         }
-        exclude_keys = [:job_class, :queue_name, :arguments]
-        metadata.merge!(body.reject { |key| exclude_keys.member?(key.to_sym) })
+
+        if body.is_a?(String)
+          metadata['body_string'] = body
+        else
+          exclude_keys = [:job_class, :queue_name, :arguments]
+          metadata.merge!(body.reject { |key| exclude_keys.member?(key.to_sym) })
+        end
+
         metadata.merge!(sqs_msg.attributes)
 
         options = {

--- a/lib/appsignal/hooks/shoryuken.rb
+++ b/lib/appsignal/hooks/shoryuken.rb
@@ -2,30 +2,19 @@ module Appsignal
   class Hooks
     # @api private
     class ShoryukenMiddleware
-      EXCLUDE_KEYS = %w(job_class queue_name arguments).freeze
-
-      def call(_worker_instance, queue, sqs_msg, body)
-        metadata = {
-          :queue => queue
-        }
-
+      def call(worker_instance, queue, sqs_msg, body)
+        metadata = { :queue => queue }.merge(sqs_msg.attributes)
         options = {
+          :class => worker_instance.class.name,
           :method => "perform",
           :metadata => metadata
         }
 
-        if body.is_a?(Hash)
-          body = body.each_with_object({}) { |(key, value), object| object[key.to_s] = value }
-          metadata.merge!(body.reject { |key, _value| EXCLUDE_KEYS.member?(key) })
-          options[:class] = body["job_class"]
-          options[:params] = body["arguments"] if body.key?("arguments")
-        else
-          metadata[:body] = body
+        options[:params] = body.is_a?(Hash) ? body : { :params => body }
+
+        if sqs_msg.attributes.key?("SentTimestamp")
+          options[:queue_start] = Time.at(sqs_msg.attributes["SentTimestamp"].to_i / 1000)
         end
-
-        metadata.merge!(sqs_msg.attributes)
-
-        options[:queue_start] = Time.at(sqs_msg.attributes["SentTimestamp"].to_i / 1000) if sqs_msg.attributes.key?("SentTimestamp")
 
         Appsignal.monitor_transaction("perform_job.shoryuken", options) do
           yield

--- a/lib/appsignal/hooks/shoryuken.rb
+++ b/lib/appsignal/hooks/shoryuken.rb
@@ -10,10 +10,9 @@ module Appsignal
           :metadata => metadata
         }
 
-        params = body.is_a?(Hash) ? body : { :params => body }
-        config = { filter_parameters: Appsignal.config[:filter_parameters] }
-        truncated_params = Appsignal::Utils::ParamsSanitizer.sanitize(params, config)
-        options[:params] = truncated_params
+        args = body.is_a?(Hash) ? body : { :params => body }
+        options[:params] = Appsignal::Utils::ParamsSanitizer.sanitize args,
+          :filter_parameters => Appsignal.config[:filter_parameters]
 
         if sqs_msg.attributes.key?("SentTimestamp")
           options[:queue_start] = Time.at(sqs_msg.attributes["SentTimestamp"].to_i / 1000)

--- a/lib/appsignal/hooks/shoryuken.rb
+++ b/lib/appsignal/hooks/shoryuken.rb
@@ -7,21 +7,22 @@ module Appsignal
           :queue => queue
         }
 
-        if body.is_a?(String)
-          metadata['body_string'] = body
-        else
+        options = {
+          :method => "perform",
+          :metadata => metadata
+        }
+
+        if body.respond_to?(:reject)
           exclude_keys = [:job_class, :queue_name, :arguments]
           metadata.merge!(body.reject { |key| exclude_keys.member?(key.to_sym) })
+          options[:class] = body["job_class"] # can it be a symbol? Shoryuken allows custom serialization
+          options[:params] = body["arguments"] if body.key?("arguments")
+        else
+          metadata[:body] = body
         end
 
         metadata.merge!(sqs_msg.attributes)
 
-        options = {
-          :class => body["job_class"],
-          :method => "perform",
-          :metadata => metadata
-        }
-        options[:params] = body["arguments"] if body.key?("arguments")
         options[:queue_start] = Time.at(sqs_msg.attributes["SentTimestamp"].to_i / 1000) if sqs_msg.attributes.key?("SentTimestamp")
 
         Appsignal.monitor_transaction("perform_job.shoryuken", options) do

--- a/spec/lib/appsignal/hooks/shoryuken_spec.rb
+++ b/spec/lib/appsignal/hooks/shoryuken_spec.rb
@@ -46,6 +46,7 @@ describe Appsignal::Hooks::ShoryukenMiddleware do
         end
       end
     end
+
     it "should handle string bodies" do
       expect(Appsignal).to receive(:monitor_transaction).with(
         "perform_job.shoryuken",
@@ -63,6 +64,7 @@ describe Appsignal::Hooks::ShoryukenMiddleware do
         end
       end
     end
+
     it "should handle any type of body" do
       body = 1
       expect(Appsignal).to receive(:monitor_transaction).with(

--- a/spec/lib/appsignal/hooks/shoryuken_spec.rb
+++ b/spec/lib/appsignal/hooks/shoryuken_spec.rb
@@ -24,8 +24,7 @@ describe Appsignal::Hooks::ShoryukenMiddleware do
       let(:body) do
         {
           :foo => "Foo",
-          :bar => "Bar",
-          :baz => "s" * 300
+          :bar => "Bar"
         }
       end
       after do
@@ -47,8 +46,7 @@ describe Appsignal::Hooks::ShoryukenMiddleware do
           },
           :params => {
             :foo => "Foo",
-            :bar => "Bar",
-            :baz => "s" * 197 + "..."
+            :bar => "Bar"
           },
           :queue_start => Time.parse("1976-11-18 0:00:00UTC").utc
         )
@@ -71,8 +69,7 @@ describe Appsignal::Hooks::ShoryukenMiddleware do
             },
             :params => {
               :foo => "[FILTERED]",
-              :bar => "Bar",
-              :baz => "s" * 197 + "..."
+              :bar => "Bar"
             },
             :queue_start => Time.parse("1976-11-18 0:00:00UTC").utc
           )


### PR DESCRIPTION
If Shoryuken option for `body_parser` is `:text` or `nil` (or just not passed), then `body` will be a `String` and it will crash at `body.reject {...}`