### PR TITLE
Extension returns agent diagnostics report 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,5 +48,8 @@ Style/MethodMissing:
     - "lib/appsignal/extension.rb"
     - "lib/appsignal/transaction.rb"
 
+Style/TrailingUnderscoreVariable:
+  Enabled: false
+
 # Metrics/LineLength:
 #   Max: 80

--- a/ext/agent.yml
+++ b/ext/agent.yml
@@ -1,18 +1,18 @@
 ---
-version: 7ade8ff
+version: da14f3b
 triples:
   x86_64-linux:
-    checksum: 4c9a40b6215aa5598f546050817448e698479a2e6594feb8f7d46b755ae959e9
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/7ade8ff/appsignal-x86_64-linux-all-static.tar.gz
+    checksum: 690ae21a087fc9bc8089f492bd2f751c77d9e9573441aa5b2b9427ab8b1e5433
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/da14f3b/appsignal-x86_64-linux-all-static.tar.gz
   i686-linux:
-    checksum: 0caf5d0ef96f663b03b36d4c37741856ded851d205e0c1403550d6c04266eb6b
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/7ade8ff/appsignal-i686-linux-all-static.tar.gz
+    checksum: 18345e70afdcfc0378503fc6ec48c0949425ad5a650b36a20d721a54c356fe3d
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/da14f3b/appsignal-i686-linux-all-static.tar.gz
   x86-linux:
-    checksum: 0caf5d0ef96f663b03b36d4c37741856ded851d205e0c1403550d6c04266eb6b
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/7ade8ff/appsignal-i686-linux-all-static.tar.gz
+    checksum: 18345e70afdcfc0378503fc6ec48c0949425ad5a650b36a20d721a54c356fe3d
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/da14f3b/appsignal-i686-linux-all-static.tar.gz
   x86_64-darwin:
-    checksum: bc72d9f7485b66802f9642e1d2fee4d2fe2f1b5b363f1378c46469d112b9442e
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/7ade8ff/appsignal-x86_64-darwin-all-static.tar.gz
+    checksum: 33dfccb7d422343d3baaed9f2f3d0f70c71162413ab05f4aef59b9cc09acd6b9
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/da14f3b/appsignal-x86_64-darwin-all-static.tar.gz
   universal-darwin:
-    checksum: bc72d9f7485b66802f9642e1d2fee4d2fe2f1b5b363f1378c46469d112b9442e
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/7ade8ff/appsignal-x86_64-darwin-all-static.tar.gz
+    checksum: 33dfccb7d422343d3baaed9f2f3d0f70c71162413ab05f4aef59b9cc09acd6b9
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/da14f3b/appsignal-x86_64-darwin-all-static.tar.gz

--- a/ext/appsignal_extension.c
+++ b/ext/appsignal_extension.c
@@ -32,6 +32,10 @@ static VALUE stop(VALUE self) {
   return Qnil;
 }
 
+static VALUE diagnose(VALUE self) {
+  return make_ruby_string(appsignal_diagnose());
+}
+
 static VALUE get_server_state(VALUE self, VALUE key) {
   appsignal_string_t string;
 
@@ -609,8 +613,10 @@ void Init_appsignal_extension(void) {
   Data = rb_define_class_under(Extension, "Data", rb_cObject);
 
   // Starting and stopping
-  rb_define_singleton_method(Extension, "start", start, 0);
-  rb_define_singleton_method(Extension, "stop",  stop,  0);
+  rb_define_singleton_method(Extension, "start",    start,    0);
+  rb_define_singleton_method(Extension, "stop",     stop,     0);
+  // Diagnostics
+  rb_define_singleton_method(Extension, "diagnose", diagnose, 0);
 
   // Server state
   rb_define_singleton_method(Extension, "get_server_state", get_server_state, 1);


### PR DESCRIPTION
The extension returns a JSON object, as a string, which contains the
agent diagnostics report.

The report definition is defined in the diagnose CLI task so we can
check all the tests and display them in a human readable format.

This change makes it possible to return the agent diagnostics report
without capturing the STDOUT while the agent is running. This proved
difficult to do in Elixir, where we now call the agent executable
directly. That will be changed once this change is accepted.

Instead of printing the report to STDOUT the extension will now return
the report as a JSON object, which is formatted as a string which needs
to be parsed into JSON first.

This should no longer require `$stdout.reopen` in the tests to capture
all the CLI output. We'll leave that logic for now, as it captures the
output from the AppSignal extension as well, so it's useful in other
specs as well.

This report may be incomplete when the agent fails to start or something
else goes wrong. Any error will be captured and added to the agent
report.

Needs to be updated in Elixir as well https://github.com/appsignal/appsignal-elixir/pull/132
Depends on: https://github.com/appsignal/appsignal-agent/pull/240