### PR TITLE
Send diagnostics data report to AppSignal

### DIFF
--- a/lib/appsignal/auth_check.rb
+++ b/lib/appsignal/auth_check.rb
@@ -33,7 +33,7 @@ module Appsignal
     # @return [String] response status code.
     # @raise [StandardError] see {Appsignal::Transmitter#transmit}.
     def perform
-      Appsignal::Transmitter.new(ACTION, config).transmit({})
+      Appsignal::Transmitter.new(ACTION, config).transmit({}).code
     end
 
     # Perform push api validation request and return a descriptive response

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -388,7 +388,7 @@ module Appsignal
           config = Appsignal.config
           log_file_path = config.log_file_path
           {
-            :current_path => Dir.pwd,
+            :working_dir => Dir.pwd,
             :root_path => config.root_path,
             :log_dir_path => log_file_path ? File.dirname(log_file_path) : "",
             :log_file_path => log_file_path

--- a/lib/appsignal/cli/helpers.rb
+++ b/lib/appsignal/cli/helpers.rb
@@ -37,6 +37,9 @@ module Appsignal
       def ask_for_input
         value = stdin.gets
         value ? value.chomp : ""
+      rescue Interrupt
+        puts "\nExiting..."
+        exit 1
       end
 
       def required_input(prompt)

--- a/lib/appsignal/cli/helpers.rb
+++ b/lib/appsignal/cli/helpers.rb
@@ -50,13 +50,15 @@ module Appsignal
         end
       end
 
-      def yes_or_no(prompt)
+      def yes_or_no(prompt, options = {})
         loop do
           print prompt
-          case ask_for_input
-          when "y"
+          input = ask_for_input.strip
+          input = options[:default] if input.empty? && options[:default]
+          case input
+          when "y", "Y", "yes"
             return true
-          when "n"
+          when "n", "N", "no"
             return false
           end
         end

--- a/lib/appsignal/marker.rb
+++ b/lib/appsignal/marker.rb
@@ -50,11 +50,11 @@ module Appsignal
       puts "Notifying AppSignal of deploy with: "\
         "revision: #{marker_data[:revision]}, user: #{marker_data[:user]}"
 
-      result = transmitter.transmit(marker_data)
-      if result == "200"
+      response = transmitter.transmit(marker_data)
+      if response.code == "200"
         puts "AppSignal has been notified of this deploy!"
       else
-        raise "#{result} at #{transmitter.uri}"
+        raise "#{response.code} at #{transmitter.uri}"
       end
     rescue => e
       puts "Something went wrong while trying to notify AppSignal: #{e}"

--- a/lib/appsignal/transmitter.rb
+++ b/lib/appsignal/transmitter.rb
@@ -21,20 +21,33 @@ module Appsignal
       OpenSSL::SSL::SSLError
     ].freeze
 
-    attr_reader :config, :action
+    attr_reader :config, :base_uri
 
-    def initialize(action, config = Appsignal.config)
-      @action = action
+    # @param base_uri [String] Base URI for the transmitter to use. If a full
+    #   URI is given (including the HTTP protocol) it is used as the full base.
+    #   If only a path is given the `config[:endpoint]` is prefixed along with
+    #   `/1/` (API v1 endpoint).
+    # @param config [Appsignal::Config] AppSignal configuration to use for this
+    #   transmission.
+    def initialize(base_uri, config = Appsignal.config)
+      @base_uri =
+        if base_uri.start_with? "http"
+          base_uri
+        else
+          "#{config[:endpoint]}/1/#{base_uri}"
+        end
       @config = config
     end
 
     def uri
-      @uri ||= URI("#{config[:endpoint]}/1/#{action}").tap do |uri|
-        uri.query = ::Rack::Utils.build_query(:api_key => config[:push_api_key],
+      @uri ||= URI(base_uri).tap do |uri|
+        uri.query = ::Rack::Utils.build_query(
+          :api_key => config[:push_api_key],
           :name => config[:name],
           :environment => config.env,
           :hostname => config[:hostname],
-          :gem_version => Appsignal::VERSION)
+          :gem_version => Appsignal::VERSION
+        )
       end
     end
 

--- a/lib/appsignal/transmitter.rb
+++ b/lib/appsignal/transmitter.rb
@@ -40,7 +40,7 @@ module Appsignal
 
     def transmit(payload)
       config.logger.debug "Transmitting payload to #{uri}"
-      http_client.request(http_post(payload)).code
+      http_client.request(http_post(payload))
     end
 
     private

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -699,17 +699,17 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :report => true do
         end
       end
 
-      describe "current_path" do
+      describe "working_dir" do
         let(:root_path) { tmp_dir }
         let(:config) { Appsignal::Config.new(root_path, "production") }
         before { run_within_dir root_path }
 
         it "outputs current path" do
-          expect(output).to include %(current_path: "#{tmp_dir}"\n    Writable?: true)
+          expect(output).to include %(working_dir: "#{tmp_dir}"\n    Writable?: true)
         end
 
         it "transmits path data in report" do
-          expect(received_report["paths"]["current_path"]).to eq(
+          expect(received_report["paths"]["working_dir"]).to eq(
             "path" => tmp_dir,
             "configured" => true,
             "exists" => true,

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -1,21 +1,53 @@
 require "appsignal/cli"
 
-describe Appsignal::CLI::Diagnose, :api_stub => true do
+describe Appsignal::CLI::Diagnose, :api_stub => true, :report => true do
+  include CLIHelpers
+
+  class DiagnosticsReportEndpoint
+    class << self
+      attr_reader :received_report
+
+      def clear_report!
+        @received_report = nil
+      end
+
+      def call(env)
+        @received_report = JSON.parse(env["rack.input"].read)["diagnose"]
+        [200, {}, [JSON.generate(:token => "my_support_token")]]
+      end
+    end
+  end
+
   describe ".run" do
     let(:out_stream) { std_stream }
     let(:output) { out_stream.read }
     let(:config) { project_fixture_config }
     let(:cli) { described_class }
     let(:options) { { :environment => config.env } }
+    let(:gem_path) { Bundler::CLI::Common.select_spec("appsignal").full_gem_path.strip }
+    let(:received_report) { DiagnosticsReportEndpoint.received_report }
+    let(:process_user) { Etc.getpwuid(Process.uid).name }
     before(:context) { Appsignal.stop }
     before do
+      DiagnosticsReportEndpoint.clear_report!
       if DependencyHelper.rails_present?
         allow(Rails).to receive(:root).and_return(Pathname.new(config.root_path))
       end
     end
+    around do |example|
+      original_stdin = $stdin
+      $stdin = StringIO.new
+      example.run
+      $stdin = original_stdin
+    end
     before :api_stub => true do
       stub_api_request config, "auth"
     end
+    before :report => true do
+      send_diagnostics_report
+      stub_diagnostics_report_request.to_rack(DiagnosticsReportEndpoint)
+    end
+    before(:report => false) { dont_send_diagnostics_report }
     after { Appsignal.config = nil }
 
     def run
@@ -23,9 +55,31 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
     end
 
     def run_within_dir(chdir)
+      prepare_input
       Dir.chdir chdir do
         capture_stdout(out_stream) { cli.run(options) }
       end
+    end
+
+    def stub_diagnostics_report_request
+      stub_request(:post, "https://appsignal.com/diag").with(
+        :query => {
+          :api_key => config[:push_api_key],
+          :environment => config.env,
+          :gem_version => Appsignal::VERSION,
+          :hostname => config[:hostname],
+          :name => config[:name]
+        },
+        :headers => { "Content-Type" => "application/json; charset=UTF-8" }
+      )
+    end
+
+    def send_diagnostics_report
+      set_input "y"
+    end
+
+    def dont_send_diagnostics_report
+      set_input "n"
     end
 
     it "outputs header and support text" do
@@ -36,20 +90,87 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
         "support@appsignal.com"
     end
 
+    describe "report" do
+      context "when user wants to send report" do
+        it "sends report" do
+          run
+          expect(output).to include "Diagnostics report",
+            "Send diagnostics report to AppSignal? (Y/n): ",
+            "Your diagnostics report has been sent to AppSignal."
+        end
+
+        it "outputs the support token from the server" do
+          run
+          expect(output).to include "Your support token: my_support_token"
+        end
+
+        context "when server response is invalid" do
+          before do
+            stub_diagnostics_report_request
+              .to_return(:status => 200, :body => %({ foo: "Invalid json", a: }))
+            run
+          end
+
+          it "outputs the server response in full" do
+            expect(output).to include "Error: Couldn't decode server response.",
+              %({ foo: "Invalid json", a: })
+          end
+        end
+
+        context "when server returns an error" do
+          before do
+            stub_diagnostics_report_request
+              .to_return(:status => 500, :body => "report: server error")
+            run
+          end
+
+          it "outputs the server response in full" do
+            expect(output).to include "report: server error"
+          end
+        end
+      end
+
+      context "when user doesn't want to send report", :report => false do
+        it "does not send report" do
+          run
+          expect(output).to include "Diagnostics report",
+            "Send diagnostics report to AppSignal? (Y/n): ",
+            "Not sending diagnostics information to AppSignal."
+        end
+      end
+    end
+
     describe "agent information" do
+      before { run }
+
       it "outputs version numbers" do
-        run
-        gem_path = Bundler::CLI::Common.select_spec("appsignal").full_gem_path.strip
         expect(output).to include \
           "Gem version: #{Appsignal::VERSION}",
           "Agent version: #{Appsignal::Extension.agent_version}",
           "Gem install path: #{gem_path}"
       end
 
+      it "transmits version numbers in report" do
+        expect(received_report).to include(
+          "library" => {
+            "language" => "ruby",
+            "package_version" => Appsignal::VERSION,
+            "agent_version" => Appsignal::Extension.agent_version,
+            "package_install_path" => gem_path,
+            "extension_loaded" => true
+          }
+        )
+      end
+
       context "with extension" do
+        before { run }
+
         it "outputs extension is loaded" do
-          run
-          expect(output).to include "Extension loaded: yes"
+          expect(output).to include "Extension loaded: true"
+        end
+
+        it "transmits extension_loaded: true in report" do
+          expect(received_report["library"]["extension_loaded"]).to eq(true)
         end
       end
 
@@ -64,7 +185,11 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
         after { Appsignal.extension_loaded = true }
 
         it "outputs extension is not loaded" do
-          expect(output).to include "Extension loaded: no"
+          expect(output).to include "Extension loaded: false"
+        end
+
+        it "transmits extension_loaded: false in report" do
+          expect(received_report["library"]["extension_loaded"]).to eq(false)
         end
       end
     end
@@ -80,6 +205,21 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
           "  Agent lock path: writable"
       end
 
+      it "adds the agent diagnostics to the report" do
+        run
+        expect(received_report["agent"]).to eq(
+          "extension" => {
+            "config" => { "valid" => { "result" => true } }
+          },
+          "agent" => {
+            "boot" => { "started" => { "result" => true } },
+            "config" => { "valid" => { "result" => true } },
+            "logger" => { "started" => { "result" => true } },
+            "lock_path" => { "created" => { "result" => true } }
+          }
+        )
+      end
+
       context "when user config has active: false" do
         before do
           # ENV is leading so easiest to set in test to force user config with active: false
@@ -92,6 +232,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
           expect(output).to include \
             "Agent diagnostics",
             "  Extension config: valid",
+            "  Agent started: started",
             "  Agent config: valid",
             "  Agent logger: started",
             "  Agent lock path: writable"
@@ -99,108 +240,162 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
       end
 
       context "when the extention returns invalid JSON" do
-        it "prints a JSON parse error and prints the returned value" do
-          expect(Appsignal::Extension).to receive(:diagnose).and_return("invalid agent json")
+        before do
+          expect(Appsignal::Extension).to receive(:diagnose).and_return("invalid agent\njson")
           run
+        end
+
+        it "prints a JSON parse error and prints the returned value" do
           expect(output).to include \
             "Agent diagnostics",
             "  Error while parsing agent diagnostics report:",
-            "    Output: invalid agent json"
-          expect(output).to match(/Error: \d+: unexpected token at 'invalid agent json'/)
+            "    Output: invalid agent\njson"
+          expect(output).to match(/Error: \d+: unexpected token at 'invalid agent\njson'/)
+        end
+
+        it "adds the output to the report" do
+          expect(received_report["agent"]["error"])
+            .to match(/\d+: unexpected token at 'invalid agent\njson'/)
+          expect(received_report["agent"]["output"]).to eq(["invalid agent", "json"])
+        end
+      end
+
+      context "when the report contains an error" do
+        let(:agent_report) do
+          { "error" => "fatal error" }
+        end
+        before do
+          expect(Appsignal::Extension).to receive(:diagnose).and_return(JSON.generate(agent_report))
+          run
+        end
+
+        it "prints an error for the entire report" do
+          expect(output).to include "Agent diagnostics\n  Error: fatal error"
+        end
+
+        it "adds the error to the report" do
+          expect(received_report["agent"]).to eq(agent_report)
         end
       end
 
       context "when the report is incomplete (agent failed to start)" do
         let(:agent_report) do
           {
-            :extension => {
-              :config => { :valid => { :result => true } }
+            "extension" => {
+              "config" => { "valid" => { "result" => false } }
             }
             # missing agent section
           }
         end
-
-        it "prints the tests, but shows a dash `-` as a missed result" do
+        before do
           expect(Appsignal::Extension).to receive(:diagnose).and_return(JSON.generate(agent_report))
           run
+        end
+
+        it "prints the tests, but shows a dash `-` for missed results" do
           expect(output).to include \
             "Agent diagnostics",
-            "  Extension config: valid",
+            "  Extension config: invalid",
+            "  Agent started: -",
             "  Agent config: -",
             "  Agent logger: -",
             "  Agent lock path: -"
         end
-      end
 
-      context "when a test contains an error and output" do
-        let(:agent_report) do
-          {
-            :extension => {
-              :config => { :valid => { :result => true } }
-            },
-            :agent => {
-              :boot => {
-                :started => {
-                  :result => false,
-                  :error => "some-error",
-                  :output => "some-output"
-                }
-              }
-            }
-          }
-        end
-
-        it "prints the error and output" do
-          expect(Appsignal::Extension).to receive(:diagnose).and_return(JSON.generate(agent_report))
-          run
-          expect(output).to include \
-            "Agent diagnostics",
-            "  Extension config: valid",
-            "  Agent started: not started",
-            "    Error: some-error",
-            "    Output: some-output"
+        it "adds the output to the report" do
+          expect(received_report["agent"]).to eq(agent_report)
         end
       end
 
       context "when a test contains an error" do
         let(:agent_report) do
           {
-            :extension => {
-              :config => { :valid => { :result => true } }
+            "extension" => {
+              "config" => { "valid" => { "result" => true } }
             },
-            :agent => {
-              :config => { :valid => { :result => false, :error => "some-error" } }
+            "agent" => {
+              "boot" => {
+                "started" => { "result" => false, "error" => "some-error" }
+              }
+            }
+          }
+        end
+        before do
+          expect(Appsignal::Extension).to receive(:diagnose).and_return(JSON.generate(agent_report))
+          run
+        end
+
+        it "prints the error and output" do
+          expect(output).to include \
+            "Agent diagnostics",
+            "  Extension config: valid",
+            "  Agent started: not started\n    Error: some-error"
+        end
+
+        it "adds the agent report to the diagnostics report" do
+          expect(received_report["agent"]).to eq(agent_report)
+        end
+      end
+
+      context "when a test contains command output" do
+        let(:agent_report) do
+          {
+            "extension" => {
+              "config" => { "valid" => { "result" => true } }
+            },
+            "agent" => {
+              "config" => { "valid" => { "result" => false, "output" => "some output" } }
             }
           }
         end
 
-        it "prints the error" do
+        it "prints the command output" do
           expect(Appsignal::Extension).to receive(:diagnose).and_return(JSON.generate(agent_report))
           run
           expect(output).to include \
             "Agent diagnostics",
             "  Extension config: valid",
-            "  Agent config: invalid",
-            "    Error: some-error"
+            "  Agent config: invalid\n    Output: some output"
         end
       end
     end
 
     describe "host information" do
+      let(:rbconfig) { RbConfig::CONFIG }
+      let(:language_version) { "#{rbconfig["ruby_version"]}-p#{rbconfig["PATCHLEVEL"]}" }
+
       it "outputs host information" do
         run
         expect(output).to include \
           "Host information",
-          "Architecture: #{RbConfig::CONFIG["host_cpu"]}",
-          "Operating System: #{RbConfig::CONFIG["host_os"]}",
-          "Ruby version: #{RbConfig::CONFIG["RUBY_VERSION_NAME"]}"
+          "Architecture: #{rbconfig["host_cpu"]}",
+          "Operating System: #{rbconfig["host_os"]}",
+          "Ruby version: #{language_version}"
+      end
+
+      it "transmits host information in report" do
+        run
+        host_report = received_report["host"]
+        host_report.delete("running_in_container") # Tested elsewhere
+        expect(host_report).to eq(
+          "architecture" => rbconfig["host_cpu"],
+          "os" => rbconfig["host_os"],
+          "language_version" => language_version,
+          "heroku" => false,
+          "root" => false
+        )
       end
 
       describe "root user detection" do
         context "when not root user" do
-          it "prints no" do
+          it "outputs false" do
             run
-            expect(output).to include "root user: no"
+            expect(output).to include "root user: false"
+          end
+
+          it "transmits root: false in report" do
+            run
+            expect(received_report["host"]["root"]).to eq(false)
           end
         end
 
@@ -210,16 +405,26 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
             run
           end
 
-          it "prints yes, with warning" do
-            expect(output).to include "root user: yes (not recommended)"
+          it "outputs true, with warning" do
+            expect(output).to include "root user: true (not recommended)"
+          end
+
+          it "transmits root: true in report" do
+            expect(received_report["host"]["root"]).to eq(true)
           end
         end
       end
 
       describe "Heroku detection" do
         context "when not on Heroku" do
+          before { run }
+
           it "does not output Heroku detection" do
             expect(output).to_not include("Heroku:")
+          end
+
+          it "transmits heroku: false in report" do
+            expect(received_report["host"]["heroku"]).to eq(false)
           end
         end
 
@@ -228,6 +433,10 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
 
           it "outputs Heroku detection" do
             expect(output).to include("Heroku: true")
+          end
+
+          it "transmits heroku: true in report" do
+            expect(received_report["host"]["heroku"]).to eq(true)
           end
         end
       end
@@ -239,8 +448,12 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
             run
           end
 
-          it "outputs: no" do
-            expect(output).to include("Running in container: no")
+          it "outputs: false" do
+            expect(output).to include("Running in container: false")
+          end
+
+          it "transmits running_in_container: false in report" do
+            expect(received_report["host"]["running_in_container"]).to eq(false)
           end
         end
 
@@ -250,8 +463,12 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
             run
           end
 
-          it "outputs: yes" do
-            expect(output).to include("Running in container: yes")
+          it "outputs: true" do
+            expect(output).to include("Running in container: true")
+          end
+
+          it "transmits running_in_container: true in report" do
+            expect(received_report["host"]["running_in_container"]).to eq(true)
           end
         end
       end
@@ -321,7 +538,16 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
         end
 
         it "outputs valid" do
-          expect(output).to include("Validating API key: Valid")
+          expect(output).to include "Validation",
+            "Validating Push API key: valid"
+        end
+
+        it "transmits validation in report" do
+          expect(received_report).to include(
+            "validation" => {
+              "push_api_key" => "valid"
+            }
+          )
         end
       end
 
@@ -332,7 +558,16 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
         end
 
         it "outputs invalid" do
-          expect(output).to include("Validating API key: Invalid")
+          expect(output).to include "Validation",
+            "Validating Push API key: invalid"
+        end
+
+        it "transmits validation in report" do
+          expect(received_report).to include(
+            "validation" => {
+              "push_api_key" => "invalid"
+            }
+          )
         end
       end
 
@@ -343,7 +578,17 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
         end
 
         it "outputs failure with status code" do
-          expect(output).to include("Validating API key: Failed with status 500")
+          expect(output).to include "Validation",
+            "Validating Push API key: Failed with status 500\n" +
+            %("Could not confirm authorization: 500")
+        end
+
+        it "transmits validation in report" do
+          expect(received_report).to include(
+            "validation" => {
+              "push_api_key" => %(Failed with status 500\n\"Could not confirm authorization: 500")
+            }
+          )
         end
       end
     end
@@ -356,6 +601,16 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
       end
       after { FileUtils.rm_rf([root_path, system_tmp_dir]) }
 
+      describe "report" do
+        let(:root_path) { tmp_dir }
+
+        it "adds paths to the report" do
+          run
+          expect(received_report["paths"].keys)
+            .to match_array(%w(root_path working_dir log_dir_path log_file_path))
+        end
+      end
+
       context "when a directory is not configured" do
         let(:root_path) { File.join(tmp_dir, "writable_path") }
         let(:config) { Appsignal::Config.new(root_path, "production", :log_file => nil) }
@@ -366,7 +621,16 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
         end
 
         it "outputs unconfigured directory" do
-          expect(output).to include %(log_file_path: ""\n    - Configured?: no)
+          expect(output).to include %(log_file_path: ""\n    Configured?: false)
+        end
+
+        it "transmits path data in report" do
+          expect(received_report["paths"]["log_file_path"]).to eq(
+            "path" => nil,
+            "configured" => false,
+            "exists" => false,
+            "writable" => false
+          )
         end
       end
 
@@ -380,29 +644,46 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
         end
 
         it "outputs not existing path" do
-          expect(output).to include %(root_path: "#{execution_path}"\n    - Exists?: no)
+          expect(output).to include %(root_path: "#{execution_path}"\n    Exists?: false)
+        end
+
+        it "transmits path data in report" do
+          expect(received_report["paths"]["root_path"]).to eq(
+            "path" => execution_path,
+            "configured" => true,
+            "exists" => false,
+            "writable" => false
+          )
         end
       end
 
       describe "ownership" do
+        let(:config) { Appsignal::Config.new(root_path, "production") }
+
         context "when a directory is owned by the current user" do
           let(:root_path) { File.join(tmp_dir, "owned_path") }
-          let(:config) { Appsignal::Config.new(root_path, "production") }
-          let(:process_user) { Etc.getpwuid(Process.uid).name }
           before { run_within_dir root_path }
 
           it "outputs ownership" do
             expect(output).to include \
-              %(root_path: "#{root_path}"\n    - Writable?: yes\n    ) \
-                "- Ownership?: yes (file: #{process_user}:#{Process.uid}, "\
+              %(root_path: "#{root_path}"\n    Writable?: true\n    ) \
+                "Ownership?: true (file: #{process_user}:#{Process.uid}, "\
                 "process: #{process_user}:#{Process.uid})"
+          end
+
+          it "transmits path data in report" do
+            expect(received_report["paths"]["root_path"]).to eq(
+              "path" => root_path,
+              "configured" => true,
+              "exists" => true,
+              "writable" => true,
+              "ownership" => { "uid" => Process.uid, "user" => process_user }
+            )
           end
         end
 
         context "when a directory is not owned by the current user" do
           let(:root_path) { File.join(tmp_dir, "not_owned_path") }
-          let(:config) { Appsignal::Config.new(root_path, "production") }
-          let(:process_user) { Etc.getpwuid(Process.uid).name }
           before do
             stat = File.stat(root_path)
             allow(stat).to receive(:uid).and_return(0)
@@ -412,8 +693,8 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
 
           it "outputs no ownership" do
             expect(output).to include \
-              %(root_path: "#{root_path}"\n    - Writable?: yes\n    ) \
-                "- Ownership?: no (file: root:0, process: #{process_user}:#{Process.uid})"
+              %(root_path: "#{root_path}"\n    Writable?: true\n    ) \
+                "Ownership?: false (file: root:0, process: #{process_user}:#{Process.uid})"
           end
         end
       end
@@ -424,34 +705,54 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
         before { run_within_dir root_path }
 
         it "outputs current path" do
-          expect(output).to include %(current_path: "#{tmp_dir}"\n    - Writable?: yes)
+          expect(output).to include %(current_path: "#{tmp_dir}"\n    Writable?: true)
+        end
+
+        it "transmits path data in report" do
+          expect(received_report["paths"]["current_path"]).to eq(
+            "path" => tmp_dir,
+            "configured" => true,
+            "exists" => true,
+            "writable" => true,
+            "ownership" => { "uid" => Process.uid, "user" => process_user }
+          )
         end
       end
 
       describe "root_path" do
         let(:system_tmp_log_file) { File.join(system_tmp_dir, "appsignal.log") }
+        let(:config) { Appsignal::Config.new(root_path, "production") }
+
         context "when not writable" do
           let(:root_path) { File.join(tmp_dir, "not_writable_path") }
-          let(:config) { Appsignal::Config.new(root_path, "production") }
           before do
             FileUtils.chmod(0o555, root_path)
             run_within_dir root_path
           end
 
           it "outputs not writable root path" do
-            expect(output).to include %(root_path: "#{root_path}"\n    - Writable?: no)
+            expect(output).to include %(root_path: "#{root_path}"\n    Writable?: false)
           end
 
           it "log files fall back on system tmp directory" do
             expect(output).to include \
-              %(log_dir_path: "#{system_tmp_dir}"\n    - Writable?: yes),
-              %(log_file_path: "#{system_tmp_log_file}"\n    - Exists?: no)
+              %(log_dir_path: "#{system_tmp_dir}"\n    Writable?: true),
+              %(log_file_path: "#{system_tmp_log_file}"\n    Exists?: false)
+          end
+
+          it "transmits path data in report" do
+            expect(received_report["paths"]["root_path"]).to eq(
+              "path" => root_path,
+              "configured" => true,
+              "exists" => true,
+              "writable" => false,
+              "ownership" => { "uid" => Process.uid, "user" => process_user }
+            )
           end
         end
 
         context "when writable" do
           let(:root_path) { File.join(tmp_dir, "writable_path") }
-          let(:config) { Appsignal::Config.new(root_path, "production") }
 
           context "without log dir" do
             before do
@@ -460,13 +761,23 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
             end
 
             it "outputs writable root path" do
-              expect(output).to include %(root_path: "#{root_path}"\n    - Writable?: yes)
+              expect(output).to include %(root_path: "#{root_path}"\n    Writable?: true)
             end
 
             it "log files fall back on system tmp directory" do
               expect(output).to include \
-                %(log_dir_path: "#{system_tmp_dir}"\n    - Writable?: yes),
-                %(log_file_path: "#{system_tmp_log_file}"\n    - Exists?: no)
+                %(log_dir_path: "#{system_tmp_dir}"\n    Writable?: true),
+                %(log_file_path: "#{system_tmp_log_file}"\n    Exists?: false)
+            end
+
+            it "transmits path data in report" do
+              expect(received_report["paths"]["root_path"]).to eq(
+                "path" => root_path,
+                "configured" => true,
+                "exists" => true,
+                "writable" => true,
+                "ownership" => { "uid" => Process.uid, "user" => process_user }
+              )
             end
           end
 
@@ -483,8 +794,13 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
 
               it "log files fall back on system tmp directory" do
                 expect(output).to include \
-                  %(log_dir_path: "#{system_tmp_dir}"\n    - Writable?: yes),
-                  %(log_file_path: "#{system_tmp_log_file}"\n    - Exists?: no)
+                  %(log_dir_path: "#{system_tmp_dir}"\n    Writable?: true),
+                  %(log_file_path: "#{system_tmp_log_file}"\n    Exists?: false)
+              end
+
+              it "transmits path data in report" do
+                expect(received_report["paths"]["log_dir_path"]).to be_kind_of(Hash)
+                expect(received_report["paths"]["log_file_path"]).to be_kind_of(Hash)
               end
             end
 
@@ -494,9 +810,14 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
 
                 it "outputs writable but without log file" do
                   expect(output).to include \
-                    %(root_path: "#{root_path}"\n    - Writable?: yes),
-                    %(log_dir_path: "#{log_dir}"\n    - Writable?: yes),
-                    %(log_file_path: "#{log_file}"\n    - Exists?: no)
+                    %(root_path: "#{root_path}"\n    Writable?: true),
+                    %(log_dir_path: "#{log_dir}"\n    Writable?: true),
+                    %(log_file_path: "#{log_file}"\n    Exists?: false)
+                end
+
+                it "transmits path data in report" do
+                  expect(received_report["paths"]["log_dir_path"]).to be_kind_of(Hash)
+                  expect(received_report["paths"]["log_file_path"]).to be_kind_of(Hash)
                 end
               end
 
@@ -508,7 +829,12 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
                   end
 
                   it "lists log file as writable" do
-                    expect(output).to include %(log_file_path: "#{log_file}"\n    - Writable?: yes)
+                    expect(output).to include %(log_file_path: "#{log_file}"\n    Writable?: true)
+                  end
+
+                  it "transmits path data in report" do
+                    expect(received_report["paths"]["log_dir_path"]).to be_kind_of(Hash)
+                    expect(received_report["paths"]["log_file_path"]).to be_kind_of(Hash)
                   end
                 end
 
@@ -520,7 +846,12 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
                   end
 
                   it "lists log file as not writable" do
-                    expect(output).to include %(log_file_path: "#{log_file}"\n    - Writable?: no)
+                    expect(output).to include %(log_file_path: "#{log_file}"\n    Writable?: false)
+                  end
+
+                  it "transmits path data in report" do
+                    expect(received_report["paths"]["log_dir_path"]).to be_kind_of(Hash)
+                    expect(received_report["paths"]["log_file_path"]).to be_kind_of(Hash)
                   end
                 end
               end
@@ -542,19 +873,32 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
 
         context "when file exists" do
           let(:gem_path) { File.join(tmp_dir, "gem") }
+          let(:log_content) do
+            [
+              "log line 1",
+              "log line 2"
+            ]
+          end
           before do
             File.open log_path, "a" do |f|
-              f.write "log line 1"
-              f.write "log line 2"
+              log_content.each do |line|
+                f.puts line
+              end
             end
             run
           end
 
           it "outputs install.log" do
-            expect(output).to include \
-              %(Path: "#{log_path}"),
-              "log line 1",
-              "log line 2"
+            expect(output).to include(%(Path: "#{log_path}"))
+            expect(output).to include(*log_content)
+          end
+
+          it "transmits log data in report" do
+            expect(received_report["logs"][File.join("ext", log_file)]).to eq(
+              "path" => log_path,
+              "exists" => true,
+              "content" => log_content
+            )
           end
 
           after { FileUtils.rm_rf(gem_path) }
@@ -565,7 +909,14 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
           before { run }
 
           it "outputs install.log" do
-            expect(output).to include %(Path: "#{log_path}"\n  File not found.)
+            expect(output).to include %(Path: "#{log_path}"\n    File not found.)
+          end
+
+          it "transmits log data in report" do
+            expect(received_report["logs"][File.join("ext", log_file)]).to eq(
+              "path" => log_path,
+              "exists" => false
+            )
           end
         end
       end
@@ -584,7 +935,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true do
 
         it "outputs header" do
           run
-          expect(output).to include("Extension install log")
+          expect(output).to include("Makefile install log")
         end
       end
     end

--- a/spec/lib/appsignal/cli/helpers_spec.rb
+++ b/spec/lib/appsignal/cli/helpers_spec.rb
@@ -51,11 +51,40 @@ describe Appsignal::CLI::Helpers do
   describe ".press_any_key" do
     before do
       set_input "a" # a as in any
+      prepare_input
     end
 
     it "continues after press" do
       capture_stdout(out_stream) { cli.send :press_any_key }
       expect(output).to include("Press any key")
+    end
+  end
+
+  describe ".ask_for_input" do
+    it "returns the input" do
+      set_input "foo"
+      prepare_input
+      expect(cli.send(:ask_for_input)).to eq("foo")
+    end
+
+    context "with input ending with a line break" do
+      it "returns only the input" do
+        set_input "foo\n"
+        prepare_input
+        expect(cli.send(:ask_for_input)).to eq("foo")
+      end
+    end
+
+    context "when user interrupts the program" do
+      before do
+        expect(cli).to receive(:stdin).and_raise(Interrupt)
+        expect(cli).to receive(:exit).with(1)
+        capture_stdout(out_stream) { cli.send :ask_for_input }
+      end
+
+      it "exits the process" do
+        expect(output).to include("Exiting...")
+      end
     end
   end
 

--- a/spec/lib/appsignal/cli/helpers_spec.rb
+++ b/spec/lib/appsignal/cli/helpers_spec.rb
@@ -93,7 +93,7 @@ describe Appsignal::CLI::Helpers do
       capture_stdout(out_stream) { cli.send(:yes_or_no, "yes or no?: ") }
     end
 
-    it "takes yes for an answer" do
+    it "takes 'y' for an answer" do
       set_input ""
       set_input "nonsense"
       set_input "y"
@@ -102,13 +102,56 @@ describe Appsignal::CLI::Helpers do
       expect(yes_or_no).to be_truthy
     end
 
-    it "takes no for an answer" do
+    it "takes 'Y' for an answer" do
+      set_input "Y"
+      prepare_input
+
+      expect(yes_or_no).to be_truthy
+    end
+
+    it "takes 'yes' for an answer" do
+      set_input "yes"
+      prepare_input
+
+      expect(yes_or_no).to be_truthy
+    end
+
+    it "takes 'n' for an answer" do
       set_input ""
       set_input "nonsense"
       set_input "n"
       prepare_input
 
       expect(yes_or_no).to be_falsy
+    end
+
+    it "takes 'N' for an answer" do
+      set_input "N"
+      prepare_input
+
+      expect(yes_or_no).to be_falsy
+    end
+
+    it "takes 'no' for an answer" do
+      set_input "no"
+      prepare_input
+
+      expect(yes_or_no).to be_falsy
+    end
+
+    context "with a default" do
+      def yes_or_no
+        capture_stdout(out_stream) do
+          cli.send(:yes_or_no, "yes or no?: ", :default => "y")
+        end
+      end
+
+      it "returns the default if no input is received from the user" do
+        set_input ""
+        prepare_input
+
+        expect(yes_or_no).to be_truthy
+      end
     end
   end
 

--- a/spec/lib/appsignal/transmitter_spec.rb
+++ b/spec/lib/appsignal/transmitter_spec.rb
@@ -21,30 +21,36 @@ describe Appsignal::Transmitter do
 
   describe "#transmit" do
     before do
-      stub_request(
-        :post,
-        "https://push.appsignal.com/1/action?api_key=abc"\
-          "&environment=production&gem_version=#{Appsignal::VERSION}"\
-          "&hostname=#{config.config_hash[:hostname]}&name=TestApp"
-      ).with(
+      stub_request(:post, "https://push.appsignal.com/1/action").with(
+        :query => {
+          :api_key => "abc",
+          :environment => "production",
+          :gem_version => Appsignal::VERSION,
+          :hostname => config[:hostname],
+          :name => "TestApp"
+        },
         :body => "{\"the\":\"payload\"}",
         :headers => {
           "Content-Type" => "application/json; charset=UTF-8"
         }
       ).to_return(:status => 200)
     end
-    subject { instance.transmit(:the => :payload) }
+    let(:response) { instance.transmit(:the => :payload) }
 
-    it { is_expected.to eq "200" }
+    it "returns Net::HTTP response" do
+      expect(response).to be_kind_of(Net::HTTPResponse)
+      expect(response.code).to eq "200"
+    end
 
     context "with ca_file_path config option set" do
-      context "when not existing file" do
+      context "when file does not exist" do
         before do
           config.config_hash[:ca_file_path] = File.join(resources_dir, "cacert.pem")
         end
 
         it "ignores the config and logs a warning" do
-          expect(subject).to eq "200"
+          expect(response).to be_kind_of(Net::HTTPResponse)
+          expect(response.code).to eq "200"
           expect(log.string).to_not include "Ignoring non-existing or unreadable " \
             "`ca_file_path`: #{config[:ca_file_path]}"
         end
@@ -56,7 +62,8 @@ describe Appsignal::Transmitter do
         end
 
         it "ignores the config and logs a warning" do
-          expect(subject).to eq "200"
+          expect(response).to be_kind_of(Net::HTTPResponse)
+          expect(response.code).to eq "200"
           expect(log.string).to include "Ignoring non-existing or unreadable " \
             "`ca_file_path`: #{config[:ca_file_path]}"
         end
@@ -70,7 +77,8 @@ describe Appsignal::Transmitter do
         end
 
         it "ignores the config and logs a warning" do
-          expect(subject).to eq "200"
+          expect(response).to be_kind_of(Net::HTTPResponse)
+          expect(response.code).to eq "200"
           expect(log.string).to include "Ignoring non-existing or unreadable " \
             "`ca_file_path`: #{config[:ca_file_path]}"
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ APPSIGNAL_SPEC_DIR = File.expand_path(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(APPSIGNAL_SPEC_DIR, "support/stubs"))
 
 Bundler.require :default
+require "cgi"
 require "rack"
 require "rspec"
 require "pry"


### PR DESCRIPTION
This change will allow users to send the diagnostics report to
AppSignal. We'll ask before sending if the user wants this, but because
we see how useful this can be when debugging an issue it sends the
report by default. When you press enter, no input, "Y" (yes) is
submitted.

Why this change?
We've seen that in every support request we get we'll ask for the
diagnostics report. To make it easier for everyone this change allows
users to send it directly to AppSignal so our support team can review it
without valuable data getting lost by formatting by our support system
for example.

We also provide the user with a support token when they send the report.
This can be useful for a user if they see a problem with the output and
want to dive right in with the report. They can contact us with the
support token, after which we can immediately review the report.

~~Relies on https://github.com/appsignal/appsignal-server/pull/2042 for the diagnostics endpoint to become available. We need something to send this to :)~~

Depends on PR #267, which changes the agent diagnostics mode output from a bunch of printed lines to a hash object.

## Other changes in this PR

- `Transmitter.perform` returns a response object so we can read the response body on a request.
- `Transmitter.initialize` accepts a full URI so we can call another endpoint rather than the endpoint configured in the configuration `:endpoint`.
- When a user interrupts a CLI prompt (ctrl-c) we no longer print a backtrace, but print "Exiting..." and exit the program with status code 1.
- `CLI::Helpers.yes_or_no` accepts a default value, which the prompt for the diagnostics report uses.