### PR TITLE
When JS endpoint payload is empty return 400 code

### DIFF
--- a/lib/appsignal/rack/js_exception_catcher.rb
+++ b/lib/appsignal/rack/js_exception_catcher.rb
@@ -41,7 +41,12 @@ module Appsignal
           ]
         end
 
-        body = JSON.parse(env["rack.input"].read)
+        begin
+          body = JSON.parse(env["rack.input"].read)
+        rescue JSON::ParserError
+          return [400, {}, ["Request payload is not valid JSON."]]
+        end
+
         if body["name"].is_a?(String) && !body["name"].empty?
           transaction = JSExceptionTransaction.new(body)
           transaction.complete!

--- a/spec/lib/appsignal/rack/js_exception_catcher_spec.rb
+++ b/spec/lib/appsignal/rack/js_exception_catcher_spec.rb
@@ -79,6 +79,23 @@ describe Appsignal::Rack::JSExceptionCatcher do
           expect(catcher.call(env)).to eq([200, {}, []])
         end
 
+        context "when request payload is empty" do
+          let(:env) do
+            {
+              "PATH_INFO"  => "/appsignal_error_catcher",
+              "rack.input" => double(:read => "")
+            }
+          end
+
+          it "does not create a transaction" do
+            expect(Appsignal::JSExceptionTransaction).to_not receive(:new)
+          end
+
+          it "returns 400" do
+            expect(catcher.call(env)).to eq([400, {}, ["Request payload is not valid JSON."]])
+          end
+        end
+
         context "when `frontend_error_catching_path` is different" do
           let(:config_options) { { :frontend_error_catching_path => "/foo" } }
 


### PR DESCRIPTION
Problem originally reported in #261, but the exact error was not
reproduced. Regardless, there is a scenario where if the payload is
empty it crashes in the endpoint. Instead, rescue the error and return a
400 "bad request" response.

This should create a somewhat more pleasant development experience with
more descriptive error messages instead of cryptic errors such as:

```
$ JSON.parse("")
JSON::ParserError: A JSON text must at least contain two octets!
```