### PR TITLE
Fix ActiveSupport instrumentation

### DIFF
--- a/lib/appsignal/hooks/active_support_notifications.rb
+++ b/lib/appsignal/hooks/active_support_notifications.rb
@@ -11,6 +11,16 @@ module Appsignal
       end
 
       def install
+        ::ActiveSupport::Notifications.class_eval do
+          def self.instrument(name, payload = {})
+            # Don't check the notifier if any subscriber is listening:
+            # AppSignal is listening
+            instrumenter.instrument(name, payload) do
+              yield payload if block_given?
+            end
+          end
+        end
+
         ::ActiveSupport::Notifications::Instrumenter.class_eval do
           alias instrument_without_appsignal instrument
 

--- a/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
@@ -1,14 +1,14 @@
 describe Appsignal::Hooks::ActiveSupportNotificationsHook do
   if active_support_present?
+    let(:notifier) { ActiveSupport::Notifications::Fanout.new }
+    let(:as) { ActiveSupport::Notifications }
     before :context do
       start_agent
     end
     before do
+      as.notifier = notifier
       Appsignal::Transaction.create("uuid", Appsignal::Transaction::HTTP_REQUEST, "test")
     end
-
-    let(:notifier) { ActiveSupport::Notifications::Fanout.new }
-    let(:instrumenter) { ActiveSupport::Notifications::Instrumenter.new(notifier) }
 
     describe "#dependencies_present?" do
       subject { described_class.new.dependencies_present? }
@@ -16,25 +16,25 @@ describe Appsignal::Hooks::ActiveSupportNotificationsHook do
       it { is_expected.to be_truthy }
     end
 
-    it "should instrument an AS notifications instrument call with a block" do
+    it "instruments an ActiveSupport::Notifications.instrument call with a block" do
       expect(Appsignal::Transaction.current).to receive(:start_event)
         .at_least(:once)
       expect(Appsignal::Transaction.current).to receive(:finish_event)
         .at_least(:once)
         .with("sql.active_record", nil, "SQL", 1)
 
-      return_value = instrumenter.instrument("sql.active_record", :sql => "SQL") do
+      return_value = as.instrument("sql.active_record", :sql => "SQL") do
         "value"
       end
 
       expect(return_value).to eq "value"
     end
 
-    it "should not instrument events whose name starts with a bang" do
+    it "does not instrument events whose name starts with a bang" do
       expect(Appsignal::Transaction.current).not_to receive(:start_event)
       expect(Appsignal::Transaction.current).not_to receive(:finish_event)
 
-      return_value = instrumenter.instrument("!sql.active_record", :sql => "SQL") do
+      return_value = as.instrument("!sql.active_record", :sql => "SQL") do
         "value"
       end
 


### PR DESCRIPTION
Some events are now not picked up when there's no subscriber for it.

Previously we had a subscriber for all events, except private events
prefixed with a exclamation mark `!`. This subscriber would make sure
all events would be picked up.

With the current setup though we don't capture all events if there's no
subscriber. The check in `ActiveSupport::Notifications.instrument`
prevents it from hitting
`ActiveSupport::Notifications::Instrumenter.instrument`, so we override
the method to ignore the check.

---

**Note**: This is a really quick experiment to see if it works and to update our test suite to detect the problem in the first place, added a test for that. Let's discuss if we really want to take this approach or if we should (largely) revert PR #150.