### PR TITLE
Allow configuration of DNS servers used by agent

### DIFF
--- a/ext/agent.yml
+++ b/ext/agent.yml
@@ -1,18 +1,18 @@
 ---
-version: da14f3b
+version: f16607c
 triples:
   x86_64-linux:
-    checksum: 690ae21a087fc9bc8089f492bd2f751c77d9e9573441aa5b2b9427ab8b1e5433
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/da14f3b/appsignal-x86_64-linux-all-static.tar.gz
+    checksum: '0479e8b0aeba95360e9fd8cfd7e7f7f4c1a8dfc555f6149c0c35d27593a05193'
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/f16607c/appsignal-x86_64-linux-all-static.tar.gz
   i686-linux:
-    checksum: 18345e70afdcfc0378503fc6ec48c0949425ad5a650b36a20d721a54c356fe3d
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/da14f3b/appsignal-i686-linux-all-static.tar.gz
+    checksum: 3c3c63f26bec0304649cad4fb69410dd6b13313a178f3db7cdeba72b24834715
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/f16607c/appsignal-i686-linux-all-static.tar.gz
   x86-linux:
-    checksum: 18345e70afdcfc0378503fc6ec48c0949425ad5a650b36a20d721a54c356fe3d
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/da14f3b/appsignal-i686-linux-all-static.tar.gz
+    checksum: 3c3c63f26bec0304649cad4fb69410dd6b13313a178f3db7cdeba72b24834715
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/f16607c/appsignal-i686-linux-all-static.tar.gz
   x86_64-darwin:
-    checksum: 33dfccb7d422343d3baaed9f2f3d0f70c71162413ab05f4aef59b9cc09acd6b9
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/da14f3b/appsignal-x86_64-darwin-all-static.tar.gz
+    checksum: 853398d93cda5f16edd2a931346f97fedea4c16f729bb987564cfbc29e73ef33
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/f16607c/appsignal-x86_64-darwin-all-static.tar.gz
   universal-darwin:
-    checksum: 33dfccb7d422343d3baaed9f2f3d0f70c71162413ab05f4aef59b9cc09acd6b9
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/da14f3b/appsignal-x86_64-darwin-all-static.tar.gz
+    checksum: 853398d93cda5f16edd2a931346f97fedea4c16f729bb987564cfbc29e73ef33
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/f16607c/appsignal-x86_64-darwin-all-static.tar.gz

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -25,7 +25,8 @@ module Appsignal
       :enable_host_metrics            => true,
       :enable_minutely_probes         => false,
       :hostname                       => ::Socket.gethostname,
-      :ca_file_path                   => File.expand_path(File.join("../../../resources/cacert.pem"), __FILE__)
+      :ca_file_path                   => File.expand_path(File.join("../../../resources/cacert.pem"), __FILE__),
+      :dns_servers                    => []
     }.freeze
 
     ENV_TO_KEY_MAPPING = {
@@ -54,7 +55,8 @@ module Appsignal
       "APPSIGNAL_ENABLE_HOST_METRICS"            => :enable_host_metrics,
       "APPSIGNAL_ENABLE_MINUTELY_PROBES"         => :enable_minutely_probes,
       "APPSIGNAL_HOSTNAME"                       => :hostname,
-      "APPSIGNAL_CA_FILE_PATH"                   => :ca_file_path
+      "APPSIGNAL_CA_FILE_PATH"                   => :ca_file_path,
+      "APPSIGNAL_DNS_SERVERS"                    => :dns_servers
     }.freeze
 
     attr_reader :root_path, :env, :initial_config, :config_hash
@@ -114,7 +116,7 @@ module Appsignal
       @valid && config_hash[:active]
     end
 
-    def write_to_environment
+    def write_to_environment # rubocop:disable Metrics/AbcSize
       ENV["_APPSIGNAL_ACTIVE"]                       = active?.to_s
       ENV["_APPSIGNAL_APP_PATH"]                     = root_path.to_s
       ENV["_APPSIGNAL_AGENT_PATH"]                   = File.expand_path("../../../ext", __FILE__).to_s
@@ -139,6 +141,7 @@ module Appsignal
       ENV["_APPSIGNAL_HOSTNAME"]                     = config_hash[:hostname].to_s
       ENV["_APPSIGNAL_PROCESS_NAME"]                 = $PROGRAM_NAME
       ENV["_APPSIGNAL_CA_FILE_PATH"]                 = config_hash[:ca_file_path].to_s
+      ENV["_APPSIGNAL_DNS_SERVERS"]                  = config_hash[:dns_servers].join(",")
     end
 
     private

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -103,7 +103,8 @@ describe Appsignal::Config do
         :enable_host_metrics            => true,
         :enable_minutely_probes         => false,
         :hostname                       => Socket.gethostname,
-        :ca_file_path                   => File.join(resources_dir, "cacert.pem")
+        :ca_file_path                   => File.join(resources_dir, "cacert.pem"),
+        :dns_servers                    => []
       )
     end
 
@@ -370,6 +371,7 @@ describe Appsignal::Config do
       config[:hostname] = "app1.local"
       config[:filter_parameters] = %w(password confirm_password)
       config[:running_in_container] = false
+      config[:dns_servers] = ["8.8.8.8", "8.8.4.4"]
       config.write_to_environment
     end
 
@@ -397,7 +399,8 @@ describe Appsignal::Config do
       expect(ENV["_APPSIGNAL_HOSTNAME"]).to                     eq "app1.local"
       expect(ENV["_APPSIGNAL_PROCESS_NAME"]).to                 include "rspec"
       expect(ENV["_APPSIGNAL_CA_FILE_PATH"]).to                 eq File.join(resources_dir, "cacert.pem")
-      expect(ENV).to_not                                        have_key("APPSIGNAL_WORKING_DIR_PATH")
+      expect(ENV["_APPSIGNAL_DNS_SERVERS"]).to                  eq "8.8.8.8,8.8.4.4"
+      expect(ENV).to_not                                        have_key("_APPSIGNAL_WORKING_DIR_PATH")
     end
 
     context "with :working_dir_path" do


### PR DESCRIPTION
This change allows users to configure DNS servers for when our agent
can't read the host's DNS settings. Musl libc has a known issue where it
can't read all configuration of the `/etc/resolv.conf` file, as
documented here:
http://wiki.musl-libc.org/wiki/Functional_differences_from_glibc#Name_Resolver_.2F_DNS

```yml
# config/appsignal.yml
production:
  dns_servers:
    - 8.8.8.8
    - 8.8.4.4
```

The transmitter in the Ruby gem ignores this setting. It's only for the
AppSignal rust agent.