### PR TITLE
Save parameters consistently between web requests and background jobs

### DIFF
--- a/lib/appsignal/hooks.rb
+++ b/lib/appsignal/hooks.rb
@@ -82,12 +82,6 @@ module Appsignal
           value
         end
       end
-
-      def format_args(args)
-        args.map do |arg|
-          truncate(string_or_inspect(arg))
-        end
-      end
     end
   end
 end

--- a/lib/appsignal/hooks/sidekiq.rb
+++ b/lib/appsignal/hooks/sidekiq.rb
@@ -14,12 +14,14 @@ module Appsignal
       end
 
       def call(_worker, item, _queue)
-        params =
+        args =
           if item["class"] == "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper"
-            format_args(item["args"].first["arguments"])
+            item["args"].first["arguments"]
           else
-            format_args(item["args"])
+            item["args"]
           end
+        params = Appsignal::Utils::ParamsSanitizer.sanitize args,
+          :filter_parameters => Appsignal.config[:filter_parameters]
 
         Appsignal.monitor_transaction(
           "perform_job.sidekiq",

--- a/lib/appsignal/integrations/delayed_job_plugin.rb
+++ b/lib/appsignal/integrations/delayed_job_plugin.rb
@@ -26,7 +26,11 @@ module Appsignal
           class_name, method_name = job.job_data[:name].split("#")
           args = job.job_data[:args] || {}
           job_data = job.job_data
+        else
+          args = {}
         end
+        params = Appsignal::Utils::ParamsSanitizer.sanitize args,
+          :filter_parameters => Appsignal.config[:filter_parameters]
 
         Appsignal.monitor_transaction(
           "perform_job.delayed_job",
@@ -38,7 +42,7 @@ module Appsignal
             :priority => extract_value(job_data, :priority, 0),
             :attempts => extract_value(job_data, :attempts, 0)
           },
-          :params      => format_args(args),
+          :params      => params,
           :queue_start => extract_value(job_data, :created_at)
         ) do
           block.call(job)

--- a/lib/appsignal/integrations/resque_active_job.rb
+++ b/lib/appsignal/integrations/resque_active_job.rb
@@ -7,11 +7,14 @@ module Appsignal
       def self.included(base)
         base.class_eval do
           around_perform do |job, block|
+            params = Appsignal::Utils::ParamsSanitizer.sanitize job.arguments,
+              :filter_parameters => Appsignal.config[:filter_parameters]
+
             Appsignal.monitor_single_transaction(
               "perform_job.resque",
               :class    => job.class.to_s,
               :method   => "perform",
-              :params   => job.format_args(job.arguments),
+              :params   => params,
               :metadata => {
                 :id       => job.job_id,
                 :queue    => job.queue_name

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -2,13 +2,14 @@ describe Appsignal::Hooks::SidekiqPlugin do
   let(:worker) { double }
   let(:queue) { double }
   let(:current_transaction) { background_job_transaction }
+  let(:args) { ["Model", 1] }
   let(:item) do
     {
       "class"       => "TestClass",
       "retry_count" => 0,
       "queue"       => "default",
       "enqueued_at" => Time.parse("01-01-2001 10:00:00UTC"),
-      "args"        => ["Model", 1],
+      "args"        => args,
       "extra"       => "data"
     }
   end
@@ -20,7 +21,15 @@ describe Appsignal::Hooks::SidekiqPlugin do
   end
 
   context "with a performance call" do
-    it "should wrap in a transaction with the correct params" do
+    after do
+      Timecop.freeze(Time.parse("01-01-2001 10:01:00UTC")) do
+        Appsignal::Hooks::SidekiqPlugin.new.call(worker, item, queue) do
+          # nothing
+        end
+      end
+    end
+
+    it "wraps it in a transaction with the correct params" do
       expect(Appsignal).to receive(:monitor_transaction).with(
         "perform_job.sidekiq",
         :class    => "TestClass",
@@ -30,10 +39,67 @@ describe Appsignal::Hooks::SidekiqPlugin do
           "queue"       => "default",
           "extra"       => "data"
         },
-        :params      => %w(Model 1),
+        :params      => ["Model", 1],
         :queue_start => Time.parse("01-01-2001 10:00:00UTC"),
         :queue_time  => 60_000.to_f
       )
+    end
+
+    context "with more complex arguments" do
+      let(:default_params) do
+        {
+          :class    => "TestClass",
+          :method   => "perform",
+          :metadata => {
+            "retry_count" => "0",
+            "queue"       => "default",
+            "extra"       => "data"
+          },
+          :params => {
+            :foo => "Foo",
+            :bar => "Bar"
+          },
+          :queue_start => Time.parse("01-01-2001 10:00:00UTC"),
+          :queue_time  => 60_000.to_f
+        }
+      end
+      let(:args) do
+        {
+          :foo => "Foo",
+          :bar => "Bar"
+        }
+      end
+
+      it "adds the more complex arguments" do
+        expect(Appsignal).to receive(:monitor_transaction).with(
+          "perform_job.sidekiq",
+          default_params.merge(
+            :params => {
+              :foo => "Foo",
+              :bar => "Bar"
+            }
+          )
+        )
+      end
+
+      context "with parameter filtering" do
+        before do
+          Appsignal.config = project_fixture_config("production")
+          Appsignal.config[:filter_parameters] = ["foo"]
+        end
+
+        it "filters selected arguments" do
+          expect(Appsignal).to receive(:monitor_transaction).with(
+            "perform_job.sidekiq",
+            default_params.merge(
+              :params => {
+                :foo => "[FILTERED]",
+                :bar => "Bar"
+              }
+            )
+          )
+        end
+      end
     end
 
     context "when wrapped by ActiveJob" do
@@ -46,7 +112,7 @@ describe Appsignal::Hooks::SidekiqPlugin do
             "job_class" => "TestJob",
             "job_id" => "23e79d48-6966-40d0-b2d4-f7938463a263",
             "queue_name" => "default",
-            "arguments" => ["Model", 1]
+            "arguments" => args
           }],
           "retry" => true,
           "jid" => "efb140489485999d32b5504c",
@@ -54,50 +120,103 @@ describe Appsignal::Hooks::SidekiqPlugin do
           "enqueued_at" => Time.parse("01-01-2001 10:00:00UTC").to_f
         }
       end
-
-      it "should wrap in a transaction with the correct params" do
-        expect(Appsignal).to receive(:monitor_transaction).with(
-          "perform_job.sidekiq",
+      let(:default_params) do
+        {
           :class    => "TestClass",
           :method   => "perform",
           :metadata => {
             "queue" => "default"
           },
-          :params      => %w(Model 1),
           :queue_start => Time.parse("01-01-2001 10:00:00UTC").to_f,
           :queue_time  => 60_000.to_f
+        }
+      end
+
+      it "wraps it in a transaction with the correct params" do
+        expect(Appsignal).to receive(:monitor_transaction).with(
+          "perform_job.sidekiq",
+          default_params.merge(:params => ["Model", 1])
         )
       end
-    end
 
-    after do
-      Timecop.freeze(Time.parse("01-01-2001 10:01:00UTC")) do
-        Appsignal::Hooks::SidekiqPlugin.new.call(worker, item, queue) do
-          # nothing
+      context "with more complex arguments" do
+        let(:args) do
+          {
+            :foo => "Foo",
+            :bar => "Bar"
+          }
+        end
+
+        it "adds the more complex arguments" do
+          expect(Appsignal).to receive(:monitor_transaction).with(
+            "perform_job.sidekiq",
+            default_params.merge(
+              :params => {
+                :foo => "Foo",
+                :bar => "Bar"
+              }
+            )
+          )
+        end
+
+        context "with parameter filtering" do
+          before do
+            Appsignal.config = project_fixture_config("production")
+            Appsignal.config[:filter_parameters] = ["foo"]
+          end
+
+          it "filters selected arguments" do
+            expect(Appsignal).to receive(:monitor_transaction).with(
+              "perform_job.sidekiq",
+              default_params.merge(
+                :params => {
+                  :foo => "[FILTERED]",
+                  :bar => "Bar"
+                }
+              )
+            )
+          end
         end
       end
     end
   end
 
   context "with an erroring call" do
-    let(:error) { VerySpecificError.new }
+    let(:error) { VerySpecificError }
+    let(:transaction) do
+      Appsignal::Transaction.new(
+        SecureRandom.uuid,
+        Appsignal::Transaction::BACKGROUND_JOB,
+        Appsignal::Transaction::GenericRequest.new({})
+      )
+    end
+    before do
+      allow(Appsignal::Transaction).to receive(:current).and_return(transaction)
+      expect(Appsignal::Transaction).to receive(:create)
+        .with(
+          kind_of(String),
+          Appsignal::Transaction::BACKGROUND_JOB,
+          kind_of(Appsignal::Transaction::GenericRequest)
+        ).and_return(transaction)
+    end
 
-    it "should add the exception to appsignal" do
-      expect_any_instance_of(Appsignal::Transaction).to receive(:set_error).with(error)
+    it "adds the error to the transaction" do
+      expect(transaction).to receive(:set_error).with(error)
+      expect(transaction).to receive(:complete)
     end
 
     after do
-      begin
+      expect do
         Timecop.freeze(Time.parse("01-01-2001 10:01:00UTC")) do
           Appsignal::Hooks::SidekiqPlugin.new.call(worker, item, queue) do
             raise error
           end
         end
-      rescue VerySpecificError
-      end
+      end.to raise_error(error)
     end
   end
 
+  # TODO: Don't test (what are basically) private methods
   describe "#formatted_data" do
     let(:item) do
       {
@@ -106,7 +225,7 @@ describe Appsignal::Hooks::SidekiqPlugin do
       }
     end
 
-    it "should only add items to the hash that do not appear in JOB_KEYS" do
+    it "only adds items to the hash that do not appear in JOB_KEYS" do
       expect(plugin.formatted_metadata(item)).to eq("foo" => "bar")
     end
   end

--- a/spec/lib/appsignal/hooks_spec.rb
+++ b/spec/lib/appsignal/hooks_spec.rb
@@ -192,25 +192,4 @@ describe Appsignal::Hooks::Helpers do
       it { is_expected.to eq "1" }
     end
   end
-
-  describe "#format_args" do
-    let(:object) { Object.new }
-    let(:args) do
-      [
-        "Model",
-        1,
-        object,
-        "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
-      ]
-    end
-
-    it "should format the arguments" do
-      expect(with_helpers.format_args(args)).to eq([
-        "Model",
-        "1",
-        object.inspect,
-        "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ..."
-      ])
-    end
-  end
 end


### PR DESCRIPTION
This PR includes two changes:

## Truncate lengthy parameter values

~~Truncate lengthy parameter values from requests. We prefer it if apps
don't send too long values to our servers. We assume these long values
won't add too much extra context so we truncate the values at length
200.~~

Will be done in a later PR in our Rust extension.

## Add background job integrations argument filtering

Previously we truncated long values in the background jobs to prevent
apps from sending large payloads with data that's unused and doesn't
provide more context. This logic was added to the parameter filtering in
the commit before this.

This change utilizes the parameter filtering for the background job
integrations as well. Which adds support for filtering arguments to
background job libraries and also truncates large argument values.