### PR TITLE
Reorder record_event arguments

### DIFF
--- a/ext/agent.yml
+++ b/ext/agent.yml
@@ -1,18 +1,18 @@
 ---
-version: f16607c
+version: d54a76a
 triples:
   x86_64-linux:
-    checksum: '0479e8b0aeba95360e9fd8cfd7e7f7f4c1a8dfc555f6149c0c35d27593a05193'
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/f16607c/appsignal-x86_64-linux-all-static.tar.gz
+    checksum: 281d91b060365e05fc2df94eb88b0b8d7f6fde06c439829bdd170f202f5aa5b1
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/d54a76a/appsignal-x86_64-linux-all-static.tar.gz
   i686-linux:
-    checksum: 3c3c63f26bec0304649cad4fb69410dd6b13313a178f3db7cdeba72b24834715
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/f16607c/appsignal-i686-linux-all-static.tar.gz
+    checksum: 91e9d317a45d0a5e1a03b5a12480c221182b8f460638532181b58b362941d3d5
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/d54a76a/appsignal-i686-linux-all-static.tar.gz
   x86-linux:
-    checksum: 3c3c63f26bec0304649cad4fb69410dd6b13313a178f3db7cdeba72b24834715
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/f16607c/appsignal-i686-linux-all-static.tar.gz
+    checksum: 91e9d317a45d0a5e1a03b5a12480c221182b8f460638532181b58b362941d3d5
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/d54a76a/appsignal-i686-linux-all-static.tar.gz
   x86_64-darwin:
-    checksum: 853398d93cda5f16edd2a931346f97fedea4c16f729bb987564cfbc29e73ef33
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/f16607c/appsignal-x86_64-darwin-all-static.tar.gz
+    checksum: f9732af3f4913341d0ec70474d893472fd1bf9720c5cea098a24be92379872aa
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/d54a76a/appsignal-x86_64-darwin-all-static.tar.gz
   universal-darwin:
-    checksum: 853398d93cda5f16edd2a931346f97fedea4c16f729bb987564cfbc29e73ef33
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/f16607c/appsignal-x86_64-darwin-all-static.tar.gz
+    checksum: f9732af3f4913341d0ec70474d893472fd1bf9720c5cea098a24be92379872aa
+    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/d54a76a/appsignal-x86_64-darwin-all-static.tar.gz

--- a/ext/appsignal_extension.c
+++ b/ext/appsignal_extension.c
@@ -119,7 +119,7 @@ static VALUE finish_event(VALUE self, VALUE name, VALUE title, VALUE body, VALUE
   return Qnil;
 }
 
-static VALUE record_event(VALUE self, VALUE name, VALUE title, VALUE body, VALUE duration, VALUE body_format, VALUE gc_duration_ms) {
+static VALUE record_event(VALUE self, VALUE name, VALUE title, VALUE body, VALUE body_format, VALUE duration, VALUE gc_duration_ms) {
   appsignal_transaction_t* transaction;
   appsignal_data_t* body_data;
   int body_type;

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -278,8 +278,8 @@ module Appsignal
         name,
         title || BLANK,
         body || BLANK,
-        duration,
         body_format || Appsignal::EventFormatter::DEFAULT,
+        duration,
         self.class.garbage_collection_profiler.total_time
       )
     end

--- a/spec/lib/appsignal/extension_spec.rb
+++ b/spec/lib/appsignal/extension_spec.rb
@@ -48,7 +48,7 @@ describe "extension loading and operation" do
         end
 
         it "should have a record_event method" do
-          subject.record_event("name", "title", "body", 1000, 0, 1000)
+          subject.record_event("name", "title", "body", 0, 1000, 1000)
         end
 
         it "should have a set_error method" do

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -568,8 +568,8 @@ describe Appsignal::Transaction do
           "name",
           "title",
           "body",
-          1000,
           1,
+          1000,
           fake_gc_time
         ).and_call_original
 
@@ -587,8 +587,8 @@ describe Appsignal::Transaction do
           "name",
           "",
           "",
-          1000,
           0,
+          1000,
           fake_gc_time
         ).and_call_original
 


### PR DESCRIPTION
Change record_event arguments after merging the change on the agent
side: https://github.com/appsignal/appsignal-agent/pull/259

Same change was submitting to the Elixir package. https://github.com/appsignal/appsignal-elixir/pull/217

This change follows that change to the C-extension, so that the
C-extension and Rust extension behave the same. This change does not
change the public interface to AppSignal for Ruby transactions and
such.

**Note:** This branch is aimed at master for a `2.2.1` release
**Note:** Requires agent update from https://github.com/appsignal/appsignal-agent/pull/259

Closes #287 