### PR TITLE
Implement Transaction#to_json

### DIFF
--- a/ext/appsignal_extension.c
+++ b/ext/appsignal_extension.c
@@ -281,6 +281,21 @@ static VALUE complete_transaction(VALUE self) {
   return Qnil;
 }
 
+static VALUE transaction_to_json(VALUE self) {
+  appsignal_transaction_t* transaction;
+  appsignal_string_t json;
+
+  Data_Get_Struct(self, appsignal_transaction_t, transaction);
+
+  json = appsignal_transaction_to_json(transaction);
+
+  if (json.len == 0) {
+    return Qnil;
+  } else {
+    return make_ruby_string(json);
+  }
+}
+
 static VALUE data_map_new(VALUE self) {
   appsignal_data_t* data;
 
@@ -636,6 +651,7 @@ void Init_appsignal_extension(void) {
   rb_define_method(Transaction, "set_metadata",    set_transaction_metadata,    2);
   rb_define_method(Transaction, "finish",          finish_transaction,          1);
   rb_define_method(Transaction, "complete",        complete_transaction,        0);
+  rb_define_method(Transaction, "to_json",         transaction_to_json,         0);
 
   // Create a data map or array
   rb_define_singleton_method(Extension, "data_map_new", data_map_new, 0);
@@ -660,7 +676,7 @@ void Init_appsignal_extension(void) {
   // Data equality
   rb_define_method(Data, "==", data_equal, 1);
 
-  // Get Json content of a data
+  // Get JSON content of a data
   rb_define_method(Data, "to_s", data_to_s, 0);
 
   // Event hook installation

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -291,6 +291,10 @@ module Appsignal
       r
     end
 
+    def to_json
+      @ext.to_json
+    end
+
     class GenericRequest
       attr_reader :env
 


### PR DESCRIPTION
Allows for testing of actual transaction data so we don't have to stub
all calls to the Extension/Transaction-class.

Example usage:

```
describe Appsignal::Transaction do
  it "#to_json" do
    start_agent
    transaction = Appsignal::Transaction.create(
      SecureRandom.uuid,
      Appsignal::Transaction::HTTP_REQUEST,
      Appsignal::Transaction::GenericRequest.new({})
    )
    transaction.set_action("foo#bar")
    transaction.set_metadata("path", "/bar")
    transaction.set_metadata("method", "GET")
    puts transaction.to_json.inspect
  end
end
```

Resolves (partially) #252