### PR TITLE
Fix raise and throws in instrument helper

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -461,10 +461,12 @@ module Appsignal
     #   instrumented. Accepted values are {EventFormatter::DEFAULT} and
     #   {EventFormatter::SQL_BODY_FORMAT}, but we recommend you use
     #   {.instrument_sql} instead of {EventFormatter::SQL_BODY_FORMAT}.
-    # @yield yields the given block of code instrumented in an AppSignal event.
+    # @yield yields the given block of code instrumented in an AppSignal
+    #   event.
     # @return [Object] Returns the blocks return value.
     #
-    # @see .instrument_sql Specific helper for SQL queries.
+    # @see Appsignal::Transaction#instrument
+    # @see .instrument_sql
     # @see http://docs.appsignal.com/ruby/instrumentation/instrumentation.html
     #   AppSignal custom instrumentation guide
     # @see http://docs.appsignal.com/api/event-names.html
@@ -472,9 +474,9 @@ module Appsignal
     # @since 1.3.0
     def instrument(name, title = nil, body = nil, body_format = Appsignal::EventFormatter::DEFAULT)
       Appsignal::Transaction.current.start_event
-      return_value = yield if block_given?
+      yield if block_given?
+    ensure
       Appsignal::Transaction.current.finish_event(name, title, body, body_format)
-      return_value
     end
 
     # Instrumentation helper for SQL queries.

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -286,9 +286,9 @@ module Appsignal
 
     def instrument(name, title = nil, body = nil, body_format = Appsignal::EventFormatter::DEFAULT)
       start_event
-      r = yield
+      yield if block_given?
+    ensure
       finish_event(name, title, body, body_format)
-      r
     end
 
     class GenericRequest

--- a/spec/lib/appsignal/integrations/padrino_spec.rb
+++ b/spec/lib/appsignal/integrations/padrino_spec.rb
@@ -57,6 +57,7 @@ if DependencyHelper.padrino_present?
       let(:base)     { double }
       let(:router)   { PadrinoClassWithRouter.new }
       let(:env)      { {} }
+      # TODO: use an instance double
       let(:settings) { double(:name => "TestApp") }
 
       describe "routes" do
@@ -107,6 +108,7 @@ if DependencyHelper.padrino_present?
             Appsignal::Transaction::HTTP_REQUEST,
             request_kind
           ).and_return(transaction)
+
           expect(Appsignal).to receive(:instrument)
             .at_least(:once)
             .with("process_action.padrino")

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -603,22 +603,8 @@ describe Appsignal::Transaction do
     end
 
     describe "#instrument" do
-      it "should start and finish an event around the given block" do
-        stub = double
-        expect(stub).to receive(:method_call).and_return("return value")
-
-        expect(transaction).to receive(:start_event)
-        expect(transaction).to receive(:finish_event).with(
-          "name",
-          "title",
-          "body",
-          0
-        )
-
-        return_value = transaction.instrument "name", "title", "body" do
-          stub.method_call
-        end
-        expect(return_value).to eq "return value"
+      it_behaves_like "instrument helper" do
+        let(:instrumenter) { transaction }
       end
     end
 

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -298,18 +298,6 @@ describe Appsignal do
         end.to_not raise_error
       end
     end
-
-    describe ".instrument" do
-      it "should not instrument, but still call the block" do
-        stub = double
-        expect(stub).to receive(:method_call).and_return("return value")
-
-        return_value = Appsignal.instrument "name" do
-          stub.method_call
-        end
-        expect(return_value).to eq "return value"
-      end
-    end
   end
 
   context "with config and started" do
@@ -848,28 +836,11 @@ describe Appsignal do
     end
 
     describe ".instrument" do
-      before do
-        expect(Appsignal::Transaction).to receive(:current).at_least(:once).and_return(transaction)
-      end
-
-      it "should instrument through the transaction" do
-        expect(transaction).to receive(:start_event)
-        expect(transaction).to receive(:finish_event)
-          .with("name", "title", "body", Appsignal::EventFormatter::DEFAULT)
-
-        result = Appsignal.instrument "name", "title", "body" do
-          "return value"
+      it_behaves_like "instrument helper" do
+        let(:instrumenter) { Appsignal }
+        before do
+          expect(Appsignal::Transaction).to receive(:current).at_least(:once).and_return(transaction)
         end
-        expect(result).to eq "return value"
-      end
-
-      it "should instrument without a block given" do
-        expect(transaction).to receive(:start_event)
-        expect(transaction).to receive(:finish_event)
-          .with("name", "title", "body", Appsignal::EventFormatter::DEFAULT)
-
-        result = Appsignal.instrument "name", "title", "body"
-        expect(result).to be_nil
       end
     end
 
@@ -878,7 +849,7 @@ describe Appsignal do
         expect(Appsignal::Transaction).to receive(:current).at_least(:once).and_return(transaction)
       end
 
-      it "should instrument sql through the transaction" do
+      it "creates an SQL event on the transaction" do
         expect(transaction).to receive(:start_event)
         expect(transaction).to receive(:finish_event)
           .with("name", "title", "body", Appsignal::EventFormatter::SQL_BODY_FORMAT)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,9 @@ end
 Dir[File.join(APPSIGNAL_SPEC_DIR, "support/mocks", "*.rb")].each do |f|
   require f
 end
+Dir[File.join(APPSIGNAL_SPEC_DIR, "support/shared_examples", "*.rb")].each do |f|
+  require f
+end
 if DependencyHelper.rails_present?
   Dir[File.join(DirectoryHelper.support_dir, "rails", "*.rb")].each do |f|
     require f

--- a/spec/support/shared_examples/instrument.rb
+++ b/spec/support/shared_examples/instrument.rb
@@ -1,0 +1,43 @@
+RSpec.shared_examples "instrument helper" do
+  let(:stub) { double }
+  before do
+    expect(stub).to receive(:method_call).and_return("return value")
+
+    expect(transaction).to receive(:start_event)
+    expect(transaction).to receive(:finish_event).with(
+      "name",
+      "title",
+      "body",
+      0
+    )
+  end
+
+  it "records an event around the given block" do
+    return_value = instrumenter.instrument "name", "title", "body" do
+      stub.method_call
+    end
+    expect(return_value).to eq "return value"
+  end
+
+  context "with an error raised in the passed block" do
+    it "records an event around the given block" do
+      expect do
+        instrumenter.instrument "name", "title", "body" do
+          stub.method_call
+          raise "foo"
+        end
+      end.to raise_error(StandardError, "foo")
+    end
+  end
+
+  context "with an error raise in the passed block" do
+    it "records an event around the given block" do
+      expect do
+        instrumenter.instrument "name", "title", "body" do
+          stub.method_call
+          throw :foo
+        end
+      end.to throw_symbol(:foo)
+    end
+  end
+end


### PR DESCRIPTION
By using a "soft return", by saving the return value in a variable, it
can happen that an event is not finished when the block that's given to
an instrument method raises and error or uses `throw` to throw a signal.
Using `ensure` we _ensure_ that the event is finished even when that
happens.

## Reported in

As reported in https://github.com/appsignal/appsignal-ruby/issues/289#issuecomment-300191774. Doesn't fix the (potential) parent issue of padrino starting two transactions in certain scenarios, still debugging that.

## Notes

- Separated from PR https://github.com/appsignal/appsignal-ruby/pull/288 which highlights a too tightly coupled spec with mocks in the Padrino specs.
- Aimed at a 2.2.1 release on the master branch