### PR TITLE
Remove thread_safe dependency

### DIFF
--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |gem|
   gem.extensions = %w(ext/extconf.rb)
 
   gem.add_dependency "rack"
-  gem.add_dependency "thread_safe"
 
   gem.add_development_dependency "rake", "~> 11"
   gem.add_development_dependency "rspec", "~> 3.6"


### PR DESCRIPTION
The code that was using it was replaced with the Rust agent. Since it's
no longer used, remove it as dependency.