### PR TITLE
Fix raise and throw in ActiveSupport Notifications

### DIFF
--- a/lib/appsignal/hooks/active_support_notifications.rb
+++ b/lib/appsignal/hooks/active_support_notifications.rb
@@ -33,8 +33,8 @@ module Appsignal
               transaction.start_event
             end
 
-            return_value = instrument_without_appsignal(name, payload, &block)
-
+            instrument_without_appsignal(name, payload, &block)
+          ensure
             if instrument_this
               title, body, body_format = Appsignal::EventFormatter.format(name, payload)
               transaction.finish_event(
@@ -44,8 +44,6 @@ module Appsignal
                 body_format
               )
             end
-
-            return_value
           end
         end
       end

--- a/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
@@ -16,7 +16,7 @@ describe Appsignal::Hooks::ActiveSupportNotificationsHook do
       it { is_expected.to be_truthy }
     end
 
-    it "instruments an ActiveSupport::Notifications.instrument call with a block" do
+    it "instruments an ActiveSupport::Notifications.instrument event" do
       expect(Appsignal::Transaction.current).to receive(:start_event)
         .at_least(:once)
       expect(Appsignal::Transaction.current).to receive(:finish_event)
@@ -39,6 +39,38 @@ describe Appsignal::Hooks::ActiveSupportNotificationsHook do
       end
 
       expect(return_value).to eq "value"
+    end
+
+    context "when an error is raised in an instrumented block" do
+      it "instruments an ActiveSupport::Notifications.instrument event" do
+        expect(Appsignal::Transaction.current).to receive(:start_event)
+          .at_least(:once)
+        expect(Appsignal::Transaction.current).to receive(:finish_event)
+          .at_least(:once)
+          .with("sql.active_record", nil, "SQL", 1)
+
+        expect do
+          as.instrument("sql.active_record", :sql => "SQL") do
+            raise VerySpecificError, "foo"
+          end
+        end.to raise_error(VerySpecificError, "foo")
+      end
+    end
+
+    context "when a message is thrown in an instrumented block" do
+      it "instruments an ActiveSupport::Notifications.instrument event" do
+        expect(Appsignal::Transaction.current).to receive(:start_event)
+          .at_least(:once)
+        expect(Appsignal::Transaction.current).to receive(:finish_event)
+          .at_least(:once)
+          .with("sql.active_record", nil, "SQL", 1)
+
+        expect do
+          as.instrument("sql.active_record", :sql => "SQL") do
+            throw :foo
+          end
+        end.to throw_symbol(:foo)
+      end
     end
   else
     describe "#dependencies_present?" do

--- a/spec/support/shared_examples/instrument.rb
+++ b/spec/support/shared_examples/instrument.rb
@@ -24,9 +24,9 @@ RSpec.shared_examples "instrument helper" do
       expect do
         instrumenter.instrument "name", "title", "body" do
           stub.method_call
-          raise "foo"
+          raise VerySpecificError, "foo"
         end
-      end.to raise_error(StandardError, "foo")
+      end.to raise_error(VerySpecificError, "foo")
     end
   end
 


### PR DESCRIPTION
By using a "soft return", by saving the return value in a variable, it
can happen that an event is not finished when the block that's given to
an instrument method raises and error or uses throw to throw a signal.
Using ensure we ensure that the event is finished even when that
happens.

Follow up from #292.