### PR TITLE
Add ignore_namespaces option

### DIFF
--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -9,8 +9,9 @@ module Appsignal
     DEFAULT_CONFIG = {
       :debug                          => false,
       :log                            => "file",
-      :ignore_errors                  => [],
       :ignore_actions                 => [],
+      :ignore_errors                  => [],
+      :ignore_namespaces              => [],
       :filter_parameters              => [],
       :send_params                    => true,
       :endpoint                       => "https://push.appsignal.com",
@@ -43,8 +44,9 @@ module Appsignal
       "APPSIGNAL_INSTRUMENT_SEQUEL"              => :instrument_sequel,
       "APPSIGNAL_SKIP_SESSION_DATA"              => :skip_session_data,
       "APPSIGNAL_ENABLE_FRONTEND_ERROR_CATCHING" => :enable_frontend_error_catching,
-      "APPSIGNAL_IGNORE_ERRORS"                  => :ignore_errors,
       "APPSIGNAL_IGNORE_ACTIONS"                 => :ignore_actions,
+      "APPSIGNAL_IGNORE_ERRORS"                  => :ignore_errors,
+      "APPSIGNAL_IGNORE_NAMESPACES"              => :ignore_namespaces,
       "APPSIGNAL_FILTER_PARAMETERS"              => :filter_parameters,
       "APPSIGNAL_SEND_PARAMS"                    => :send_params,
       "APPSIGNAL_HTTP_PROXY"                     => :http_proxy,
@@ -132,6 +134,7 @@ module Appsignal
       ENV["_APPSIGNAL_HTTP_PROXY"]                   = config_hash[:http_proxy]
       ENV["_APPSIGNAL_IGNORE_ACTIONS"]               = config_hash[:ignore_actions].join(",")
       ENV["_APPSIGNAL_IGNORE_ERRORS"]                = config_hash[:ignore_errors].join(",")
+      ENV["_APPSIGNAL_IGNORE_NAMESPACES"]            = config_hash[:ignore_namespaces].join(",")
       ENV["_APPSIGNAL_FILTER_PARAMETERS"]            = config_hash[:filter_parameters].join(",")
       ENV["_APPSIGNAL_SEND_PARAMS"]                  = config_hash[:send_params].to_s
       ENV["_APPSIGNAL_RUNNING_IN_CONTAINER"]         = config_hash[:running_in_container].to_s
@@ -209,8 +212,8 @@ module Appsignal
       end
 
       # Configuration with array of strings type
-      %w(APPSIGNAL_IGNORE_ERRORS APPSIGNAL_IGNORE_ACTIONS
-         APPSIGNAL_FILTER_PARAMETERS).each do |var|
+      %w(APPSIGNAL_IGNORE_ACTIONS APPSIGNAL_IGNORE_ERRORS
+         APPSIGNAL_IGNORE_NAMESPACES APPSIGNAL_FILTER_PARAMETERS).each do |var|
         env_var = ENV[var]
         next unless env_var
         config[ENV_TO_KEY_MAPPING[var]] = env_var.split(",")

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -84,8 +84,9 @@ describe Appsignal::Config do
       expect(config.config_hash).to eq(
         :debug                          => false,
         :log                            => "file",
-        :ignore_errors                  => [],
         :ignore_actions                 => [],
+        :ignore_errors                  => [],
+        :ignore_namespaces              => [],
         :filter_parameters              => [],
         :instrument_net_http            => true,
         :instrument_redis               => true,
@@ -279,6 +280,8 @@ describe Appsignal::Config do
       ENV["APPSIGNAL_APP_NAME"]             = "App name"
       ENV["APPSIGNAL_DEBUG"]                = "true"
       ENV["APPSIGNAL_IGNORE_ACTIONS"]       = "action1,action2"
+      ENV["APPSIGNAL_IGNORE_ERRORS"]        = "VerySpecificError,AnotherError"
+      ENV["APPSIGNAL_IGNORE_NAMESPACES"]    = "admin,private_namespace"
       ENV["APPSIGNAL_INSTRUMENT_NET_HTTP"]  = "false"
       ENV["APPSIGNAL_INSTRUMENT_REDIS"]     = "false"
       ENV["APPSIGNAL_INSTRUMENT_SEQUEL"]    = "false"
@@ -294,6 +297,8 @@ describe Appsignal::Config do
       expect(config[:name]).to eq "App name"
       expect(config[:debug]).to be_truthy
       expect(config[:ignore_actions]).to eq %w(action1 action2)
+      expect(config[:ignore_errors]).to eq %w(VerySpecificError AnotherError)
+      expect(config[:ignore_namespaces]).to eq %w(admin private_namespace)
       expect(config[:instrument_net_http]).to be_falsey
       expect(config[:instrument_redis]).to be_falsey
       expect(config[:instrument_sequel]).to be_falsey
@@ -366,6 +371,7 @@ describe Appsignal::Config do
       config[:http_proxy] = "http://localhost"
       config[:ignore_actions] = %w(action1 action2)
       config[:ignore_errors] = %w(VerySpecificError AnotherError)
+      config[:ignore_namespaces] = %w(admin private_namespace)
       config[:log] = "stdout"
       config[:log_path] = "/tmp"
       config[:hostname] = "app1.local"
@@ -391,6 +397,7 @@ describe Appsignal::Config do
       expect(ENV["_APPSIGNAL_HTTP_PROXY"]).to                   eq "http://localhost"
       expect(ENV["_APPSIGNAL_IGNORE_ACTIONS"]).to               eq "action1,action2"
       expect(ENV["_APPSIGNAL_IGNORE_ERRORS"]).to                eq "VerySpecificError,AnotherError"
+      expect(ENV["_APPSIGNAL_IGNORE_NAMESPACES"]).to            eq "admin,private_namespace"
       expect(ENV["_APPSIGNAL_FILTER_PARAMETERS"]).to            eq "password,confirm_password"
       expect(ENV["_APPSIGNAL_SEND_PARAMS"]).to                  eq "true"
       expect(ENV["_APPSIGNAL_RUNNING_IN_CONTAINER"]).to         eq "false"


### PR DESCRIPTION
Closes #272.

This feature was added to the AppSignal extension in PR
https://github.com/appsignal/appsignal-agent/pull/255, this PR adds the
config option to the Ruby gem.

Configure `ignore_namespaces` to ignore transactions (requests and jobs)
from certain namespaces configured as described in our docs:
http://docs.appsignal.com/application/namespaces.html

This allows users to ignore entire namespaces, such as administration
panels, without having to ignore all the controllers in that namespace
with `ignore_actions`.