### PR TITLE
Fix Microsoft Windows crashes

### DIFF
--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -69,6 +69,7 @@ module Appsignal
         # @return [void]
         # @api private
         def run(options = {})
+          $stdout.sync = true
           header
           empty_line
 

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -171,6 +171,11 @@ module Appsignal
 
         def run_agent_diagnose_mode
           puts "Agent diagnostics"
+          unless Appsignal.extension_loaded?
+            puts "  Extension is not loaded. No agent report created."
+            return
+          end
+
           ENV["_APPSIGNAL_DIAGNOSE"] = "true"
           diagnostics_report_string = Appsignal::Extension.diagnose
           ENV.delete("_APPSIGNAL_DIAGNOSE")

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -293,7 +293,12 @@ module Appsignal
           puts "Host information"
           data_section :host do
             puts_and_save :architecture, "Architecture", rbconfig["host_cpu"]
-            puts_and_save :os, "Operating System", rbconfig["host_os"]
+
+            os_label = os = rbconfig["host_os"]
+            os_label = "#{os_label} (Microsoft Windows is not supported.)" if Gem.win_platform?
+            save :os, os
+            puts_value "Operating System", os_label
+
             puts_and_save :language_version, "Ruby version",
               "#{rbconfig["ruby_version"]}-p#{rbconfig["PATCHLEVEL"]}"
 

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -380,7 +380,7 @@ module Appsignal
           file_uid = File.stat(path).uid
           {
             :uid => file_uid,
-            :user => Etc.getpwuid(file_uid).name
+            :user => username_for_uid(file_uid)
           }
         end
 
@@ -390,7 +390,7 @@ module Appsignal
           process_uid = Process.uid
           @process_user = {
             :uid => process_uid,
-            :user => Etc.getpwuid(process_uid).name
+            :user => username_for_uid(process_uid)
           }
         end
 
@@ -466,6 +466,12 @@ module Appsignal
           else
             puts "    File not found."
           end
+        end
+
+        def username_for_uid(uid)
+          passwd_struct = Etc.getpwuid(uid)
+          return unless passwd_struct
+          passwd_struct.name
         end
 
         def empty_line

--- a/lib/appsignal/cli/helpers.rb
+++ b/lib/appsignal/cli/helpers.rb
@@ -29,7 +29,7 @@ module Appsignal
       def press_any_key
         puts
         print "  Ready? Press any key:"
-        stdin.getch
+        stdin.getc
         puts
         puts
       end

--- a/lib/appsignal/cli/install.rb
+++ b/lib/appsignal/cli/install.rb
@@ -59,7 +59,12 @@ module Appsignal
           elsif installed_frameworks.include?(:sinatra)
             install_for_sinatra(config)
           else
-            puts "We could not detect which framework you are using. We'd be very grateful if you email us on support@appsignal.com with information about your setup."
+            print colorize "Warning:", :red
+            puts " We could not detect which framework you are using. "\
+              "We'd be very grateful if you email us on support@appsignal.com "\
+              "with information about your setup."
+            puts
+            done_notice
           end
         end
 
@@ -199,7 +204,10 @@ module Appsignal
           sleep 0.3
           puts
           if Gem.win_platform?
-            puts "The AppSignal agent currently does not work on Windows, please push these changes to your test/staging/production environment"
+            puts "The AppSignal agent currently does not work on Microsoft " \
+              "Windows. Please push these changes to your staging/production " \
+              "environment and make sure some actions are performed. " \
+              "AppSignal should pick up your app after a few minutes."
           else
             puts "  Sending example data to AppSignal..."
             if Appsignal::Demo.transmit

--- a/lib/appsignal/cli/install.rb
+++ b/lib/appsignal/cli/install.rb
@@ -12,6 +12,8 @@ module Appsignal
 
       class << self
         def run(push_api_key)
+          $stdout.sync = true
+
           puts
           puts colorize "#######################################", :green
           puts colorize "## Starting AppSignal Installer      ##", :green

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -2,10 +2,10 @@ require "erb"
 require "yaml"
 require "uri"
 require "socket"
+require "tmpdir"
 
 module Appsignal
   class Config
-    SYSTEM_TMP_DIR = File.realpath("/tmp")
     DEFAULT_CONFIG = {
       :debug                          => false,
       :log                            => "file",
@@ -82,6 +82,16 @@ module Appsignal
       validate
     end
 
+    # @api private
+    # @return [String] System's tmp directory.
+    def self.system_tmp_dir
+      if Gem.win_platform?
+        Dir.tmpdir
+      else
+        File.realpath("/tmp")
+      end
+    end
+
     def [](key)
       config_hash[key]
     end
@@ -96,14 +106,15 @@ module Appsignal
         return File.join(File.realpath(path), "appsignal.log")
       end
 
-      if File.writable? SYSTEM_TMP_DIR
+      system_tmp_dir = self.class.system_tmp_dir
+      if File.writable? system_tmp_dir
         $stdout.puts "appsignal: Unable to log to '#{path}'. Logging to "\
-          "'#{SYSTEM_TMP_DIR}' instead. Please check the "\
+          "'#{system_tmp_dir}' instead. Please check the "\
           "permissions for the application's (log) directory."
-        File.join(SYSTEM_TMP_DIR, "appsignal.log")
+        File.join(system_tmp_dir, "appsignal.log")
       else
         $stdout.puts "appsignal: Unable to log to '#{path}' or the "\
-          "'#{SYSTEM_TMP_DIR}' fallback. Please check the permissions "\
+          "'#{system_tmp_dir}' fallback. Please check the permissions "\
           "for the application's (log) directory."
       end
     end

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -594,7 +594,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :report => true do
     end
 
     describe "paths" do
-      let(:system_tmp_dir) { Appsignal::Config::SYSTEM_TMP_DIR }
+      let(:system_tmp_dir) { Appsignal::Config.system_tmp_dir }
       before do
         FileUtils.mkdir_p(root_path)
         FileUtils.mkdir_p(system_tmp_dir)

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -399,6 +399,23 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :report => true do
           "Ruby version: #{language_version}"
       end
 
+      context "when on Microsoft Windows" do
+        before do
+          expect(RbConfig::CONFIG).to receive(:[]).with("host_os").and_return("mingw32")
+          expect(RbConfig::CONFIG).to receive(:[]).at_least(:once).and_call_original
+          expect(Gem).to receive(:win_platform?).and_return(true)
+          run
+        end
+
+        it "adds the arch to the report" do
+          expect(received_report["host"]["os"]).to eq("mingw32")
+        end
+
+        it "prints warning that Microsoft Windows is not supported" do
+          expect(output).to match(/Operating System: .+ \(Microsoft Windows is not supported\.\)/)
+        end
+      end
+
       it "transmits host information in report" do
         run
         host_report = received_report["host"]

--- a/spec/lib/appsignal/cli/install_spec.rb
+++ b/spec/lib/appsignal/cli/install_spec.rb
@@ -210,8 +210,8 @@ describe Appsignal::CLI::Install do
     end
 
     it "prints a warning for windows" do
-      expect(output).to include("The AppSignal agent currently does not work on Windows")
-      expect(output).to include("test/staging/production environment")
+      expect(output).to include("The AppSignal agent currently does not work on Microsoft Windows")
+      expect(output).to include("staging/production environment")
     end
   end
 
@@ -614,12 +614,15 @@ describe Appsignal::CLI::Install do
     context "with unknown framework" do
       let(:push_api_key) { "my_key" }
 
+      it_behaves_like "windows installation"
       it_behaves_like "push_api_key validation"
+      it_behaves_like "demo data"
 
       it "prints a message about unknown framework" do
         run
 
-        expect(output).to include "We could not detect which framework you are using."
+        expect(output).to include \
+          "\e[31mWarning:\e[0m We could not detect which framework you are using."
         expect(output).to_not include_env_push_api_key
         expect(output).to_not include_env_app_name
         expect(File.exist?(config_file_path)).to be_falsy

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -437,7 +437,7 @@ describe Appsignal::Config do
     end
 
     shared_examples "#log_file_path: tmp path" do
-      let(:system_tmp_dir) { described_class::SYSTEM_TMP_DIR }
+      let(:system_tmp_dir) { described_class.system_tmp_dir }
       before { FileUtils.mkdir_p(system_tmp_dir) }
       after { FileUtils.rm_rf(system_tmp_dir) }
 
@@ -548,6 +548,33 @@ describe Appsignal::Config do
             expect(subject).to eq(File.join(real_path, "appsignal.log"))
           end
         end
+      end
+    end
+  end
+
+  describe ".system_tmp_dir" do
+    before do
+      # To counteract the stub in spec_helper
+      expect(Appsignal::Config).to receive(:system_tmp_dir).and_call_original
+    end
+
+    context "when on a *NIX OS" do
+      before do
+        expect(Gem).to receive(:win_platform?).and_return(false)
+      end
+
+      it "returns the system's tmp dir" do
+        expect(described_class.system_tmp_dir).to eq(File.realpath("/tmp"))
+      end
+    end
+
+    context "when on Microsoft Windows" do
+      before do
+        expect(Gem).to receive(:win_platform?).and_return(true)
+      end
+
+      it "returns the system's tmp dir" do
+        expect(described_class.system_tmp_dir).to eq(Dir.tmpdir)
       end
     end
   end

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -605,7 +605,7 @@ describe Appsignal do
       context "when the log path and fallback path are not writable" do
         before do
           FileUtils.chmod 0o444, log_path
-          FileUtils.chmod 0o444, Appsignal::Config::SYSTEM_TMP_DIR
+          FileUtils.chmod 0o444, Appsignal::Config.system_tmp_dir
 
           capture_stdout(out_stream) do
             Appsignal.start_logger
@@ -613,7 +613,7 @@ describe Appsignal do
           end
         end
         after do
-          FileUtils.chmod 0o755, Appsignal::Config::SYSTEM_TMP_DIR
+          FileUtils.chmod 0o755, Appsignal::Config.system_tmp_dir
         end
 
         it "logs to stdout" do
@@ -628,7 +628,7 @@ describe Appsignal do
         it "outputs a warning" do
           expect(output).to include \
             "appsignal: Unable to log to '#{log_path}' "\
-            "or the '#{Appsignal::Config::SYSTEM_TMP_DIR}' fallback."
+            "or the '#{Appsignal::Config.system_tmp_dir}' fallback."
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,14 +54,13 @@ RSpec.configure do |config|
   config.include SystemHelpers
   config.extend DependencyHelper
 
-  config.before :context do
-    # Use modified SYSTEM_TMP_DIR
-    Appsignal::Config.send :remove_const, :SYSTEM_TMP_DIR
-    Appsignal::Config.send :const_set, :SYSTEM_TMP_DIR,
-      File.join(tmp_dir, "system-tmp")
+  def spec_system_tmp_dir
+    File.join(tmp_dir, "system-tmp")
+  end
 
+  config.before :context do
     FileUtils.rm_rf(tmp_dir)
-    FileUtils.mkdir_p(Appsignal::Config::SYSTEM_TMP_DIR)
+    FileUtils.mkdir_p(spec_system_tmp_dir)
   end
 
   config.before do
@@ -73,6 +72,9 @@ RSpec.configure do |config|
     appsignal_key_prefixes = %w(APPSIGNAL_ _APPSIGNAL_)
     env_keys = ENV.keys.select { |key| key.start_with?(*appsignal_key_prefixes) }
     env_keys.each { |key| ENV.delete(key) }
+
+    # Stub system_tmp_dir to something in the project dir for specs
+    allow(Appsignal::Config).to receive(:system_tmp_dir).and_return(spec_system_tmp_dir)
   end
 
   config.after do


### PR DESCRIPTION
Fixes #311 

## Steps to test

- Download a virtualbox image for Windows: https://developer.microsoft.com/en-us/windows/downloads/virtual-machines
- Use https://rubyinstaller.org/ to install Ruby on that machine
- Install the RubyInstaller DevKit https://rubyinstaller.org/downloads/ (see DevKit download)
- Download/clone this repo and this branch
  - When cloning: Install git on windows https://git-scm.com/download/win
- Set up an app and add AppSignal as a dependency
- Run `appsignal install PUSH_API_KEY` (with an without a supported framework as a dependency to the app)
- Run `appsignal diagnose`

## ~~TODO~~

- [x] Print message about windows support in installer when on windows
- [x] Mention windows support in diagnose output?
- [x] Installer (prompt to customize app name) and Diagnose (prompt to send report to AppSignal) "hang" the CLI. No content has been flushed to STDOUT on Windows (need to do that manually) so it appears to hang when we ask for user input on Windows.