### PR TITLE
Hanami support

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ including but not limited to:
 - Delayed Job
 - Resque
 - Rake
+- Hanami
 
 AppSignal instrumentation doesn't depend on automatic integrations. It's easy
 to set up [custom instrumentation][custom-instrumentation] to add keep track of

--- a/lib/appsignal/rack/hanami_instrumentation.rb
+++ b/lib/appsignal/rack/hanami_instrumentation.rb
@@ -1,0 +1,50 @@
+require "rack"
+
+module Appsignal
+  module Rack
+    # Add this middleware to your app
+    class HanamiInstrumentation
+      def initialize(app, options = {})
+        Appsignal.logger.debug "Initializing Appsignal::Rack::HanamiInstrumentation"
+        @app = app
+        @options = options
+      end
+
+      def call(env)
+        if Appsignal.active?
+          call_with_appsignal_monitoring(env)
+        else
+          @app.call(env)
+        end
+      end
+
+      def call_with_appsignal_monitoring(env)
+        controller = hanami_action(env)
+        request = ::Rack::Request.new(env)
+        transaction = Appsignal::Transaction.create(
+          SecureRandom.uuid,
+          Appsignal::Transaction::HTTP_REQUEST,
+          request
+        )
+        begin
+          Appsignal.instrument("process_action.generic") do
+            @app.call(env)
+          end
+        rescue => error
+          transaction.set_error(error)
+          raise error
+        ensure
+          transaction.set_action_if_nil(controller) if controller
+          transaction.set_metadata("path", request.path)
+          transaction.set_metadata("method", request.request_method)
+          transaction.set_http_or_background_queue_start
+          Appsignal::Transaction.complete_current!
+        end
+      end
+
+      def hanami_action(env)
+        Web.routes.recognize(env).action.to_s
+      end
+    end
+  end
+end

--- a/spec/lib/appsignal/rack/hanami_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/hanami_instrumentation_spec.rb
@@ -1,0 +1,106 @@
+require "appsignal/rack/hanami_instrumentation"
+
+describe Appsignal::Rack::HanamiInstrumentation do
+  class RecognizedRoute
+    def self.action
+      "mockcontroller#show"
+    end
+  end
+
+  class Routes
+    def self.recognize(_path)
+      RecognizedRoute
+    end
+  end
+
+  class Web
+    def self.routes
+      Routes
+    end
+  end
+
+  before :context do
+    start_agent
+  end
+
+  let(:app) { double(:call => true) }
+  let(:env) { { :path => "/", :method => "GET" } }
+  let(:options) { {} }
+  let(:middleware) { Appsignal::Rack::HanamiInstrumentation.new(app, options) }
+
+  describe "#call" do
+    before do
+      allow(middleware).to receive(:raw_payload).and_return({})
+    end
+
+    context "when appsignal is active" do
+      before { allow(Appsignal).to receive(:active?).and_return(true) }
+
+      it "should call with monitoring" do
+        expect(middleware).to receive(:call_with_appsignal_monitoring).with(env)
+      end
+    end
+
+    context "when appsignal is not active" do
+      before { allow(Appsignal).to receive(:active?).and_return(false) }
+
+      it "should not call with monitoring" do
+        expect(middleware).to_not receive(:call_with_appsignal_monitoring)
+      end
+
+      it "should call the stack" do
+        expect(app).to receive(:call).with(env)
+      end
+    end
+
+    after { middleware.call(env) }
+  end
+
+  describe "#call_with_appsignal_monitoring", :error => false do
+    it "should create a transaction" do
+      expect(Appsignal::Transaction).to receive(:create).with(
+        kind_of(String),
+        Appsignal::Transaction::HTTP_REQUEST,
+        kind_of(Rack::Request)
+      ).and_return(double(:set_action_if_nil => nil, :set_http_or_background_queue_start => nil, :set_metadata => nil))
+    end
+
+    it "should call the app" do
+      expect(app).to receive(:call).with(env)
+    end
+
+    context "with an error", :error => true do
+      let(:error) { VerySpecificError.new }
+      let(:app) do
+        double.tap do |d|
+          allow(d).to receive(:call).and_raise(error)
+        end
+      end
+
+      it "should set the error" do
+        expect_any_instance_of(Appsignal::Transaction).to receive(:set_error).with(error)
+      end
+    end
+
+    context "with a route specified in the env" do
+      before do
+        env["appsignal.route"] = "GET /"
+      end
+
+      it "should set the action" do
+        expect_any_instance_of(Appsignal::Transaction).to receive(:set_action_if_nil).with("mockcontroller#show")
+      end
+    end
+
+    it "should set metadata" do
+      expect_any_instance_of(Appsignal::Transaction).to receive(:set_metadata).twice
+    end
+
+    it "should set the queue start" do
+      expect_any_instance_of(Appsignal::Transaction).to receive(:set_http_or_background_queue_start)
+    end
+
+    after(:error => false) { middleware.call(env) }
+    after(:error => true) { expect { middleware.call(env) }.to raise_error(VerySpecificError) }
+  end
+end


### PR DESCRIPTION
* mostly the same as the rack implementation, in the middleware
stack Hanami apps can now
`use Appsignal::Rack::HanamiInstrumentation`

* Hanami router matches a path to a controller action, we
set that as the controller. Similar to the rails instrument