### PR TITLE
ActiveSupportNotificationsHook handles non-string names

### DIFF
--- a/lib/appsignal/hooks/active_support_notifications.rb
+++ b/lib/appsignal/hooks/active_support_notifications.rb
@@ -38,7 +38,7 @@ module Appsignal
             if instrument_this
               title, body, body_format = Appsignal::EventFormatter.format(name, payload)
               transaction.finish_event(
-                name,
+                name.to_s,
                 title,
                 body,
                 body_format

--- a/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
@@ -30,6 +30,16 @@ describe Appsignal::Hooks::ActiveSupportNotificationsHook do
       expect(return_value).to eq "value"
     end
 
+    it "should convert non-string names to strings" do
+      expect(Appsignal::Transaction.current).to receive(:start_event)
+        .at_least(:once)
+      expect(Appsignal::Transaction.current).to receive(:finish_event)
+        .at_least(:once)
+        .with("not_a_string", nil, nil, nil)
+
+      as.instrument(:not_a_string) { }
+    end
+
     it "does not instrument events whose name starts with a bang" do
       expect(Appsignal::Transaction.current).not_to receive(:start_event)
       expect(Appsignal::Transaction.current).not_to receive(:finish_event)

--- a/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
@@ -37,7 +37,7 @@ describe Appsignal::Hooks::ActiveSupportNotificationsHook do
         .at_least(:once)
         .with("not_a_string", nil, nil, nil)
 
-      as.instrument(:not_a_string) { }
+      as.instrument(:not_a_string) {}
     end
 
     it "does not instrument events whose name starts with a bang" do


### PR DESCRIPTION
Via [support (private Intercom link)](https://app.intercom.io/a/apps/yzor8gyw/inbox/all/conversations/10826032978?nsrc=slack). Daniel tested this change [in the "daniel" branch](https://github.com/appsignal/appsignal-ruby/commit/5e2c3a48b598c3d2bb528badce4fedf46473c7da), and it solved his issue.