### PR TITLE
Improve Rake integration argument handling

### DIFF
--- a/lib/appsignal/hooks/rake.rb
+++ b/lib/appsignal/hooks/rake.rb
@@ -15,11 +15,15 @@ module Appsignal
           def execute(*args)
             execute_without_appsignal(*args)
           rescue => error
+            # Format given arguments and cast to hash if possible
+            params, _ = args
+            params = params.to_hash if params.respond_to?(:to_hash)
+
             transaction = Appsignal::Transaction.create(
               SecureRandom.uuid,
               Appsignal::Transaction::BACKGROUND_JOB,
               Appsignal::Transaction::GenericRequest.new(
-                :params => args
+                :params => params
               )
             )
             transaction.set_action(name)

--- a/spec/lib/appsignal/hooks/rake_spec.rb
+++ b/spec/lib/appsignal/hooks/rake_spec.rb
@@ -51,7 +51,7 @@ describe Appsignal::Hooks::RakeHook do
 
       it "adds the task arguments to the request" do
         expect(Appsignal::Transaction::GenericRequest).to receive(:new)
-          .with(:params => {:foo => "bar"})
+          .with(:params => { :foo => "bar" })
           .and_return(genric_request)
       end
 

--- a/spec/lib/appsignal/hooks/rake_spec.rb
+++ b/spec/lib/appsignal/hooks/rake_spec.rb
@@ -3,7 +3,7 @@ require "rake"
 describe Appsignal::Hooks::RakeHook do
   let(:task) { Rake::Task.new("task:name", Rake::Application.new) }
   let(:arguments) { Rake::TaskArguments.new(["foo"], ["bar"]) }
-  let(:genric_request) { Appsignal::Transaction::GenericRequest.new({}) }
+  let(:generic_request) { Appsignal::Transaction::GenericRequest.new({}) }
   before(:context) do
     Appsignal.config = project_fixture_config
     expect(Appsignal.active?).to be_truthy
@@ -52,7 +52,7 @@ describe Appsignal::Hooks::RakeHook do
       it "adds the task arguments to the request" do
         expect(Appsignal::Transaction::GenericRequest).to receive(:new)
           .with(:params => { :foo => "bar" })
-          .and_return(genric_request)
+          .and_return(generic_request)
       end
 
       context "when first argument is not a `Rake::TaskArguments`" do
@@ -61,7 +61,7 @@ describe Appsignal::Hooks::RakeHook do
         it "adds the first argument regardless" do
           expect(Appsignal::Transaction::GenericRequest).to receive(:new)
             .with(:params => nil)
-            .and_return(genric_request)
+            .and_return(generic_request)
         end
       end
 


### PR DESCRIPTION
If a user has the following Rake task:

```ruby
task :work, [:foo, :bar] => [:environment] do |t, args|
  raise 'the roof'
end
```
That is called `bundle exec rake work[1,2]`

We show the following array as our given arguments in the AppSignal interface

```ruby
[
  "#<Rake::TaskArguments>"
]
```

This pullreq adds code that tries to cast these `TaskArguments` to a hash, resulting in the following params in the Interface

```ruby
{
  "foo": "2",
  "option": "1"
}
```
