### PR TITLE
Deprecate Transaction#store

### DIFF
--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -2,6 +2,8 @@ require "json"
 
 module Appsignal
   class Transaction
+    extend Gem::Deprecate
+
     HTTP_REQUEST   = "http_request".freeze
     BACKGROUND_JOB = "background_job".freeze
     ACTION_CABLE   = "action_cable".freeze
@@ -135,9 +137,11 @@ module Appsignal
       @discarded == true
     end
 
+    # @deprecated No replacement
     def store(key)
       @store[key]
     end
+    deprecate :store, :none, 2017, 9
 
     def params
       return @params if defined?(@params)

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -290,15 +290,28 @@ describe Appsignal::Transaction do
     end
 
     describe "#store" do
+      let(:err_stream) { std_stream }
+      let(:stderr) { err_stream.read }
+
+      def store_call(*args)
+        capture_std_streams(std_stream, err_stream) do
+          transaction.store(*args)
+        end
+      end
+
       it "should return an empty store when it's not already present" do
-        expect(transaction.store("test")).to eql({})
+        expect(store_call("test")).to eql({})
       end
 
       it "should store changes to the store" do
-        transaction_store = transaction.store("test")
+        transaction_store = store_call("test")
         transaction_store["transaction"] = "value"
 
-        expect(transaction.store("test")).to eql("transaction" => "value")
+        expect(store_call("test")).to eql("transaction" => "value")
+      end
+
+      after do
+        expect(stderr).to include("Appsignal::Transaction#store is deprecated with no replacement.")
       end
     end
 


### PR DESCRIPTION
Unused code, but probably used in an earlier version. Deprecated in case
someone or some gem is still using it.

Closes #319 
Added to #202 