### PR TITLE
Don't rescue Exception in minutely probes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,10 +11,9 @@ Lint/HandleExceptions:
   Exclude:
     - 'lib/appsignal/cli/install.rb'
 
-# Offense count: 4
+# Offense count: 3
 Lint/RescueException:
   Exclude:
-    - 'lib/appsignal/minutely.rb'
     - 'lib/appsignal/rack/streaming_listener.rb'
 
 # Offense count: 41

--- a/lib/appsignal/minutely.rb
+++ b/lib/appsignal/minutely.rb
@@ -16,7 +16,7 @@ module Appsignal
               probes.each(&:call)
               sleep(wait_time)
             end
-          rescue Exception => ex
+          rescue => ex
             Appsignal.logger.error("Error in minutely thread: #{ex}")
           end
         end


### PR DESCRIPTION
Rescuing Exception, without raising the error again, could potentially
hang the process. Instead, don't rescue Exception and fatal errors, but
only StandardErrors and subclassed errors.

Closes #168 