### PR TITLE
Support dry run for Capistrano 3

### DIFF
--- a/gemfiles/capistrano3.gemfile
+++ b/gemfiles/capistrano3.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'capistrano', '3.4.0'
+gem 'capistrano', '~> 3.0'
 gem 'net-ssh', '2.9.2'
 gem 'rack', '~> 1.6'
 

--- a/lib/appsignal/integrations/capistrano/appsignal.cap
+++ b/lib/appsignal/integrations/capistrano/appsignal.cap
@@ -1,12 +1,12 @@
 namespace :appsignal do
   task :deploy do
-    env = fetch(:appsignal_env, fetch(:stage, fetch(:rails_env, fetch(:rack_env, "production"))))
+    appsignal_env = fetch(:appsignal_env, fetch(:stage, fetch(:rails_env, fetch(:rack_env, "production"))))
     user = ENV["USER"] || ENV["USERNAME"]
     revision = fetch(:appsignal_revision, fetch(:current_revision))
 
     appsignal_config = Appsignal::Config.new(
       ENV["PWD"],
-      env,
+      appsignal_env,
       fetch(:appsignal_config, {}),
       Logger.new(StringIO.new)
     )
@@ -20,7 +20,7 @@ namespace :appsignal do
       marker = Appsignal::Marker.new(marker_data, appsignal_config)
       marker.transmit
     else
-      puts "Not notifying of deploy, config is not active for environment: #{env}"
+      puts "Not notifying of deploy, config is not active for environment: #{appsignal_env}"
     end
   end
 end

--- a/lib/appsignal/integrations/capistrano/appsignal.cap
+++ b/lib/appsignal/integrations/capistrano/appsignal.cap
@@ -18,7 +18,13 @@ namespace :appsignal do
       }
 
       marker = Appsignal::Marker.new(marker_data, appsignal_config)
-      marker.transmit
+      # {#dry_run?} helper was added in Capistrano 3.5.0
+      # https://github.com/capistrano/capistrano/commit/38d8d6d2c8485f1b5643857465b16ff01da57aff
+      if respond_to?(:dry_run?) && dry_run?
+        puts "Dry run: AppSignal deploy marker not actually sent."
+      else
+        marker.transmit
+      end
     else
       puts "Not notifying of deploy, config is not active for environment: #{appsignal_env}"
     end

--- a/spec/lib/appsignal/capistrano3_spec.rb
+++ b/spec/lib/appsignal/capistrano3_spec.rb
@@ -152,6 +152,19 @@ if DependencyHelper.capistrano3_present?
             end
           end
 
+          if Gem::Version.new(Capistrano::VERSION) >= Gem::Version.new("3.5.0")
+            context "when dry run" do
+              before do
+                expect(capistrano_config).to receive(:dry_run?).and_return(true)
+                run
+              end
+
+              it "does not transmit the marker" do
+                expect(output).to include "Dry run: AppSignal deploy marker not actually sent."
+              end
+            end
+          end
+
           context "with failed request" do
             before do
               stub_marker_request.to_return(:status => 500)


### PR DESCRIPTION
This supports Capistrano 3.5.0 and higher. Before that the helper method
was not exposed. On older versions it will ignore/be unaware of the dry
run option.

Fixes #338 