### PR TITLE
Fix DelayedJob ActiveJob integration

### DIFF
--- a/spec/lib/appsignal/hooks/delayed_job_spec.rb
+++ b/spec/lib/appsignal/hooks/delayed_job_spec.rb
@@ -215,7 +215,27 @@ describe Appsignal::Hooks::DelayedJobHook do
           require "active_job"
 
           context "when wrapped by ActiveJob" do
-            let(:job) { ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper.new(job_data) }
+            let(:wrapped_job) do
+              ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper.new(
+                "arguments"  => args,
+                "job_class"  => "TestClass",
+                "job_id"     => 123,
+                "locale"     => :en,
+                "queue_name" => "default"
+              )
+            end
+            let(:job) do
+              double(
+                :id             => 123,
+                :name           => "ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper",
+                :priority       => 1,
+                :attempts       => 1,
+                :queue          => "default",
+                :created_at     => created_at,
+                :run_at         => run_at,
+                :payload_object => wrapped_job
+              )
+            end
             let(:default_params) do
               {
                 :class    => "TestClass",
@@ -231,7 +251,6 @@ describe Appsignal::Hooks::DelayedJobHook do
               }
             end
             let(:args) { ["activejob_argument"] }
-            before { job_data[:args] = args }
 
             context "with simple params" do
               it "wraps it in a transaction with the correct params" do


### PR DESCRIPTION
I think there was a wrong assumption about how ActiveJob jobs are
wrapped in ActiveJob. The object being passed to
`DelayedJobPlugin.invoke` is not the
`ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper`, instead the
payload object is wrapped in the `JobWrapper`. The DelayedJob "backend"
stays the same and so does the object being passed to
`DelayedJobPlugin.invoke`, just the payload on the job differs.