### PR TITLE
Detect musl on extension install

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -9,7 +9,16 @@ require File.expand_path("../../lib/appsignal/version.rb", __FILE__)
 
 EXT_PATH     = File.expand_path("..", __FILE__).freeze
 AGENT_CONFIG = YAML.load(File.read(File.join(EXT_PATH, "agent.yml"))).freeze
-ARCH         = "#{Gem::Platform.local.cpu}-#{Gem::Platform.local.os}".freeze
+
+local_os = Gem::Platform.local.os
+chosen_os =
+  # Detect musl platforms
+  # Use `export APPSIGNAL_BUILD_FOR_MUSL=1` if the detection doesn't work.
+  if ENV["APPSIGNAL_BUILD_FOR_MUSL"] || (local_os =~ /linux/ && `ldd --version 2>&1` =~ /musl/)
+    "linux-musl"
+  end
+OS           = chosen_os || local_os
+ARCH         = "#{Gem::Platform.local.cpu}-#{OS}".freeze
 CA_CERT_PATH = File.join(EXT_PATH, "../resources/cacert.pem").freeze
 
 def ext_path(path)


### PR DESCRIPTION
Change how we detect musl architectures by asking `ldd` on the host
itself. If the output from `ldd` contains "musl" download a
musl-compatible package, otherwise download the normal GNU-compatible
package.

Part of https://github.com/appsignal/appsignal-agent/pull/286 (private link)

## TODO

- [x] Wait until the new build PR is merged PR https://github.com/appsignal/appsignal-agent/issues/286
- [x] Add an updated `agent.yml` to ~~this PR~~ develop
- [x] Test things
- [x] Get reviews
- [x] Update docs with `APPSIGNAL_BUILD_FOR_MUSL` env var