### PR TITLE
Add `appsignal_user` Capistrano config option

### DIFF
--- a/lib/appsignal/integrations/capistrano/appsignal.cap
+++ b/lib/appsignal/integrations/capistrano/appsignal.cap
@@ -1,7 +1,7 @@
 namespace :appsignal do
   task :deploy do
     appsignal_env = fetch(:appsignal_env, fetch(:stage, fetch(:rails_env, fetch(:rack_env, "production"))))
-    user = ENV["USER"] || ENV["USERNAME"]
+    user = fetch(:appsignal_user, ENV["USER"] || ENV["USERNAME"])
     revision = fetch(:appsignal_revision, fetch(:current_revision))
 
     appsignal_config = Appsignal::Config.new(

--- a/lib/appsignal/integrations/capistrano/capistrano_2_tasks.rb
+++ b/lib/appsignal/integrations/capistrano/capistrano_2_tasks.rb
@@ -10,7 +10,7 @@ module Appsignal
         namespace :appsignal do
           task :deploy do
             env = fetch(:appsignal_env, fetch(:stage, fetch(:rails_env, fetch(:rack_env, "production"))))
-            user = ENV["USER"] || ENV["USERNAME"]
+            user = fetch(:appsignal_user, ENV["USER"] || ENV["USERNAME"])
             revision = fetch(:appsignal_revision, fetch(:current_revision))
 
             appsignal_config = Appsignal::Config.new(

--- a/spec/lib/appsignal/capistrano2_spec.rb
+++ b/spec/lib/appsignal/capistrano2_spec.rb
@@ -152,6 +152,20 @@ if DependencyHelper.capistrano2_present?
             end
           end
 
+          context "with overridden deploy user" do
+            before do
+              capistrano_config.set(:appsignal_user, "robin")
+              stub_marker_request(:user => "robin").to_return(:status => 200)
+              run
+            end
+
+            it "transmits the overriden deploy user" do
+              expect(output).to include \
+                "Notifying AppSignal of deploy with: revision: 503ce0923ed177a3ce000005, user: robin",
+                "AppSignal has been notified of this deploy!"
+            end
+          end
+
           context "with failed request" do
             before do
               stub_marker_request.to_return(:status => 500)

--- a/spec/lib/appsignal/capistrano3_spec.rb
+++ b/spec/lib/appsignal/capistrano3_spec.rb
@@ -152,6 +152,20 @@ if DependencyHelper.capistrano3_present?
             end
           end
 
+          context "with overridden deploy user" do
+            before do
+              capistrano_config.set(:appsignal_user, "robin")
+              stub_marker_request(:user => "robin").to_return(:status => 200)
+              run
+            end
+
+            it "transmits the overriden deploy user" do
+              expect(output).to include \
+                "Notifying AppSignal of deploy with: revision: 503ce0923ed177a3ce000005, user: robin",
+                "AppSignal has been notified of this deploy!"
+            end
+          end
+
           if Gem::Version.new(Capistrano::VERSION) >= Gem::Version.new("3.5.0")
             context "when dry run" do
               before do


### PR DESCRIPTION
This config option allows for configuration of the deploy user for
AppSignal without overriding that of Capistrano. Not always do people
want to use the username of their local machine for this.

```ruby
# Capistrano config file

# Examples of how to set this config option (dynamically)
set :appsignal_user, "tom"
set :appsignal_user, `echo $USER`
set :appsignal_user, ENV["APPSIGNAL_DEPLOY_USER"]
```

Note that this is different than what we discussed in #350. I was looking at the implementation and the reason we're using the `ENV["USER"]` vars is not for customizability, but because that's the easiest way to get the current user. To require users to override this setting with an env var while the rest of the config is done with `set :appsignal_{some_option}` seemed odd. So instead, this uses `set :appsignal_user` to override the default deploy user for AppSignal.

This particular ENV var would only have worked for the Capistrano integration while other configuration using ENV vars usually applies for all AppSignal config. That could confuse people if we add it to our docs page.
Also, `appsignal notify_of_deploy` already works with [a CLI option](https://docs.appsignal.com/ruby/command-line/notify_of_deploy.html) and adding support for the env var didn't seem provide complete coverage either. The `APP_REVISION` env var should probably support `APPSIGNAL_DEPLOY_USER` instead.

Fixes #350 