### PR TITLE
Track Exception-level exceptions in integrations

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,11 +11,6 @@ Lint/HandleExceptions:
   Exclude:
     - 'lib/appsignal/cli/install.rb'
 
-# Offense count: 3
-Lint/RescueException:
-  Exclude:
-    - 'lib/appsignal/rack/streaming_listener.rb'
-
 # Offense count: 41
 Metrics/AbcSize:
   Max: 59

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -196,7 +196,7 @@ module Appsignal
         Appsignal.instrument(name) do
           yield
         end
-      rescue => error
+      rescue Exception => error # rubocop:disable Lint/RescueException
         transaction.set_error(error)
         raise error
       ensure
@@ -219,7 +219,7 @@ module Appsignal
 
     def listen_for_error
       yield
-    rescue => error
+    rescue Exception => error # rubocop:disable Lint/RescueException
       send_error(error)
       raise error
     end

--- a/lib/appsignal/hooks/action_cable.rb
+++ b/lib/appsignal/hooks/action_cable.rb
@@ -37,7 +37,7 @@ module Appsignal
 
             begin
               original_perform_action(*args, &block)
-            rescue => exception
+            rescue Exception => exception # rubocop:disable Lint/RescueException
               transaction.set_error(exception)
               raise exception
             ensure
@@ -69,7 +69,7 @@ module Appsignal
             Appsignal.instrument "subscribed.action_cable" do
               inner.call
             end
-          rescue => exception
+          rescue Exception => exception # rubocop:disable Lint/RescueException
             transaction.set_error(exception)
             raise exception
           ensure
@@ -97,7 +97,7 @@ module Appsignal
             Appsignal.instrument "unsubscribed.action_cable" do
               inner.call
             end
-          rescue => exception
+          rescue Exception => exception # rubocop:disable Lint/RescueException
             transaction.set_error(exception)
             raise exception
           ensure

--- a/lib/appsignal/hooks/rake.rb
+++ b/lib/appsignal/hooks/rake.rb
@@ -14,7 +14,7 @@ module Appsignal
 
           def execute(*args)
             execute_without_appsignal(*args)
-          rescue => error
+          rescue Exception => error # rubocop:disable Lint/RescueException
             # Format given arguments and cast to hash if possible
             params, _ = args
             params = params.to_hash if params.respond_to?(:to_hash)

--- a/lib/appsignal/integrations/grape.rb
+++ b/lib/appsignal/integrations/grape.rb
@@ -20,7 +20,7 @@ module Appsignal
         )
         begin
           app.call(env)
-        rescue => error
+        rescue Exception => error # rubocop:disable Lint/RescueException
           transaction.set_error(error)
           raise error
         ensure

--- a/lib/appsignal/integrations/padrino.rb
+++ b/lib/appsignal/integrations/padrino.rb
@@ -34,7 +34,7 @@ module Padrino::Routing::InstanceMethods
       Appsignal.instrument("process_action.padrino") do
         route_without_appsignal(base, pass_block)
       end
-    rescue => error
+    rescue Exception => error # rubocop:disable Lint/RescueException
       transaction.set_error(error)
       raise error
     ensure

--- a/lib/appsignal/integrations/webmachine.rb
+++ b/lib/appsignal/integrations/webmachine.rb
@@ -26,7 +26,7 @@ module Appsignal
           handle_exceptions_without_appsignal do
             begin
               yield
-            rescue => e
+            rescue Exception => e # rubocop:disable Lint/RescueException
               Appsignal.set_error(e)
               raise e
             end

--- a/lib/appsignal/rack/generic_instrumentation.rb
+++ b/lib/appsignal/rack/generic_instrumentation.rb
@@ -29,7 +29,7 @@ module Appsignal
           Appsignal.instrument("process_action.generic") do
             @app.call(env)
           end
-        rescue => error
+        rescue Exception => error # rubocop:disable Lint/RescueException
           transaction.set_error(error)
           raise error
         ensure

--- a/lib/appsignal/rack/rails_instrumentation.rb
+++ b/lib/appsignal/rack/rails_instrumentation.rb
@@ -28,7 +28,7 @@ module Appsignal
         )
         begin
           @app.call(env)
-        rescue => error
+        rescue Exception => error # rubocop:disable Lint/RescueException
           transaction.set_error(error)
           raise error
         ensure

--- a/lib/appsignal/rack/sinatra_instrumentation.rb
+++ b/lib/appsignal/rack/sinatra_instrumentation.rb
@@ -59,7 +59,7 @@ module Appsignal
           Appsignal.instrument("process_action.sinatra") do
             @app.call(env)
           end
-        rescue => error
+        rescue Exception => error # rubocop:disable Lint/RescueException
           transaction.set_error(error)
           raise error
         ensure

--- a/lib/appsignal/rack/streaming_listener.rb
+++ b/lib/appsignal/rack/streaming_listener.rb
@@ -31,7 +31,7 @@ module Appsignal
           Appsignal.instrument("process_action.rack") do
             begin
               @app.call(env)
-            rescue Exception => e
+            rescue Exception => e # rubocop:disable Lint/RescueException
               transaction.set_error(e)
               raise e
             ensure
@@ -56,14 +56,14 @@ module Appsignal
 
     def each
       @stream.each { |c| yield(c) }
-    rescue Exception => e
+    rescue Exception => e # rubocop:disable Lint/RescueException
       @transaction.set_error(e)
       raise e
     end
 
     def close
       @stream.close if @stream.respond_to?(:close)
-    rescue Exception => e
+    rescue Exception => e # rubocop:disable Lint/RescueException
       @transaction.set_error(e)
       raise e
     ensure

--- a/resources/appsignal.yml.erb
+++ b/resources/appsignal.yml.erb
@@ -10,6 +10,22 @@ default: &defaults
   # ignore_actions:
   #   - ApplicationController#isup
 
+  # Errors that should not be recorded by AppSignal
+  # For more information see our docs:
+  # https://docs.appsignal.com/ruby/configuration/ignore-errors.html
+  # ignore_errors:
+  #   - Exception
+  #   - NoMemoryError
+  #   - ScriptError
+  #   - LoadError
+  #   - NotImplementedError
+  #   - SyntaxError
+  #   - SecurityError
+  #   - SignalException
+  #   - Interrupt
+  #   - SystemExit
+  #   - SystemStackError
+
   # See http://docs.appsignal.com/ruby/configuration/options.html for
   # all configuration options.
 

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -281,7 +281,7 @@ describe Appsignal::Config do
       ENV["APPSIGNAL_APP_NAME"]                = "App name"
       ENV["APPSIGNAL_DEBUG"]                   = "true"
       ENV["APPSIGNAL_IGNORE_ACTIONS"]          = "action1,action2"
-      ENV["APPSIGNAL_IGNORE_ERRORS"]           = "VerySpecificError,AnotherError"
+      ENV["APPSIGNAL_IGNORE_ERRORS"]           = "ExampleStandardError,AnotherError"
       ENV["APPSIGNAL_IGNORE_NAMESPACES"]       = "admin,private_namespace"
       ENV["APPSIGNAL_INSTRUMENT_NET_HTTP"]     = "false"
       ENV["APPSIGNAL_INSTRUMENT_REDIS"]        = "false"
@@ -299,7 +299,7 @@ describe Appsignal::Config do
       expect(config[:name]).to eq "App name"
       expect(config[:debug]).to eq(true)
       expect(config[:ignore_actions]).to eq %w(action1 action2)
-      expect(config[:ignore_errors]).to eq %w(VerySpecificError AnotherError)
+      expect(config[:ignore_errors]).to eq %w(ExampleStandardError AnotherError)
       expect(config[:ignore_namespaces]).to eq %w(admin private_namespace)
       expect(config[:instrument_net_http]).to eq(false)
       expect(config[:instrument_redis]).to eq(false)
@@ -385,7 +385,7 @@ describe Appsignal::Config do
     before do
       config[:http_proxy] = "http://localhost"
       config[:ignore_actions] = %w(action1 action2)
-      config[:ignore_errors] = %w(VerySpecificError AnotherError)
+      config[:ignore_errors] = %w(ExampleStandardError AnotherError)
       config[:ignore_namespaces] = %w(admin private_namespace)
       config[:log] = "stdout"
       config[:log_path] = "/tmp"
@@ -411,7 +411,7 @@ describe Appsignal::Config do
       expect(ENV["_APPSIGNAL_LANGUAGE_INTEGRATION_VERSION"]).to eq "ruby-#{Appsignal::VERSION}"
       expect(ENV["_APPSIGNAL_HTTP_PROXY"]).to                   eq "http://localhost"
       expect(ENV["_APPSIGNAL_IGNORE_ACTIONS"]).to               eq "action1,action2"
-      expect(ENV["_APPSIGNAL_IGNORE_ERRORS"]).to                eq "VerySpecificError,AnotherError"
+      expect(ENV["_APPSIGNAL_IGNORE_ERRORS"]).to                eq "ExampleStandardError,AnotherError"
       expect(ENV["_APPSIGNAL_IGNORE_NAMESPACES"]).to            eq "admin,private_namespace"
       expect(ENV["_APPSIGNAL_FILTER_PARAMETERS"]).to            eq "password,confirm_password"
       expect(ENV["_APPSIGNAL_SEND_PARAMS"]).to                  eq "true"

--- a/spec/lib/appsignal/hooks/action_cable_spec.rb
+++ b/spec/lib/appsignal/hooks/action_cable_spec.rb
@@ -143,7 +143,7 @@ describe Appsignal::Hooks::ActionCableHook do
             let(:channel) do
               Class.new(ActionCable::Channel::Base) do
                 def speak(_data)
-                  raise ExampleStandardError, "oh no!"
+                  raise ExampleException, "oh no!"
                 end
 
                 def self.to_s
@@ -155,7 +155,7 @@ describe Appsignal::Hooks::ActionCableHook do
             it "registers an error on the transaction" do
               expect do
                 instance.perform_action("message" => "foo", "action" => "speak")
-              end.to raise_error(ExampleStandardError)
+              end.to raise_error(ExampleException)
 
               expect(subject).to include(
                 "action" => "MyChannel#speak",
@@ -168,7 +168,7 @@ describe Appsignal::Hooks::ActionCableHook do
               )
               expect(subject["error"]).to include(
                 "backtrace" => kind_of(String),
-                "name" => "ExampleStandardError",
+                "name" => "ExampleException",
                 "message" => "oh no!"
               )
               expect(subject["sample_data"]).to include(
@@ -233,7 +233,7 @@ describe Appsignal::Hooks::ActionCableHook do
             let(:channel) do
               Class.new(ActionCable::Channel::Base) do
                 def subscribed
-                  raise ExampleStandardError, "oh no!"
+                  raise ExampleException, "oh no!"
                 end
 
                 def self.to_s
@@ -245,7 +245,7 @@ describe Appsignal::Hooks::ActionCableHook do
             it "registers an error on the transaction" do
               expect do
                 instance.subscribe_to_channel
-              end.to raise_error(ExampleStandardError)
+              end.to raise_error(ExampleException)
 
               expect(subject).to include(
                 "action" => "MyChannel#subscribed",
@@ -258,7 +258,7 @@ describe Appsignal::Hooks::ActionCableHook do
               )
               expect(subject["error"]).to include(
                 "backtrace" => kind_of(String),
-                "name" => "ExampleStandardError",
+                "name" => "ExampleException",
                 "message" => "oh no!"
               )
               expect(subject["sample_data"]).to include(
@@ -320,7 +320,7 @@ describe Appsignal::Hooks::ActionCableHook do
             let(:channel) do
               Class.new(ActionCable::Channel::Base) do
                 def unsubscribed
-                  raise ExampleStandardError, "oh no!"
+                  raise ExampleException, "oh no!"
                 end
 
                 def self.to_s
@@ -332,7 +332,7 @@ describe Appsignal::Hooks::ActionCableHook do
             it "registers an error on the transaction" do
               expect do
                 instance.unsubscribe_from_channel
-              end.to raise_error(ExampleStandardError)
+              end.to raise_error(ExampleException)
 
               expect(subject).to include(
                 "action" => "MyChannel#unsubscribed",
@@ -345,7 +345,7 @@ describe Appsignal::Hooks::ActionCableHook do
               )
               expect(subject["error"]).to include(
                 "backtrace" => kind_of(String),
-                "name" => "ExampleStandardError",
+                "name" => "ExampleException",
                 "message" => "oh no!"
               )
               expect(subject["sample_data"]).to include(

--- a/spec/lib/appsignal/hooks/action_cable_spec.rb
+++ b/spec/lib/appsignal/hooks/action_cable_spec.rb
@@ -143,7 +143,7 @@ describe Appsignal::Hooks::ActionCableHook do
             let(:channel) do
               Class.new(ActionCable::Channel::Base) do
                 def speak(_data)
-                  raise VerySpecificError, "oh no!"
+                  raise ExampleStandardError, "oh no!"
                 end
 
                 def self.to_s
@@ -155,7 +155,7 @@ describe Appsignal::Hooks::ActionCableHook do
             it "registers an error on the transaction" do
               expect do
                 instance.perform_action("message" => "foo", "action" => "speak")
-              end.to raise_error(VerySpecificError)
+              end.to raise_error(ExampleStandardError)
 
               expect(subject).to include(
                 "action" => "MyChannel#speak",
@@ -168,7 +168,7 @@ describe Appsignal::Hooks::ActionCableHook do
               )
               expect(subject["error"]).to include(
                 "backtrace" => kind_of(String),
-                "name" => "VerySpecificError",
+                "name" => "ExampleStandardError",
                 "message" => "oh no!"
               )
               expect(subject["sample_data"]).to include(
@@ -233,7 +233,7 @@ describe Appsignal::Hooks::ActionCableHook do
             let(:channel) do
               Class.new(ActionCable::Channel::Base) do
                 def subscribed
-                  raise VerySpecificError, "oh no!"
+                  raise ExampleStandardError, "oh no!"
                 end
 
                 def self.to_s
@@ -245,7 +245,7 @@ describe Appsignal::Hooks::ActionCableHook do
             it "registers an error on the transaction" do
               expect do
                 instance.subscribe_to_channel
-              end.to raise_error(VerySpecificError)
+              end.to raise_error(ExampleStandardError)
 
               expect(subject).to include(
                 "action" => "MyChannel#subscribed",
@@ -258,7 +258,7 @@ describe Appsignal::Hooks::ActionCableHook do
               )
               expect(subject["error"]).to include(
                 "backtrace" => kind_of(String),
-                "name" => "VerySpecificError",
+                "name" => "ExampleStandardError",
                 "message" => "oh no!"
               )
               expect(subject["sample_data"]).to include(
@@ -320,7 +320,7 @@ describe Appsignal::Hooks::ActionCableHook do
             let(:channel) do
               Class.new(ActionCable::Channel::Base) do
                 def unsubscribed
-                  raise VerySpecificError, "oh no!"
+                  raise ExampleStandardError, "oh no!"
                 end
 
                 def self.to_s
@@ -332,7 +332,7 @@ describe Appsignal::Hooks::ActionCableHook do
             it "registers an error on the transaction" do
               expect do
                 instance.unsubscribe_from_channel
-              end.to raise_error(VerySpecificError)
+              end.to raise_error(ExampleStandardError)
 
               expect(subject).to include(
                 "action" => "MyChannel#unsubscribed",
@@ -345,7 +345,7 @@ describe Appsignal::Hooks::ActionCableHook do
               )
               expect(subject["error"]).to include(
                 "backtrace" => kind_of(String),
-                "name" => "VerySpecificError",
+                "name" => "ExampleStandardError",
                 "message" => "oh no!"
               )
               expect(subject["sample_data"]).to include(

--- a/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
@@ -61,9 +61,9 @@ describe Appsignal::Hooks::ActiveSupportNotificationsHook do
 
         expect do
           as.instrument("sql.active_record", :sql => "SQL") do
-            raise ExampleStandardError, "foo"
+            raise ExampleException, "foo"
           end
-        end.to raise_error(ExampleStandardError, "foo")
+        end.to raise_error(ExampleException, "foo")
       end
     end
 

--- a/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
@@ -61,9 +61,9 @@ describe Appsignal::Hooks::ActiveSupportNotificationsHook do
 
         expect do
           as.instrument("sql.active_record", :sql => "SQL") do
-            raise VerySpecificError, "foo"
+            raise ExampleStandardError, "foo"
           end
-        end.to raise_error(VerySpecificError, "foo")
+        end.to raise_error(ExampleStandardError, "foo")
       end
     end
 

--- a/spec/lib/appsignal/hooks/delayed_job_spec.rb
+++ b/spec/lib/appsignal/hooks/delayed_job_spec.rb
@@ -316,7 +316,7 @@ describe Appsignal::Hooks::DelayedJobHook do
       end
 
       context "with an erroring call" do
-        let(:error) { ExampleStandardError }
+        let(:error) { ExampleException }
         let(:transaction) do
           Appsignal::Transaction.new(
             SecureRandom.uuid,

--- a/spec/lib/appsignal/hooks/delayed_job_spec.rb
+++ b/spec/lib/appsignal/hooks/delayed_job_spec.rb
@@ -316,7 +316,7 @@ describe Appsignal::Hooks::DelayedJobHook do
       end
 
       context "with an erroring call" do
-        let(:error) { VerySpecificError }
+        let(:error) { ExampleStandardError }
         let(:transaction) do
           Appsignal::Transaction.new(
             SecureRandom.uuid,

--- a/spec/lib/appsignal/hooks/rake_spec.rb
+++ b/spec/lib/appsignal/hooks/rake_spec.rb
@@ -24,7 +24,7 @@ describe Appsignal::Hooks::RakeHook do
     end
 
     context "with error" do
-      let(:error) { ExampleStandardError.new }
+      let(:error) { ExampleException }
       let(:transaction) { background_job_transaction }
       before do
         task.enhance { raise error }
@@ -66,7 +66,7 @@ describe Appsignal::Hooks::RakeHook do
       end
 
       after do
-        expect { task.execute(arguments) }.to raise_error ExampleStandardError
+        expect { task.execute(arguments) }.to raise_error ExampleException
       end
     end
   end

--- a/spec/lib/appsignal/hooks/rake_spec.rb
+++ b/spec/lib/appsignal/hooks/rake_spec.rb
@@ -24,7 +24,7 @@ describe Appsignal::Hooks::RakeHook do
     end
 
     context "with error" do
-      let(:error) { VerySpecificError.new }
+      let(:error) { ExampleStandardError.new }
       let(:transaction) { background_job_transaction }
       before do
         task.enhance { raise error }
@@ -66,7 +66,7 @@ describe Appsignal::Hooks::RakeHook do
       end
 
       after do
-        expect { task.execute(arguments) }.to raise_error VerySpecificError
+        expect { task.execute(arguments) }.to raise_error ExampleStandardError
       end
     end
   end

--- a/spec/lib/appsignal/hooks/shoryuken_spec.rb
+++ b/spec/lib/appsignal/hooks/shoryuken_spec.rb
@@ -146,17 +146,17 @@ describe Appsignal::Hooks::ShoryukenMiddleware do
     end
 
     it "sets the exception on the transaction" do
-      expect(transaction).to receive(:set_error).with(VerySpecificError)
+      expect(transaction).to receive(:set_error).with(ExampleStandardError)
     end
 
     after do
       expect do
         Timecop.freeze(Time.parse("01-01-2001 10:01:00UTC")) do
           Appsignal::Hooks::ShoryukenMiddleware.new.call(worker_instance, queue, sqs_msg, body) do
-            raise VerySpecificError
+            raise ExampleStandardError
           end
         end
-      end.to raise_error(VerySpecificError)
+      end.to raise_error(ExampleStandardError)
     end
   end
 end

--- a/spec/lib/appsignal/hooks/shoryuken_spec.rb
+++ b/spec/lib/appsignal/hooks/shoryuken_spec.rb
@@ -146,17 +146,17 @@ describe Appsignal::Hooks::ShoryukenMiddleware do
     end
 
     it "sets the exception on the transaction" do
-      expect(transaction).to receive(:set_error).with(ExampleStandardError)
+      expect(transaction).to receive(:set_error).with(ExampleException)
     end
 
     after do
       expect do
         Timecop.freeze(Time.parse("01-01-2001 10:01:00UTC")) do
           Appsignal::Hooks::ShoryukenMiddleware.new.call(worker_instance, queue, sqs_msg, body) do
-            raise ExampleStandardError
+            raise ExampleException
           end
         end
-      end.to raise_error(ExampleStandardError)
+      end.to raise_error(ExampleException)
     end
   end
 end

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -224,7 +224,7 @@ if DependencyHelper.sidekiq_present?
     end
 
     context "with an erroring job" do
-      let(:error) { VerySpecificError }
+      let(:error) { ExampleStandardError }
       before do
         expect do
           Timecop.freeze(Time.parse("01-01-2001 10:01:00UTC")) do
@@ -240,7 +240,7 @@ if DependencyHelper.sidekiq_present?
         # TODO: backtrace should be an Array of Strings
         # https://github.com/appsignal/appsignal-agent/issues/294
         expect(transaction_hash["error"]).to include(
-          "name" => "VerySpecificError",
+          "name" => "ExampleStandardError",
           "message" => "uh oh",
           "backtrace" => kind_of(String)
         )

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -224,7 +224,7 @@ if DependencyHelper.sidekiq_present?
     end
 
     context "with an erroring job" do
-      let(:error) { ExampleStandardError }
+      let(:error) { ExampleException }
       before do
         expect do
           Timecop.freeze(Time.parse("01-01-2001 10:01:00UTC")) do
@@ -240,7 +240,7 @@ if DependencyHelper.sidekiq_present?
         # TODO: backtrace should be an Array of Strings
         # https://github.com/appsignal/appsignal-agent/issues/294
         expect(transaction_hash["error"]).to include(
-          "name" => "ExampleStandardError",
+          "name" => "ExampleException",
           "message" => "uh oh",
           "backtrace" => kind_of(String)
         )

--- a/spec/lib/appsignal/integrations/grape_spec.rb
+++ b/spec/lib/appsignal/integrations/grape_spec.rb
@@ -77,7 +77,7 @@ if DependencyHelper.grape_present?
             Class.new(::Grape::API) do
               format :json
               post :ping do
-                raise ExampleStandardError
+                raise ExampleException
               end
             end
           end
@@ -90,11 +90,11 @@ if DependencyHelper.grape_present?
           end
 
           it "sets the error" do
-            expect(transaction).to receive(:set_error).with(kind_of(ExampleStandardError))
+            expect(transaction).to receive(:set_error).with(kind_of(ExampleException))
           end
 
           after do
-            expect { middleware.call(env) }.to raise_error ExampleStandardError
+            expect { middleware.call(env) }.to raise_error ExampleException
           end
         end
 

--- a/spec/lib/appsignal/integrations/grape_spec.rb
+++ b/spec/lib/appsignal/integrations/grape_spec.rb
@@ -77,7 +77,7 @@ if DependencyHelper.grape_present?
             Class.new(::Grape::API) do
               format :json
               post :ping do
-                raise VerySpecificError
+                raise ExampleStandardError
               end
             end
           end
@@ -90,11 +90,11 @@ if DependencyHelper.grape_present?
           end
 
           it "sets the error" do
-            expect(transaction).to receive(:set_error).with(kind_of(VerySpecificError))
+            expect(transaction).to receive(:set_error).with(kind_of(ExampleStandardError))
           end
 
           after do
-            expect { middleware.call(env) }.to raise_error VerySpecificError
+            expect { middleware.call(env) }.to raise_error ExampleStandardError
           end
         end
 

--- a/spec/lib/appsignal/integrations/padrino_spec.rb
+++ b/spec/lib/appsignal/integrations/padrino_spec.rb
@@ -215,11 +215,11 @@ if DependencyHelper.padrino_present?
             context "with an exception in the controller" do
               let(:path) { "/exception" }
               before do
-                app.controllers { get(:exception) { raise ExampleStandardError } }
+                app.controllers { get(:exception) { raise ExampleException } }
                 expect_a_transaction_to_be_created
               end
               after do
-                expect { response }.to raise_error(ExampleStandardError)
+                expect { response }.to raise_error(ExampleException)
               end
 
               it "sets the action name based on the app name and action name" do
@@ -227,7 +227,7 @@ if DependencyHelper.padrino_present?
               end
 
               it "sets the error on the transaction" do
-                expect(transaction).to receive(:set_error).with(ExampleStandardError)
+                expect(transaction).to receive(:set_error).with(ExampleException)
               end
             end
 

--- a/spec/lib/appsignal/integrations/padrino_spec.rb
+++ b/spec/lib/appsignal/integrations/padrino_spec.rb
@@ -215,11 +215,11 @@ if DependencyHelper.padrino_present?
             context "with an exception in the controller" do
               let(:path) { "/exception" }
               before do
-                app.controllers { get(:exception) { raise VerySpecificError } }
+                app.controllers { get(:exception) { raise ExampleStandardError } }
                 expect_a_transaction_to_be_created
               end
               after do
-                expect { response }.to raise_error(VerySpecificError)
+                expect { response }.to raise_error(ExampleStandardError)
               end
 
               it "sets the action name based on the app name and action name" do
@@ -227,7 +227,7 @@ if DependencyHelper.padrino_present?
               end
 
               it "sets the error on the transaction" do
-                expect(transaction).to receive(:set_error).with(VerySpecificError)
+                expect(transaction).to receive(:set_error).with(ExampleStandardError)
               end
             end
 

--- a/spec/lib/appsignal/integrations/resque_spec.rb
+++ b/spec/lib/appsignal/integrations/resque_spec.rb
@@ -18,7 +18,7 @@ if DependencyHelper.resque_present?
           extend Appsignal::Integrations::ResquePlugin
 
           def self.perform
-            raise VerySpecificError
+            raise ExampleStandardError
           end
         end
       end
@@ -72,11 +72,11 @@ if DependencyHelper.resque_present?
           end
 
           it "sets the exception on the transaction" do
-            expect(transaction).to receive(:set_error).with(VerySpecificError)
+            expect(transaction).to receive(:set_error).with(ExampleStandardError)
           end
 
           after do
-            expect { job.perform }.to raise_error(VerySpecificError)
+            expect { job.perform }.to raise_error(ExampleStandardError)
           end
         end
       end

--- a/spec/lib/appsignal/integrations/resque_spec.rb
+++ b/spec/lib/appsignal/integrations/resque_spec.rb
@@ -18,7 +18,7 @@ if DependencyHelper.resque_present?
           extend Appsignal::Integrations::ResquePlugin
 
           def self.perform
-            raise ExampleStandardError
+            raise ExampleException
           end
         end
       end
@@ -72,11 +72,11 @@ if DependencyHelper.resque_present?
           end
 
           it "sets the exception on the transaction" do
-            expect(transaction).to receive(:set_error).with(ExampleStandardError)
+            expect(transaction).to receive(:set_error).with(ExampleException)
           end
 
           after do
-            expect { job.perform }.to raise_error(ExampleStandardError)
+            expect { job.perform }.to raise_error(ExampleException)
           end
         end
       end

--- a/spec/lib/appsignal/integrations/webmachine_spec.rb
+++ b/spec/lib/appsignal/integrations/webmachine_spec.rb
@@ -55,7 +55,7 @@ if DependencyHelper.webmachine_present?
     end
 
     describe "#handle_exceptions_with_appsignal" do
-      let(:error) { ExampleStandardError.new }
+      let(:error) { ExampleException.new }
 
       it "should catch the error and send it to AppSignal" do
         expect(Appsignal).to receive(:set_error).with(error)

--- a/spec/lib/appsignal/integrations/webmachine_spec.rb
+++ b/spec/lib/appsignal/integrations/webmachine_spec.rb
@@ -55,7 +55,7 @@ if DependencyHelper.webmachine_present?
     end
 
     describe "#handle_exceptions_with_appsignal" do
-      let(:error) { VerySpecificError.new }
+      let(:error) { ExampleStandardError.new }
 
       it "should catch the error and send it to AppSignal" do
         expect(Appsignal).to receive(:set_error).with(error)

--- a/spec/lib/appsignal/integrations/webmachine_spec.rb
+++ b/spec/lib/appsignal/integrations/webmachine_spec.rb
@@ -55,7 +55,7 @@ if DependencyHelper.webmachine_present?
     end
 
     describe "#handle_exceptions_with_appsignal" do
-      let(:error) { ExampleException.new }
+      let(:error) { ExampleException }
 
       it "should catch the error and send it to AppSignal" do
         expect(Appsignal).to receive(:set_error).with(error)

--- a/spec/lib/appsignal/rack/generic_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/generic_instrumentation_spec.rb
@@ -50,7 +50,7 @@ describe Appsignal::Rack::GenericInstrumentation do
     end
 
     context "with an error", :error => true do
-      let(:error) { VerySpecificError.new }
+      let(:error) { ExampleStandardError.new }
       let(:app) do
         double.tap do |d|
           allow(d).to receive(:call).and_raise(error)
@@ -85,6 +85,6 @@ describe Appsignal::Rack::GenericInstrumentation do
     end
 
     after(:error => false) { middleware.call(env) }
-    after(:error => true) { expect { middleware.call(env) }.to raise_error(VerySpecificError) }
+    after(:error => true) { expect { middleware.call(env) }.to raise_error(ExampleStandardError) }
   end
 end

--- a/spec/lib/appsignal/rack/generic_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/generic_instrumentation_spec.rb
@@ -49,15 +49,15 @@ describe Appsignal::Rack::GenericInstrumentation do
       expect(app).to receive(:call).with(env)
     end
 
-    context "with an error", :error => true do
-      let(:error) { ExampleStandardError.new }
+    context "with an exception", :error => true do
+      let(:error) { ExampleException }
       let(:app) do
         double.tap do |d|
           allow(d).to receive(:call).and_raise(error)
         end
       end
 
-      it "should set the error" do
+      it "records the exception" do
         expect_any_instance_of(Appsignal::Transaction).to receive(:set_error).with(error)
       end
     end
@@ -85,6 +85,6 @@ describe Appsignal::Rack::GenericInstrumentation do
     end
 
     after(:error => false) { middleware.call(env) }
-    after(:error => true) { expect { middleware.call(env) }.to raise_error(ExampleStandardError) }
+    after(:error => true) { expect { middleware.call(env) }.to raise_error(error) }
   end
 end

--- a/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
@@ -68,15 +68,15 @@ if DependencyHelper.rails_present?
         expect(app).to receive(:call).with(env)
       end
 
-      context "with an error", :error => true do
-        let(:error) { VerySpecificError }
+      context "with an exception", :error => true do
+        let(:error) { ExampleStandardError }
         let(:app) do
           double.tap do |d|
             allow(d).to receive(:call).and_raise(error)
           end
         end
 
-        it "should set the error" do
+        it "records the exception" do
           expect_any_instance_of(Appsignal::Transaction).to receive(:set_error).with(error)
         end
       end
@@ -91,7 +91,7 @@ if DependencyHelper.rails_present?
       end
 
       after(:error => false) { middleware.call(env) }
-      after(:error => true) { expect { middleware.call(env) }.to raise_error(VerySpecificError) }
+      after(:error => true) { expect { middleware.call(env) }.to raise_error(error) }
     end
 
     describe "#request_id" do

--- a/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
@@ -69,7 +69,7 @@ if DependencyHelper.rails_present?
       end
 
       context "with an exception", :error => true do
-        let(:error) { ExampleStandardError }
+        let(:error) { ExampleException }
         let(:app) do
           double.tap do |d|
             allow(d).to receive(:call).and_raise(error)

--- a/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
@@ -118,7 +118,7 @@ if DependencyHelper.sinatra_present?
       end
 
       context "with an error", :error => true do
-        let(:error) { ExampleStandardError }
+        let(:error) { ExampleException }
         let(:app) do
           double.tap do |d|
             allow(d).to receive(:call).and_raise(error)
@@ -126,23 +126,23 @@ if DependencyHelper.sinatra_present?
           end
         end
 
-        it "should set the error" do
+        it "records the exception" do
           expect_any_instance_of(Appsignal::Transaction).to receive(:set_error).with(error)
         end
       end
 
       context "with an error in sinatra.error" do
-        let(:error) { ExampleStandardError }
+        let(:error) { ExampleException }
         let(:env) { { "sinatra.error" => error } }
 
-        it "should set the error" do
+        it "records the exception" do
           expect_any_instance_of(Appsignal::Transaction).to receive(:set_error).with(error)
         end
 
-        context "if raise_errors is on" do
+        context "when raise_errors is on" do
           let(:settings) { double(:raise_errors => true) }
 
-          it "should not set the error" do
+          it "does not record the error" do
             expect_any_instance_of(Appsignal::Transaction).to_not receive(:set_error)
           end
         end
@@ -150,7 +150,7 @@ if DependencyHelper.sinatra_present?
         context "if sinatra.skip_appsignal_error is set" do
           let(:env) { { "sinatra.error" => error, "sinatra.skip_appsignal_error" => true } }
 
-          it "should not set the error" do
+          it "does not record the error" do
             expect_any_instance_of(Appsignal::Transaction).to_not receive(:set_error)
           end
         end
@@ -207,7 +207,7 @@ if DependencyHelper.sinatra_present?
       end
 
       after(:error => false) { middleware.call(env) }
-      after(:error => true) { expect { middleware.call(env) }.to raise_error(ExampleStandardError) }
+      after(:error => true) { expect { middleware.call(env) }.to raise_error(error) }
     end
   end
 end

--- a/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
@@ -118,7 +118,7 @@ if DependencyHelper.sinatra_present?
       end
 
       context "with an error", :error => true do
-        let(:error) { VerySpecificError }
+        let(:error) { ExampleStandardError }
         let(:app) do
           double.tap do |d|
             allow(d).to receive(:call).and_raise(error)
@@ -132,7 +132,7 @@ if DependencyHelper.sinatra_present?
       end
 
       context "with an error in sinatra.error" do
-        let(:error) { VerySpecificError }
+        let(:error) { ExampleStandardError }
         let(:env) { { "sinatra.error" => error } }
 
         it "should set the error" do
@@ -207,7 +207,7 @@ if DependencyHelper.sinatra_present?
       end
 
       after(:error => false) { middleware.call(env) }
-      after(:error => true) { expect { middleware.call(env) }.to raise_error(VerySpecificError) }
+      after(:error => true) { expect { middleware.call(env) }.to raise_error(ExampleStandardError) }
     end
   end
 end

--- a/spec/lib/appsignal/rack/streaming_listener_spec.rb
+++ b/spec/lib/appsignal/rack/streaming_listener_spec.rb
@@ -87,7 +87,7 @@ describe Appsignal::Rack::StreamingListener do
     end
 
     context "with an exception in the instrumentation call" do
-      let(:error) { ExampleStandardError }
+      let(:error) { ExampleException }
 
       it "should add the exception to the transaction" do
         allow(app).to receive(:call).and_raise(error)
@@ -118,18 +118,17 @@ describe Appsignal::StreamWrapper do
   let(:wrapper)     { Appsignal::StreamWrapper.new(stream, transaction) }
 
   describe "#each" do
-    it "should call the original stream" do
+    it "calls the original stream" do
       expect(stream).to receive(:each)
 
       wrapper.each
     end
 
-    context "when each raises an error" do
-      let(:error) { ExampleStandardError }
+    context "when #each raises an error" do
+      let(:error) { ExampleException }
 
-      it "should add the exception to the transaction" do
-        allow(stream).to receive(:each)
-          .and_raise(error)
+      it "records the exception" do
+        allow(stream).to receive(:each).and_raise(error)
 
         expect(transaction).to receive(:set_error).with(error)
 
@@ -139,17 +138,17 @@ describe Appsignal::StreamWrapper do
   end
 
   describe "#close" do
-    it "should call the original stream and close the transaction" do
+    it "closes the original stream and completes the transaction" do
       expect(stream).to receive(:close)
       expect(Appsignal::Transaction).to receive(:complete_current!)
 
       wrapper.close
     end
 
-    context "when each raises an error" do
-      let(:error) { ExampleStandardError }
+    context "when #close raises an error" do
+      let(:error) { ExampleException }
 
-      it "adds the exception to the transaction and close it" do
+      it "records the exception and completes the transaction" do
         allow(stream).to receive(:close).and_raise(error)
 
         expect(transaction).to receive(:set_error).with(error)

--- a/spec/lib/appsignal/rack/streaming_listener_spec.rb
+++ b/spec/lib/appsignal/rack/streaming_listener_spec.rb
@@ -87,7 +87,7 @@ describe Appsignal::Rack::StreamingListener do
     end
 
     context "with an exception in the instrumentation call" do
-      let(:error) { VerySpecificError }
+      let(:error) { ExampleStandardError }
 
       it "should add the exception to the transaction" do
         allow(app).to receive(:call).and_raise(error)
@@ -125,7 +125,7 @@ describe Appsignal::StreamWrapper do
     end
 
     context "when each raises an error" do
-      let(:error) { VerySpecificError }
+      let(:error) { ExampleStandardError }
 
       it "should add the exception to the transaction" do
         allow(stream).to receive(:each)
@@ -147,7 +147,7 @@ describe Appsignal::StreamWrapper do
     end
 
     context "when each raises an error" do
-      let(:error) { VerySpecificError }
+      let(:error) { ExampleStandardError }
 
       it "adds the exception to the transaction and close it" do
         allow(stream).to receive(:close).and_raise(error)

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -133,13 +133,13 @@ describe Appsignal::Transaction do
 
       context "when encountering an error while completing" do
         before do
-          expect(transaction).to receive(:complete).and_raise VerySpecificError
+          expect(transaction).to receive(:complete).and_raise ExampleStandardError
         end
 
         it "logs an error message" do
           Appsignal::Transaction.complete_current!
           expect(log_contents(log)).to contains_log :error,
-            "Failed to complete transaction ##{transaction.transaction_id}. VerySpecificError"
+            "Failed to complete transaction ##{transaction.transaction_id}. ExampleStandardError"
         end
 
         it "clears the current transaction" do

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -348,7 +348,7 @@ describe Appsignal do
       end
 
       context "with an erroring call" do
-        let(:error) { ExampleStandardError.new }
+        let(:error) { ExampleException.new }
 
         it "should add the error to the current transaction and complete" do
           expect_any_instance_of(Appsignal::Transaction).to receive(:set_error).with(error)
@@ -379,7 +379,7 @@ describe Appsignal do
       end
 
       context "with an erroring call" do
-        let(:error) { ExampleStandardError.new }
+        let(:error) { ExampleException.new }
 
         it "should call monitor_transaction and stop and then raise the error" do
           expect(Appsignal).to receive(:monitor_transaction).with(
@@ -719,7 +719,7 @@ describe Appsignal do
           Appsignal::Transaction::GenericRequest.new({})
         )
       end
-      let(:error) { ExampleStandardError.new }
+      let(:error) { ExampleException.new }
 
       it "sends the error to AppSignal" do
         expect(Appsignal::Transaction).to receive(:new).with(

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -348,7 +348,7 @@ describe Appsignal do
       end
 
       context "with an erroring call" do
-        let(:error) { VerySpecificError.new }
+        let(:error) { ExampleStandardError.new }
 
         it "should add the error to the current transaction and complete" do
           expect_any_instance_of(Appsignal::Transaction).to receive(:set_error).with(error)
@@ -379,7 +379,7 @@ describe Appsignal do
       end
 
       context "with an erroring call" do
-        let(:error) { VerySpecificError.new }
+        let(:error) { ExampleStandardError.new }
 
         it "should call monitor_transaction and stop and then raise the error" do
           expect(Appsignal).to receive(:monitor_transaction).with(
@@ -719,7 +719,7 @@ describe Appsignal do
           Appsignal::Transaction::GenericRequest.new({})
         )
       end
-      let(:error) { VerySpecificError.new }
+      let(:error) { ExampleStandardError.new }
 
       it "sends the error to AppSignal" do
         expect(Appsignal::Transaction).to receive(:new).with(

--- a/spec/support/helpers/example_exception.rb
+++ b/spec/support/helpers/example_exception.rb
@@ -1,0 +1,13 @@
+# This ExampleException is used for throwing Exceptions in specs that are
+# allowed or expected.
+#
+# For example, this error can be thrown to raise an exception in AppSignal's
+# run, which should stop the program and the appsignal gem, but not crash the
+# test suite.
+#
+# There's also {ExampleStandardError}, use this when you need to test against
+# StandardError-level Ruby exceptions.
+#
+# @see ExampleStandardError
+class ExampleException < Exception # rubocop:disable Lint/InheritException
+end

--- a/spec/support/helpers/example_standard_error.rb
+++ b/spec/support/helpers/example_standard_error.rb
@@ -4,5 +4,10 @@
 # For example, this error can be thrown to raise an exception in AppSignal's
 # run, which should stop the program and the appsignal gem, but not crash the
 # test suite.
+#
+# There's also {ExampleException}, use this when you need to test against
+# Exception-level Ruby exceptions.
+#
+# @see ExampleException
 class ExampleStandardError < StandardError
 end

--- a/spec/support/helpers/example_standard_error.rb
+++ b/spec/support/helpers/example_standard_error.rb
@@ -1,8 +1,8 @@
-# This VerySpecificError is used for throwing errors in specs that are allowed
-# or expected.
+# This ExampleStandardError is used for throwing errors in specs that are
+# allowed or expected.
 #
 # For example, this error can be thrown to raise an exception in AppSignal's
 # run, which should stop the program and the appsignal gem, but not crash the
 # test suite.
-class VerySpecificError < RuntimeError
+class ExampleStandardError < StandardError
 end

--- a/spec/support/shared_examples/instrument.rb
+++ b/spec/support/shared_examples/instrument.rb
@@ -24,9 +24,9 @@ RSpec.shared_examples "instrument helper" do
       expect do
         instrumenter.instrument "name", "title", "body" do
           stub.method_call
-          raise ExampleStandardError, "foo"
+          raise ExampleException, "foo"
         end
-      end.to raise_error(ExampleStandardError, "foo")
+      end.to raise_error(ExampleException, "foo")
     end
   end
 

--- a/spec/support/shared_examples/instrument.rb
+++ b/spec/support/shared_examples/instrument.rb
@@ -24,9 +24,9 @@ RSpec.shared_examples "instrument helper" do
       expect do
         instrumenter.instrument "name", "title", "body" do
           stub.method_call
-          raise VerySpecificError, "foo"
+          raise ExampleStandardError, "foo"
         end
-      end.to raise_error(VerySpecificError, "foo")
+      end.to raise_error(ExampleStandardError, "foo")
     end
   end
 


### PR DESCRIPTION
This allows us to track more Exceptions in Ruby without breaking the
normal Exception handling in Ruby. The main thing to keep in mind while
rescuing Exception is that you re-raise the Exception in case it's an
`SystemExit` or `SignalException`, otherwise we might break the normal
shutdown behavior of Ruby processes.

Also update appsignal.yml template with `ignore_errors` defaults in the
comments. List all errors previously ignored by default in the template
and link to our docs for more information on this subject.

Continuation of #344 
Closes #168 
🚨 Does **not** close #174, see the "TODO" section in that issue