### PR TITLE
Add tags and namespace options to listen_for_error

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -217,10 +217,37 @@ module Appsignal
       stop("monitor_single_transaction")
     end
 
-    def listen_for_error
+    # Listen for an error to occur and send it to AppSignal.
+    #
+    # Uses {.send_error} to directly send the error in a separate transaction.
+    # Does not add the error to the current transaction.
+    #
+    # Make sure that AppSignal is integrated in your application beforehand.
+    # AppSignal won't record errors unless {Config#active?} is `true`.
+    #
+    # @example
+    #   # my_app.rb
+    #   # setup AppSignal beforehand
+    #
+    #   Appsignal.listen_for_error do
+    #     # my code
+    #     raise "foo"
+    #   end
+    #
+    # @see Transaction.set_tags
+    # @see Transaction.set_namespace
+    # @see .send_error
+    # @see https://docs.appsignal.com/ruby/instrumentation/integrating-appsignal.html
+    #   AppSignal integration guide
+    #
+    # @param tags [Hash, nil]
+    # @param namespace [String] the namespace for this error.
+    # @yield yields the given block.
+    # @return [Object] returns the return value of the given block.
+    def listen_for_error(tags = nil, namespace = Appsignal::Transaction::HTTP_REQUEST)
       yield
     rescue Exception => error # rubocop:disable Lint/RescueException
-      send_error(error)
+      send_error(error, tags, namespace)
       raise error
     end
     alias :listen_for_exception :listen_for_error


### PR DESCRIPTION
`Appsignal.listen_for_error` is the only helper that doesn't support
custom tags and a custom namespace.
This change adds support for the tags and namespace and passes the
values along to `Appsignal.send_error`.

Did not change this spec to use `Appsignal::Transaction#to_h`, because
the change would be a lot more involved as we can't fetch the current
transaction from the current thread. To record a transaction we'd need
to be able to capture the transaction as it's being created.

Fixes #353