### PR TITLE
🐞 Better Sidekiq action names

### DIFF
--- a/lib/appsignal/hooks/sidekiq.rb
+++ b/lib/appsignal/hooks/sidekiq.rb
@@ -22,15 +22,10 @@ module Appsignal
     class SidekiqPlugin
       include Appsignal::Hooks::Helpers
 
-      # TODO: Make constant
-      def job_keys
-        @job_keys ||= Set.new(%w(
-          class args retried_at failed_at
-          error_message error_class backtrace
-          error_backtrace enqueued_at retry
-          jid retry created_at wrapped
-        ))
-      end
+      JOB_KEYS = Set.new(%w(
+        args backtrace class created_at enqueued_at error_backtrace error_class
+        error_message failed_at jid retried_at retry wrapped
+      )).freeze
 
       def call(_worker, item, _queue)
         transaction = Appsignal::Transaction.create(
@@ -79,7 +74,7 @@ module Appsignal
       def formatted_metadata(item)
         {}.tap do |hash|
           (item || {}).each do |key, value|
-            next if job_keys.include?(key)
+            next if JOB_KEYS.include?(key)
             hash[key] = truncate(string_or_inspect(value))
           end
         end

--- a/lib/appsignal/hooks/sidekiq.rb
+++ b/lib/appsignal/hooks/sidekiq.rb
@@ -1,50 +1,7 @@
+require "yaml"
+
 module Appsignal
   class Hooks
-    # @api private
-    class SidekiqPlugin
-      include Appsignal::Hooks::Helpers
-
-      def job_keys
-        @job_keys ||= Set.new(%w(
-          class args retried_at failed_at
-          error_message error_class backtrace
-          error_backtrace enqueued_at retry
-          jid retry created_at wrapped
-        ))
-      end
-
-      def call(_worker, item, _queue)
-        args =
-          if item["class"] == "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper"
-            item["args"].first["arguments"]
-          else
-            item["args"]
-          end
-        params = Appsignal::Utils::ParamsSanitizer.sanitize args,
-          :filter_parameters => Appsignal.config[:filter_parameters]
-
-        Appsignal.monitor_transaction(
-          "perform_job.sidekiq",
-          :class       => item["wrapped"] || item["class"],
-          :method      => "perform",
-          :metadata    => formatted_metadata(item),
-          :params      => params,
-          :queue_start => item["enqueued_at"],
-          :queue_time  => (Time.now.to_f - item["enqueued_at"].to_f) * 1000
-        ) do
-          yield
-        end
-      end
-
-      def formatted_metadata(item)
-        {}.tap do |hsh|
-          item.each do |key, val|
-            hsh[key] = truncate(string_or_inspect(val)) unless job_keys.include?(key)
-          end
-        end
-      end
-    end
-
     class SidekiqHook < Appsignal::Hooks::Hook
       register :sidekiq
 
@@ -58,6 +15,128 @@ module Appsignal
             chain.add Appsignal::Hooks::SidekiqPlugin
           end
         end
+      end
+    end
+
+    # @api private
+    class SidekiqPlugin
+      include Appsignal::Hooks::Helpers
+
+      # TODO: Make constant
+      def job_keys
+        @job_keys ||= Set.new(%w(
+          class args retried_at failed_at
+          error_message error_class backtrace
+          error_backtrace enqueued_at retry
+          jid retry created_at wrapped
+        ))
+      end
+
+      def call(_worker, item, _queue)
+        transaction = Appsignal::Transaction.create(
+          SecureRandom.uuid,
+          Appsignal::Transaction::BACKGROUND_JOB,
+          Appsignal::Transaction::GenericRequest.new(
+            :queue_start => item["enqueued_at"]
+          )
+        )
+
+        Appsignal.instrument "perform_job.sidekiq" do
+          begin
+            yield
+          rescue Exception => exception # rubocop:disable Lint/RescueException
+            transaction.set_error(exception)
+            raise exception
+          end
+        end
+      ensure
+        if transaction
+          transaction.set_action_if_nil(formatted_action_name(item))
+          transaction.params = filtered_arguments(item)
+          formatted_metadata(item).each do |key, value|
+            transaction.set_metadata key, value
+          end
+          transaction.set_http_or_background_queue_start
+          Appsignal::Transaction.complete_current!
+        end
+      end
+
+      private
+
+      def formatted_action_name(job)
+        sidekiq_action_name = parse_action_name(job)
+        return sidekiq_action_name if sidekiq_action_name =~ /\.|#/
+        "#{sidekiq_action_name}#perform"
+      end
+
+      def filtered_arguments(job)
+        Appsignal::Utils::ParamsSanitizer.sanitize(
+          parse_arguments(job),
+          :filter_parameters => Appsignal.config[:filter_parameters]
+        )
+      end
+
+      def formatted_metadata(item)
+        {}.tap do |hash|
+          (item || {}).each do |key, value|
+            next if job_keys.include?(key)
+            hash[key] = truncate(string_or_inspect(value))
+          end
+        end
+      end
+
+      # Based on: https://github.com/mperham/sidekiq/blob/63ee43353bd3b753beb0233f64865e658abeb1c3/lib/sidekiq/api.rb#L316-L334
+      def parse_action_name(job)
+        args = job["args"]
+        case job["class"]
+        when /\ASidekiq::Extensions::Delayed/
+          safe_load(job["args"][0], job["class"]) do |target, method, _|
+            "#{target}.#{method}"
+          end
+        when "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper"
+          job_class = job["wrapped"] || args[0]
+          if "ActionMailer::DeliveryJob" == job_class
+            # MailerClass#mailer_method
+            args[0]["arguments"][0..1].join("#")
+          else
+            job_class
+          end
+        else
+          job["class"]
+        end
+      end
+
+      # Based on: https://github.com/mperham/sidekiq/blob/63ee43353bd3b753beb0233f64865e658abeb1c3/lib/sidekiq/api.rb#L336-L358
+      def parse_arguments(job)
+        args = job["args"]
+        case job["class"]
+        when /\ASidekiq::Extensions::Delayed/
+          safe_load(args[0], args) do |_, _, arg|
+            arg
+          end
+        when "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper"
+          is_wrapped = job["wrapped"]
+          job_args = is_wrapped ? args[0]["arguments"] : []
+          if "ActionMailer::DeliveryJob" == (is_wrapped || args[0])
+            # Remove MailerClass, mailer_method and "deliver_now"
+            job_args.drop(3)
+          else
+            job_args
+          end
+        else
+          args
+        end
+      end
+
+      # Based on: https://github.com/mperham/sidekiq/blob/63ee43353bd3b753beb0233f64865e658abeb1c3/lib/sidekiq/api.rb#L403-L412
+      def safe_load(content, default)
+        yield(*YAML.load(content))
+      rescue => error
+        # Sidekiq issue #1761: in dev mode, it's possible to have jobs enqueued
+        # which haven't been loaded into memory yet so the YAML can't be
+        # loaded.
+        Appsignal.logger.warn "Unable to load YAML: #{error.message}"
+        default
       end
     end
   end

--- a/lib/appsignal/hooks/sidekiq.rb
+++ b/lib/appsignal/hooks/sidekiq.rb
@@ -119,6 +119,12 @@ module Appsignal
             job_args
           end
         else
+          # Sidekiq Enterprise argument encryption.
+          # More information: https://github.com/mperham/sidekiq/wiki/Ent-Encryption
+          if job["encrypt".freeze]
+            # No point in showing 150+ bytes of random garbage
+            args[-1] = "[encrypted data]".freeze
+          end
           args
         end
       end

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -54,6 +54,12 @@ module Appsignal
       rescue => e
         Appsignal.logger.error("Failed to complete transaction ##{current.transaction_id}. #{e.message}")
       ensure
+        clear_current_transaction!
+      end
+
+      # Remove current transaction from current Thread.
+      # @api private
+      def clear_current_transaction!
         Thread.current[:appsignal_transaction] = nil
       end
 
@@ -312,6 +318,7 @@ module Appsignal
       finish_event(name, title, body, body_format)
     end
 
+    # @api private
     def to_h
       JSON.parse(@ext.to_json)
     end

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -1,85 +1,242 @@
-describe Appsignal::Hooks::SidekiqPlugin do
-  let(:worker) { double }
-  let(:queue) { double }
-  let(:current_transaction) { background_job_transaction }
-  let(:args) { ["Model", 1] }
+describe Appsignal::Hooks::SidekiqPlugin, :with_yaml_parse_error => false do
+  class DelayedTestClass; end
+
+  let(:namespace) { Appsignal::Transaction::BACKGROUND_JOB }
+  let(:worker) { anything }
+  let(:queue) { anything }
+  let(:given_args) do
+    [
+      "foo",
+      {
+        :foo => "Foo",
+        :bar => "Bar",
+        "baz" => { 1 => :foo }
+      }
+    ]
+  end
+  let(:expected_args) do
+    [
+      "foo",
+      {
+        "foo" => "Foo",
+        "bar" => "Bar",
+        "baz" => { "1" => "foo" }
+      }
+    ]
+  end
+  let(:job_class) { "TestClass" }
   let(:item) do
     {
-      "class"       => "TestClass",
+      "jid"         => "b4a577edbccf1d805744efa9",
+      "class"       => job_class,
       "retry_count" => 0,
       "queue"       => "default",
-      "enqueued_at" => Time.parse("01-01-2001 10:00:00UTC"),
-      "args"        => args,
+      "created_at"  => Time.parse("2001-01-01 10:00:00UTC").to_f,
+      "enqueued_at" => Time.parse("2001-01-01 10:00:00UTC").to_f,
+      "args"        => given_args,
       "extra"       => "data"
     }
   end
   let(:plugin) { Appsignal::Hooks::SidekiqPlugin.new }
-
+  let(:test_store) { {} }
+  let(:log) { StringIO.new }
   before do
-    allow(Appsignal::Transaction).to receive(:current).and_return(current_transaction)
     start_agent
-  end
+    Appsignal.logger = test_logger(log)
 
-  context "with a performance call" do
-    after do
-      Timecop.freeze(Time.parse("01-01-2001 10:01:00UTC")) do
-        Appsignal::Hooks::SidekiqPlugin.new.call(worker, item, queue) do
-          # nothing
+    # Stub calls to extension, because that would remove the transaction
+    # from the extension.
+    allow_any_instance_of(Appsignal::Extension::Transaction).to receive(:finish).and_return(true)
+    allow_any_instance_of(Appsignal::Extension::Transaction).to receive(:complete)
+
+    # Stub removal of current transaction from current thread so we can fetch
+    # it later.
+    expect(Appsignal::Transaction).to receive(:clear_current_transaction!).at_least(:once) do
+      transaction = Thread.current[:appsignal_transaction]
+      test_store[:transaction] = transaction if transaction
+    end
+  end
+  after :with_yaml_parse_error => false do
+    expect(log_contents(log)).to_not contains_log(:warn, "Unable to load YAML")
+  end
+  after { clear_current_transaction! }
+
+  shared_examples "sidekiq metadata" do
+    describe "internal Sidekiq job values" do
+      it "does not save internal Sidekiq values as metadata on transaction" do
+        perform_job
+
+        transaction_hash = transaction.to_h
+        expect(transaction_hash["metadata"].keys)
+          .to_not include(*Appsignal::Hooks::SidekiqPlugin::JOB_KEYS)
+      end
+    end
+
+    context "with parameter filtering" do
+      before do
+        Appsignal.config = project_fixture_config("production")
+        Appsignal.config[:filter_parameters] = ["foo"]
+      end
+
+      it "filters selected arguments" do
+        perform_job
+
+        transaction_hash = transaction.to_h
+        expect(transaction_hash["sample_data"]).to include(
+          "params" => [
+            "foo",
+            {
+              "foo" => "[FILTERED]",
+              "bar" => "Bar",
+              "baz" => { "1" => "foo" }
+            }
+          ]
+        )
+      end
+    end
+
+    context "when using the Sidekiq delayed extension" do
+      let(:item) do
+        {
+          "jid" => "efb140489485999d32b5504c",
+          "class" => "Sidekiq::Extensions::DelayedClass",
+          "queue" => "default",
+          "args" => [
+            "---\n- !ruby/class 'DelayedTestClass'\n- :foo_method\n- - :bar: baz\n"
+          ],
+          "retry" => true,
+          "created_at" => Time.parse("2001-01-01 10:00:00UTC").to_f,
+          "enqueued_at" => Time.parse("2001-01-01 10:00:00UTC").to_f,
+          "extra" => "data"
+        }
+      end
+
+      it "uses the delayed class and method name for the action" do
+        perform_job
+
+        transaction_hash = transaction.to_h
+        expect(transaction_hash["action"]).to eq("DelayedTestClass.foo_method")
+        expect(transaction_hash["sample_data"]).to include(
+          "params" => ["bar" => "baz"]
+        )
+      end
+
+      context "when job arguments is a malformed YAML object", :with_yaml_parse_error => true do
+        before { item["args"] = [] }
+
+        it "logs a warning and uses the default argument" do
+          perform_job
+
+          transaction_hash = transaction.to_h
+          expect(transaction_hash["action"]).to eq("Sidekiq::Extensions::DelayedClass#perform")
+          expect(transaction_hash["sample_data"]).to include("params" => [])
+          expect(log_contents(log)).to contains_log(:warn, "Unable to load YAML")
         end
       end
     end
 
-    it "wraps it in a transaction with the correct params" do
-      expect(Appsignal).to receive(:monitor_transaction).with(
-        "perform_job.sidekiq",
-        :class    => "TestClass",
-        :method   => "perform",
-        :metadata => {
-          "retry_count" => "0",
-          "queue"       => "default",
-          "extra"       => "data"
-        },
-        :params      => ["Model", 1],
-        :queue_start => Time.parse("01-01-2001 10:00:00UTC"),
-        :queue_time  => 60_000.to_f
-      )
-    end
-
-    context "with more complex arguments" do
-      let(:default_params) do
+    context "when using ActiveJob" do
+      let(:item) do
         {
-          :class    => "TestClass",
-          :method   => "perform",
-          :metadata => {
-            "retry_count" => "0",
-            "queue"       => "default",
-            "extra"       => "data"
-          },
-          :params => {
-            :foo => "Foo",
-            :bar => "Bar"
-          },
-          :queue_start => Time.parse("01-01-2001 10:00:00UTC"),
-          :queue_time  => 60_000.to_f
-        }
-      end
-      let(:args) do
-        {
-          :foo => "Foo",
-          :bar => "Bar"
+          "class" => "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper",
+          "wrapped" => "ActiveJobTestClass",
+          "queue" => "default",
+          "args" => [{
+            "job_class" => "ActiveJobTestJob",
+            "job_id" => "23e79d48-6966-40d0-b2d4-f7938463a263",
+            "queue_name" => "default",
+            "arguments" => [
+              "foo", { "foo" => "Foo", "bar" => "Bar", "baz" => { 1 => :bar } }
+            ]
+          }],
+          "retry" => true,
+          "jid" => "efb140489485999d32b5504c",
+          "created_at" => Time.parse("2001-01-01 10:00:00UTC").to_f,
+          "enqueued_at" => Time.parse("2001-01-01 10:00:00UTC").to_f
         }
       end
 
-      it "adds the more complex arguments" do
-        expect(Appsignal).to receive(:monitor_transaction).with(
-          "perform_job.sidekiq",
-          default_params.merge(
-            :params => {
-              :foo => "Foo",
-              :bar => "Bar"
+      it "creates a transaction with events" do
+        perform_job
+
+        transaction_hash = transaction.to_h
+        expect(transaction_hash).to include(
+          "id" => kind_of(String),
+          "action" => "ActiveJobTestClass#perform",
+          "error" => nil,
+          "namespace" => namespace,
+          "metadata" => {
+            "queue" => "default"
+          },
+          "sample_data" => {
+            "environment" => {},
+            "params" => [
+              "foo",
+              {
+                "foo" => "Foo",
+                "bar" => "Bar",
+                "baz" => { "1" => "bar" }
+              }
+            ],
+            "tags" => {}
+          }
+        )
+        # TODO: Not available in transaction.to_h yet.
+        # https://github.com/appsignal/appsignal-agent/issues/293
+        expect(transaction.request.env).to eq(
+          :queue_start => Time.parse("2001-01-01 10:00:00UTC").to_f
+        )
+        expect_transaction_to_have_sidekiq_event(transaction_hash)
+      end
+
+      context "with ActionMailer job" do
+        let(:item) do
+          {
+            "class" => "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper",
+            "wrapped" => "ActionMailer::DeliveryJob",
+            "queue" => "default",
+            "args" => [{
+              "job_class" => "ActiveMailerTestJob",
+              "job_id" => "23e79d48-6966-40d0-b2d4-f7938463a263",
+              "queue_name" => "default",
+              "arguments" => [
+                "MailerClass", "mailer_method", "deliver_now",
+                "foo", { "foo" => "Foo", "bar" => "Bar", "baz" => { 1 => :bar } }
+              ]
+            }],
+            "retry" => true,
+            "jid" => "efb140489485999d32b5504c",
+            "created_at" => Time.parse("2001-01-01 10:00:00UTC").to_f,
+            "enqueued_at" => Time.parse("2001-01-01 10:00:00UTC").to_f
+          }
+        end
+
+        it "creates a transaction for the ActionMailer class" do
+          perform_job
+
+          transaction_hash = transaction.to_h
+          expect(transaction_hash).to include(
+            "id" => kind_of(String),
+            "action" => "MailerClass#mailer_method",
+            "error" => nil,
+            "namespace" => namespace,
+            "metadata" => {
+              "queue" => "default"
+            },
+            "sample_data" => {
+              "environment" => {},
+              "params" => [
+                "foo",
+                {
+                  "foo" => "Foo",
+                  "bar" => "Bar",
+                  "baz" => { "1" => "bar" }
+                }
+              ],
+              "tags" => {}
             }
           )
-        )
+        end
       end
 
       context "with parameter filtering" do
@@ -89,171 +246,158 @@ describe Appsignal::Hooks::SidekiqPlugin do
         end
 
         it "filters selected arguments" do
-          expect(Appsignal).to receive(:monitor_transaction).with(
-            "perform_job.sidekiq",
-            default_params.merge(
-              :params => {
-                :foo => "[FILTERED]",
-                :bar => "Bar"
+          perform_job
+
+          transaction_hash = transaction.to_h
+          expect(transaction_hash["sample_data"]).to include(
+            "params" => [
+              "foo",
+              {
+                "foo" => "[FILTERED]",
+                "bar" => "Bar",
+                "baz" => { "1" => "bar" }
               }
-            )
+            ]
           )
-        end
-      end
-    end
-
-    context "when wrapped by ActiveJob" do
-      let(:item) do
-        {
-          "class" => "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper",
-          "wrapped" => "TestClass",
-          "queue" => "default",
-          "args" => [{
-            "job_class" => "TestJob",
-            "job_id" => "23e79d48-6966-40d0-b2d4-f7938463a263",
-            "queue_name" => "default",
-            "arguments" => args
-          }],
-          "retry" => true,
-          "jid" => "efb140489485999d32b5504c",
-          "created_at" => Time.parse("01-01-2001 10:00:00UTC").to_f,
-          "enqueued_at" => Time.parse("01-01-2001 10:00:00UTC").to_f
-        }
-      end
-      let(:default_params) do
-        {
-          :class    => "TestClass",
-          :method   => "perform",
-          :metadata => {
-            "queue" => "default"
-          },
-          :queue_start => Time.parse("01-01-2001 10:00:00UTC").to_f,
-          :queue_time  => 60_000.to_f
-        }
-      end
-
-      it "wraps it in a transaction with the correct params" do
-        expect(Appsignal).to receive(:monitor_transaction).with(
-          "perform_job.sidekiq",
-          default_params.merge(:params => ["Model", 1])
-        )
-      end
-
-      context "with more complex arguments" do
-        let(:args) do
-          {
-            :foo => "Foo",
-            :bar => "Bar"
-          }
-        end
-
-        it "adds the more complex arguments" do
-          expect(Appsignal).to receive(:monitor_transaction).with(
-            "perform_job.sidekiq",
-            default_params.merge(
-              :params => {
-                :foo => "Foo",
-                :bar => "Bar"
-              }
-            )
-          )
-        end
-
-        context "with parameter filtering" do
-          before do
-            Appsignal.config = project_fixture_config("production")
-            Appsignal.config[:filter_parameters] = ["foo"]
-          end
-
-          it "filters selected arguments" do
-            expect(Appsignal).to receive(:monitor_transaction).with(
-              "perform_job.sidekiq",
-              default_params.merge(
-                :params => {
-                  :foo => "[FILTERED]",
-                  :bar => "Bar"
-                }
-              )
-            )
-          end
         end
       end
     end
   end
 
-  context "with an erroring call" do
+  context "with an error" do
     let(:error) { ExampleException }
-    let(:transaction) do
-      Appsignal::Transaction.new(
-        SecureRandom.uuid,
-        Appsignal::Transaction::BACKGROUND_JOB,
-        Appsignal::Transaction::GenericRequest.new({})
-      )
-    end
-    before do
-      allow(Appsignal::Transaction).to receive(:current).and_return(transaction)
-      expect(Appsignal::Transaction).to receive(:create)
-        .with(
-          kind_of(String),
-          Appsignal::Transaction::BACKGROUND_JOB,
-          kind_of(Appsignal::Transaction::GenericRequest)
-        ).and_return(transaction)
-    end
 
-    it "adds the error to the transaction" do
-      expect(transaction).to receive(:set_error).with(error)
-      expect(transaction).to receive(:complete)
-    end
-
-    after do
+    it "creates a transaction and adds the error" do
       expect do
-        Timecop.freeze(Time.parse("01-01-2001 10:01:00UTC")) do
-          Appsignal::Hooks::SidekiqPlugin.new.call(worker, item, queue) do
-            raise error
-          end
-        end
+        perform_job { raise error, "uh oh" }
       end.to raise_error(error)
+
+      transaction_hash = transaction.to_h
+      expect(transaction_hash).to include(
+        "id" => kind_of(String),
+        "action" => "TestClass#perform",
+        "error" => {
+          "name" => "ExampleException",
+          "message" => "uh oh",
+          # TODO: backtrace should be an Array of Strings
+          # https://github.com/appsignal/appsignal-agent/issues/294
+          "backtrace" => kind_of(String)
+        },
+        "metadata" => {
+          "extra" => "data",
+          "queue" => "default",
+          "retry_count" => "0"
+        },
+        "namespace" => namespace,
+        "sample_data" => {
+          "environment" => {},
+          "params" => expected_args,
+          "tags" => {}
+        }
+      )
+      expect_transaction_to_have_sidekiq_event(transaction_hash)
+    end
+
+    include_examples "sidekiq metadata"
+  end
+
+  context "without an error" do
+    it "creates a transaction with events" do
+      perform_job
+
+      transaction_hash = transaction.to_h
+      expect(transaction_hash).to include(
+        "id" => kind_of(String),
+        "action" => "TestClass#perform",
+        "error" => nil,
+        "metadata" => {
+          "extra" => "data",
+          "queue" => "default",
+          "retry_count" => "0"
+        },
+        "namespace" => namespace,
+        "sample_data" => {
+          "environment" => {},
+          "params" => expected_args,
+          "tags" => {}
+        }
+      )
+      # TODO: Not available in transaction.to_h yet.
+      # https://github.com/appsignal/appsignal-agent/issues/293
+      expect(transaction.request.env).to eq(
+        :queue_start => Time.parse("2001-01-01 10:00:00UTC").to_f
+      )
+      expect_transaction_to_have_sidekiq_event(transaction_hash)
+    end
+
+    include_examples "sidekiq metadata"
+  end
+
+  def perform_job
+    Timecop.freeze(Time.parse("2001-01-01 10:01:00UTC")) do
+      plugin.call(worker, item, queue) do
+        yield if block_given?
+      end
     end
   end
 
-  # TODO: Don't test (what are basically) private methods
-  describe "#formatted_data" do
-    let(:item) do
-      {
-        "foo"   => "bar",
-        "class" => "TestClass"
-      }
-    end
+  def transaction
+    test_store[:transaction]
+  end
 
-    it "only adds items to the hash that do not appear in JOB_KEYS" do
-      expect(plugin.formatted_metadata(item)).to eq("foo" => "bar")
-    end
+  def expect_transaction_to_have_sidekiq_event(transaction_hash)
+    events = transaction_hash["events"]
+    expect(events.count).to eq(1)
+    expect(events.first).to include(
+      "name"        => "perform_job.sidekiq",
+      "title"       => "",
+      "count"       => 1,
+      "body"        => "",
+      "body_format" => Appsignal::EventFormatter::DEFAULT
+    )
   end
 end
 
 describe Appsignal::Hooks::SidekiqHook do
-  context "with sidekiq" do
-    before :context do
-      module Sidekiq
-        def self.configure_server
-        end
-      end
-      Appsignal::Hooks::SidekiqHook.new.install
-    end
-    after(:context) { Object.send(:remove_const, :Sidekiq) }
+  describe "#dependencies_present?" do
+    subject { described_class.new.dependencies_present? }
 
-    describe "#dependencies_present?" do
-      subject { described_class.new.dependencies_present? }
+    context "when Sidekiq constant is found" do
+      before { Object.const_set("Sidekiq", 1) }
+      after { Object.send(:remove_const, "Sidekiq") }
 
       it { is_expected.to be_truthy }
     end
-  end
 
-  context "without sidekiq" do
-    describe "#dependencies_present?" do
-      subject { described_class.new.dependencies_present? }
+    context "when Sidekiq constant is not found" do
+      before { Object.send(:remove_const, "Sidekiq") if defined?(Sidekiq) }
 
       it { is_expected.to be_falsy }
+    end
+  end
+
+  describe "#install" do
+    before do
+      class Sidekiq
+        def self.middlewares
+          @middlewares ||= Set.new
+        end
+
+        def self.configure_server
+          yield self
+        end
+
+        def self.server_middleware
+          yield middlewares
+        end
+      end
+    end
+    after { Object.send(:remove_const, "Sidekiq") }
+
+    it "adds the AppSignal SidekiqPlugin to the Sidekiq middleware chain" do
+      described_class.new.install
+
+      expect(Sidekiq.middlewares).to include(Appsignal::Hooks::SidekiqPlugin)
     end
   end
 end

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -95,6 +95,22 @@ describe Appsignal::Hooks::SidekiqPlugin, :with_yaml_parse_error => false do
       end
     end
 
+    context "with encrypted arguments" do
+      before do
+        item["encrypt"] = true
+        item["args"] << "super secret value" # Last argument will be replaced
+      end
+
+      it "replaces the last argument (the secret bag) with an [encrypted data] string" do
+        perform_job
+
+        transaction_hash = transaction.to_h
+        expect(transaction_hash["sample_data"]).to include(
+          "params" => expected_args << "[encrypted data]"
+        )
+      end
+    end
+
     context "when using the Sidekiq delayed extension" do
       let(:item) do
         {

--- a/spec/support/helpers/log_helpers.rb
+++ b/spec/support/helpers/log_helpers.rb
@@ -1,13 +1,18 @@
 module LogHelpers
   def use_logger_with(log)
-    Appsignal.logger = Logger.new(log)
-    Appsignal.logger.formatter =
-      proc do |severity, _datetime, _progname, msg|
-        # This format is used in the `contains_log` matcher.
-        "[#{severity}] #{msg}\n"
-      end
+    Appsignal.logger = test_logger(log)
     yield
     Appsignal.logger = nil
+  end
+
+  def test_logger(log)
+    Logger.new(log).tap do |logger|
+      logger.formatter =
+        proc do |severity, _datetime, _progname, msg|
+          # This format is used in the `contains_log` matcher.
+          "[#{severity}] #{msg}\n"
+        end
+    end
   end
 
   def log_contents(log)

--- a/spec/support/helpers/transaction_helpers.rb
+++ b/spec/support/helpers/transaction_helpers.rb
@@ -28,4 +28,10 @@ module TransactionHelpers
       }.merge(args))
     )
   end
+
+  # Use when {Appsignal::Transaction.clear_current_transaction!} is stubbed to
+  # clear the current transaction on the current thread.
+  def clear_current_transaction!
+    Thread.current[:appsignal_transaction] = nil
+  end
 end


### PR DESCRIPTION
Redo of #348 

Support Sidekiq's delay extension action names better by  unwrapping the job payload.
This also adds better support for ActiveJob arguments and ActionMailer jobs.

## TODO

- [x] Support Sidekiq's delay extension
- [x] Properly support ActiveJob and ActionMailer
- [x] Support Sidekiq enterprise encrypted values (by replacing the value). PR #365 
- [x] Base branch on master branch: cherry-pick `test_logger` method?
- [x] Double check the test suite for all scenarios covered
- [x] Test against Sidekiq v2
- [x] Test against Sidekiq v3-5
- [x] Add shared examples for action name logic and also add to "with an error" context?