### PR TITLE
⌨️ Remove unused yaml requires

### DIFF
--- a/lib/appsignal/cli.rb
+++ b/lib/appsignal/cli.rb
@@ -1,6 +1,5 @@
 require "optparse"
 require "logger"
-require "yaml"
 require "appsignal"
 require "appsignal/cli/helpers"
 require "appsignal/cli/demo"

--- a/lib/appsignal/version.rb
+++ b/lib/appsignal/version.rb
@@ -1,5 +1,3 @@
-require "yaml"
-
 module Appsignal
   VERSION = "2.4.0".freeze
 end


### PR DESCRIPTION
CLI and Version don't actively use the YAML library. Only the files that
use the YAML library require it.