### PR TITLE
⌨️ Only extend ActiveSupport when it's present

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,12 +35,14 @@ require "appsignal"
 puts "Running specs in #{RUBY_VERSION} on #{RUBY_PLATFORM}\n\n"
 
 # Add way to clear subscribers between specs
-module ActiveSupport
-  module Notifications
-    class Fanout
-      def clear_subscribers
-        @subscribers.clear
-        @listeners_for.clear
+if defined?(ActiveSupport)
+  module ActiveSupport
+    module Notifications
+      class Fanout
+        def clear_subscribers
+          @subscribers.clear
+          @listeners_for.clear
+        end
       end
     end
   end


### PR DESCRIPTION
Otherwise it could conflict with libraries and helpers that check if the
ActiveSupport constant is present or not and falsely report that
ActiveSupport is loaded.

PR only for build.