### PR TITLE
🚀 Support Sidekiq encrypted values

### DIFF
--- a/lib/appsignal/hooks/sidekiq.rb
+++ b/lib/appsignal/hooks/sidekiq.rb
@@ -119,6 +119,12 @@ module Appsignal
             job_args
           end
         else
+          # Sidekiq Enterprise argument encryption.
+          # More information: https://github.com/mperham/sidekiq/wiki/Ent-Encryption
+          if job["encrypt".freeze]
+            # No point in showing 150+ bytes of random garbage
+            args[-1] = "[encrypted data]".freeze
+          end
           args
         end
       end

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -95,6 +95,22 @@ describe Appsignal::Hooks::SidekiqPlugin, :with_yaml_parse_error => false do
       end
     end
 
+    context "with encrypted arguments" do
+      before do
+        item["encrypt"] = true
+        item["args"] << "super secret value" # Last argument will be replaced
+      end
+
+      it "replaces the last argument (the secret bag) with an [encrypted data] string" do
+        perform_job
+
+        transaction_hash = transaction.to_h
+        expect(transaction_hash["sample_data"]).to include(
+          "params" => expected_args << "[encrypted data]"
+        )
+      end
+    end
+
     context "when using the Sidekiq delayed extension" do
       let(:item) do
         {


### PR DESCRIPTION
In Sidekiq enterprise secret bag values are supported as the last
argument for a job. When this is the case the job is marked as encrypted
with the `"encrypt"` key set to `true`.

None of the other values are touched, only the last one is encrypted and
replaced by AppSignal with the `"[encrypted data]"` string, like how the
Sidekiq web UI displays it.

See also: https://github.com/mperham/sidekiq/wiki/Ent-Encryption

❗️This PR is based on #362 , if #362 is merged before this one, update the base to `master` before merging.