### PR TITLE
🐞 Use musl build for older systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ bundle_and_spec_all_rvm
 ext/libappsignal.*
 ext/appsignal-agent
 ext/appsignal.h
+ext/appsignal.platform
 ext/appsignal.version
 ext/Makefile
 ext/*.bundle

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@ Lint/HandleExceptions:
 
 # Offense count: 41
 Metrics/AbcSize:
-  Max: 59
+  Max: 59.92
 
 # Offense count: 5
 # Configuration parameters: CountComments.

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -6,19 +6,12 @@ require "zlib"
 require "rubygems/package"
 require "yaml"
 require File.expand_path("../../lib/appsignal/version.rb", __FILE__)
+require File.expand_path("../../lib/appsignal/system.rb", __FILE__)
 
 EXT_PATH     = File.expand_path("..", __FILE__).freeze
 AGENT_CONFIG = YAML.load(File.read(File.join(EXT_PATH, "agent.yml"))).freeze
 
-local_os = Gem::Platform.local.os
-chosen_os =
-  # Detect musl platforms
-  # Use `export APPSIGNAL_BUILD_FOR_MUSL=1` if the detection doesn't work.
-  if ENV["APPSIGNAL_BUILD_FOR_MUSL"] || (local_os =~ /linux/ && `ldd --version 2>&1` =~ /musl/)
-    "linux-musl"
-  end
-OS           = chosen_os || local_os
-ARCH         = "#{Gem::Platform.local.cpu}-#{OS}".freeze
+ARCH         = "#{Gem::Platform.local.cpu}-#{Appsignal::System.agent_platform}".freeze
 CA_CERT_PATH = File.join(EXT_PATH, "../resources/cacert.pem").freeze
 
 def ext_path(path)

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -11,7 +11,8 @@ require File.expand_path("../../lib/appsignal/system.rb", __FILE__)
 EXT_PATH     = File.expand_path("..", __FILE__).freeze
 AGENT_CONFIG = YAML.load(File.read(File.join(EXT_PATH, "agent.yml"))).freeze
 
-ARCH         = "#{Gem::Platform.local.cpu}-#{Appsignal::System.agent_platform}".freeze
+PLATFORM     = Appsignal::System.agent_platform
+ARCH         = "#{Gem::Platform.local.cpu}-#{PLATFORM}".freeze
 CA_CERT_PATH = File.join(EXT_PATH, "../resources/cacert.pem").freeze
 
 def ext_path(path)
@@ -29,8 +30,15 @@ def installation_failed(reason)
   end
 end
 
+def write_agent_platform
+  File.open(File.join(EXT_PATH, "appsignal.platform"), "w") do |file|
+    file.write PLATFORM
+  end
+end
+
 def install
   logger.info "Installing appsignal agent #{Appsignal::VERSION} for Ruby #{RUBY_VERSION} on #{RUBY_PLATFORM}"
+  write_agent_platform
 
   if RUBY_PLATFORM =~ /java/
     installation_failed(

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -285,6 +285,7 @@ module Appsignal
             save :language, "ruby"
             puts_and_save :package_version, "Gem version", Appsignal::VERSION
             puts_and_save :agent_version, "Agent version", Appsignal::Extension.agent_version
+            puts_and_save :agent_platform, "Agent platform", Appsignal::System.agent_platform
             puts_and_save :package_install_path, "Gem install path", gem_path
             puts_and_save :extension_loaded, "Extension loaded", Appsignal.extension_loaded
           end
@@ -297,7 +298,7 @@ module Appsignal
             puts_and_save :architecture, "Architecture", rbconfig["host_cpu"]
 
             os_label = os = rbconfig["host_os"]
-            os_label = "#{os_label} (Microsoft Windows is not supported.)" if Gem.win_platform?
+            os_label = "#{os} (Microsoft Windows is not supported.)" if Gem.win_platform?
             save :os, os
             puts_value "Operating System", os_label
 

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -285,7 +285,8 @@ module Appsignal
             save :language, "ruby"
             puts_and_save :package_version, "Gem version", Appsignal::VERSION
             puts_and_save :agent_version, "Agent version", Appsignal::Extension.agent_version
-            puts_and_save :agent_platform, "Agent platform", Appsignal::System.agent_platform
+            puts_and_save :agent_platform, "Agent platform",
+              Appsignal::System.installed_agent_platform
             puts_and_save :package_install_path, "Gem install path", gem_path
             puts_and_save :extension_loaded, "Extension loaded", Appsignal.extension_loaded
           end

--- a/lib/appsignal/system.rb
+++ b/lib/appsignal/system.rb
@@ -5,8 +5,39 @@ module Appsignal
   #
   # @api private
   module System
+    MUSL_TARGET = "linux-musl".freeze
+
     def self.heroku?
       ENV.key? "DYNO".freeze
+    end
+
+    # Detect agent and extension platform build
+    #
+    # Used by ext/extconf.rb to select which build it should download and
+    # install.
+    #
+    # Use `export APPSIGNAL_BUILD_FOR_MUSL=1` if the detection doesn't work
+    # and to force selection of the musl build.
+    #
+    # @api private
+    # @return [String]
+    def self.agent_platform
+      return MUSL_TARGET if ENV["APPSIGNAL_BUILD_FOR_MUSL"]
+
+      local_os = Gem::Platform.local.os
+      if local_os =~ /linux/
+        ldd_output = ldd_version_output
+        return MUSL_TARGET if ldd_output.include? "musl"
+        ldd_version = ldd_output.match(/\d+\.\d+/)
+        return MUSL_TARGET if ldd_version && ldd_version[0] < "2.15"
+      end
+
+      local_os
+    end
+
+    # @api private
+    def self.ldd_version_output
+      `ldd --version 2>&1`
     end
   end
 end

--- a/lib/appsignal/system.rb
+++ b/lib/appsignal/system.rb
@@ -29,10 +29,17 @@ module Appsignal
         ldd_output = ldd_version_output
         return MUSL_TARGET if ldd_output.include? "musl"
         ldd_version = ldd_output.match(/\d+\.\d+/)
-        return MUSL_TARGET if ldd_version && ldd_version[0] < "2.15"
+        if ldd_version && versionify(ldd_version[0]) < versionify("2.15")
+          return MUSL_TARGET
+        end
       end
 
       local_os
+    end
+
+    # @api private
+    def self.versionify(version)
+      Gem::Version.new(version)
     end
 
     # @api private

--- a/lib/appsignal/system.rb
+++ b/lib/appsignal/system.rb
@@ -6,14 +6,30 @@ module Appsignal
   # @api private
   module System
     MUSL_TARGET = "linux-musl".freeze
+    GEM_EXT_PATH = File.expand_path("../../../ext", __FILE__).freeze
 
     def self.heroku?
       ENV.key? "DYNO".freeze
     end
 
+    # Returns the platform for which the agent was installed.
+    #
+    # This value is saved when the gem is installed in `ext/extconf.rb`.
+    # We use this value to build the diagnose report with the installed
+    # platform, rather than the detected platform in {.agent_platform} during
+    # the diagnose run.
+    #
+    # @api private
+    # @return [String]
+    def self.installed_agent_platform
+      platform_file = File.join(GEM_EXT_PATH, "appsignal.platform")
+      return unless File.exist?(platform_file)
+      File.read(platform_file)
+    end
+
     # Detect agent and extension platform build
     #
-    # Used by ext/extconf.rb to select which build it should download and
+    # Used by `ext/extconf.rb` to select which build it should download and
     # install.
     #
     # Use `export APPSIGNAL_BUILD_FOR_MUSL=1` if the detection doesn't work

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -155,7 +155,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :report => true do
         expect(output).to include \
           "Gem version: #{Appsignal::VERSION}",
           "Agent version: #{Appsignal::Extension.agent_version}",
-          "Agent platform: #{Appsignal::System.agent_platform}",
+          "Agent platform: #{Appsignal::System.installed_agent_platform}",
           "Gem install path: #{gem_path}"
       end
 
@@ -165,7 +165,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :report => true do
             "language" => "ruby",
             "package_version" => Appsignal::VERSION,
             "agent_version" => Appsignal::Extension.agent_version,
-            "agent_platform" => Appsignal::System.agent_platform,
+            "agent_platform" => Appsignal::System.installed_agent_platform,
             "package_install_path" => gem_path,
             "extension_loaded" => true
           }

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -155,6 +155,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :report => true do
         expect(output).to include \
           "Gem version: #{Appsignal::VERSION}",
           "Agent version: #{Appsignal::Extension.agent_version}",
+          "Agent platform: #{Appsignal::System.agent_platform}",
           "Gem install path: #{gem_path}"
       end
 
@@ -164,6 +165,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :report => true do
             "language" => "ruby",
             "package_version" => Appsignal::VERSION,
             "agent_version" => Appsignal::Extension.agent_version,
+            "agent_platform" => Appsignal::System.agent_platform,
             "package_install_path" => gem_path,
             "extension_loaded" => true
           }

--- a/spec/lib/appsignal/system_spec.rb
+++ b/spec/lib/appsignal/system_spec.rb
@@ -64,6 +64,14 @@ describe Appsignal::System do
           is_expected.to eq("linux-musl")
         end
       end
+
+      context "when on a very old libc system" do
+        let(:ldd_output) { "ldd (Debian GLIBC 2.5-18+deb8u7) 2.5" }
+
+        it "returns the musl build" do
+          is_expected.to eq("linux-musl")
+        end
+      end
     end
 
     context "when on macOS" do

--- a/spec/lib/appsignal/system_spec.rb
+++ b/spec/lib/appsignal/system_spec.rb
@@ -1,3 +1,5 @@
+require "appsignal/system"
+
 describe Appsignal::System do
   describe ".heroku?" do
     subject { described_class.heroku? }
@@ -13,6 +15,72 @@ describe Appsignal::System do
     context "when not on Heroku" do
       it "returns false" do
         is_expected.to eq(false)
+      end
+    end
+  end
+
+  describe ".agent_platform" do
+    let(:os) { "linux" }
+    let(:ldd_output) { "" }
+    before do
+      allow(described_class).to receive(:ldd_version_output).and_return(ldd_output)
+      allow(Gem::Platform.local).to receive(:os).and_return(os)
+    end
+    subject { described_class.agent_platform }
+
+    context "when the system detection doesn't work" do
+      it "returns the libc build" do
+        is_expected.to eq("linux")
+      end
+    end
+
+    context "when using the APPSIGNAL_BUILD_FOR_MUSL env var" do
+      it "returns the musl build" do
+        ENV["APPSIGNAL_BUILD_FOR_MUSL"] = "1"
+        is_expected.to eq("linux-musl")
+        ENV.delete("APPSIGNAL_BUILD_FOR_MUSL")
+      end
+    end
+
+    context "when on a musl system" do
+      let(:ldd_output) { "musl libc (x86_64)\nVersion 1.1.16" }
+
+      it "returns the musl build" do
+        is_expected.to eq("linux-musl")
+      end
+    end
+
+    context "when on a libc system" do
+      let(:ldd_output) { "ldd (Debian GLIBC 2.15-18+deb8u7) 2.15" }
+
+      it "returns the libc build" do
+        is_expected.to eq("linux")
+      end
+
+      context "when on an old libc system" do
+        let(:ldd_output) { "ldd (Debian GLIBC 2.14-18+deb8u7) 2.14" }
+
+        it "returns the musl build" do
+          is_expected.to eq("linux-musl")
+        end
+      end
+    end
+
+    context "when on macOS" do
+      let(:os) { "darwin" }
+      let(:ldd_output) { "ldd: command not found" }
+
+      it "returns the darwin build" do
+        is_expected.to eq("darwin")
+      end
+    end
+
+    context "when on FreeBSD" do
+      let(:os) { "freebsd" }
+      let(:ldd_output) { "ldd: illegal option -- -" }
+
+      it "returns the darwin build" do
+        is_expected.to eq("freebsd")
       end
     end
   end


### PR DESCRIPTION
With the AppSignal for Ruby gem v2.4.0 release we dropped support for
some older Operating Systems that use a libc version older than 2.12.

Since gem v2.1.0 we started using a musl build so the libc version
didn't matter on the user's macine. Before that we used a very old
machine that used the libc version from CentOS 5, so we supported some
very old systems.

To now support older Operating System versions, with a libc older than
2.12, this change adds a check for the older versions and selects the
musl build instead.

This should fix the problem for people upgrading to (future) gem 2.4.1
and higher.

Also move the build detection to module so we can reuse the logic and
add specs for its behavior.

---

## Add agent build to diagnose report 

So we can see which agent build was detected, and presumably installed,
based on the diagnose report.

