### PR TITLE
⌨️ Store agent architecture rather than platform

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -30,15 +30,15 @@ def installation_failed(reason)
   end
 end
 
-def write_agent_platform
-  File.open(File.join(EXT_PATH, "appsignal.platform"), "w") do |file|
-    file.write PLATFORM
+def write_agent_architecture
+  File.open(File.join(EXT_PATH, "appsignal.architecture"), "w") do |file|
+    file.write ARCH
   end
 end
 
 def install
   logger.info "Installing appsignal agent #{Appsignal::VERSION} for Ruby #{RUBY_VERSION} on #{RUBY_PLATFORM}"
-  write_agent_platform
+  write_agent_architecture
 
   if RUBY_PLATFORM =~ /java/
     installation_failed(

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -285,8 +285,8 @@ module Appsignal
             save :language, "ruby"
             puts_and_save :package_version, "Gem version", Appsignal::VERSION
             puts_and_save :agent_version, "Agent version", Appsignal::Extension.agent_version
-            puts_and_save :agent_platform, "Agent platform",
-              Appsignal::System.installed_agent_platform
+            puts_and_save :agent_architecture, "Agent architecture",
+              Appsignal::System.installed_agent_architecture
             puts_and_save :package_install_path, "Gem install path", gem_path
             puts_and_save :extension_loaded, "Extension loaded", Appsignal.extension_loaded
           end

--- a/lib/appsignal/system.rb
+++ b/lib/appsignal/system.rb
@@ -12,19 +12,19 @@ module Appsignal
       ENV.key? "DYNO".freeze
     end
 
-    # Returns the platform for which the agent was installed.
+    # Returns the architecture for which the agent was installed.
     #
     # This value is saved when the gem is installed in `ext/extconf.rb`.
     # We use this value to build the diagnose report with the installed
-    # platform, rather than the detected platform in {.agent_platform} during
-    # the diagnose run.
+    # CPU type and platform, rather than the detected architecture in
+    # {.agent_platform} during the diagnose run.
     #
     # @api private
     # @return [String]
-    def self.installed_agent_platform
-      platform_file = File.join(GEM_EXT_PATH, "appsignal.platform")
-      return unless File.exist?(platform_file)
-      File.read(platform_file)
+    def self.installed_agent_architecture
+      architecture_file = File.join(GEM_EXT_PATH, "appsignal.architecture")
+      return unless File.exist?(architecture_file)
+      File.read(architecture_file)
     end
 
     # Detect agent and extension platform build

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -155,7 +155,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :report => true do
         expect(output).to include \
           "Gem version: #{Appsignal::VERSION}",
           "Agent version: #{Appsignal::Extension.agent_version}",
-          "Agent platform: #{Appsignal::System.installed_agent_platform}",
+          "Agent architecture: #{Appsignal::System.installed_agent_architecture}",
           "Gem install path: #{gem_path}"
       end
 
@@ -165,7 +165,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :report => true do
             "language" => "ruby",
             "package_version" => Appsignal::VERSION,
             "agent_version" => Appsignal::Extension.agent_version,
-            "agent_platform" => Appsignal::System.installed_agent_platform,
+            "agent_architecture" => Appsignal::System.installed_agent_architecture,
             "package_install_path" => gem_path,
             "extension_loaded" => true
           }

--- a/spec/lib/appsignal/system_spec.rb
+++ b/spec/lib/appsignal/system_spec.rb
@@ -19,10 +19,10 @@ describe Appsignal::System do
     end
   end
 
-  describe ".installed_agent_platform" do
+  describe ".installed_agent_architecture" do
     let(:const_name) { "GEM_EXT_PATH".freeze }
     let(:tmp_ext_dir) { File.join(tmp_dir, "ext") }
-    let(:platform_file) { File.join(Appsignal::System::GEM_EXT_PATH, "appsignal.platform") }
+    let(:architecture_file) { File.join(Appsignal::System::GEM_EXT_PATH, "appsignal.architecture") }
     around do |example|
       original_gem_ext_path = Appsignal::System.const_get(const_name)
       Appsignal::System.send(:remove_const, const_name)
@@ -32,12 +32,12 @@ describe Appsignal::System do
       Appsignal::System.const_set(const_name, original_gem_ext_path)
     end
     after { FileUtils.rm_rf(tmp_ext_dir) }
-    subject { described_class.installed_agent_platform }
+    subject { described_class.installed_agent_architecture }
 
-    context "with an ext/appsignal.platform file" do
+    context "with an ext/appsignal.architecture file" do
       before do
         FileUtils.mkdir_p(Appsignal::System::GEM_EXT_PATH)
-        File.open(platform_file, "w") do |file|
+        File.open(architecture_file, "w") do |file|
           file.write "foo"
         end
       end
@@ -47,7 +47,7 @@ describe Appsignal::System do
       end
     end
 
-    context "without an ext/appsignal.platform file" do
+    context "without an ext/appsignal.architecture file" do
       it "returns nil" do
         expect(subject).to be_nil
       end


### PR DESCRIPTION
The agent architecture is the combination of CPU type and build
platform. This change stores the architecture to the
`ext/appsignal.architecture` file and includes this in the diagnose
report.

Why save the architecture? As gives a more complete picture of what was
installed? Did it accidentally install the 32-bit version or the 64-bit
version? With this change we'll know and we'll know exactly which
package it used from the `ext/agent.yml` file, which allows us to debug
the install even better.

Follow up from #366 
Same change applied to Elixir when applying the fix for older libc systems: https://github.com/appsignal/appsignal-elixir/pull/274