### PR TITLE
Safe load YAML config files

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -119,6 +119,3 @@ Style/IfUnlessModifier:
 Style/NonNilCheck:
   Exclude:
     - 'lib/appsignal/transaction.rb'
-
-Security/YAMLLoad:
-  Enabled: false

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -9,7 +9,7 @@ require File.expand_path("../../lib/appsignal/version.rb", __FILE__)
 require File.expand_path("../../lib/appsignal/system.rb", __FILE__)
 
 EXT_PATH     = File.expand_path("..", __FILE__).freeze
-AGENT_CONFIG = YAML.load(File.read(File.join(EXT_PATH, "agent.yml"))).freeze
+AGENT_CONFIG = YAML.safe_load(File.read(File.join(EXT_PATH, "agent.yml")), [], [], true).freeze
 
 PLATFORM     = Appsignal::System.agent_platform
 ARCH         = "#{Gem::Platform.local.cpu}-#{PLATFORM}".freeze

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -184,7 +184,7 @@ module Appsignal
     def load_from_disk
       return if !config_file || !File.exist?(config_file)
 
-      configurations = YAML.load(ERB.new(IO.read(config_file)).result)
+      configurations = YAML.safe_load(ERB.new(IO.read(config_file)).result, [], [], true)
       config_for_this_env = configurations[env]
       if config_for_this_env
         config_for_this_env =

--- a/lib/appsignal/extension.rb
+++ b/lib/appsignal/extension.rb
@@ -16,8 +16,11 @@ module Appsignal
   class Extension
     class << self
       def agent_config
-        @agent_config ||= YAML.load(
-          File.read(File.join(File.dirname(__FILE__), "../../ext/agent.yml"))
+        @agent_config ||= YAML.safe_load(
+          File.read(File.join(File.dirname(__FILE__), "../../ext/agent.yml")),
+          [],
+          [],
+          true
         )
       end
 

--- a/lib/appsignal/hooks/sidekiq.rb
+++ b/lib/appsignal/hooks/sidekiq.rb
@@ -131,7 +131,7 @@ module Appsignal
 
       # Based on: https://github.com/mperham/sidekiq/blob/63ee43353bd3b753beb0233f64865e658abeb1c3/lib/sidekiq/api.rb#L403-L412
       def safe_load(content, default)
-        yield(*YAML.load(content))
+        yield(*YAML.load(content)) # rubocop:disable Security/YAMLLoad
       rescue => error
         # Sidekiq issue #1761: in dev mode, it's possible to have jobs enqueued
         # which haven't been loaded into memory yet so the YAML can't be


### PR DESCRIPTION
Brought to my attention by the RuboCop Security/YAMLLoad rule, switch to
using `YAML.safe_load` for most uses.

We don't support custom serialized data in the `config/appsignal.yml`
filr or in the `ext/agent.yml` file so we can safely switch to
`YAML.safe_load` from `YAML.load` without having to worry users will run
into problems when upgrading to a new gem version with this change.

Exception made for the Sidekiq integration. We don't know the contents
of Sidekiq job payloads and if `YAML.safe_load` encounters an unknown
serialized data it raises an error.

Depends on #368 