### PR TITLE
⌨️   Test warning on ext start with invalid config

### DIFF
--- a/spec/lib/appsignal/extension_spec.rb
+++ b/spec/lib/appsignal/extension_spec.rb
@@ -21,9 +21,29 @@ describe Appsignal::Extension do
       expect(Appsignal.extension_loaded?).to be_truthy
     end
 
-    it "should have a start and stop method" do
-      subject.start
-      subject.stop
+    context "without valid config" do
+      let(:out_stream) { std_stream }
+      let(:output) { out_stream.read }
+
+      describe ".start" do
+        it "outputs a warning about not starting the extension" do
+          capture_std_streams(out_stream, out_stream) do
+            subject.start
+          end
+
+          expect(output).to include \
+            "WARNING: Error when reading appsignal config, appsignal not starting"
+        end
+      end
+
+      describe ".stop" do
+        it "does nothing" do
+          capture_std_streams(out_stream, out_stream) do
+            subject.stop
+          end
+          expect(output).to be_empty
+        end
+      end
     end
 
     context "with a valid config" do

--- a/spec/lib/appsignal/extension_spec.rb
+++ b/spec/lib/appsignal/extension_spec.rb
@@ -1,6 +1,6 @@
 require "fileutils"
 
-describe "extension loading and operation" do
+describe Appsignal::Extension do
   describe ".agent_config" do
     subject { Appsignal::Extension.agent_config }
 
@@ -11,7 +11,7 @@ describe "extension loading and operation" do
   describe ".agent_version" do
     subject { Appsignal::Extension.agent_version }
 
-    it { is_expected.to_not be_nil }
+    it { is_expected.to be_kind_of(String) }
   end
 
   context "when the extension library can be loaded" do


### PR DESCRIPTION
Test actual behavior of the start and stop methods. Also test if the
output that appeared in the RSpec test output actually is present and
hide it from the output in the terminal.