### PR TITLE
Remove Set usage

### DIFF
--- a/lib/appsignal/hooks/sidekiq.rb
+++ b/lib/appsignal/hooks/sidekiq.rb
@@ -22,10 +22,10 @@ module Appsignal
     class SidekiqPlugin
       include Appsignal::Hooks::Helpers
 
-      JOB_KEYS = Set.new(%w(
+      JOB_KEYS = %w(
         args backtrace class created_at enqueued_at error_backtrace error_class
         error_message failed_at jid retried_at retry wrapped
-      )).freeze
+      ).freeze
 
       def call(_worker, item, _queue)
         transaction = Appsignal::Transaction.create(


### PR DESCRIPTION
In PR #362 the Sidekiq hook `job_keys` method was moved to the
`JOB_KEYS` constant. As its value is a `Set` instance the `set` library
is required to be loaded beforehand. This was loaded by Sidekiq in
https://github.com/mperham/sidekiq/blob/58d5ff1e6d96df4a0b3a53d74a8aa26cf08dc467/lib/sidekiq/manager.rb#L7
which is loaded before the AppSignal hooks is called.

The `JOB_KEYS` constant doesn't have to be of type `Set`, we don't use
it any different from a normal array. This change removes the set type
from the `JOB_KEYS` constant.

This fixes the problem of AppSignal CLI crashing on start:

```
bin/appsignal diagnose
/appsignal/gem/lib/appsignal/hooks/sidekiq.rb:25:in
  `<class:SidekiqPlugin>': uninitialized constant
  Appsignal::Hooks::SidekiqPlugin::Set (NameError)
```

Fixes #372