### PR TITLE
Add body for redis instrumentation

### DIFF
--- a/lib/appsignal/hooks/redis.rb
+++ b/lib/appsignal/hooks/redis.rb
@@ -16,7 +16,7 @@ module Appsignal
 
           def process(commands, &block)
             sanitized_commands = commands.map do |command, *args|
-              "#{command}#{' ?' * args.size}"
+              "#{command}#{" ?" * args.size}"
             end.join("\n")
 
             Appsignal.instrument "query.redis", id, sanitized_commands do

--- a/lib/appsignal/hooks/redis.rb
+++ b/lib/appsignal/hooks/redis.rb
@@ -15,7 +15,11 @@ module Appsignal
           alias process_without_appsignal process
 
           def process(commands, &block)
-            Appsignal.instrument "query.redis" do
+            sanitized_commands = commands.map do |command, *args|
+              "#{command}#{' ?' * args.size}"
+            end.join("\n")
+
+            Appsignal.instrument "query.redis", id, sanitized_commands do
               process_without_appsignal(commands, &block)
             end
           end

--- a/spec/lib/appsignal/hooks/redis_spec.rb
+++ b/spec/lib/appsignal/hooks/redis_spec.rb
@@ -24,10 +24,10 @@ describe Appsignal::Hooks::RedisHook do
             .at_least(:once)
           expect(Appsignal::Transaction.current).to receive(:finish_event)
             .at_least(:once)
-            .with("query.redis", nil, nil, 0)
+            .with("query.redis", "redis://127.0.0.1:6379/0", "get ?", 0)
 
           client = Redis::Client.new
-          expect(client.process([])).to eq 1
+          expect(client.process([[:get, 'key']])).to eq 1
         end
       end
 

--- a/spec/lib/appsignal/hooks/redis_spec.rb
+++ b/spec/lib/appsignal/hooks/redis_spec.rb
@@ -27,7 +27,7 @@ describe Appsignal::Hooks::RedisHook do
             .with("query.redis", "redis://127.0.0.1:6379/0", "get ?", 0)
 
           client = Redis::Client.new
-          expect(client.process([[:get, 'key']])).to eq 1
+          expect(client.process([[:get, "key"]])).to eq 1
         end
       end
 


### PR DESCRIPTION
This pull adds an instrumentation body to Redis instrument calls.

For example, a raw Sidekiq "add to queue" command that looks like this:

```
[[:multi], [:sadd, "x:queues", "default"], [:lpush, "x:queue:default", ["{\"class\":\"Test\",\"args\":[\"Moo\",3],\"retry\":true,\"queue\":\"default\",\"jid\":\"caba172b4a835464606252aa\",\"created_at\":1511518946.82925,\"enqueued_at\":1511518946.835087}"]], [:exec]]
```

Will be sanitised to an instrumentation call with a body of:

```
multi
sadd ? ?
lpush ? ?
exec
```


![incident - testapp - appsignal 2017-11-27 14-49-13](https://user-images.githubusercontent.com/282402/33269786-30f282b6-d382-11e7-934c-bbdd9ec4541d.png)
