### PR TITLE
Fix Capistrano config overrides

### DIFF
--- a/lib/appsignal/integrations/capistrano/appsignal.cap
+++ b/lib/appsignal/integrations/capistrano/appsignal.cap
@@ -7,9 +7,14 @@ namespace :appsignal do
     appsignal_config = Appsignal::Config.new(
       ENV["PWD"],
       appsignal_env,
-      fetch(:appsignal_config, {}),
+      {},
       Logger.new(StringIO.new)
-    )
+    ).tap do |c|
+      fetch(:appsignal_config, {}).each do |key, value|
+        c[key] = value
+      end
+      c.validate
+    end
 
     if appsignal_config && appsignal_config.active?
       marker_data = {

--- a/lib/appsignal/integrations/capistrano/capistrano_2_tasks.rb
+++ b/lib/appsignal/integrations/capistrano/capistrano_2_tasks.rb
@@ -3,7 +3,7 @@ module Appsignal
   # @api private
   class Capistrano
     def self.tasks(config)
-      config.load do
+      config.load do # rubocop:disable Metrics/BlockLength
         after "deploy", "appsignal:deploy"
         after "deploy:migrations", "appsignal:deploy"
 
@@ -16,9 +16,14 @@ module Appsignal
             appsignal_config = Appsignal::Config.new(
               ENV["PWD"],
               env,
-              fetch(:appsignal_config, {}),
+              {},
               Logger.new(StringIO.new)
-            )
+            ).tap do |c|
+              fetch(:appsignal_config, {}).each do |key, value|
+                c[key] = value
+              end
+              c.validate
+            end
 
             if appsignal_config && appsignal_config.active?
               marker_data = {

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -601,4 +601,26 @@ describe Appsignal::Config do
       end
     end
   end
+
+  describe "#validate" do
+    before { config.validate }
+    subject { config.valid? }
+    let(:config) { described_class.new(Dir.pwd, "production", :push_api_key => push_api_key) }
+
+    context "with missing push_api_key" do
+      let(:push_api_key) { nil }
+
+      it "sets valid to false" do
+        is_expected.to eq(false)
+      end
+    end
+
+    context "with push_api_key present" do
+      let(:push_api_key) { "abc" }
+
+      it "sets valid to true" do
+        is_expected.to eq(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Fix Capistrano config overrides

Previously any config given to the Capistrano deploy definition was
given as the initial config of Appsignal::Config. This initial config is
then overridden by any next step of the config: config file and env
variables, which made it kind of useless. Instead, override the config
with the Capistrano config after all the other config is loaded.

## Make Appsignal::Config#validate public

So you can validate the config after it has been initialized.

Fixes #264 