### PR TITLE
Add jRuby support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ ext/Makefile
 ext/*.bundle
 ext/*.o
 ext/*.so
+pkg/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,6 +54,10 @@ Style/MethodMissing:
 Style/TrailingUnderscoreVariable:
   Enabled: false
 
+Style/FileName:
+  Exclude:
+    - "ext/Rakefile"
+
 Metrics/BlockLength:
   Exclude:
     - "Rakefile"

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,6 @@ matrix:
       gemfile: "gemfiles/no_dependencies.gemfile"
       script: "bundle exec rubocop"
   exclude:
-    # We don't currently support jRuby
-    - rvm: "jruby-19mode"
-
     # Rails 5 doesn't support Ruby < 2.2
     - rvm: "2.0.0"
       gemfile: "gemfiles/rails-5.0.gemfile"
@@ -62,7 +59,9 @@ matrix:
       gemfile: "gemfiles/rails-4.1.gemfile"
 
 env:
-  global: "RAILS_ENV=test"
+  global:
+    - "RAILS_ENV=test"
+    - "JRUBY_OPTS=''" # Workaround https://github.com/travis-ci/travis-ci/issues/6471
 
 before_install:
   - "gem update --system"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.5.0 (Alpha)
+* Add jRuby support. PR #376
+
 # 2.4.3
 * Store more details for Redis events. PR #374
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require "bundler"
+require "rubygems/package_task"
 require "fileutils"
 
 GEMFILES = %w[
@@ -38,75 +39,116 @@ VERSION_MANAGERS = {
   :rvm => ->(version) { "rvm use --default #{version.split("-").first}" }
 }.freeze
 
-task :publish do
-  require "appsignal/version"
+namespace :build do
+  def modify_base_gemspec
+    eval(File.read("appsignal.gemspec")).tap do |s| # rubocop:disable Security/Eval
+      yield s
+    end
+  end
 
-  NAME = "appsignal".freeze
+  namespace :ruby do
+    spec = modify_base_gemspec do |s|
+      s.extensions = %w[ext/extconf.rb]
+    end
+
+    Gem::PackageTask.new(spec) { |_pkg| }
+  end
+
+  namespace :jruby do
+    spec = modify_base_gemspec do |s|
+      s.platform = "java"
+      s.extensions = %w[ext/Rakefile]
+      s.add_dependency "ffi"
+    end
+
+    Gem::PackageTask.new(spec) { |_pkg| }
+  end
+
+  desc "Build all gem versions"
+  task :all => ["ruby:gem", "jruby:gem"]
+
+  desc "Clean up all gem build artifacts"
+  task :clean do
+    FileUtils.rm_rf File.expand_path("../pkg", __FILE__)
+  end
+end
+
+namespace :publish do
   VERSION_FILE = "lib/appsignal/version.rb".freeze
   CHANGELOG_FILE = "CHANGELOG.md".freeze
 
-  raise "$EDITOR should be set" unless ENV["EDITOR"]
-
-  def build_and_push_gem
-    puts "# Building gem"
-    FileUtils.rm_f("#{NAME}-#{gem_version}.gem")
-    puts `gem build #{NAME}.gemspec`
-    puts "# Publishing Gem"
-    puts `gem push #{NAME}-#{gem_version}.gem`
-  end
-
-  def create_and_push_tag
-    puts `git commit -am 'Bump to #{version} [ci skip]'`
-    puts "# Creating tag #{version}"
-    puts `git tag #{version}`
-    puts `git push origin #{version}`
-    puts `git push origin #{current_branch}`
-  rescue
-    raise "Tag: '#{version}' already exists"
-  end
-
   def changes
     git_status_to_array(`git status -s -u`)
-  end
-
-  def gem_version
-    Appsignal::VERSION
-  end
-
-  def version
-    @version ||= "v#{gem_version}"
-  end
-
-  def current_branch
-    `git rev-parse --abbrev-ref HEAD`.chomp
   end
 
   def git_status_to_array(changes)
     changes.split("\n").each { |change| change.gsub!(/^.. /, "") }
   end
 
-  raise "Branch should hold no uncommitted file change)" unless changes.empty?
-
-  system("$EDITOR #{VERSION_FILE}")
-  unless changes.member?(VERSION_FILE)
-    raise "Actually change the version in: #{VERSION_FILE}"
+  def current_branch
+    `git rev-parse --abbrev-ref HEAD`.chomp
   end
 
-  Appsignal.send(:remove_const, :VERSION)
-  load File.expand_path(VERSION_FILE)
-  system("$EDITOR #{CHANGELOG_FILE}")
+  task :check_requirements do
+    unless changes.empty?
+      puts "ERROR: There should be no uncommitted file changes."
+      exit 1
+    end
+    unless ENV["EDITOR"]
+      puts "ERROR: $EDITOR environment variable should be set."
+      exit 1
+    end
+  end
 
-  # Build and push for MRI
-  ENV.delete("APPSIGNAL_PUSH_JAVA_GEM")
-  build_and_push_gem
+  task :configure_version do
+    puts "\n# Configuring new gem version"
 
-  # Build and push for jRuby
-  ENV["APPSIGNAL_PUSH_JAVA_GEM"] = "true"
-  build_and_push_gem
+    puts `$EDITOR #{VERSION_FILE}`
+    unless changes.member?(VERSION_FILE)
+      puts "ERROR: Please actually change the gem version in: #{VERSION_FILE}"
+      exit 1
+    end
 
-  # Create tag
-  create_and_push_tag
+    puts "\n# Updating the changelog"
+    puts `$EDITOR #{CHANGELOG_FILE}`
+  end
+
+  task :push_gem_packages do
+    puts "\n# Pushing gem packages"
+    Dir.chdir("#{File.dirname(__FILE__)}/pkg") do
+      Dir["*.gem"].each do |gem_package|
+        puts "## Publishing gem package: #{gem_package}"
+        puts `gem push #{gem_package}`
+      end
+    end
+  end
+
+  task :tag_and_push_version do
+    # Make sure to load the new version number
+    Appsignal.send(:remove_const, :VERSION)
+    load File.expand_path(VERSION_FILE)
+    version = "v#{Appsignal::VERSION}"
+
+    begin
+      puts `git commit -am 'Bump to #{version} [ci skip]'`
+      puts "# Creating tag #{version}"
+      puts `git tag #{version}`
+      puts `git push origin #{version}`
+      puts `git push origin #{current_branch}`
+    rescue
+      puts "ERROR: Tag '#{version}' already exists"
+      exit 1
+    end
+  end
 end
+task :publish => [
+  "publish:check_requirements",
+  "publish:configure_version",
+  "build:clean",
+  "build:all",
+  "publish:push_gem_packages",
+  "publish:tag_and_push_version"
+]
 
 desc "Install the AppSignal gem, extension and all possible dependencies."
 task :install => "extension:install" do

--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -2,7 +2,7 @@
 
 require File.expand_path("../lib/appsignal/version", __FILE__)
 
-Gem::Specification.new do |gem| # rubocop:disable Metrics/BlockLength
+Gem::Specification.new do |gem|
   gem.authors = [
     "Robert Beekman",
     "Thijs Cadier"
@@ -21,14 +21,6 @@ Gem::Specification.new do |gem| # rubocop:disable Metrics/BlockLength
   gem.require_paths         = %w[lib ext]
   gem.version               = Appsignal::VERSION
   gem.required_ruby_version = ">= 1.9"
-
-  if RUBY_PLATFORM == "java" || ENV["APPSIGNAL_PUSH_JAVA_GEM"]
-    gem.platform = "java"
-    gem.extensions = %w[ext/Rakefile]
-    gem.add_dependency "ffi"
-  else
-    gem.extensions = %w[ext/extconf.rb]
-  end
 
   gem.add_dependency "rack"
 

--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -2,7 +2,7 @@
 
 require File.expand_path("../lib/appsignal/version", __FILE__)
 
-Gem::Specification.new do |gem|
+Gem::Specification.new do |gem| # rubocop:disable Metrics/BlockLength
   gem.authors = [
     "Robert Beekman",
     "Thijs Cadier"

--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -22,7 +22,13 @@ Gem::Specification.new do |gem|
   gem.version               = Appsignal::VERSION
   gem.required_ruby_version = ">= 1.9"
 
-  gem.extensions = %w[ext/extconf.rb]
+  if RUBY_PLATFORM == "java" || ENV["APPSIGNAL_PUSH_JAVA_GEM"]
+    gem.platform = "java"
+    gem.extensions = %w[ext/Rakefile]
+    gem.add_dependency "ffi"
+  else
+    gem.extensions = %w[ext/extconf.rb]
+  end
 
   gem.add_dependency "rack"
 

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -1,0 +1,27 @@
+require File.expand_path("../../lib/appsignal/version.rb", __FILE__)
+require File.expand_path("../base.rb", __FILE__)
+
+task :default do
+  begin
+    logger.info "Installing appsignal agent #{Appsignal::VERSION} for Ruby #{RUBY_VERSION} on #{RUBY_PLATFORM}"
+    write_agent_architecture
+    next unless check_architecture
+    arch_config = AGENT_CONFIG["triples"][ARCH]
+
+    unless File.exist?(ext_path("appsignal-agent")) &&
+        (
+          File.exist?(ext_path("libappsignal.dylib")) ||
+          File.exist?(ext_path("libappsignal.so"))
+        ) &&
+        File.exist?(ext_path("appsignal.h"))
+      archive = download_archive(arch_config, "dynamic")
+      next unless verify_archive(archive, arch_config, "dynamic")
+      unarchive(archive)
+    end
+  rescue => ex
+    installation_failed "Exception while installing: #{ex}"
+    ex.backtrace.each do |line|
+      logger.error line
+    end
+  end
+end

--- a/ext/agent.yml
+++ b/ext/agent.yml
@@ -1,33 +1,64 @@
 ---
-version: 98aef2c
+version: 57a48f4
 triples:
   x86_64-darwin:
-    checksum: 275b03a13348a853f188a1ca88c60478a802a6d75e78468234eb4842f26f666c
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/98aef2c/appsignal-x86_64-darwin-all-static.tar.gz
+    static:
+      checksum: 4fa30287925bad17abb3e86784793e13399dd9390c0579ca94bd8f4ee7a832a3
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/57a48f4/appsignal-x86_64-darwin-all-static.tar.gz
+    dynamic:
+      checksum: 1380d4d7263b0fe2a546085efa64643289010b7dd21282c2900e81164a123e8d
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/57a48f4/appsignal-x86_64-darwin-all-dynamic.tar.gz
   universal-darwin:
-    checksum: 275b03a13348a853f188a1ca88c60478a802a6d75e78468234eb4842f26f666c
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/98aef2c/appsignal-x86_64-darwin-all-static.tar.gz
+    static:
+      checksum: 4fa30287925bad17abb3e86784793e13399dd9390c0579ca94bd8f4ee7a832a3
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/57a48f4/appsignal-x86_64-darwin-all-static.tar.gz
+    dynamic:
+      checksum: 1380d4d7263b0fe2a546085efa64643289010b7dd21282c2900e81164a123e8d
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/57a48f4/appsignal-x86_64-darwin-all-dynamic.tar.gz
   i686-linux:
-    checksum: 7ae3942e3aa7cc659e2318f06cbe45b0dc9fbba219f804665b0bc60ea68efce4
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/98aef2c/appsignal-i686-linux-all-static.tar.gz
+    static:
+      checksum: 9a1e59dd42e5ddcd0af04c0cffb0aadeace05dfae46d00aec71e90490186cbfd
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/57a48f4/appsignal-i686-linux-all-static.tar.gz
+    dynamic:
+      checksum: ef45877189d3ea4be568ec2fa64a0f04fc94783c42e53f6a55672576a2cfb150
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/57a48f4/appsignal-i686-linux-all-dynamic.tar.gz
   x86-linux:
-    checksum: 7ae3942e3aa7cc659e2318f06cbe45b0dc9fbba219f804665b0bc60ea68efce4
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/98aef2c/appsignal-i686-linux-all-static.tar.gz
+    static:
+      checksum: 9a1e59dd42e5ddcd0af04c0cffb0aadeace05dfae46d00aec71e90490186cbfd
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/57a48f4/appsignal-i686-linux-all-static.tar.gz
+    dynamic:
+      checksum: ef45877189d3ea4be568ec2fa64a0f04fc94783c42e53f6a55672576a2cfb150
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/57a48f4/appsignal-i686-linux-all-dynamic.tar.gz
   i686-linux-musl:
-    checksum: 38859a7d5513f1aa3c849559807c4fba42c8fe76eb93eaf46a96fc5adb8c105a
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/98aef2c/appsignal-i686-linux-musl-all-static.tar.gz
+    static:
+      checksum: cfa14d6aa3ad419a1d87854dfb13a780b34e4ccbf3afbe6adc7704ef750fc414
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/57a48f4/appsignal-i686-linux-musl-all-static.tar.gz
   x86-linux-musl:
-    checksum: 38859a7d5513f1aa3c849559807c4fba42c8fe76eb93eaf46a96fc5adb8c105a
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/98aef2c/appsignal-i686-linux-musl-all-static.tar.gz
+    static:
+      checksum: cfa14d6aa3ad419a1d87854dfb13a780b34e4ccbf3afbe6adc7704ef750fc414
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/57a48f4/appsignal-i686-linux-musl-all-static.tar.gz
   x86_64-linux:
-    checksum: cbf6104586e004bbd6f0e67c8629224a27612ee24a5a9434a5240471330f73a4
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/98aef2c/appsignal-x86_64-linux-all-static.tar.gz
+    static:
+      checksum: 8a68e7da4710fc97be73210437c890897a84f37f6ae9095f36d61099e52f07dc
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/57a48f4/appsignal-x86_64-linux-all-static.tar.gz
+    dynamic:
+      checksum: 5b2806ae841a6052f55c0824370dad41a04ae0ad2025df87a54847cce81054c3
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/57a48f4/appsignal-x86_64-linux-all-dynamic.tar.gz
   x86_64-linux-musl:
-    checksum: 968964c84e0a640b2b7f50c376190d95aa5bee105361d0989c679bcc42f12f79
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/98aef2c/appsignal-x86_64-linux-musl-all-static.tar.gz
+    static:
+      checksum: ffc91182064c1f0dbd9d219816054903fcc28db977cdd74df15802c468a2f252
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/57a48f4/appsignal-x86_64-linux-musl-all-static.tar.gz
   x86_64-freebsd:
-    checksum: f9f604127a8315d776312a7ce608aa1df937ed0263a2f0d3ef871d6a0f470b8b
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/98aef2c/appsignal-x86_64-freebsd-all-static.tar.gz
+    static:
+      checksum: c1781a09ec4e4c9e2f08a60e662acd8790286ebad62c9d32712a7932d0852a10
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/57a48f4/appsignal-x86_64-freebsd-all-static.tar.gz
+    dynamic:
+      checksum: 0ce479051f5734b330d91811c51813d93e65758ecad97e5f6b9e86764480e7c2
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/57a48f4/appsignal-x86_64-freebsd-all-dynamic.tar.gz
   amd64-freebsd:
-    checksum: f9f604127a8315d776312a7ce608aa1df937ed0263a2f0d3ef871d6a0f470b8b
-    download_url: https://appsignal-agent-releases.global.ssl.fastly.net/98aef2c/appsignal-x86_64-freebsd-all-static.tar.gz
+    static:
+      checksum: c1781a09ec4e4c9e2f08a60e662acd8790286ebad62c9d32712a7932d0852a10
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/57a48f4/appsignal-x86_64-freebsd-all-static.tar.gz
+    dynamic:
+      checksum: 0ce479051f5734b330d91811c51813d93e65758ecad97e5f6b9e86764480e7c2
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/57a48f4/appsignal-x86_64-freebsd-all-dynamic.tar.gz

--- a/ext/base.rb
+++ b/ext/base.rb
@@ -1,0 +1,79 @@
+require "digest"
+require "logger"
+require "fileutils"
+require "open-uri"
+require "zlib"
+require "yaml"
+require "rubygems/package"
+require File.expand_path("../../lib/appsignal/system.rb", __FILE__)
+
+EXT_PATH     = File.expand_path("..", __FILE__).freeze
+AGENT_CONFIG = YAML.load(File.read(File.join(EXT_PATH, "agent.yml"))).freeze
+
+PLATFORM     = Appsignal::System.agent_platform
+ARCH         = "#{RbConfig::CONFIG["host_cpu"]}-#{PLATFORM}".freeze
+CA_CERT_PATH = File.join(EXT_PATH, "../resources/cacert.pem").freeze
+
+def ext_path(path)
+  File.join(EXT_PATH, path)
+end
+
+def logger
+  @logger ||= Logger.new(File.join(EXT_PATH, "install.log"))
+end
+
+def installation_failed(reason)
+  logger.error "Installation failed: #{reason}"
+  File.open(File.join(EXT_PATH, "Makefile"), "w") do |file|
+    file.write "default:\nclean:\ninstall:"
+  end
+end
+
+def write_agent_architecture
+  File.open(File.join(EXT_PATH, "appsignal.architecture"), "w") do |file|
+    file.write ARCH
+  end
+end
+
+def check_architecture
+  if AGENT_CONFIG["triples"].keys.include?(ARCH)
+    true
+  else
+    installation_failed(
+      "AppSignal currently does not support your system architecture (#{ARCH})." \
+      "Please let us know at support@appsignal.com, we aim to support everything our customers run."
+    )
+    false
+  end
+end
+
+def download_archive(arch_config, type)
+  logger.info "Downloading agent release from #{arch_config[type]["download_url"]}"
+  open(arch_config[type]["download_url"], :ssl_ca_cert => CA_CERT_PATH)
+end
+
+def verify_archive(archive, arch_config, type)
+  if Digest::SHA256.hexdigest(archive.read) == arch_config[type]["checksum"]
+    logger.info "Checksum of downloaded archive verified, extracting archive"
+    true
+  else
+    installation_failed(
+      "Aborting installation, checksum of downloaded archive could not be verified: " \
+      "Expected '#{arch_config[type]["checksum"]}', got '#{checksum}'."
+    )
+    false
+  end
+end
+
+def unarchive(archive)
+  Gem::Package::TarReader.new(Zlib::GzipReader.open(archive)) do |tar|
+    tar.each do |entry|
+      next unless entry.file?
+
+      File.open(ext_path(entry.full_name), "wb") do |f|
+        f.write(entry.read)
+      end
+    end
+  end
+  FileUtils.chmod(0o755, ext_path("appsignal-agent"))
+end

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -1,89 +1,18 @@
-require "digest"
-require "logger"
-require "fileutils"
-require "open-uri"
-require "zlib"
-require "rubygems/package"
-require "yaml"
 require File.expand_path("../../lib/appsignal/version.rb", __FILE__)
-require File.expand_path("../../lib/appsignal/system.rb", __FILE__)
-
-EXT_PATH     = File.expand_path("..", __FILE__).freeze
-AGENT_CONFIG = YAML.load(File.read(File.join(EXT_PATH, "agent.yml"))).freeze
-
-PLATFORM     = Appsignal::System.agent_platform
-ARCH         = "#{Gem::Platform.local.cpu}-#{PLATFORM}".freeze
-CA_CERT_PATH = File.join(EXT_PATH, "../resources/cacert.pem").freeze
-
-def ext_path(path)
-  File.join(EXT_PATH, path)
-end
-
-def logger
-  @logger ||= Logger.new(File.join(EXT_PATH, "install.log"))
-end
-
-def installation_failed(reason)
-  logger.error "Installation failed: #{reason}"
-  File.open(File.join(EXT_PATH, "Makefile"), "w") do |file|
-    file.write "default:\nclean:\ninstall:"
-  end
-end
-
-def write_agent_architecture
-  File.open(File.join(EXT_PATH, "appsignal.architecture"), "w") do |file|
-    file.write ARCH
-  end
-end
+require File.expand_path("../base.rb", __FILE__)
 
 def install
   logger.info "Installing appsignal agent #{Appsignal::VERSION} for Ruby #{RUBY_VERSION} on #{RUBY_PLATFORM}"
   write_agent_architecture
-
-  if RUBY_PLATFORM =~ /java/
-    installation_failed(
-      "We do not support jRuby at the moment, email support@appsignal.com if you want to join the beta"
-    )
-    return
-  end
-
-  unless AGENT_CONFIG["triples"].keys.include?(ARCH)
-    installation_failed(
-      "AppSignal currently does not support your system architecture (#{ARCH})." \
-      "Please let us know at support@appsignal.com, we aim to support everything our customers run."
-    )
-    return
-  end
-
+  return unless check_architecture
   arch_config = AGENT_CONFIG["triples"][ARCH]
 
   unless File.exist?(ext_path("appsignal-agent")) &&
       File.exist?(ext_path("libappsignal.a")) &&
       File.exist?(ext_path("appsignal.h"))
-    logger.info "Downloading agent release from #{arch_config["download_url"]}"
-
-    archive = open(arch_config["download_url"], :ssl_ca_cert => CA_CERT_PATH)
-
-    if Digest::SHA256.hexdigest(archive.read) == arch_config["checksum"]
-      logger.info "Checksum of downloaded archive verified, extracting archive"
-    else
-      installation_failed(
-        "Aborting installation, checksum of downloaded archive could not be verified: " \
-        "Expected '#{arch_config["checksum"]}', got '#{checksum}'."
-      )
-      return
-    end
-
-    Gem::Package::TarReader.new(Zlib::GzipReader.open(archive)) do |tar|
-      tar.each do |entry|
-        next unless entry.file?
-
-        File.open(ext_path(entry.full_name), "wb") do |f|
-          f.write(entry.read)
-        end
-      end
-    end
-    FileUtils.chmod(0o755, ext_path("appsignal-agent"))
+    archive = download_archive(arch_config, "static")
+    return unless verify_archive(archive, arch_config, "static")
+    unarchive(archive)
   end
 
   logger.info "Creating makefile"

--- a/gemfiles/sequel-435.gemfile
+++ b/gemfiles/sequel-435.gemfile
@@ -1,7 +1,11 @@
 source 'https://rubygems.org'
 
 gem 'sequel', '~> 4.35'
-gem 'sqlite3'
+if RUBY_PLATFORM == "java"
+  gem 'jdbc-sqlite3'
+else
+  gem 'sqlite3'
+end
 gem 'rack', '~> 1.6'
 
 gemspec :path => '../'

--- a/gemfiles/sequel.gemfile
+++ b/gemfiles/sequel.gemfile
@@ -1,7 +1,11 @@
 source 'https://rubygems.org'
 
 gem 'sequel', '< 4.35'
-gem 'sqlite3'
+if RUBY_PLATFORM == "java"
+  gem 'jdbc-sqlite3'
+else
+  gem 'sqlite3'
+end
 gem 'rack', '~> 1.6'
 
 gemspec :path => '../'

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -63,6 +63,11 @@ module Appsignal
       end
     end
 
+    # @api private
+    def testing?
+      false
+    end
+
     # Start the AppSignal integration.
     #
     # Starts AppSignal with the given configuration. If no configuration is set
@@ -88,7 +93,7 @@ module Appsignal
     #
     # @return [void]
     # @since 0.7.0
-    def start
+    def start # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       unless extension_loaded?
         logger.info("Not starting appsignal, extension is not loaded")
         return
@@ -119,7 +124,7 @@ module Appsignal
           Appsignal::EventFormatter.initialize_formatters
           initialize_extensions
 
-          if config[:enable_allocation_tracking]
+          if config[:enable_allocation_tracking] && !Appsignal::System.jruby?
             Appsignal::Extension.install_allocation_event_hook
           end
 
@@ -698,7 +703,7 @@ module Appsignal
     # @see Extension
     # @since 1.0.0
     def extension_loaded?
-      !!@extension_loaded
+      !!extension_loaded
     end
 
     # Returns the active state of the AppSignal integration.

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -778,6 +778,7 @@ module Appsignal
   end
 end
 
+require "appsignal/system"
 require "appsignal/utils"
 require "appsignal/extension"
 require "appsignal/auth_check"
@@ -796,4 +797,3 @@ require "appsignal/rack/generic_instrumentation"
 require "appsignal/rack/js_exception_catcher"
 require "appsignal/js_exception_transaction"
 require "appsignal/transmitter"
-require "appsignal/system"

--- a/lib/appsignal/extension.rb
+++ b/lib/appsignal/extension.rb
@@ -1,12 +1,17 @@
 require "yaml"
 
 begin
-  require "appsignal_extension"
-  Appsignal.extension_loaded = true
+  if Appsignal::System.jruby?
+    require "appsignal/extension/jruby"
+    # {Appsignal.extension_loaded} is set in the jRuby extension file
+  else
+    require "appsignal_extension"
+    Appsignal.extension_loaded = true
+  end
 rescue LoadError => err
   Appsignal.logger.error(
     "Failed to load extension (#{err}), please check the install.log file in " \
-    "the ext directory of the gem and e-mail us at support@appsignal.com"
+    "the ext directory of the gem and email us at support@appsignal.com"
   )
   Appsignal.extension_loaded = false
 end
@@ -25,9 +30,28 @@ module Appsignal
         agent_config["version"]
       end
 
+      # Do nothing if the extension methods are not loaded
+      #
+      # Disabled in testing so we can make sure that we don't miss a extension
+      # function implementation.
       def method_missing(m, *args, &block)
-        # Do nothing if the extension methods are not loaded
+        super if Appsignal.testing?
       end
+    end
+
+    if Appsignal::System.jruby?
+      extend Appsignal::Extension::Jruby
+
+      # Reassign Transaction class for jRuby extension usage.
+      #
+      # Makes sure the generated docs aren't always overwritten with the jRuby
+      # version.
+      Transaction = Jruby::Transaction
+      # Reassign Data class for jRuby extension usage.
+      #
+      # Makes sure the generated docs aren't always overwritten with the jRuby
+      # version.
+      Data = Jruby::Data
     end
 
     class Data

--- a/lib/appsignal/extension/jruby.rb
+++ b/lib/appsignal/extension/jruby.rb
@@ -1,0 +1,460 @@
+require "ffi"
+
+module Appsignal
+  class Extension
+    # jRuby extension wrapper
+    #
+    # Only loaded if the system is detected as jRuby.
+    #
+    # @api private
+    module Jruby # rubocop:disable Metrics/ModuleLength
+      extend FFI::Library
+
+      # jRuby extension String helpers.
+      #
+      # Based on the make_appsignal_string and make_ruby_string helpers from the
+      # AppSignal C-extension in `ext/appsignal_extension.c`.
+      module StringHelpers
+        class AppsignalString < FFI::Struct
+          layout :len, :size_t,
+            :buf, :pointer
+        end
+
+        def make_appsignal_string(ruby_string)
+          unless ruby_string.is_a?(String)
+            raise ArgumentError, "argument is not a string"
+          end
+
+          AppsignalString.new.tap do |appsignal_string|
+            appsignal_string[:len] = ruby_string.bytesize
+            appsignal_string[:buf] = FFI::MemoryPointer.from_string(ruby_string)
+          end
+        end
+
+        def make_ruby_string(appsignal_string)
+          appsignal_string[:buf].read_string(appsignal_string[:len]).tap do |ruby_string|
+            ruby_string.force_encoding(Encoding::UTF_8)
+          end
+        end
+      end
+      include StringHelpers
+
+      def self.lib_extension
+        if Appsignal::System.agent_platform.include?("darwin")
+          "dylib"
+        else
+          "so"
+        end
+      end
+
+      begin
+        ffi_lib File.join(File.dirname(__FILE__), "../../../ext/libappsignal.#{lib_extension}")
+        typedef AppsignalString.by_value, :appsignal_string
+
+        attach_function :appsignal_start, [], :void
+        attach_function :appsignal_stop, [], :void
+        attach_function :appsignal_diagnose, [], :appsignal_string
+        attach_function :appsignal_get_server_state,
+          [:appsignal_string],
+          :appsignal_string
+        attach_function :appsignal_running_in_container, [], :bool
+
+        # Metrics methods
+        attach_function :appsignal_set_gauge,
+          [:appsignal_string, :double],
+          :void
+        attach_function :appsignal_set_host_gauge,
+          [:appsignal_string, :double],
+          :void
+        attach_function :appsignal_set_process_gauge,
+          [:appsignal_string, :double],
+          :void
+        attach_function :appsignal_increment_counter,
+          [:appsignal_string, :int64],
+          :void
+        attach_function :appsignal_add_distribution_value,
+          [:appsignal_string, :double],
+          :void
+
+        # Transaction methods
+        attach_function :appsignal_free_transaction,
+          [],
+          :void
+        attach_function :appsignal_start_transaction,
+          [:appsignal_string, :appsignal_string, :long],
+          :pointer
+        attach_function :appsignal_start_event,
+          [:pointer, :long],
+          :void
+        attach_function :appsignal_finish_event,
+          [:pointer, :appsignal_string, :appsignal_string, :appsignal_string, :int64, :long],
+          :void
+        attach_function :appsignal_finish_event_data,
+          [:pointer, :appsignal_string, :appsignal_string, :pointer, :int64, :long],
+          :void
+        attach_function :appsignal_record_event,
+          [:pointer, :appsignal_string, :appsignal_string, :appsignal_string, :int64, :long, :long],
+          :void
+        attach_function :appsignal_record_event_data,
+          [:pointer, :appsignal_string, :appsignal_string, :pointer, :int64, :long, :long],
+          :void
+        attach_function :appsignal_set_transaction_error,
+          [:pointer, :appsignal_string, :appsignal_string, :pointer],
+          :void
+        attach_function :appsignal_set_transaction_action,
+          [:pointer, :appsignal_string],
+          :void
+        attach_function :appsignal_set_transaction_namespace,
+          [:pointer, :appsignal_string],
+          :void
+        attach_function :appsignal_set_transaction_sample_data,
+          [:pointer, :appsignal_string, :pointer],
+          :void
+        attach_function :appsignal_set_transaction_queue_start,
+          [:pointer, :long],
+          :void
+        attach_function :appsignal_set_transaction_metadata,
+          [:pointer, :appsignal_string, :appsignal_string],
+          :void
+        attach_function :appsignal_finish_transaction,
+          [:pointer, :long],
+          :void
+        attach_function :appsignal_complete_transaction,
+          [:pointer],
+          :void
+        attach_function :appsignal_transaction_to_json,
+          [:pointer],
+          :appsignal_string
+
+        # Data struct methods
+        attach_function :appsignal_free_data, [], :void
+        attach_function :appsignal_data_map_new, [], :pointer
+        attach_function :appsignal_data_array_new, [], :pointer
+        attach_function :appsignal_data_map_set_string,
+          [:pointer, :appsignal_string, :appsignal_string],
+          :void
+        attach_function :appsignal_data_map_set_integer,
+          [:pointer, :appsignal_string, :int64],
+          :void
+        attach_function :appsignal_data_map_set_float,
+          [:pointer, :appsignal_string, :double],
+          :void
+        attach_function :appsignal_data_map_set_boolean,
+          [:pointer, :appsignal_string, :bool],
+          :void
+        attach_function :appsignal_data_map_set_null,
+          [:pointer, :appsignal_string],
+          :void
+        attach_function :appsignal_data_map_set_data,
+          [:pointer, :appsignal_string, :pointer],
+          :void
+        attach_function :appsignal_data_array_append_string,
+          [:pointer, :appsignal_string],
+          :void
+        attach_function :appsignal_data_array_append_integer,
+          [:pointer, :int64],
+          :void
+        attach_function :appsignal_data_array_append_float,
+          [:pointer, :double],
+          :void
+        attach_function :appsignal_data_array_append_boolean,
+          [:pointer, :bool],
+          :void
+        attach_function :appsignal_data_array_append_null,
+          [:pointer],
+          :void
+        attach_function :appsignal_data_array_append_data,
+          [:pointer, :pointer],
+          :void
+        attach_function :appsignal_data_equal,
+          [:pointer, :pointer],
+          :bool
+        attach_function :appsignal_data_to_json,
+          [:pointer],
+          :appsignal_string
+
+        Appsignal.extension_loaded = true
+      rescue LoadError => err
+        Appsignal.logger.error(
+          "Failed to load extension (#{err}), please email us at " \
+          "support@appsignal.com"
+        )
+        Appsignal.extension_loaded = false
+      end
+
+      def start
+        appsignal_start
+      end
+
+      def stop
+        appsignal_stop
+      end
+
+      def diagnose
+        make_ruby_string(appsignal_diagnose)
+      end
+
+      def get_server_state(key)
+        state = appsignal_get_server_state(make_appsignal_string(key))
+        make_ruby_string state if state[:len] > 0
+      end
+
+      def start_transaction(transaction_id, namespace, gc_duration_ms)
+        transaction = appsignal_start_transaction(
+          make_appsignal_string(transaction_id),
+          make_appsignal_string(namespace),
+          gc_duration_ms
+        )
+
+        return if !transaction || transaction.null?
+        Transaction.new(transaction)
+      end
+
+      def data_map_new
+        Data.new(appsignal_data_map_new)
+      end
+
+      def data_array_new
+        Data.new(appsignal_data_array_new)
+      end
+
+      def running_in_container?
+        appsignal_running_in_container
+      end
+
+      def set_gauge(key, value)
+        appsignal_set_gauge(make_appsignal_string(key), value)
+      end
+
+      def set_host_gauge(key, value)
+        appsignal_set_host_gauge(make_appsignal_string(key), value)
+      end
+
+      def set_process_gauge(key, value)
+        appsignal_set_process_gauge(make_appsignal_string(key), value)
+      end
+
+      def increment_counter(key, value)
+        appsignal_increment_counter(make_appsignal_string(key), value)
+      end
+
+      def add_distribution_value(key, value)
+        appsignal_add_distribution_value(make_appsignal_string(key), value)
+      end
+
+      class Transaction # rubocop:disable Metrics/ClassLength
+        include StringHelpers
+
+        attr_reader :pointer
+
+        def initialize(pointer)
+          @pointer = FFI::AutoPointer.new(
+            pointer,
+            Extension.method(:appsignal_free_transaction)
+          )
+        end
+
+        def start_event(gc_duration_ms)
+          Extension.appsignal_start_event(pointer, gc_duration_ms)
+        end
+
+        def finish_event(name, title, body, body_format, gc_duration_ms)
+          case body
+          when String
+            method = :appsignal_finish_event
+            body_arg = make_appsignal_string(body)
+          when Data
+            method = :appsignal_finish_event_data
+            body_arg = body.pointer
+          else
+            raise ArgumentError,
+              "body argument should be a String or Appsignal::Extension::Data"
+          end
+          Extension.public_send(
+            method,
+            pointer,
+            make_appsignal_string(name),
+            make_appsignal_string(title),
+            body_arg,
+            body_format,
+            gc_duration_ms
+          )
+        end
+
+        def record_event(name, title, body, body_format, duration, gc_duration_ms) # rubocop:disable Metrics/ParameterLists
+          case body
+          when String
+            method = :appsignal_record_event
+            body_arg = make_appsignal_string(body)
+          when Data
+            method = :appsignal_record_event_data
+            body_arg = body.pointer
+          else
+            raise ArgumentError,
+              "body argument should be a String or Appsignal::Extension::Data"
+          end
+          Extension.public_send(
+            method,
+            pointer,
+            make_appsignal_string(name),
+            make_appsignal_string(title),
+            body_arg,
+            body_format,
+            duration,
+            gc_duration_ms
+          )
+        end
+
+        def set_error(name, message, backtrace)
+          Extension.appsignal_set_transaction_error(
+            pointer,
+            make_appsignal_string(name),
+            make_appsignal_string(message),
+            backtrace.pointer
+          )
+        end
+
+        def set_action(action_name) # rubocop:disable Style/AccessorMethodName
+          Extension.appsignal_set_transaction_action(
+            pointer,
+            make_appsignal_string(action_name)
+          )
+        end
+
+        def set_namespace(namespace) # rubocop:disable Style/AccessorMethodName
+          Extension.appsignal_set_transaction_namespace(
+            pointer,
+            make_appsignal_string(namespace)
+          )
+        end
+
+        def set_sample_data(key, payload)
+          Extension.appsignal_set_transaction_sample_data(
+            pointer,
+            make_appsignal_string(key),
+            payload.pointer
+          )
+        end
+
+        def set_queue_start(time) # rubocop:disable Style/AccessorMethodName
+          Extension.appsignal_set_transaction_queue_start(pointer, time)
+        end
+
+        def set_metadata(key, value)
+          Extension.appsignal_set_transaction_metadata(
+            pointer,
+            make_appsignal_string(key),
+            make_appsignal_string(value)
+          )
+        end
+
+        def finish(gc_duration_ms)
+          Extension.appsignal_finish_transaction(pointer, gc_duration_ms)
+        end
+
+        def complete
+          Extension.appsignal_complete_transaction(pointer)
+        end
+
+        def to_json
+          json = Extension.appsignal_transaction_to_json(pointer)
+          make_ruby_string(json) if json[:len] > 0
+        end
+      end
+
+      class Data
+        include StringHelpers
+        attr_reader :pointer
+
+        def initialize(pointer)
+          @pointer = FFI::AutoPointer.new(
+            pointer,
+            Extension.method(:appsignal_free_data)
+          )
+        end
+
+        def set_string(key, value)
+          Extension.appsignal_data_map_set_string(
+            pointer,
+            make_appsignal_string(key),
+            make_appsignal_string(value)
+          )
+        end
+
+        def set_integer(key, value)
+          Extension.appsignal_data_map_set_integer(
+            pointer,
+            make_appsignal_string(key),
+            value
+          )
+        end
+
+        def set_float(key, value)
+          Extension.appsignal_data_map_set_float(
+            pointer,
+            make_appsignal_string(key),
+            value
+          )
+        end
+
+        def set_boolean(key, value)
+          Extension.appsignal_data_map_set_boolean(
+            pointer,
+            make_appsignal_string(key),
+            value
+          )
+        end
+
+        def set_nil(key) # rubocop:disable Style/AccessorMethodName
+          Extension.appsignal_data_map_set_null(
+            pointer,
+            make_appsignal_string(key)
+          )
+        end
+
+        def set_data(key, value)
+          Extension.appsignal_data_map_set_data(
+            pointer,
+            make_appsignal_string(key),
+            value.pointer
+          )
+        end
+
+        def append_string(value)
+          Extension.appsignal_data_array_append_string(
+            pointer,
+            make_appsignal_string(value)
+          )
+        end
+
+        def append_integer(value)
+          Extension.appsignal_data_array_append_integer(pointer, value)
+        end
+
+        def append_float(value)
+          Extension.appsignal_data_array_append_float(pointer, value)
+        end
+
+        def append_boolean(value)
+          Extension.appsignal_data_array_append_boolean(pointer, value)
+        end
+
+        def append_nil
+          Extension.appsignal_data_array_append_null(pointer)
+        end
+
+        def append_data(value)
+          Extension.appsignal_data_array_append_data(pointer, value.pointer)
+        end
+
+        def ==(other)
+          Extension.appsignal_data_equal(pointer, other.pointer)
+        end
+
+        def to_s
+          make_ruby_string Extension.appsignal_data_to_json(pointer)
+        end
+      end
+    end
+  end
+end

--- a/lib/appsignal/system.rb
+++ b/lib/appsignal/system.rb
@@ -40,7 +40,7 @@ module Appsignal
     def self.agent_platform
       return MUSL_TARGET if ENV["APPSIGNAL_BUILD_FOR_MUSL"]
 
-      local_os = Gem::Platform.local.os
+      local_os = RbConfig::CONFIG["host_os"]
       if local_os =~ /linux/
         ldd_output = ldd_version_output
         return MUSL_TARGET if ldd_output.include? "musl"

--- a/lib/appsignal/system.rb
+++ b/lib/appsignal/system.rb
@@ -40,7 +40,18 @@ module Appsignal
     def self.agent_platform
       return MUSL_TARGET if ENV["APPSIGNAL_BUILD_FOR_MUSL"]
 
-      local_os = RbConfig::CONFIG["host_os"]
+      host_os = RbConfig::CONFIG["host_os"].downcase
+      local_os =
+        case host_os
+        when /linux/
+          "linux"
+        when /darwin/
+          "darwin"
+        when /freebsd/
+          "freebsd"
+        else
+          host_os
+        end
       if local_os =~ /linux/
         ldd_output = ldd_version_output
         return MUSL_TARGET if ldd_output.include? "musl"
@@ -61,6 +72,10 @@ module Appsignal
     # @api private
     def self.ldd_version_output
       `ldd --version 2>&1`
+    end
+
+    def self.jruby?
+      RUBY_PLATFORM == "java"
     end
   end
 end

--- a/lib/appsignal/version.rb
+++ b/lib/appsignal/version.rb
@@ -1,3 +1,3 @@
 module Appsignal
-  VERSION = "2.4.3".freeze
+  VERSION = "2.5.0.alpha.1".freeze
 end

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -260,12 +260,12 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :report => true do
             "Agent diagnostics",
             "  Error while parsing agent diagnostics report:",
             "    Output: invalid agent\njson"
-          expect(output).to match(/Error: \d+: unexpected token at 'invalid agent\njson'/)
+          expect(output).to match(/Error:( \d+:)? unexpected token at 'invalid agent\njson'/)
         end
 
         it "adds the output to the report" do
           expect(received_report["agent"]["error"])
-            .to match(/\d+: unexpected token at 'invalid agent\njson'/)
+            .to match(/unexpected token at 'invalid agent\njson'/)
           expect(received_report["agent"]["output"]).to eq(["invalid agent", "json"])
         end
       end

--- a/spec/lib/appsignal/extension/jruby_spec.rb
+++ b/spec/lib/appsignal/extension/jruby_spec.rb
@@ -1,0 +1,43 @@
+if Appsignal::System.jruby?
+  describe Appsignal::Extension::Jruby do
+    let(:extension) { Appsignal::Extension }
+
+    describe "string conversions" do
+      it "keeps the same value during string type conversions" do
+        # UTF-8 string with NULL
+        # Tests if the conversions between the conversions without breaking on
+        # NULL terminated strings in C.
+        string = "Merry Christmas! \u0000 🎄"
+
+        appsignal_string = extension.make_appsignal_string(string)
+        ruby_string = extension.make_ruby_string(appsignal_string)
+
+        expect(ruby_string).to eq("Merry Christmas! \u0000 🎄")
+      end
+    end
+
+    it "loads libappsignal with FFI" do
+      expect(described_class.ffi_libraries.map(&:name).first).to include "libappsignal"
+    end
+
+    describe ".lib_extension" do
+      subject { described_class.lib_extension }
+
+      context "when on a darwin system" do
+        before { expect(Appsignal::System).to receive(:agent_platform).and_return("darwin") }
+
+        it "returns the extension for darwin" do
+          is_expected.to eq "dylib"
+        end
+      end
+
+      context "when on a linux system" do
+        before { expect(Appsignal::System).to receive(:agent_platform).and_return("linux") }
+
+        it "returns the lib extension for linux" do
+          is_expected.to eq "so"
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/appsignal/extension_spec.rb
+++ b/spec/lib/appsignal/extension_spec.rb
@@ -119,11 +119,9 @@ describe Appsignal::Extension do
   context "when the extension library cannot be loaded" do
     subject { Appsignal::Extension }
 
-    before :context do
-      Appsignal.extension_loaded = false
-    end
-    after :context do
-      Appsignal.extension_loaded = true
+    before do
+      allow(Appsignal).to receive(:extension_loaded).and_return(false)
+      allow(Appsignal).to receive(:testing?).and_return(false)
     end
 
     it "should indicate that the extension is not loaded" do

--- a/spec/lib/appsignal/hooks/sequel_spec.rb
+++ b/spec/lib/appsignal/hooks/sequel_spec.rb
@@ -1,6 +1,12 @@
 describe Appsignal::Hooks::SequelHook do
   if DependencyHelper.sequel_present?
-    let(:db) { Sequel.sqlite }
+    let(:db) do
+      if Appsignal::System.jruby?
+        Sequel.connect("jdbc:sqlite::memory:")
+      else
+        Sequel.sqlite
+      end
+    end
 
     before :context do
       start_agent

--- a/spec/lib/appsignal/system_spec.rb
+++ b/spec/lib/appsignal/system_spec.rb
@@ -55,11 +55,12 @@ describe Appsignal::System do
   end
 
   describe ".agent_platform" do
-    let(:os) { "linux" }
+    let(:os) { "linux-gnu" }
     let(:ldd_output) { "" }
     before do
       allow(described_class).to receive(:ldd_version_output).and_return(ldd_output)
-      allow(Gem::Platform.local).to receive(:os).and_return(os)
+      allow(RbConfig::CONFIG).to receive(:[])
+      allow(RbConfig::CONFIG).to receive(:[]).with("host_os").and_return(os)
     end
     subject { described_class.agent_platform }
 
@@ -110,7 +111,7 @@ describe Appsignal::System do
     end
 
     context "when on macOS" do
-      let(:os) { "darwin" }
+      let(:os) { "darwin16.7.0" }
       let(:ldd_output) { "ldd: command not found" }
 
       it "returns the darwin build" do
@@ -119,7 +120,7 @@ describe Appsignal::System do
     end
 
     context "when on FreeBSD" do
-      let(:os) { "freebsd" }
+      let(:os) { "freebsd11" }
       let(:ldd_output) { "ldd: illegal option -- -" }
 
       it "returns the darwin build" do

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -87,9 +87,11 @@ describe Appsignal do
           Appsignal.start
         end
 
-        it "should install the allocation event hook" do
-          expect(Appsignal::Extension).to receive(:install_allocation_event_hook)
-          Appsignal.start
+        unless Appsignal::System.jruby?
+          it "installs the allocation event hook" do
+            expect(Appsignal::Extension).to receive(:install_allocation_event_hook)
+            Appsignal.start
+          end
         end
 
         it "should add the gc probe to minutely" do


### PR DESCRIPTION
Use FFI to link to functions from the Rust extension. Add a small Ruby
wrapper for the Extension, Transaction and Data types so the interface
stays the same between the C-extension and FFI. By using constant
reassignment in `lib/appsignal/extension.rb` we can keep the docs
intact for both implementations.

Add a new agent build to work with empty strings for configuration options,
they are now considered unset config options. Was necessary to work
around something that appears to be a jRuby bug when unsetting keys
on the `ENV` hash.

## Support jRuby gem installation
Configure the jRuby compatible gem version to build using the
ext/Rakefile default task. Extract the same logic for downloading the
extension and gem to a separate file so it can be easily reused.

Change the host OS detection from `Gem::Platform.local.os` to
`RbConfig::CONFIG["host_os"]` as `Gem::Platform.local.os` returns "java"
on jRuby, which isn't very helpful in detecting the system OS.

Closes https://github.com/appsignal/appsignal-agent/issues/214 (private issue)
Built in collaboration with @thijsc 

## TODO

- [ ] Fix reported issue in: https://app.intercom.io/a/apps/yzor8gyw/respond/inbox/540709/conversations/8290612100
- [ ] Write blog post for 2.5 release and announce it it as beta/early-access