### PR TITLE
Silence backtrace lines with Rails' backtrace cleaner

### DIFF
--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -472,7 +472,7 @@ module Appsignal
 
     def cleaned_backtrace(backtrace)
       if defined?(::Rails) && backtrace
-        ::Rails.backtrace_cleaner.clean(backtrace, nil)
+        ::Rails.backtrace_cleaner.clean(backtrace)
       else
         backtrace
       end

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -1082,11 +1082,18 @@ describe Appsignal::Transaction do
 
       if rails_present?
         context "with rails" do
-          it "cleans the backtrace with the Rails backtrace cleaner" do
+          it "filters the backtrace with the Rails backtrace cleaner" do
             ::Rails.backtrace_cleaner.add_filter do |line|
               line.tr("2", "?")
             end
             expect(subject).to eq ["line 1", "line ?"]
+          end
+
+          it "silences lines from the backtrace with the Rails backtrace cleaner" do
+            ::Rails.backtrace_cleaner.add_silencer do |line|
+              line =~ /2/
+            end
+            expect(subject).to eq ["line 1"]
           end
         end
       end


### PR DESCRIPTION
As reported via [support](https://app.intercom.io/a/apps/yzor8gyw/respond/inbox/540654/conversations/13024983021) (private Intercom link).

As discussed with @thijsc. We currently only use the filtering part of Rails' backtrace silencer, but it defaults to both filtering (replacing matching strings) and silencing (removing matching lines). This patch removes the second argument to use Rails' default.