### PR TITLE
⌨️ Don't set _APPSIGNAL_AGENT_VERSION environment variable

### DIFF
--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -142,7 +142,6 @@ module Appsignal
       ENV["_APPSIGNAL_APP_PATH"]                     = root_path.to_s
       ENV["_APPSIGNAL_AGENT_PATH"]                   = File.expand_path("../../../ext", __FILE__).to_s
       ENV["_APPSIGNAL_ENVIRONMENT"]                  = env
-      ENV["_APPSIGNAL_AGENT_VERSION"]                = Appsignal::Extension.agent_version
       ENV["_APPSIGNAL_LANGUAGE_INTEGRATION_VERSION"] = "ruby-#{Appsignal::VERSION}"
       ENV["_APPSIGNAL_DEBUG_LOGGING"]                = config_hash[:debug].to_s
       ENV["_APPSIGNAL_LOG"]                          = config_hash[:log]

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -418,7 +418,6 @@ describe Appsignal::Config do
       expect(ENV["_APPSIGNAL_PUSH_API_KEY"]).to                 eq "abc"
       expect(ENV["_APPSIGNAL_APP_NAME"]).to                     eq "TestApp"
       expect(ENV["_APPSIGNAL_ENVIRONMENT"]).to                  eq "production"
-      expect(ENV["_APPSIGNAL_AGENT_VERSION"]).to                eq Appsignal::Extension.agent_version
       expect(ENV["_APPSIGNAL_LANGUAGE_INTEGRATION_VERSION"]).to eq "ruby-#{Appsignal::VERSION}"
       expect(ENV["_APPSIGNAL_HTTP_PROXY"]).to                   eq "http://localhost"
       expect(ENV["_APPSIGNAL_IGNORE_ACTIONS"]).to               eq "action1,action2"


### PR DESCRIPTION
Setting the agent version in an environment variable hasn't been
required since agent version ea78a58, as the agent now finds its
revision
itself.