### PR TITLE
🐞  Support Sidekiq delay extension for ActiveRecord instances 

### DIFF
--- a/lib/appsignal/hooks/sidekiq.rb
+++ b/lib/appsignal/hooks/sidekiq.rb
@@ -19,7 +19,7 @@ module Appsignal
     end
 
     # @api private
-    class SidekiqPlugin
+    class SidekiqPlugin # rubocop:disable Metrics/ClassLength
       include Appsignal::Hooks::Helpers
 
       JOB_KEYS = %w[
@@ -84,6 +84,10 @@ module Appsignal
       def parse_action_name(job)
         args = job["args"]
         case job["class"]
+        when "Sidekiq::Extensions::DelayedModel"
+          safe_load(job["args"][0], job["class"]) do |target, method, _|
+            "#{target.class}##{method}"
+          end
         when /\ASidekiq::Extensions::Delayed/
           safe_load(job["args"][0], job["class"]) do |target, method, _|
             "#{target}.#{method}"


### PR DESCRIPTION
Sidekiq supports the Delayed::Job `.delay` extension on instance level
for ActiveRecord models. "This is not recommended" and "is here for
backwards compatibility with Delayed::Job only" as per
https://github.com/mperham/sidekiq/blob/167b871183e9e1636b0654e9644acd1672dfb193/lib/sidekiq/extensions/active_record.rb#L12-L14

This change adds support for proper action names in AppSignal as well
when using this extension on ActiveRecord instances.