### PR TITLE
Upgrade RuboCop to version 0.50

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,9 @@ AllCops:
   UseCache: true
   CacheRootDirectory: ./tmp
 
+Lint/RescueWithoutErrorClass:
+  Enabled: false
+
 Style/Documentation:
   Enabled: false
 
@@ -55,7 +58,10 @@ Style/MethodMissing:
 Style/TrailingUnderscoreVariable:
   Enabled: false
 
-Style/FileName:
+Style/Encoding: # For Ruby 1.9 as it doesn't default to UTF-8
+  Enabled: false
+
+Naming/FileName:
   Exclude:
     - "ext/Rakefile"
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -55,7 +55,7 @@ Metrics/PerceivedComplexity:
   Max: 14
 
 # Offense count: 10
-Style/AccessorMethodName:
+Naming/AccessorMethodName:
   Exclude:
     - 'lib/appsignal.rb'
     - 'lib/appsignal/transaction.rb'

--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "pry"
   gem.add_development_dependency "timecop"
   gem.add_development_dependency "webmock"
-  gem.add_development_dependency "rubocop", "0.49.0"
+  gem.add_development_dependency "rubocop", "0.50.0"
   gem.add_development_dependency "yard"
 end

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -93,7 +93,7 @@ module Appsignal
     #
     # @return [void]
     # @since 0.7.0
-    def start # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    def start
       unless extension_loaded?
         logger.info("Not starting appsignal, extension is not loaded")
         return
@@ -101,12 +101,10 @@ module Appsignal
 
       logger.debug("Starting appsignal")
 
-      unless @config
-        @config = Config.new(
-          Dir.pwd,
-          ENV["APPSIGNAL_APP_ENV"] || ENV["RAILS_ENV"] || ENV["RACK_ENV"]
-        )
-      end
+      @config ||= Config.new(
+        Dir.pwd,
+        ENV["APPSIGNAL_APP_ENV"] || ENV["RAILS_ENV"] || ENV["RACK_ENV"]
+      )
 
       if config.valid?
         logger.level =
@@ -736,14 +734,14 @@ module Appsignal
     end
 
     # @deprecated No replacement
-    def is_ignored_error?(error) # rubocop:disable Style/PredicateName
+    def is_ignored_error?(error) # rubocop:disable Naming/PredicateName
       Appsignal.config[:ignore_errors].include?(error.class.name)
     end
     alias :is_ignored_exception? :is_ignored_error?
     deprecate :is_ignored_error?, :none, 2017, 3
 
     # @deprecated No replacement
-    def is_ignored_action?(action) # rubocop:disable Style/PredicateName
+    def is_ignored_action?(action) # rubocop:disable Naming/PredicateName
       Appsignal.config[:ignore_actions].include?(action)
     end
     deprecate :is_ignored_action?, :none, 2017, 3

--- a/lib/appsignal/extension/jruby.rb
+++ b/lib/appsignal/extension/jruby.rb
@@ -314,14 +314,14 @@ module Appsignal
           )
         end
 
-        def set_action(action_name) # rubocop:disable Style/AccessorMethodName
+        def set_action(action_name) # rubocop:disable Naming/AccessorMethodName
           Extension.appsignal_set_transaction_action(
             pointer,
             make_appsignal_string(action_name)
           )
         end
 
-        def set_namespace(namespace) # rubocop:disable Style/AccessorMethodName
+        def set_namespace(namespace) # rubocop:disable Naming/AccessorMethodName
           Extension.appsignal_set_transaction_namespace(
             pointer,
             make_appsignal_string(namespace)
@@ -336,7 +336,7 @@ module Appsignal
           )
         end
 
-        def set_queue_start(time) # rubocop:disable Style/AccessorMethodName
+        def set_queue_start(time) # rubocop:disable Naming/AccessorMethodName
           Extension.appsignal_set_transaction_queue_start(pointer, time)
         end
 
@@ -405,7 +405,7 @@ module Appsignal
           )
         end
 
-        def set_nil(key) # rubocop:disable Style/AccessorMethodName
+        def set_nil(key) # rubocop:disable Naming/AccessorMethodName
           Extension.appsignal_data_map_set_null(
             pointer,
             make_appsignal_string(key)


### PR DESCRIPTION
- Above it drops Ruby 1.9 support, which I don't want to touch right
  now.
- Update rule names.
- Use memoization for AppSignal config in `Appsignal.start`.