### PR TITLE
Improve padrino action names

### DIFF
--- a/lib/appsignal/integrations/padrino.rb
+++ b/lib/appsignal/integrations/padrino.rb
@@ -60,9 +60,6 @@ module Padrino::Routing::InstanceMethods
     controller_name = request.controller if request.respond_to?(:controller)
     action_name = request.action if request.respond_to?(:action)
     action_name ||= ""
-    if action_name.empty? && request.respond_to?(:fullpath)
-      action_name = request.fullpath
-    end
 
     unless action_name.empty?
       return "#{settings.name}:#{controller_name}##{action_name}"
@@ -75,7 +72,7 @@ module Padrino::Routing::InstanceMethods
 
     # Fall back to the application name if we haven't found an action name in
     # any previous methods.
-    settings.name.to_s
+    "#{settings.name}#unknown"
   end
 end
 


### PR DESCRIPTION
Improve Padrino Action name logic

Instead of using the `full_path` we ask the router for it's parsed path.

Old situation: `Padrinotest::Admin:sessions#/accounts/show/1`
New situation: `Padrinotest::Admin:sessions#/accounts/show/:id`

If all else fails, use `"#{settings.name}#unknown"` to indicate that we can't get the action information.

I've also improved the specs by running the requests through the router, instead of reading mocks/stubs.
