### PR TITLE
⌨️ Add :request_headers and APPSIGNAL_REQUEST_HEADERS configuration

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -187,10 +187,6 @@ module Appsignal
     # This helper method also captures any exception that occurs in the given
     # block.
     #
-    # The other (request) `env` argument hash keys, not listed here, can be
-    # found on the {Appsignal::Transaction::ENV_METHODS} array.
-    # Each of these keys are available as keys in the `env` hash argument.
-    #
     # @example
     #   Appsignal.monitor_transaction("perform_job.nightly_update") do
     #     # your code

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -61,6 +61,7 @@ module Appsignal
       "APPSIGNAL_CA_FILE_PATH"                   => :ca_file_path,
       "APPSIGNAL_DNS_SERVERS"                    => :dns_servers,
       "APPSIGNAL_FILES_WORLD_ACCESSIBLE"         => :files_world_accessible,
+      "APPSIGNAL_REQUEST_HEADERS"                => :request_headers,
       "APP_REVISION"                             => :revision
     }.freeze
 
@@ -267,7 +268,8 @@ module Appsignal
 
       # Configuration with array of strings type
       %w[APPSIGNAL_IGNORE_ACTIONS APPSIGNAL_IGNORE_ERRORS
-         APPSIGNAL_IGNORE_NAMESPACES APPSIGNAL_FILTER_PARAMETERS].each do |var|
+         APPSIGNAL_IGNORE_NAMESPACES APPSIGNAL_FILTER_PARAMETERS
+         APPSIGNAL_REQUEST_HEADERS].each do |var|
         env_var = ENV[var]
         next unless env_var
         config[ENV_TO_KEY_MAPPING[var]] = env_var.split(",")

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -416,7 +416,8 @@ module Appsignal
       return if env.empty?
 
       {}.tap do |out|
-        FALLBACK_REQUEST_HEADERS.each do |key|
+        (Appsignal.config[:request_headers] ||
+          FALLBACK_REQUEST_HEADERS).each do |key|
           out[key] = env[key] if env[key]
         end
       end

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -9,7 +9,7 @@ module Appsignal
     BLANK          = "".freeze
 
     # Based on what Rails uses + some variables we'd like to show
-    ENV_METHODS = %w[
+    FALLBACK_REQUEST_HEADERS = %w[
       CONTENT_LENGTH AUTH_TYPE GATEWAY_INTERFACE
       PATH_TRANSLATED REMOTE_HOST REMOTE_IDENT REMOTE_USER REMOTE_ADDR
       REQUEST_METHOD SERVER_NAME SERVER_PORT SERVER_PROTOCOL REQUEST_URI
@@ -406,7 +406,8 @@ module Appsignal
     # The environment of a transaction can contain a lot of information, not
     # all of it useful for debugging.
     #
-    # Only the values from the keys specified in {ENV_METHODS} are returned.
+    # Only the values from the keys specified in {FALLBACK_REQUEST_HEADERS} are
+    # returned.
     #
     # @return [nil] if no environment is present.
     # @return [Hash<String, Object>]
@@ -415,7 +416,7 @@ module Appsignal
       return if env.empty?
 
       {}.tap do |out|
-        ENV_METHODS.each do |key|
+        FALLBACK_REQUEST_HEADERS.each do |key|
           out[key] = env[key] if env[key]
         end
       end

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -300,6 +300,7 @@ describe Appsignal::Config do
       ENV["APPSIGNAL_INSTRUMENT_REDIS"]        = "false"
       ENV["APPSIGNAL_INSTRUMENT_SEQUEL"]       = "false"
       ENV["APPSIGNAL_FILES_WORLD_ACCESSIBLE"]  = "false"
+      ENV["APPSIGNAL_REQUEST_HEADERS"]         = "accept,accept-charset"
       ENV["APP_REVISION"] = "v2.5.1"
     end
 
@@ -319,6 +320,7 @@ describe Appsignal::Config do
       expect(config[:instrument_redis]).to eq(false)
       expect(config[:instrument_sequel]).to eq(false)
       expect(config[:files_world_accessible]).to eq(false)
+      expect(config[:request_headers]).to eq(%w[accept accept-charset])
       expect(config[:revision]).to eq("v2.5.1")
     end
 

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -912,7 +912,7 @@ describe Appsignal::Transaction do
     end
 
     describe "#sanitized_environment" do
-      let(:whitelisted_keys) { Appsignal::Transaction::ENV_METHODS }
+      let(:whitelisted_keys) { Appsignal::Transaction::FALLBACK_REQUEST_HEADERS }
 
       subject { transaction.send(:sanitized_environment) }
 

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -940,6 +940,16 @@ describe Appsignal::Transaction do
         it "only sets whitelisted keys" do
           expect(subject.keys).to match_array(whitelisted_keys)
         end
+
+        context "with configured request_heades" do
+          before do
+            Appsignal.config.config_hash[:request_headers] = %w[CONTENT_LENGTH]
+          end
+
+          it "only sets whitelisted keys" do
+            expect(subject.keys).to match_array(%w[CONTENT_LENGTH])
+          end
+        end
       end
     end
 


### PR DESCRIPTION
First part of https://github.com/appsignal/appsignal-ruby/issues/389.

Adds the :request_headers and APPSIGNAL_REQUEST_HEADERS configurations, which will override the default list when set. This *does not* include writing a list of header keys to the configuration file yet. That will be part two.