### PR TITLE
Refactor event_formatter registration code

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -121,6 +121,7 @@ module Appsignal
           config.write_to_environment
           Appsignal::Extension.start
           Appsignal::Hooks.load_hooks
+          Appsignal::EventFormatter.initialize_deprecated_formatters
           initialize_extensions
 
           if config[:enable_allocation_tracking] && !Appsignal::System.jruby?

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -121,7 +121,6 @@ module Appsignal
           config.write_to_environment
           Appsignal::Extension.start
           Appsignal::Hooks.load_hooks
-          Appsignal::EventFormatter.initialize_formatters
           initialize_extensions
 
           if config[:enable_allocation_tracking] && !Appsignal::System.jruby?

--- a/lib/appsignal/event_formatter.rb
+++ b/lib/appsignal/event_formatter.rb
@@ -31,7 +31,10 @@ module Appsignal
         end
 
         if registered?(name, formatter)
-          Appsignal.logger.warn("Formatter for '#{name}' already initialized, not initializing '#{formatter.name}'")
+          Appsignal.logger.warn(
+            "Formatter for '#{name}' already registered, not registering "\
+            "'#{formatter.name}'"
+          )
           return
         end
 
@@ -82,9 +85,9 @@ module Appsignal
 
       def register_deprecated_formatter(name)
         Appsignal.logger.warn(
-          "Formatter for '#{name}' is using a deprecated registration method." \
-          "This event formatter will not be loaded." \
-          "please update the formatter according to the documentation at: " \
+          "Formatter for '#{name}' is using a deprecated registration " \
+          "method. This event formatter will not be loaded. " \
+          "Please update the formatter according to the documentation at: " \
           "https://docs.appsignal.com/ruby/instrumentation/event-formatters.html"
         )
 

--- a/lib/appsignal/event_formatter.rb
+++ b/lib/appsignal/event_formatter.rb
@@ -16,6 +16,10 @@ module Appsignal
         @@formatters ||= {}
       end
 
+      def deprecated_formatter_classes
+        @@deprecated_formatter_classes ||= {}
+      end
+
       def formatter_classes
         @@formatter_classes ||= {}
       end
@@ -26,6 +30,8 @@ module Appsignal
                                 "This event formatter will not be loaded" \
                                 "please update the formatter according to the documentation at: " \
                                 "https://docs.appsignal.com/ruby/instrumentation/event-formatters.html")
+
+          deprecated_formatter_classes[name] = self
           return
         end
 
@@ -40,12 +46,18 @@ module Appsignal
             formatter_classes[name] = formatter
             formatters[name] = formatter.new
           else
-            raise "#{f} does not have a format(payload) method"
+            raise "#{formatter} does not have a format(payload) method"
           end
         rescue => ex
           formatter_classes.delete(name)
           formatters.delete(name)
           Appsignal.logger.warn("'#{ex.message}' when initializing #{name} event formatter")
+        end
+      end
+
+      def initialize_deprecated_formatters
+        deprecated_formatter_classes.each do |name, formatter|
+          register(name, formatter)
         end
       end
 

--- a/lib/appsignal/event_formatter/action_view/render_formatter.rb
+++ b/lib/appsignal/event_formatter/action_view/render_formatter.rb
@@ -2,7 +2,7 @@ module Appsignal
   class EventFormatter
     # @api private
     module ActionView
-      class RenderFormatter < Appsignal::EventFormatter
+      class RenderFormatter
         BLANK = "".freeze
 
         attr_reader :root_path

--- a/lib/appsignal/event_formatter/action_view/render_formatter.rb
+++ b/lib/appsignal/event_formatter/action_view/render_formatter.rb
@@ -3,9 +3,6 @@ module Appsignal
     # @api private
     module ActionView
       class RenderFormatter < Appsignal::EventFormatter
-        register "render_partial.action_view"
-        register "render_template.action_view"
-
         BLANK = "".freeze
 
         attr_reader :root_path
@@ -22,3 +19,12 @@ module Appsignal
     end
   end
 end
+
+Appsignal::EventFormatter.register(
+  "render_partial.action_view",
+  Appsignal::EventFormatter::ActionView::RenderFormatter
+)
+Appsignal::EventFormatter.register(
+  "render_template.action_view",
+  Appsignal::EventFormatter::ActionView::RenderFormatter
+)

--- a/lib/appsignal/event_formatter/active_record/instantiation_formatter.rb
+++ b/lib/appsignal/event_formatter/active_record/instantiation_formatter.rb
@@ -3,8 +3,6 @@ module Appsignal
     # @api private
     module ActiveRecord
       class InstantiationFormatter < Appsignal::EventFormatter
-        register "instantiation.active_record"
-
         def format(payload)
           [payload[:class_name], nil]
         end
@@ -12,3 +10,8 @@ module Appsignal
     end
   end
 end
+
+Appsignal::EventFormatter.register(
+  "instantiation.active_record",
+  Appsignal::EventFormatter::ActiveRecord::InstantiationFormatter
+)

--- a/lib/appsignal/event_formatter/active_record/instantiation_formatter.rb
+++ b/lib/appsignal/event_formatter/active_record/instantiation_formatter.rb
@@ -2,7 +2,7 @@ module Appsignal
   class EventFormatter
     # @api private
     module ActiveRecord
-      class InstantiationFormatter < Appsignal::EventFormatter
+      class InstantiationFormatter
         def format(payload)
           [payload[:class_name], nil]
         end

--- a/lib/appsignal/event_formatter/active_record/sql_formatter.rb
+++ b/lib/appsignal/event_formatter/active_record/sql_formatter.rb
@@ -2,7 +2,7 @@ module Appsignal
   class EventFormatter
     # @api private
     module ActiveRecord
-      class SqlFormatter < Appsignal::EventFormatter
+      class SqlFormatter
         def format(payload)
           [payload[:name], payload[:sql], SQL_BODY_FORMAT]
         end

--- a/lib/appsignal/event_formatter/active_record/sql_formatter.rb
+++ b/lib/appsignal/event_formatter/active_record/sql_formatter.rb
@@ -3,8 +3,6 @@ module Appsignal
     # @api private
     module ActiveRecord
       class SqlFormatter < Appsignal::EventFormatter
-        register "sql.active_record"
-
         def format(payload)
           [payload[:name], payload[:sql], SQL_BODY_FORMAT]
         end
@@ -12,3 +10,8 @@ module Appsignal
     end
   end
 end
+
+Appsignal::EventFormatter.register(
+  "sql.active_record",
+  Appsignal::EventFormatter::ActiveRecord::SqlFormatter
+)

--- a/lib/appsignal/event_formatter/elastic_search/search_formatter.rb
+++ b/lib/appsignal/event_formatter/elastic_search/search_formatter.rb
@@ -2,7 +2,7 @@ module Appsignal
   class EventFormatter
     # @api private
     module ElasticSearch
-      class SearchFormatter < Appsignal::EventFormatter
+      class SearchFormatter
         def format(payload)
           [
             "#{payload[:name]}: #{payload[:klass]}",

--- a/lib/appsignal/event_formatter/elastic_search/search_formatter.rb
+++ b/lib/appsignal/event_formatter/elastic_search/search_formatter.rb
@@ -3,8 +3,6 @@ module Appsignal
     # @api private
     module ElasticSearch
       class SearchFormatter < Appsignal::EventFormatter
-        register "search.elasticsearch"
-
         def format(payload)
           [
             "#{payload[:name]}: #{payload[:klass]}",
@@ -30,3 +28,8 @@ module Appsignal
     end
   end
 end
+
+Appsignal::EventFormatter.register(
+  "search.elasticsearch",
+  Appsignal::EventFormatter::ElasticSearch::SearchFormatter
+)

--- a/lib/appsignal/event_formatter/faraday/request_formatter.rb
+++ b/lib/appsignal/event_formatter/faraday/request_formatter.rb
@@ -2,7 +2,7 @@ module Appsignal
   class EventFormatter
     # @api private
     module Faraday
-      class RequestFormatter < Appsignal::EventFormatter
+      class RequestFormatter
         def format(payload)
           http_method = payload[:method].to_s.upcase
           uri = payload[:url]

--- a/lib/appsignal/event_formatter/faraday/request_formatter.rb
+++ b/lib/appsignal/event_formatter/faraday/request_formatter.rb
@@ -3,8 +3,6 @@ module Appsignal
     # @api private
     module Faraday
       class RequestFormatter < Appsignal::EventFormatter
-        register "request.faraday"
-
         def format(payload)
           http_method = payload[:method].to_s.upcase
           uri = payload[:url]
@@ -17,3 +15,8 @@ module Appsignal
     end
   end
 end
+
+Appsignal::EventFormatter.register(
+  "request.faraday",
+  Appsignal::EventFormatter::Faraday::RequestFormatter
+)

--- a/lib/appsignal/event_formatter/moped/query_formatter.rb
+++ b/lib/appsignal/event_formatter/moped/query_formatter.rb
@@ -3,8 +3,6 @@ module Appsignal
     # @api private
     module Moped
       class QueryFormatter < Appsignal::EventFormatter
-        register "query.moped"
-
         def format(payload)
           if payload[:ops] && !payload[:ops].empty?
             op = payload[:ops].first
@@ -78,3 +76,8 @@ module Appsignal
     end
   end
 end
+
+Appsignal::EventFormatter.register(
+  "query.moped",
+  Appsignal::EventFormatter::Moped::QueryFormatter
+)

--- a/lib/appsignal/event_formatter/moped/query_formatter.rb
+++ b/lib/appsignal/event_formatter/moped/query_formatter.rb
@@ -2,7 +2,7 @@ module Appsignal
   class EventFormatter
     # @api private
     module Moped
-      class QueryFormatter < Appsignal::EventFormatter
+      class QueryFormatter
         def format(payload)
           if payload[:ops] && !payload[:ops].empty?
             op = payload[:ops].first

--- a/spec/lib/appsignal/event_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter_spec.rb
@@ -1,5 +1,4 @@
 class MockFormatter < Appsignal::EventFormatter
-
   attr_reader :body
 
   def initialize
@@ -38,7 +37,7 @@ describe Appsignal::EventFormatter do
   let(:klass) { Appsignal::EventFormatter }
 
   let(:deprecated_formatter) do
-    class DeprecatedMockFormatter < Appsignal::EventFormatter
+    Class.new(Appsignal::EventFormatter) do
       register "mock.deprecated"
 
       def format(_payload)

--- a/spec/lib/appsignal/event_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter_spec.rb
@@ -41,7 +41,7 @@ describe Appsignal::EventFormatter do
     class DeprecatedMockFormatter < Appsignal::EventFormatter
       register "mock.deprecated"
 
-      def transform(_payload)
+      def format(_payload)
       end
     end
   end
@@ -100,6 +100,15 @@ describe Appsignal::EventFormatter do
               "https://docs.appsignal.com/ruby/instrumentation/event-formatters.html")
 
       deprecated_formatter
+
+      expect(Appsignal::EventFormatter.deprecated_formatter_classes.keys).to include("mock.deprecated")
+    end
+
+    it "should initialize deprecated formatters" do
+      deprecated_formatter
+      Appsignal::EventFormatter.initialize_deprecated_formatters
+
+      expect(klass.registered?("mock.deprecated")).to be_truthy
     end
   end
 

--- a/spec/lib/appsignal/event_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter_spec.rb
@@ -86,16 +86,16 @@ describe Appsignal::EventFormatter do
 
     it "should not register two formatters for the same name" do
       expect(Appsignal.logger).to receive(:warn)
-        .with("Formatter for 'mock.twice' already initialized, not initializing 'MockFormatter'")
+        .with("Formatter for 'mock.twice' already registered, not registering 'MockFormatter'")
       klass.register("mock.twice", MockFormatter)
       klass.register("mock.twice", MockFormatter)
     end
 
     it "should not register deprecated formatter" do
       expect(Appsignal.logger).to receive(:warn)
-        .with("Formatter for 'mock.deprecated' is using a deprecated registration method." \
-              "This event formatter will not be loaded" \
-              "please update the formatter according to the documentation at: " \
+        .with("Formatter for 'mock.deprecated' is using a deprecated registration method. " \
+              "This event formatter will not be loaded. " \
+              "Please update the formatter according to the documentation at: " \
               "https://docs.appsignal.com/ruby/instrumentation/event-formatters.html")
 
       deprecated_formatter

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -61,11 +61,6 @@ describe Appsignal do
         Appsignal.start
       end
 
-      it "should initialize formatters" do
-        expect(Appsignal::EventFormatter).to receive(:initialize_formatters)
-        Appsignal.start
-      end
-
       context "with an extension" do
         before { Appsignal.extensions << Appsignal::MockExtension }
 

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -61,6 +61,11 @@ describe Appsignal do
         Appsignal.start
       end
 
+      it "should load deprecated event formatters" do
+        expect(Appsignal::EventFormatter).to receive(:initialize_deprecated_formatters)
+        Appsignal.start
+      end
+
       context "with an extension" do
         before { Appsignal.extensions << Appsignal::MockExtension }
 


### PR DESCRIPTION
Improves usability of registering new event_formatters.

The old situation required new formatters to be included
before `Appsignal.start` was called.

The refactored code allows for new event formatters to be added at any time by
moving the initialize code to the `register` call.

Fixes #394 