### PR TITLE
Honor filter_parameters keys for session data

### DIFF
--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -435,7 +435,11 @@ module Appsignal
       session = request.session
       return unless session
 
-      Appsignal::Utils::ParamsSanitizer.sanitize(session.to_hash)
+      options = {}
+      if Appsignal.config[:filter_parameters]
+        options[:filter_parameters] = Appsignal.config[:filter_parameters]
+      end
+      Appsignal::Utils::ParamsSanitizer.sanitize session.to_hash, options
     end
 
     # Returns metadata from the environment.

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -971,15 +971,34 @@ describe Appsignal::Transaction do
       end
 
       context "when there is a session" do
+        let(:foo_filter) { { filter_parameters: %w[foo] } }
+
         before do
           expect(transaction).to respond_to(:request)
           allow(transaction).to receive_message_chain(:request, :session => { :foo => :bar })
           allow(transaction).to receive_message_chain(:request, :fullpath => :bar)
         end
 
+        context "with AppSignal filtering" do
+          before { Appsignal.config.config_hash.merge!(foo_filter) }
+          after { Appsignal.config.config_hash[:filter_parameters] = [] }
+
+          it "filters foo" do
+            expect(subject).to eq(:foo => "[FILTERED]")
+          end
+        end
+
+        context "without AppSignal filtering" do
+          before { Appsignal.config.config_hash[:filter_parameters] = [] }
+
+          it "passes foo" do
+            expect(subject).to eq(:foo => :bar)
+          end
+        end
+
         it "passes the session data into the params sanitizer" do
-          expect(Appsignal::Utils::ParamsSanitizer).to receive(:sanitize).with(:foo => :bar)
-            .and_return(:sanitized_foo)
+          expect(Appsignal::Utils::ParamsSanitizer).to receive(:sanitize)
+            .with({ :foo => :bar }, any_args).and_return(:sanitized_foo)
           expect(subject).to eq :sanitized_foo
         end
 
@@ -992,8 +1011,8 @@ describe Appsignal::Transaction do
             end
 
             it "should return an session hash" do
-              expect(Appsignal::Utils::ParamsSanitizer).to receive(:sanitize).with("foo" => :bar)
-                .and_return(:sanitized_foo)
+              expect(Appsignal::Utils::ParamsSanitizer).to receive(:sanitize)
+                .with({ "foo" => :bar }, any_args).and_return(:sanitized_foo)
               subject
             end
 

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -971,7 +971,7 @@ describe Appsignal::Transaction do
       end
 
       context "when there is a session" do
-        let(:foo_filter) { { filter_parameters: %w[foo] } }
+        let(:foo_filter) { { :filter_parameters => %w[foo] } }
 
         before do
           expect(transaction).to respond_to(:request)


### PR DESCRIPTION
- Appsignal allows filtering keys with sensitive data values from
  being output from the application.

- Keys with sensitive data may exist in the session as well as the
  parameter hash

- pass in options with `filter_parameters` to
  Appsignal::Utils::ParamsSanitizer.sanitize for session data the same
  as is done for parameters