### PR TITLE
 Fix Sidekiq action names containing arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.5.3
+- Fix Sidekiq action names containing arguments. PR #401
+
 # 2.5.2
 - Support Sidekiq delay extension for ActiveRecord instances. If using this
   feature in your app, an update is strongly recommended! PR #387

--- a/lib/appsignal/hooks/sidekiq.rb
+++ b/lib/appsignal/hooks/sidekiq.rb
@@ -86,37 +86,95 @@ module Appsignal
 
       # Based on: https://github.com/mperham/sidekiq/blob/63ee43353bd3b753beb0233f64865e658abeb1c3/lib/sidekiq/api.rb#L316-L334
       def parse_action_name(job)
-        args = job["args"]
-        case job["class"]
+        args = job.fetch("args", [])
+        job_class = job["class"]
+        case job_class
         when "Sidekiq::Extensions::DelayedModel"
-          safe_load(job["args"][0], job["class"]) do |target, method, _|
+          safe_load(args[0], job_class) do |target, method, _|
             "#{target.class}##{method}"
           end
         when /\ASidekiq::Extensions::Delayed/
-          safe_load(job["args"][0], job["class"]) do |target, method, _|
+          safe_load(args[0], job_class) do |target, method, _|
             "#{target}.#{method}"
           end
         when "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper"
-          job_class = job["wrapped"] || args[0]
-          case job_class
-          when "ActionMailer::DeliveryJob"
-            # MailerClass#mailer_method
-            args[0]["arguments"][0..1].join("#")
-          when String
-            job_class
+          wrapped_job = job["wrapped"]
+          if wrapped_job
+            parse_active_job_action_name_from_wrapped job
           else
-            Appsignal.logger.debug \
-              "Unable to determine an action name from Sidekiq payload: #{job}"
-            UNKNOWN_ACTION_NAME
+            parse_active_job_action_name_from_arguments job
           end
         else
-          job["class"]
+          job_class
         end
+      end
+
+      # Return the ActiveJob wrapped job name.
+      #
+      # Returns "unknown" if no acceptable job class name could be found.
+      #
+      # @example Payload with "wrapped" value
+      #   {
+      #     "class" => "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper",
+      #     "wrapped" => "MyWrappedJob",
+      #     # ...
+      #   }
+      def parse_active_job_action_name_from_wrapped(job)
+        job_class = job["wrapped"]
+        case job_class
+        when "ActionMailer::DeliveryJob"
+          extract_action_mailer_name job["args"]
+        when String
+          job_class
+        else
+          unknown_action_name_for job
+        end
+      end
+
+      # Return the ActiveJob job name based on the job's arguments.
+      #
+      # Returns "unknown" if no acceptable job class name could be found.
+      #
+      # @example Payload without "wrapped" value
+      #   {
+      #     "class" => "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper",
+      #     "args" => [{
+      #       "job_class" => "MyWrappedJob",
+      #       # ...
+      #     }]
+      #     # ...
+      #   }
+      def parse_active_job_action_name_from_arguments(job)
+        args = job.fetch("args", [])
+        first_arg = args[0]
+        if first_arg == "ActionMailer::DeliveryJob"
+          extract_action_mailer_name args
+        elsif active_job_payload?(first_arg)
+          first_arg["job_class"]
+        else
+          unknown_action_name_for job
+        end
+      end
+
+      # Checks if the first argument in the job payload is an ActiveJob payload.
+      def active_job_payload?(arg)
+        arg.is_a?(Hash) && arg["job_class"].is_a?(String)
+      end
+
+      def unknown_action_name_for(job)
+        Appsignal.logger.debug \
+          "Unable to determine an action name from Sidekiq payload: #{job}"
+        UNKNOWN_ACTION_NAME
+      end
+
+      def extract_action_mailer_name(args)
+        # Returns in format: MailerClass#mailer_method
+        args[0]["arguments"][0..1].join("#")
       end
 
       # Based on: https://github.com/mperham/sidekiq/blob/63ee43353bd3b753beb0233f64865e658abeb1c3/lib/sidekiq/api.rb#L336-L358
       def parse_arguments(job)
-        args = job["args"]
+        args = job.fetch("args", [])
         case job["class"]
         when /\ASidekiq::Extensions::Delayed/
           safe_load(args[0], args) do |_, _, arg|
@@ -124,8 +182,14 @@ module Appsignal
           end
         when "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper"
           is_wrapped = job["wrapped"]
-          job_args = is_wrapped ? args[0]["arguments"] : []
-          if (is_wrapped || args[0]) == "ActionMailer::DeliveryJob"
+          first_arg = args[0]
+          job_args =
+            if is_wrapped || active_job_payload?(first_arg)
+              first_arg["arguments"]
+            else
+              []
+            end
+          if (is_wrapped || first_arg) == "ActionMailer::DeliveryJob"
             # Remove MailerClass, mailer_method and "deliver_now"
             job_args.drop(3)
           else

--- a/lib/appsignal/version.rb
+++ b/lib/appsignal/version.rb
@@ -1,3 +1,3 @@
 module Appsignal
-  VERSION = "2.5.3.alpha.1".freeze
+  VERSION = "2.5.3.alpha.2".freeze
 end

--- a/lib/appsignal/version.rb
+++ b/lib/appsignal/version.rb
@@ -1,3 +1,3 @@
 module Appsignal
-  VERSION = "2.5.2".freeze
+  VERSION = "2.5.3.alpha.1".freeze
 end

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -323,56 +323,107 @@ describe Appsignal::Hooks::SidekiqPlugin, :with_yaml_parse_error => false do
           {
             "class" => "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper",
             "queue" => "default",
-            "args" => [{
-              "job_class" => "ActiveMailerTestJob",
-              "job_id" => "23e79d48-6966-40d0-b2d4-f7938463a263",
-              "queue_name" => "default",
-              "arguments" => [
-                "MailerClass", "mailer_method", "deliver_now",
-                "foo", { "foo" => "Foo", "bar" => "Bar", "baz" => { 1 => :bar } }
-              ]
-            }],
+            "args" => [first_argument],
             "retry" => true,
             "jid" => "efb140489485999d32b5504c",
             "created_at" => Time.parse("2001-01-01 10:00:00UTC").to_f,
             "enqueued_at" => Time.parse("2001-01-01 10:00:00UTC").to_f
           }
         end
+        before { perform_job }
 
-        it "sets the action name to unknown and without sample data" do
-          perform_job
+        context "when the first argument is not a Hash object" do
+          let(:first_argument) { "foo" }
 
-          transaction_hash = transaction.to_h
-          expect(transaction_hash).to include(
-            "id" => kind_of(String),
-            "action" => "unknown",
-            "error" => nil,
-            "namespace" => namespace,
-            "metadata" => {
-              "queue" => "default"
-            },
-            "sample_data" => {
-              "environment" => {},
-              "params" => [],
-              "tags" => {}
-            }
-          )
-          # TODO: Not available in transaction.to_h yet.
-          # https://github.com/appsignal/appsignal-agent/issues/293
-          expect(transaction.request.env).to eq(
-            :queue_start => Time.parse("2001-01-01 10:00:00UTC").to_f
-          )
-          expect_transaction_to_have_sidekiq_event(transaction_hash)
+          include_examples "unknown job action name"
         end
 
-        it "logs a debug message" do
-          perform_job
+        context "when the first argument is a Hash object not containing a job payload" do
+          let(:first_argument) { { "foo" => "bar" } }
 
-          expect(log_contents(log)).to contains_log(
-            :debug, "Unable to determine an action name from Sidekiq payload: #{item}"
-          )
+          include_examples "unknown job action name"
+
+          context "when the argument contains an invalid job_class value" do
+            let(:first_argument) { { "job_class" => :foo } }
+
+            include_examples "unknown job action name"
+          end
+        end
+
+        context "when the first argument is a Hash object containing a job payload" do
+          let(:first_argument) do
+            {
+              "job_class" => "ActiveMailerTestJob",
+              "job_id" => "23e79d48-6966-40d0-b2d4-f7938463a263",
+              "queue_name" => "default",
+              "arguments" => [
+                "foo", { "foo" => "Foo", "bar" => "Bar", "baz" => { 1 => :bar } }
+              ]
+            }
+          end
+
+          it "sets the action name to the job class in the first argument" do
+            transaction_hash = transaction.to_h
+            expect(transaction_hash).to include(
+              "action" => "ActiveMailerTestJob#perform"
+            )
+          end
+
+          it "stores the job metadata on the transaction" do
+            transaction_hash = transaction.to_h
+            expect(transaction_hash).to include(
+              "id" => kind_of(String),
+              "error" => nil,
+              "namespace" => namespace,
+              "metadata" => {
+                "queue" => "default"
+              },
+              "sample_data" => {
+                "environment" => {},
+                "params" => [
+                  "foo",
+                  {
+                    "foo" => "Foo",
+                    "bar" => "Bar",
+                    "baz" => { "1" => "bar" }
+                  }
+                ],
+                "tags" => {}
+              }
+            )
+          end
+
+          it "does not log a debug message" do
+            expect(log_contents(log)).to_not contains_log(
+              :debug, "Unable to determine an action name from Sidekiq payload"
+            )
+          end
         end
       end
+    end
+  end
+
+  shared_examples "unknown job action name" do
+    it "sets the action name to unknown" do
+      transaction_hash = transaction.to_h
+      expect(transaction_hash).to include("action" => "unknown")
+    end
+
+    it "stores no sample data" do
+      transaction_hash = transaction.to_h
+      expect(transaction_hash).to include(
+        "sample_data" => {
+          "environment" => {},
+          "params" => [],
+          "tags" => {}
+        }
+      )
+    end
+
+    it "logs a debug message" do
+      expect(log_contents(log)).to contains_log(
+        :debug, "Unable to determine an action name from Sidekiq payload: #{item}"
+      )
     end
   end
 

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -364,6 +364,14 @@ describe Appsignal::Hooks::SidekiqPlugin, :with_yaml_parse_error => false do
           )
           expect_transaction_to_have_sidekiq_event(transaction_hash)
         end
+
+        it "logs a debug message" do
+          perform_job
+
+          expect(log_contents(log)).to contains_log(
+            :debug, "Unable to determine an action name from Sidekiq payload: #{item}"
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
## Fix Sidekiq action names containing arguments

When the `wrapped` value is not set for an ActiveJob job we have no good
way of identifying the ActiveJob action name. To avoid creating a lot of
incidents, 1 per action name, fall back on the "unknown" action instead.

This avoids noisy incident and action pages to be created. With action
names such as:

```
"{\"job_class\"=>\"ActiveJobMailJob\", \"job_id\"=>\"1\", \"queue_name\"=>\"default\", \"arguments\"=>[{\"_aj_globalid\"=>\"gid://example/User/16\"}]}#perform"
```

Check if the fallback argument in `job_class = job["wrapped"] || args[0]`,
`args[0]` is a String object, otherwise return `unknown`.

## Debug log Sidekiq action name fallback

When we're not able to find the action name for a Sidekiq job
reliable, log the payload so we can help users in support with
determining why this failed.