### PR TITLE
Add filter_session_data config option 

### DIFF
--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -13,6 +13,7 @@ module Appsignal
       :ignore_errors                  => [],
       :ignore_namespaces              => [],
       :filter_parameters              => [],
+      :filter_session_data            => [],
       :send_params                    => true,
       :endpoint                       => "https://push.appsignal.com",
       :instrument_net_http            => true,

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -436,8 +436,8 @@ module Appsignal
       return unless session
 
       options = {}
-      if Appsignal.config[:filter_parameters]
-        options[:filter_parameters] = Appsignal.config[:filter_parameters]
+      if Appsignal.config[:filter_session_data]
+        options[:filter_parameters] = Appsignal.config[:filter_session_data]
       end
       Appsignal::Utils::ParamsSanitizer.sanitize session.to_hash, options
     end

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -435,7 +435,11 @@ module Appsignal
       session = request.session
       return unless session
 
-      Appsignal::Utils::ParamsSanitizer.sanitize(session.to_hash)
+      options = {}
+      if Appsignal.config[:filter_parameters]
+        options[:filter_parameters] = Appsignal.config[:filter_parameters]
+      end
+      Appsignal::Utils::ParamsSanitizer.sanitize session.to_hash, options
     end
 
     # Returns metadata from the environment.

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -88,6 +88,7 @@ describe Appsignal::Config do
         :ignore_errors                  => [],
         :ignore_namespaces              => [],
         :filter_parameters              => [],
+        :filter_session_data            => [],
         :instrument_net_http            => true,
         :instrument_redis               => true,
         :instrument_sequel              => true,

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -971,15 +971,34 @@ describe Appsignal::Transaction do
       end
 
       context "when there is a session" do
+        let(:foo_filter) { { filter_parameters: %w[foo] } }
+
         before do
           expect(transaction).to respond_to(:request)
           allow(transaction).to receive_message_chain(:request, :session => { :foo => :bar })
           allow(transaction).to receive_message_chain(:request, :fullpath => :bar)
         end
 
+        context "with AppSignal filtering" do
+          before { Appsignal.config.config_hash.merge!(foo_filter) }
+          after { Appsignal.config.config_hash[:filter_parameters] = [] }
+
+          it "filters foo" do
+            expect(subject).to eq(:foo => "[FILTERED]")
+          end
+        end
+
+        context "without AppSignal filtering" do
+          before { Appsignal.config.config_hash[:filter_parameters] = [] }
+
+          it "passes foo" do
+            expect(subject).to eq(:foo => :bar)
+          end
+        end
+
         it "passes the session data into the params sanitizer" do
-          expect(Appsignal::Utils::ParamsSanitizer).to receive(:sanitize).with(:foo => :bar)
-            .and_return(:sanitized_foo)
+          expect(Appsignal::Utils::ParamsSanitizer).to receive(:sanitize)
+            .with({ :foo => :bar }, any_args).and_return(:sanitized_foo)
           expect(subject).to eq :sanitized_foo
         end
 
@@ -992,8 +1011,8 @@ describe Appsignal::Transaction do
             end
 
             it "should return an session hash" do
-              expect(Appsignal::Utils::ParamsSanitizer).to receive(:sanitize).with("foo" => :bar)
-                .and_return(:sanitized_foo)
+              expect(Appsignal::Utils::ParamsSanitizer).to receive(:sanitize)
+                .with({ "foo" => :bar }, any_args).and_return(:sanitized_foo)
               subject
             end
 

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -970,56 +970,42 @@ describe Appsignal::Transaction do
         it { is_expected.to be_nil }
       end
 
-      context "when there is a session" do
-        let(:foo_filter) { { :filter_parameters => %w[foo] } }
+      context "with a session" do
+        let(:session_data_filter) { [] }
+        before { Appsignal.config[:filter_session_data] = session_data_filter }
+        after { Appsignal.config[:filter_session_data] = [] }
 
-        before do
-          expect(transaction).to respond_to(:request)
-          allow(transaction).to receive_message_chain(:request, :session => { :foo => :bar })
-          allow(transaction).to receive_message_chain(:request, :fullpath => :bar)
-        end
-
-        context "with AppSignal filtering" do
-          before { Appsignal.config.config_hash.merge!(foo_filter) }
-          after { Appsignal.config.config_hash[:filter_parameters] = [] }
-
-          it "filters foo" do
-            expect(subject).to eq(:foo => "[FILTERED]")
+        context "with generic session object" do
+          before do
+            expect(transaction).to respond_to(:request)
+            allow(transaction).to receive_message_chain(
+              :request,
+              :session => { :foo => :bar, :abc => :def }
+            )
+            allow(transaction).to receive_message_chain(:request, :fullpath => :bar)
           end
-        end
 
-        context "without AppSignal filtering" do
-          before { Appsignal.config.config_hash[:filter_parameters] = [] }
-
-          it "passes foo" do
-            expect(subject).to eq(:foo => :bar)
+          context "without session filtering" do
+            it "keeps the session data intact" do
+              expect(subject).to eq(:foo => :bar, :abc => :def)
+            end
           end
-        end
 
-        it "passes the session data into the params sanitizer" do
-          expect(Appsignal::Utils::ParamsSanitizer).to receive(:sanitize)
-            .with({ :foo => :bar }, any_args).and_return(:sanitized_foo)
-          expect(subject).to eq :sanitized_foo
+          context "with session filtering" do
+            let(:session_data_filter) { %w[foo] }
+
+            it "filters the session data" do
+              expect(subject).to eq(:foo => "[FILTERED]", :abc => :def)
+            end
+          end
         end
 
         if defined? ActionDispatch::Request::Session
           context "with ActionDispatch::Request::Session" do
-            before do
-              expect(transaction).to respond_to(:request)
-              allow(transaction).to receive_message_chain(:request, :session => action_dispatch_session)
-              allow(transaction).to receive_message_chain(:request, :fullpath => :bar)
-            end
-
-            it "should return an session hash" do
-              expect(Appsignal::Utils::ParamsSanitizer).to receive(:sanitize)
-                .with({ "foo" => :bar }, any_args).and_return(:sanitized_foo)
-              subject
-            end
-
-            def action_dispatch_session
+            let(:action_dispatch_session) do
               store = Class.new do
                 def load_session(_env)
-                  [1, { :foo => :bar }]
+                  [1, { :foo => :bar, :abc => :def }]
                 end
 
                 def session_exists?(_env)
@@ -1028,16 +1014,35 @@ describe Appsignal::Transaction do
               end.new
               ActionDispatch::Request::Session.create(store, ActionDispatch::Request.new("rack.input" => StringIO.new), {})
             end
+            before do
+              expect(transaction).to respond_to(:request)
+              allow(transaction).to receive_message_chain(
+                :request,
+                :session => action_dispatch_session
+              )
+              allow(transaction).to receive_message_chain(:request, :fullpath => :bar)
+            end
+
+            context "without session filtering" do
+              it "keeps the session data intact" do
+                expect(subject).to eq("foo" => :bar, "abc" => :def)
+              end
+            end
+
+            context "with session filtering" do
+              let(:session_data_filter) { %w[foo] }
+
+              it "filters the session data" do
+                expect(subject).to eq("foo" => "[FILTERED]", "abc" => :def)
+              end
+            end
           end
         end
 
         context "when skipping session data" do
-          before do
-            Appsignal.config = { :skip_session_data => true }
-          end
+          before { Appsignal.config[:skip_session_data] = true }
 
-          it "does not pass the session data into the params sanitizer" do
-            expect(Appsignal::Utils::ParamsSanitizer).to_not receive(:sanitize)
+          it "does not set any session data on the transaction" do
             expect(subject).to be_nil
           end
         end

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -971,7 +971,7 @@ describe Appsignal::Transaction do
       end
 
       context "when there is a session" do
-        let(:foo_filter) { { filter_parameters: %w[foo] } }
+        let(:foo_filter) { { :filter_parameters => %w[foo] } }
 
         before do
           expect(transaction).to respond_to(:request)


### PR DESCRIPTION
This PR is based on PR #399 by @dwilkins . It keeps the code largely intact, but introduces the `filter_session_data` config option rather than reusing the `filter_parameters` option for this type of data as well.

## Honor `filter_parameters` keys for session data

- Appsignal allows filtering keys with sensitive data values from
  being output from the application.
- Keys with sensitive data may exist in the session as well as the
  parameter hash
- pass in options with `filter_parameters` to
  Appsignal::Utils::ParamsSanitizer.sanitize for session data the same
  as is done for parameters

## Add filter_session_data config option

Create a separate option to filter session data and ensure we don't
overuse the `filter_parameters` option for multiple sources of data.

This is an addition on PR #399.

Also refactor the tests a bit to ensure we also test the parameter
filtering ActionDispatch session objects.

Actually use the ParamSanitizer rather than mocking the result.