### PR TITLE
Remove default hostname

### DIFF
--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -28,7 +28,6 @@ module Appsignal
       :enable_gc_instrumentation      => false,
       :enable_host_metrics            => true,
       :enable_minutely_probes         => false,
-      :hostname                       => ::Socket.gethostname,
       :ca_file_path                   => File.expand_path(File.join("../../../resources/cacert.pem"), __FILE__),
       :dns_servers                    => [],
       :files_world_accessible         => true

--- a/spec/lib/appsignal/auth_check_spec.rb
+++ b/spec/lib/appsignal/auth_check_spec.rb
@@ -2,13 +2,13 @@ describe Appsignal::AuthCheck do
   let(:config) { project_fixture_config }
   let(:auth_check) { Appsignal::AuthCheck.new(config) }
   let(:auth_url) do
-    query = {
+    query = build_uri_query_string(
       :api_key => config[:push_api_key],
       :environment => config.env,
       :gem_version => Appsignal::VERSION,
       :hostname => config[:hostname],
       :name => config[:name]
-    }.map { |k, v| "#{k}=#{v}" }.join("&")
+    )
 
     URI(config[:endpoint]).tap do |uri|
       uri.path = "/1/auth"
@@ -17,6 +17,15 @@ describe Appsignal::AuthCheck do
   end
   let(:stubbed_request) do
     WebMock.stub_request(:post, auth_url).with(:body => "{}")
+  end
+
+  def build_uri_query_string(hash)
+    hash.map do |k, v|
+      k.to_s.tap do |s|
+        next unless v
+        s << "=#{v}"
+      end
+    end.join("&")
   end
 
   describe "#perform" do

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -105,7 +105,6 @@ describe Appsignal::Config do
         :enable_gc_instrumentation      => false,
         :enable_host_metrics            => true,
         :enable_minutely_probes         => false,
-        :hostname                       => Socket.gethostname,
         :ca_file_path                   => File.join(resources_dir, "cacert.pem"),
         :dns_servers                    => [],
         :files_world_accessible         => true,
@@ -407,7 +406,7 @@ describe Appsignal::Config do
       config[:ignore_namespaces] = %w[admin private_namespace]
       config[:log] = "stdout"
       config[:log_path] = "/tmp"
-      config[:hostname] = "app1.local"
+      config[:filter_parameters] = %w[password confirm_password]
       config[:running_in_container] = false
       config[:dns_servers] = ["8.8.8.8", "8.8.4.4"]
       config[:revision] = "v2.5.1"
@@ -434,13 +433,24 @@ describe Appsignal::Config do
       expect(ENV["_APPSIGNAL_RUNNING_IN_CONTAINER"]).to         eq "false"
       expect(ENV["_APPSIGNAL_ENABLE_HOST_METRICS"]).to          eq "true"
       expect(ENV["_APPSIGNAL_ENABLE_MINUTELY_PROBES"]).to       eq "false"
-      expect(ENV["_APPSIGNAL_HOSTNAME"]).to                     eq "app1.local"
+      expect(ENV["_APPSIGNAL_HOSTNAME"]).to                     eq ""
       expect(ENV["_APPSIGNAL_PROCESS_NAME"]).to                 include "rspec"
       expect(ENV["_APPSIGNAL_CA_FILE_PATH"]).to                 eq File.join(resources_dir, "cacert.pem")
       expect(ENV["_APPSIGNAL_DNS_SERVERS"]).to                  eq "8.8.8.8,8.8.4.4"
       expect(ENV["_APPSIGNAL_FILES_WORLD_ACCESSIBLE"]).to       eq "true"
       expect(ENV["_APP_REVISION"]).to                           eq "v2.5.1"
       expect(ENV).to_not                                        have_key("_APPSIGNAL_WORKING_DIR_PATH")
+    end
+
+    context "with :hostname" do
+      before do
+        config[:hostname] = "Alices-MBP.example.com"
+        config.write_to_environment
+      end
+
+      it "sets the modified :hostname" do
+        expect(ENV["_APPSIGNAL_HOSTNAME"]).to eq "Alices-MBP.example.com"
+      end
     end
 
     context "with :working_dir_path" do


### PR DESCRIPTION
Instead we'll base determine this default as a fallback in the
extension. The integrations don't need to know about the default
hostname, also reduces the logic in the integrations.

The integrations will only set the hostname config option in the
environment `_APPSIGNAL_HOSTNAME` when it has been configured in the
app. If not, it will set an empty string, which is interpreted as an
empty value by the extension.

Depends on https://github.com/appsignal/appsignal-agent/pull/335

🚨  Needs an agent release before merging! 🚨 
Based on #398 

## TODO

- [x] Discuss what to do with the Push API key auth check