### PR TITLE
Filter session data cleanup

### DIFF
--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -435,11 +435,9 @@ module Appsignal
       session = request.session
       return unless session
 
-      options = {}
-      if Appsignal.config[:filter_session_data]
-        options[:filter_parameters] = Appsignal.config[:filter_session_data]
-      end
-      Appsignal::Utils::ParamsSanitizer.sanitize session.to_hash, options
+      Appsignal::Utils::ParamsSanitizer.sanitize_hash(
+        session.to_hash, Appsignal.config[:filter_session_data]
+      )
     end
 
     # Returns metadata from the environment.

--- a/lib/appsignal/utils/params_sanitizer.rb
+++ b/lib/appsignal/utils/params_sanitizer.rb
@@ -9,6 +9,19 @@ module Appsignal
           sanitize_value(params, options.fetch(:filter_parameters, []))
         end
 
+        def sanitize_hash(source, filter_parameter_keys)
+          {}.tap do |hash|
+            source.each_pair do |key, value|
+              hash[key] =
+                if filter_parameter_keys.include?(key.to_s)
+                  FILTERED
+                else
+                  sanitize_value(value, filter_parameter_keys)
+                end
+            end
+          end
+        end
+
         private
 
         def sanitize_value(value, filter_parameter_keys)
@@ -21,19 +34,6 @@ module Appsignal
             unmodified(value)
           else
             inspected(value)
-          end
-        end
-
-        def sanitize_hash(source, filter_parameter_keys)
-          {}.tap do |hash|
-            source.each_pair do |key, value|
-              hash[key] =
-                if filter_parameter_keys.include?(key.to_s)
-                  FILTERED
-                else
-                  sanitize_value(value, filter_parameter_keys)
-                end
-            end
           end
         end
 

--- a/lib/appsignal/utils/params_sanitizer.rb
+++ b/lib/appsignal/utils/params_sanitizer.rb
@@ -6,17 +6,17 @@ module Appsignal
 
       class << self
         def sanitize(params, options = {})
-          sanitize_value(params, options)
+          sanitize_value(params, options.fetch(:filter_parameters, []))
         end
 
         private
 
-        def sanitize_value(value, options = {})
+        def sanitize_value(value, filter_parameter_keys)
           case value
           when Hash
-            sanitize_hash(value, options)
+            sanitize_hash(value, filter_parameter_keys)
           when Array
-            sanitize_array(value, options)
+            sanitize_array(value, filter_parameter_keys)
           when TrueClass, FalseClass, NilClass, Integer, String, Symbol, Float
             unmodified(value)
           else
@@ -24,24 +24,23 @@ module Appsignal
           end
         end
 
-        def sanitize_hash(source, options)
-          filter_keys = options.fetch(:filter_parameters, [])
+        def sanitize_hash(source, filter_parameter_keys)
           {}.tap do |hash|
             source.each_pair do |key, value|
               hash[key] =
-                if filter_keys.include?(key.to_s)
+                if filter_parameter_keys.include?(key.to_s)
                   FILTERED
                 else
-                  sanitize_value(value, options)
+                  sanitize_value(value, filter_parameter_keys)
                 end
             end
           end
         end
 
-        def sanitize_array(source, options)
+        def sanitize_array(source, filter_parameter_keys)
           [].tap do |array|
             source.each_with_index do |item, index|
-              array[index] = sanitize_value(item, options)
+              array[index] = sanitize_value(item, filter_parameter_keys)
             end
           end
         end

--- a/spec/lib/appsignal/utils/params_sanitizer_spec.rb
+++ b/spec/lib/appsignal/utils/params_sanitizer_spec.rb
@@ -133,4 +133,11 @@ describe Appsignal::Utils::ParamsSanitizer do
       end
     end
   end
+
+  describe ".sanitize_hash" do
+    subject { described_class.sanitize_hash(params, %w[text nested_text]) }
+
+    it { expect(subject[:text]).to eq(described_class::FILTERED) }
+    it { expect(subject[:hash][:nested_text]).to eq(described_class::FILTERED) }
+  end
 end


### PR DESCRIPTION
Instead of creating a new options hash that renames the `:filter_session_data` to `:filter_parameters` and uses that to sanitize sessions (in #402), this patch exposes the `.sanitize_hash` method and calls that directly with the array from `:filter_session_data`.