### PR TITLE
Don't suggest request headers on install

### DIFF
--- a/lib/appsignal/cli/install.rb
+++ b/lib/appsignal/cli/install.rb
@@ -164,7 +164,7 @@ module Appsignal
           puts "How do you want to configure AppSignal?"
           puts "  (1) a config file"
           puts "  (2) environment variables"
-          loop do # rubocop:disable Metrics/BlockLength
+          loop do
             print "  Choose (1/2): "
             case ask_for_input
             when "1"
@@ -176,7 +176,6 @@ module Appsignal
               write_config_file(
                 :push_api_key => config[:push_api_key],
                 :app_name => config[:name],
-                :request_headers => multiline_request_headers,
                 :environments => environments
               )
               puts
@@ -192,7 +191,6 @@ module Appsignal
               if name_overwritten
                 puts "  export APPSIGNAL_APP_NAME=#{config[:name]}"
               end
-              puts "  export APPSIGNAL_REQUEST_HEADERS=#{single_line_request_headers}"
               puts
               puts "  See the documentation for more configuration options:"
               puts "  http://docs.appsignal.com/gem-settings/configuration.html"
@@ -274,16 +272,6 @@ module Appsignal
 
         def new_config
           Appsignal::Config.new(Dir.pwd, "")
-        end
-
-        def multiline_request_headers
-          Appsignal::Config::SUGGESTED_REQUEST_HEADERS.map do |row|
-            row.map(&:inspect).join(", ")
-          end.join(",\n    ")
-        end
-
-        def single_line_request_headers
-          Appsignal::Config::SUGGESTED_REQUEST_HEADERS.flatten.join(",")
         end
       end
     end

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -17,6 +17,13 @@ module Appsignal
       :filter_parameters              => [],
       :filter_session_data            => [],
       :send_params                    => true,
+      :request_headers                => %w[
+        HTTP_ACCEPT HTTP_ACCEPT_CHARSET HTTP_ACCEPT_ENCODING
+        HTTP_ACCEPT_LANGUAGE HTTP_CACHE_CONTROL HTTP_CONNECTION
+        CONTENT_LENGTH PATH_INFO HTTP_RANGE
+        REQUEST_METHOD REQUEST_URI SERVER_NAME SERVER_PORT
+        SERVER_PROTOCOL
+      ],
       :endpoint                       => "https://push.appsignal.com",
       :instrument_net_http            => true,
       :instrument_redis               => true,
@@ -67,14 +74,6 @@ module Appsignal
       "APPSIGNAL_REQUEST_HEADERS"                => :request_headers,
       "APP_REVISION"                             => :revision
     }.freeze
-    # Formatted in two-dimensional array for easy printing
-    SUGGESTED_REQUEST_HEADERS = [
-      %w[HTTP_ACCEPT HTTP_ACCEPT_CHARSET HTTP_ACCEPT_ENCODING],
-      %w[HTTP_ACCEPT_LANGUAGE HTTP_CACHE_CONTROL HTTP_CONNECTION],
-      %w[CONTENT_LENGTH PATH_INFO HTTP_RANGE],
-      %w[REQUEST_METHOD REQUEST_URI SERVER_NAME SERVER_PORT],
-      %w[SERVER_PROTOCOL]
-    ].freeze
 
     # Mapping of old and deprecated AppSignal configuration keys
     DEPRECATED_CONFIG_KEY_MAPPING = {
@@ -197,34 +196,9 @@ module Appsignal
         @valid = false
         @logger.error "Push api key not set after loading config"
       end
-
-      check_if_request_headers_option_is_set
     end
 
     private
-
-    def check_if_request_headers_option_is_set
-      return unless valid?
-      return if config_hash.key?(:request_headers) || env == "test"
-
-      multi_line_request_headers = SUGGESTED_REQUEST_HEADERS.map do |row|
-        row.map(&:inspect).join(", ")
-      end.join(",\n    ")
-      single_line_request_headers = SUGGESTED_REQUEST_HEADERS.flatten.join(",")
-
-      puts "Warning: The `request_headers` config option was not set " \
-        " in the AppSignal configuration, falling back to the default list. " \
-        "Please explicitly list response headers to send to AppSignal in " \
-        "config/appsignal.yml:\n\n" \
-        "  request_headers: [\n" \
-        "    #{multi_line_request_headers}\n" \
-        "]\n\n" \
-        "Or set the APPSIGNAL_REQUEST_HEADERS environment variable:\n\n"\
-        "  $ export APPSIGNAL_REQUEST_HEADERS=" \
-        "\"#{single_line_request_headers}\"\n\n" \
-        "Please check https://github.com/appsignal/appsignal-ruby/pull/406 " \
-        "for more information on this change."
-    end
 
     def config_file
       @config_file ||=

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -10,21 +10,6 @@ module Appsignal
     FRONTEND       = "frontend".freeze
     BLANK          = "".freeze
 
-    # Based on what Rails uses + some variables we'd like to show
-    FALLBACK_REQUEST_HEADERS = %w[
-      CONTENT_LENGTH AUTH_TYPE GATEWAY_INTERFACE
-      PATH_TRANSLATED REMOTE_HOST REMOTE_IDENT REMOTE_USER REMOTE_ADDR
-      REQUEST_METHOD SERVER_NAME SERVER_PORT SERVER_PROTOCOL REQUEST_URI
-      PATH_INFO
-
-      HTTP_X_REQUEST_START HTTP_X_MIDDLEWARE_START HTTP_X_QUEUE_START
-      HTTP_X_QUEUE_TIME HTTP_X_HEROKU_QUEUE_WAIT_TIME HTTP_X_APPLICATION_START
-      HTTP_ACCEPT HTTP_ACCEPT_CHARSET HTTP_ACCEPT_ENCODING HTTP_ACCEPT_LANGUAGE
-      HTTP_CACHE_CONTROL HTTP_CONNECTION HTTP_USER_AGENT HTTP_FROM
-      HTTP_NEGOTIATE HTTP_PRAGMA HTTP_REFERER HTTP_X_FORWARDED_FOR
-      HTTP_CLIENT_IP HTTP_RANGE
-    ].freeze
-
     class << self
       def create(id, namespace, request, options = {})
         # Allow middleware to force a new transaction
@@ -405,9 +390,6 @@ module Appsignal
     # The environment of a transaction can contain a lot of information, not
     # all of it useful for debugging.
     #
-    # Only the values from the keys specified in {FALLBACK_REQUEST_HEADERS} are
-    # returned.
-    #
     # @return [nil] if no environment is present.
     # @return [Hash<String, Object>]
     def sanitized_environment
@@ -415,8 +397,7 @@ module Appsignal
       return if env.empty?
 
       {}.tap do |out|
-        (Appsignal.config[:request_headers] ||
-          FALLBACK_REQUEST_HEADERS).each do |key|
+        Appsignal.config[:request_headers].each do |key|
           out[key] = env[key] if env[key]
         end
       end

--- a/resources/appsignal.yml.erb
+++ b/resources/appsignal.yml.erb
@@ -6,11 +6,6 @@ default: &defaults
   # Your app's name
   name: "<%= app_name %>"
 
-  # Request headers that should be recorded per sample
-  request_headers: [
-    <%= request_headers %>
-  ]
-
   # Actions that should not be monitored by AppSignal
   # ignore_actions:
   #   - ApplicationController#isup

--- a/spec/lib/appsignal/cli/install_spec.rb
+++ b/spec/lib/appsignal/cli/install_spec.rb
@@ -39,16 +39,6 @@ describe Appsignal::CLI::Install do
       actual.include?("export APPSIGNAL_APP_NAME=#{name}")
     end
   end
-  define :include_env_request_headers do
-    match do |actual|
-      actual.include?(
-        "export APPSIGNAL_REQUEST_HEADERS=HTTP_ACCEPT,HTTP_ACCEPT_CHARSET," \
-        "HTTP_ACCEPT_ENCODING,HTTP_ACCEPT_LANGUAGE,HTTP_CACHE_CONTROL," \
-        "HTTP_CONNECTION,CONTENT_LENGTH,PATH_INFO,HTTP_RANGE," \
-        "REQUEST_METHOD,REQUEST_URI,SERVER_NAME,SERVER_PORT,SERVER_PROTOCOL"
-      )
-    end
-  end
 
   define :configure_app_name do |name|
     match do |file_contents|
@@ -58,17 +48,6 @@ describe Appsignal::CLI::Install do
   define :configure_push_api_key do |key|
     match do |file_contents|
       file_contents =~ /^  push_api_key: "#{key}"/
-    end
-  end
-  define :configure_request_headers do
-    match do |file_contents|
-      file_contents =~ /^  request_headers: \[/ &&
-        file_contents =~ /^    "HTTP_ACCEPT", "HTTP_ACCEPT_CHARSET", "HTTP_ACCEPT_ENCODING",/ &&
-        file_contents =~ /^    "HTTP_ACCEPT_LANGUAGE", "HTTP_CACHE_CONTROL", "HTTP_CONNECTION",/ &&
-        file_contents =~ /^    "CONTENT_LENGTH", "PATH_INFO", "HTTP_RANGE",/ &&
-        file_contents =~ /^    "REQUEST_METHOD", "REQUEST_URI", "SERVER_NAME", "SERVER_PORT",/ &&
-        file_contents =~ /^    "SERVER_PROTOCOL"/ &&
-        file_contents =~ /^  \]/
     end
   end
   define :configure_environment do |env|
@@ -293,7 +272,6 @@ describe Appsignal::CLI::Install do
           expect(output).to include_file_config
           expect(config_file).to configure_app_name(app_name)
           expect(config_file).to configure_push_api_key(push_api_key)
-          expect(config_file).to configure_request_headers
           expect(config_file).to_not configure_environment("development")
           expect(config_file).to_not configure_environment("staging")
           expect(config_file).to configure_environment("production")
@@ -321,7 +299,6 @@ describe Appsignal::CLI::Install do
 
             expect(output).to include_env_push_api_key(push_api_key)
             expect(output).to_not include_env_app_name
-            expect(output).to include_env_request_headers
           end
 
           it "completes the installation" do
@@ -345,7 +322,6 @@ describe Appsignal::CLI::Install do
             expect(output).to include_file_config
             expect(config_file).to configure_app_name(app_name)
             expect(config_file).to configure_push_api_key(push_api_key)
-            expect(config_file).to configure_request_headers
             expect(config_file).to configure_environment("development")
             expect(config_file).to configure_environment("staging")
             expect(config_file).to configure_environment("production")
@@ -390,7 +366,6 @@ describe Appsignal::CLI::Install do
 
             expect(output).to include_env_push_api_key(push_api_key)
             expect(output).to include_env_app_name(app_name)
-            expect(output).to include_env_request_headers
           end
 
           it "completes the installation" do
@@ -417,7 +392,6 @@ describe Appsignal::CLI::Install do
             expect(output).to include_file_config
             expect(config_file).to configure_app_name(app_name)
             expect(config_file).to configure_push_api_key(push_api_key)
-            expect(config_file).to configure_request_headers
             expect(config_file).to configure_environment("development")
             expect(config_file).to configure_environment("staging")
             expect(config_file).to configure_environment("production")
@@ -463,7 +437,6 @@ describe Appsignal::CLI::Install do
 
             expect(output).to include_env_push_api_key(push_api_key)
             expect(output).to include_env_app_name(app_name)
-            expect(output).to include_env_request_headers
           end
 
           it "completes the installation" do
@@ -487,7 +460,6 @@ describe Appsignal::CLI::Install do
             expect(output).to include_file_config
             expect(config_file).to configure_app_name(app_name)
             expect(config_file).to configure_push_api_key(push_api_key)
-            expect(config_file).to configure_request_headers
             expect(config_file).to configure_environment("development")
             expect(config_file).to configure_environment("staging")
             expect(config_file).to configure_environment("production")
@@ -532,7 +504,6 @@ describe Appsignal::CLI::Install do
 
             expect(output).to include_env_push_api_key(push_api_key)
             expect(output).to include_env_app_name(app_name)
-            expect(output).to include_env_request_headers
           end
 
           it "completes the installation" do
@@ -556,7 +527,6 @@ describe Appsignal::CLI::Install do
             expect(output).to include_file_config
             expect(config_file).to configure_app_name(app_name)
             expect(config_file).to configure_push_api_key(push_api_key)
-            expect(config_file).to configure_request_headers
             expect(config_file).to configure_environment("development")
             expect(config_file).to configure_environment("staging")
             expect(config_file).to configure_environment("production")
@@ -601,7 +571,6 @@ describe Appsignal::CLI::Install do
 
             expect(output).to include_env_push_api_key(push_api_key)
             expect(output).to include_env_app_name(app_name)
-            expect(output).to include_env_request_headers
           end
 
           it "completes the installation" do
@@ -625,7 +594,6 @@ describe Appsignal::CLI::Install do
             expect(output).to include_file_config
             expect(config_file).to configure_app_name(app_name)
             expect(config_file).to configure_push_api_key(push_api_key)
-            expect(config_file).to configure_request_headers
             expect(config_file).to configure_environment("development")
             expect(config_file).to configure_environment("staging")
             expect(config_file).to configure_environment("production")
@@ -657,7 +625,6 @@ describe Appsignal::CLI::Install do
           "\e[31mWarning:\e[0m We could not detect which framework you are using."
         expect(output).to_not include_env_push_api_key
         expect(output).to_not include_env_app_name
-        expect(output).to_not include_env_request_headers
         expect(File.exist?(config_file_path)).to be_falsy
       end
     end

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -658,37 +658,5 @@ describe Appsignal::Config do
         end
       end
     end
-
-    describe "request_headers option validation" do
-      let(:out_stream) { std_stream }
-      let(:output) { out_stream.read }
-      let(:push_api_key) { "abc" }
-      let(:config_options) { { :push_api_key => push_api_key } }
-      before do
-        capture_stdout(out_stream) do
-          config.validate
-        end
-      end
-
-      context "with missing request_headers config option" do
-        let(:config_options) { { :push_api_key => "abc" } }
-
-        it "logs a warning" do
-          is_expected.to eq(true)
-          expect(output).to include "Warning: The `request_headers` config " \
-            "option was not set  in the AppSignal configuration"
-        end
-      end
-
-      context "with request_headers config option present" do
-        let(:config_options) { { :push_api_key => "abc", :request_headers => [] } }
-
-        it "logs no warning" do
-          is_expected.to eq(true)
-          expect(output).to_not include "Warning: The `request_headers` config " \
-            "option was not set  in the AppSignal configuration"
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
Instead replace fallback header list with the new default.

Remove the warning that's printed after upgrade and the option is not
set.

Don't add it to the config by default, but allow complete overrides of
the config option.

Conclusion: use saner defaults, don't require users to do anything to
their configuration.

If they miss any headers they can update the configuration after
upgrade. This requires a smaller segment of our users to update their
config manually.