### PR TITLE
Fix in memory logger initialization

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -682,9 +682,7 @@ module Appsignal
           Logger::INFO
         end
 
-      if in_memory_log
-        logger << in_memory_log.string
-      end
+      logger << @in_memory_log.string if @in_memory_log
 
       if path_arg
         logger.info("Setting the path in start_logger has no effect anymore, set it in the config instead")


### PR DESCRIPTION
Calling the `in_memory_logger` method will always create a new logger.
This is not useful when being called in `Appsignal.start_logger` where
we check the presence of the in memory log. Instead, check the value
instance variable `@in_memory_logger` before appending it to the new
logger.

Fixes #413