### PR TITLE
Move tag limit handling to extension

### DIFF
--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -9,6 +9,8 @@ module Appsignal
     ACTION_CABLE   = "action_cable".freeze
     FRONTEND       = "frontend".freeze
     BLANK          = "".freeze
+    ALLOWED_TAG_KEY_TYPES = [Symbol, String].freeze
+    ALLOWED_TAG_VALUE_TYPES = [Symbol, String, Integer].freeze
 
     class << self
       def create(id, namespace, request, options = {})
@@ -447,10 +449,12 @@ module Appsignal
     # * Key is a symbol or string with less then 100 chars
     # * Value is a symbol or string with less then 100 chars
     # * Value is an integer
+    #
+    # @see https://docs.appsignal.com/ruby/instrumentation/tagging.html
     def sanitized_tags
-      @tags.select do |k, v|
-        (k.is_a?(Symbol) || k.is_a?(String) && k.length <= 100) &&
-          (((v.is_a?(Symbol) || v.is_a?(String)) && v.length <= 100) || v.is_a?(Integer))
+      @tags.select do |key, value|
+        ALLOWED_TAG_KEY_TYPES.any? { |type| key.is_a? type } &&
+          ALLOWED_TAG_VALUE_TYPES.any? { |type| value.is_a? type }
       end
     end
 


### PR DESCRIPTION
Remove the limits from the gem and move it to the extension.
The extension tag truncates tag values to 2000 characters and adds ellipsis
to the end if it's longer than the limit.
At time of writing the processor truncates all metadata values back to
a maximum length of 256 characters.

Tracking issue: https://github.com/appsignal/appsignal-agent/issues/349

## TODO

- [ ] ~Add extension update~ see: https://github.com/appsignal/appsignal-agent/issues/349
- [x] Update/fix specs
  - Use `transaction#to_h` in the spec to check the tag key and value truncation