### PR TITLE
Refactor Transaction set_* methods specs

### DIFF
--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -350,7 +350,7 @@ describe Appsignal::Transaction do
         transaction.sample_data
       end
 
-      it "stores tags on transaction" do
+      it "stores tags on the transaction" do
         expect(transaction.to_h["sample_data"]["tags"]).to eq(
           "valid_key" => "valid_value",
           "valid_string_key" => "valid_value",
@@ -362,61 +362,86 @@ describe Appsignal::Transaction do
       end
     end
 
-    describe "set_action" do
-      it "should set the action in extension" do
-        expect(transaction.ext).to receive(:set_action).with(
-          "PagesController#show"
-        ).once
+    describe "#set_action" do
+      context "when the action is set" do
+        it "updates the action name on the transaction" do
+          action_name = "PagesController#show"
+          transaction.set_action(action_name)
 
-        transaction.set_action("PagesController#show")
-
-        expect(transaction.action).to eq "PagesController#show"
-      end
-
-      it "should not set the action in extension when value is nil" do
-        expect(Appsignal::Extension).to_not receive(:set_action)
-
-        transaction.set_action(nil)
-      end
-    end
-
-    describe "set_action_if_nil" do
-      context "if action is currently nil" do
-        it "should set the action" do
-          expect(transaction.ext).to receive(:set_action).with(
-            "PagesController#show"
-          ).once
-
-          transaction.set_action_if_nil("PagesController#show")
+          expect(transaction.action).to eq(action_name)
+          expect(transaction.to_h["action"]).to eq(action_name)
         end
       end
 
-      context "if action is currently set" do
-        it "should not set the action" do
+      context "when the action is nil" do
+        it "does not update the action name on the transaction" do
+          action_name = "PagesController#show"
+          transaction.set_action(action_name)
+          transaction.set_action(nil)
+
+          expect(transaction.action).to eq(action_name)
+          expect(transaction.to_h["action"]).to eq(action_name)
+        end
+      end
+    end
+
+    describe "#set_action_if_nil" do
+      context "when the action is not set" do
+        it "updates the action name on the transaction" do
+          expect(transaction.action).to eq(nil)
+          expect(transaction.to_h["action"]).to eq(nil)
+
+          action_name = "PagesController#show"
+          transaction.set_action_if_nil(action_name)
+
+          expect(transaction.action).to eq(action_name)
+          expect(transaction.to_h["action"]).to eq(action_name)
+        end
+
+        context "when the given action is nil" do
+          it "does not update the action name on the transaction" do
+            action_name = "something"
+            transaction.set_action("something")
+            transaction.set_action_if_nil(nil)
+
+            expect(transaction.action).to eq(action_name)
+            expect(transaction.to_h["action"]).to eq(action_name)
+          end
+        end
+      end
+
+      context "when the action is set" do
+        it "does not update the action name on the transaction" do
+          action_name = "something"
           transaction.set_action("something")
+          transaction.set_action_if_nil("something else")
 
-          expect(transaction.ext).not_to receive(:set_action)
-
-          transaction.set_action_if_nil("PagesController#show")
+          expect(transaction.action).to eq(action_name)
+          expect(transaction.to_h["action"]).to eq(action_name)
         end
       end
     end
 
-    describe "set_namespace" do
-      it "should set the action in extension" do
-        expect(transaction.ext).to receive(:set_namespace).with(
-          "custom"
-        ).once
+    describe "#set_namespace" do
+      context "when the namespace is not nil" do
+        it "updates the namespace on the transaction" do
+          namespace = "custom"
+          transaction.set_namespace(namespace)
 
-        transaction.set_namespace("custom")
-
-        expect(transaction.namespace).to eq "custom"
+          expect(transaction.namespace).to eq namespace
+          expect(transaction.to_h["namespace"]).to eq(namespace)
+        end
       end
 
-      it "should not set the action in extension when value is nil" do
-        expect(Appsignal::Extension).to_not receive(:set_namespace)
+      context "when the namespace is nil" do
+        it "does not update the namespace on the transaction" do
+          namespace = "custom"
+          transaction.set_namespace(namespace)
+          transaction.set_namespace(nil)
 
-        transaction.set_action(nil)
+          expect(transaction.namespace).to eq(namespace)
+          expect(transaction.to_h["namespace"]).to eq(namespace)
+        end
       end
     end
 
@@ -499,48 +524,68 @@ describe Appsignal::Transaction do
     end
 
     describe "#set_metadata" do
-      it "should set the metdata in extension" do
-        expect(transaction.ext).to receive(:set_metadata).with(
-          "request_method",
-          "GET"
-        ).once
-
+      it "updates the metadata on the transaction" do
         transaction.set_metadata("request_method", "GET")
+
+        expect(transaction.to_h["metadata"]).to eq("request_method" => "GET")
       end
 
-      it "should not set the metdata in extension when value is nil" do
-        expect(transaction.ext).to_not receive(:set_metadata)
+      context "when the key is nil" do
+        it "does not update the metadata on the transaction" do
+          transaction.set_metadata(nil, "GET")
 
-        transaction.set_metadata("request_method", nil)
+          expect(transaction.to_h["metadata"]).to eq({})
+        end
+      end
+
+      context "when the value is nil" do
+        it "does not update the metadata on the transaction" do
+          transaction.set_metadata("request_method", nil)
+
+          expect(transaction.to_h["metadata"]).to eq({})
+        end
       end
     end
 
-    describe "set_sample_data" do
-      it "should set the data" do
-        expect(transaction.ext).to receive(:set_sample_data).with(
-          "params",
-          Appsignal::Utils::Data.generate(
-            "controller" => "blog_posts",
-            "action" => "show",
-            "id" => "1"
-          )
-        ).once
-
+    describe "#set_sample_data" do
+      it "updates the sample data on the transaction" do
         transaction.set_sample_data(
           "params",
           :controller => "blog_posts",
           :action     => "show",
           :id         => "1"
         )
+
+        expect(transaction.to_h["sample_data"]).to eq(
+          "params" => {
+            "action" => "show",
+            "controller" => "blog_posts",
+            "id" => "1"
+          }
+        )
       end
 
-      it "should do nothing if the data cannot be converted to json" do
-        expect(transaction.ext).to_not receive(:set_sample_data).with(
-          "params",
-          kind_of(String)
-        )
+      context "when the data is no Array or Hash" do
+        it "does not update the sample data on the transaction" do
+          transaction.set_sample_data("params", "string")
 
-        transaction.set_sample_data("params", "string")
+          expect(transaction.to_h["sample_data"]).to eq({})
+        end
+      end
+
+      context "when the data cannot be converted to JSON" do
+        it "does not update the sample data on the transaction" do
+          klass = Class.new do
+            def to_s
+              raise "foo" # Cause a deliberate error
+            end
+          end
+          transaction.set_sample_data("params", klass.new => 1)
+
+          expect(transaction.to_h["sample_data"]).to eq({})
+          expect(log_contents(log)).to contains_log :error,
+            "Error generating data (RuntimeError: foo) for"
+        end
       end
     end
 


### PR DESCRIPTION
Test the actual data stored on the transaction with `Transaction#to_h`
and on the Transaction object.

Also found a broken assertion on `Appsignal::Extension` calls. Needs to
be performed on an instance of the extension class, not the class
itself.

This won't need to be fixed anymore as we check the value on the
transaction in the extension.

Improper calls, as we do in the test suite, would cause an error to be
raised if not handled correctly. For example:

```
Failure/Error: @ext.set_action(action)

TypeError:
  wrong argument type nil (expected String)
```