### PR TITLE
Use doubles in custom metrics

### DIFF
--- a/ext/agent.yml
+++ b/ext/agent.yml
@@ -1,64 +1,64 @@
 ---
-version: 94aaf32
+version: 64deb96
 triples:
   x86_64-darwin:
     static:
-      checksum: 1316f7c202a232ae691dc3745f2ec6ee824e01aa2a613e56a41979b19ba1ec8f
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/94aaf32/appsignal-x86_64-darwin-all-static.tar.gz
+      checksum: 1ab49acb93615b0c1e2fe9e48c179e0fd3fcadd391523940c322f154bd479a83
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-x86_64-darwin-all-static.tar.gz
     dynamic:
-      checksum: b54ae98cfedfe82d7c4b6fbb05ec6d0310484db5706eeeb29a8cda006b5ea361
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/94aaf32/appsignal-x86_64-darwin-all-dynamic.tar.gz
+      checksum: 8b1acc7825c2fd024e4fed9bd4fe5485c3ba8dc903a00dbcd26d3ab27dc2e7ee
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-x86_64-darwin-all-dynamic.tar.gz
   universal-darwin:
     static:
-      checksum: 1316f7c202a232ae691dc3745f2ec6ee824e01aa2a613e56a41979b19ba1ec8f
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/94aaf32/appsignal-x86_64-darwin-all-static.tar.gz
+      checksum: 1ab49acb93615b0c1e2fe9e48c179e0fd3fcadd391523940c322f154bd479a83
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-x86_64-darwin-all-static.tar.gz
     dynamic:
-      checksum: b54ae98cfedfe82d7c4b6fbb05ec6d0310484db5706eeeb29a8cda006b5ea361
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/94aaf32/appsignal-x86_64-darwin-all-dynamic.tar.gz
+      checksum: 8b1acc7825c2fd024e4fed9bd4fe5485c3ba8dc903a00dbcd26d3ab27dc2e7ee
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-x86_64-darwin-all-dynamic.tar.gz
   i686-linux:
     static:
-      checksum: c0c5c3ad646e500c2a4a78afadbf4828560e4b4f00901a726fd06af0e5047cdc
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/94aaf32/appsignal-i686-linux-all-static.tar.gz
+      checksum: a27cf9191f70f13263662f6ca2555cada27ebb4384d6c981a534774b5e7def0e
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-i686-linux-all-static.tar.gz
     dynamic:
-      checksum: a6b98af9a1ac6d016b7021e73b76b457b6a1890114719fe6552eb46a371731ae
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/94aaf32/appsignal-i686-linux-all-dynamic.tar.gz
+      checksum: 7a19dd1aabe68a454649155e99fd95293915d0019ba438366c9cce247cdb4bc1
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-i686-linux-all-dynamic.tar.gz
   x86-linux:
     static:
-      checksum: c0c5c3ad646e500c2a4a78afadbf4828560e4b4f00901a726fd06af0e5047cdc
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/94aaf32/appsignal-i686-linux-all-static.tar.gz
+      checksum: a27cf9191f70f13263662f6ca2555cada27ebb4384d6c981a534774b5e7def0e
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-i686-linux-all-static.tar.gz
     dynamic:
-      checksum: a6b98af9a1ac6d016b7021e73b76b457b6a1890114719fe6552eb46a371731ae
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/94aaf32/appsignal-i686-linux-all-dynamic.tar.gz
+      checksum: 7a19dd1aabe68a454649155e99fd95293915d0019ba438366c9cce247cdb4bc1
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-i686-linux-all-dynamic.tar.gz
   i686-linux-musl:
     static:
-      checksum: 05bfaa688ceef363523818b2d0d5d94db178b2596cca96d804932c129d8ede10
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/94aaf32/appsignal-i686-linux-musl-all-static.tar.gz
+      checksum: 80fb5c2f36b7e8efcfc6914bb707688e248dd06c58b174d07e8a931f4bbf97ce
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-i686-linux-musl-all-static.tar.gz
   x86-linux-musl:
     static:
-      checksum: 05bfaa688ceef363523818b2d0d5d94db178b2596cca96d804932c129d8ede10
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/94aaf32/appsignal-i686-linux-musl-all-static.tar.gz
+      checksum: 80fb5c2f36b7e8efcfc6914bb707688e248dd06c58b174d07e8a931f4bbf97ce
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-i686-linux-musl-all-static.tar.gz
   x86_64-linux:
     static:
-      checksum: db176c740e26db37d61df1f9e18d57127a1a5208495f02bf18ff2c9553b12d62
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/94aaf32/appsignal-x86_64-linux-all-static.tar.gz
+      checksum: 83befc3bb521d5e055eb92d5a5a0afca929bce8968ca6d0426fac6aeaec3df24
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-x86_64-linux-all-static.tar.gz
     dynamic:
-      checksum: cb0f024f8a027d2a059c7d1a12fb98071e3c2da0ae6277ef5ac32fddf1e7ae8c
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/94aaf32/appsignal-x86_64-linux-all-dynamic.tar.gz
+      checksum: a6a8237df0fa0c8ff62ca3cd519e0494f01fc5e52f5ae9757c5fe375f451673a
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-x86_64-linux-all-dynamic.tar.gz
   x86_64-linux-musl:
     static:
-      checksum: a3c5882bfa3ee6f9612449a8c90eb64791764f34d910c21fd436ce26cf232b4e
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/94aaf32/appsignal-x86_64-linux-musl-all-static.tar.gz
+      checksum: 3cb74695955c7bc809320fa966d7290fe3162926c239bb6a845b82ef7aec266e
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-x86_64-linux-musl-all-static.tar.gz
   x86_64-freebsd:
     static:
-      checksum: ba8e6b26b76809a22753a6e6829be72c45a1c2a31c113e04d0fe09789ff63d98
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/94aaf32/appsignal-x86_64-freebsd-all-static.tar.gz
+      checksum: 7735718e2789c71f1135100ff4fab13cd85cbebe0ba2b87c5b555b30635bdcdc
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-x86_64-freebsd-all-static.tar.gz
     dynamic:
-      checksum: 52b17d8504aa335a35c9a84cde5762096b2e94ee2c9d622397e240ffa01cf5cd
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/94aaf32/appsignal-x86_64-freebsd-all-dynamic.tar.gz
+      checksum: '059ee407610bd4154a8a94bb029d0451758bfb995b530ab5142e4fd3a1a59030'
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-x86_64-freebsd-all-dynamic.tar.gz
   amd64-freebsd:
     static:
-      checksum: ba8e6b26b76809a22753a6e6829be72c45a1c2a31c113e04d0fe09789ff63d98
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/94aaf32/appsignal-x86_64-freebsd-all-static.tar.gz
+      checksum: 7735718e2789c71f1135100ff4fab13cd85cbebe0ba2b87c5b555b30635bdcdc
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-x86_64-freebsd-all-static.tar.gz
     dynamic:
-      checksum: 52b17d8504aa335a35c9a84cde5762096b2e94ee2c9d622397e240ffa01cf5cd
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/94aaf32/appsignal-x86_64-freebsd-all-dynamic.tar.gz
+      checksum: '059ee407610bd4154a8a94bb029d0451758bfb995b530ab5142e4fd3a1a59030'
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/64deb96/appsignal-x86_64-freebsd-all-dynamic.tar.gz

--- a/ext/appsignal_extension.c
+++ b/ext/appsignal_extension.c
@@ -588,14 +588,14 @@ static VALUE increment_counter(VALUE self, VALUE key, VALUE count, VALUE tags) {
   appsignal_data_t* tags_data;
 
   Check_Type(key, T_STRING);
-  Check_Type(count, T_FIXNUM);
+  Check_Type(count, T_FLOAT);
   Check_Type(tags, RUBY_T_DATA);
 
   Data_Get_Struct(tags, appsignal_data_t, tags_data);
 
   appsignal_increment_counter(
       make_appsignal_string(key),
-      FIX2INT(count),
+      NUM2DBL(count),
       tags_data
   );
   return Qnil;

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -621,10 +621,10 @@ module Appsignal
       Appsignal.logger.warn("Process gauge value #{value} for key '#{key}' is too big")
     end
 
-    def increment_counter(key, value = 1, tags = {})
+    def increment_counter(key, value = 1.0, tags = {})
       Appsignal::Extension.increment_counter(
         key.to_s,
-        value,
+        value.to_f,
         Appsignal::Utils::Data.generate(tags)
       )
     rescue RangeError

--- a/lib/appsignal/extension/jruby.rb
+++ b/lib/appsignal/extension/jruby.rb
@@ -72,7 +72,7 @@ module Appsignal
           [:appsignal_string, :double],
           :void
         attach_function :appsignal_increment_counter,
-          [:appsignal_string, :int64, :pointer],
+          [:appsignal_string, :double, :pointer],
           :void
         attach_function :appsignal_add_distribution_value,
           [:appsignal_string, :double, :pointer],

--- a/spec/lib/appsignal/extension_spec.rb
+++ b/spec/lib/appsignal/extension_spec.rb
@@ -107,7 +107,7 @@ describe Appsignal::Extension do
       end
 
       it "should have a increment_counter method" do
-        subject.increment_counter("key", 1, Appsignal::Extension.data_map_new)
+        subject.increment_counter("key", 1.0, Appsignal::Extension.data_map_new)
       end
 
       it "should have a add_distribution_value method" do


### PR DESCRIPTION
The extension now uses doubles for all values, update the type mapping.