### PR TITLE
Add error message for unsupported architectures

### DIFF
--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -15,6 +15,7 @@ task :default do
         ) &&
         File.exist?(ext_path("appsignal.h"))
       archive = download_archive(arch_config, "dynamic")
+      next unless archive
       next unless verify_archive(archive, arch_config, "dynamic")
       unarchive(archive)
     end

--- a/ext/base.rb
+++ b/ext/base.rb
@@ -48,8 +48,18 @@ def check_architecture
 end
 
 def download_archive(arch_config, type)
-  logger.info "Downloading agent release from #{arch_config[type]["download_url"]}"
-  open(arch_config[type]["download_url"], :ssl_ca_cert => CA_CERT_PATH)
+  if arch_config.keys.include?(type)
+    logger.info "Downloading agent release from #{arch_config[type]["download_url"]}"
+    open(arch_config[type]["download_url"], :ssl_ca_cert => CA_CERT_PATH)
+  else
+    installation_failed(
+      "AppSignal currently does not support your system. " \
+      "Expected config for architecture '#{ARCH}' and package type '#{type}', but none found. " \
+      "For a full list of supported systems visit: " \
+      "https://docs.appsignal.com/support/operating-systems.html"
+    )
+    false
+  end
 end
 
 def verify_archive(archive, arch_config, type)

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -11,6 +11,7 @@ def install
       File.exist?(ext_path("libappsignal.a")) &&
       File.exist?(ext_path("appsignal.h"))
     archive = download_archive(arch_config, "static")
+    return unless archive
     return unless verify_archive(archive, arch_config, "static")
     unarchive(archive)
   end


### PR DESCRIPTION
In case someone uses an architecture that we don't support we want to
let them know instead of showing an exception.

For example, when installing AppSignal for JRuby with
`APPSIGNAL_BUILD_FOR_MUSL=1` set it would fail the installation with a
non-descriptive error and backtrace. While we do not support the JRuby
and Musl combination, at least show a more descriptive message for the
user (and us) about what went wrong.

Fixes #425