### PR TITLE
Support container memory host metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.8.0 (unreleased)
+- Support memory host metrics collection for containers. PR #428
+
 # 2.7.1 (unreleased)
 - Improve error log on unsupported architecture and build combination on
   install. PR #426

--- a/ext/agent.yml
+++ b/ext/agent.yml
@@ -1,64 +1,64 @@
 ---
-version: 7859eb4
+version: 01362a4
 triples:
   x86_64-darwin:
     static:
-      checksum: 7297a066ced652e7ec498eee30b9094586b5d0ce221c84bbb851e2de9d11a39f
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-x86_64-darwin-all-static.tar.gz
+      checksum: a33aa14ae9b8c58c379667e7f79807bdc843354baf635abc334a14c3b984114d
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-x86_64-darwin-all-static.tar.gz
     dynamic:
-      checksum: 232c43957fb17f58b1c44db3023a259b3d92a17ab576f18e5fffa47f16b23144
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-x86_64-darwin-all-dynamic.tar.gz
+      checksum: 9956fc35234bbd0f01095ee9032dbf3631d424bdf51536b50c59e8f765834ce1
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-x86_64-darwin-all-dynamic.tar.gz
   universal-darwin:
     static:
-      checksum: 7297a066ced652e7ec498eee30b9094586b5d0ce221c84bbb851e2de9d11a39f
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-x86_64-darwin-all-static.tar.gz
+      checksum: a33aa14ae9b8c58c379667e7f79807bdc843354baf635abc334a14c3b984114d
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-x86_64-darwin-all-static.tar.gz
     dynamic:
-      checksum: 232c43957fb17f58b1c44db3023a259b3d92a17ab576f18e5fffa47f16b23144
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-x86_64-darwin-all-dynamic.tar.gz
+      checksum: 9956fc35234bbd0f01095ee9032dbf3631d424bdf51536b50c59e8f765834ce1
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-x86_64-darwin-all-dynamic.tar.gz
   i686-linux:
     static:
-      checksum: 002b5d27e368444eae4308e97285faa83f13cb2aa25fde32a39000d354649917
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-i686-linux-all-static.tar.gz
+      checksum: 44d729dd8b3c6bf3041ee32dee1c155bfd19b5309cbf6ef95959fc026819915c
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-i686-linux-all-static.tar.gz
     dynamic:
-      checksum: ab0d846c6e79cf89ce8e4d38a8335e35aa0f74123d3085666cf1e4116325fdfa
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-i686-linux-all-dynamic.tar.gz
+      checksum: 30fa55577862addebe16b0fddfdd73c6613f321d769606f15bbd14be8850aa68
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-i686-linux-all-dynamic.tar.gz
   x86-linux:
     static:
-      checksum: 002b5d27e368444eae4308e97285faa83f13cb2aa25fde32a39000d354649917
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-i686-linux-all-static.tar.gz
+      checksum: 44d729dd8b3c6bf3041ee32dee1c155bfd19b5309cbf6ef95959fc026819915c
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-i686-linux-all-static.tar.gz
     dynamic:
-      checksum: ab0d846c6e79cf89ce8e4d38a8335e35aa0f74123d3085666cf1e4116325fdfa
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-i686-linux-all-dynamic.tar.gz
+      checksum: 30fa55577862addebe16b0fddfdd73c6613f321d769606f15bbd14be8850aa68
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-i686-linux-all-dynamic.tar.gz
   i686-linux-musl:
     static:
-      checksum: '038b14bf3f3cad55e3dfc4947a6eccaf90f2cb15574f2cc69b17f78b20f8075e'
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-i686-linux-musl-all-static.tar.gz
+      checksum: 0bb69e60781db9bd0867ccece63a029706cf0d5a26d34d70668bc2264b531ce4
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-i686-linux-musl-all-static.tar.gz
   x86-linux-musl:
     static:
-      checksum: '038b14bf3f3cad55e3dfc4947a6eccaf90f2cb15574f2cc69b17f78b20f8075e'
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-i686-linux-musl-all-static.tar.gz
+      checksum: 0bb69e60781db9bd0867ccece63a029706cf0d5a26d34d70668bc2264b531ce4
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-i686-linux-musl-all-static.tar.gz
   x86_64-linux:
     static:
-      checksum: d968a93822a61d39a62648c2880e52bdb4caba81c567041d27da7a3c848650b7
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-x86_64-linux-all-static.tar.gz
+      checksum: 92b3662722978b39176c9d2e986fb8cc527772470dd0d9d7a8ea808cd4780b70
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-x86_64-linux-all-static.tar.gz
     dynamic:
-      checksum: 19525e7fdfce5005332fc95d3387573c0bc28ecf86d5ce51cf4fa7e9368328b9
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-x86_64-linux-all-dynamic.tar.gz
+      checksum: 3a9af3a4280b9842702d8af6cc4af84acc452b910fc8d753ee5907807de8f58c
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-x86_64-linux-all-dynamic.tar.gz
   x86_64-linux-musl:
     static:
-      checksum: 669d0876ae3bb5033563c19aed63c298beca3dd4c2d06c3fa27d641c650b8654
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-x86_64-linux-musl-all-static.tar.gz
+      checksum: 41624a50b603eeb4f875ee19dde41bb0877a0a039f6f2f560a9efc3d6b73a195
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-x86_64-linux-musl-all-static.tar.gz
   x86_64-freebsd:
     static:
-      checksum: 9f02f723ceef3f5ebb68f226bb6f188b8f3e07551684b86f3eb37f918d549148
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-x86_64-freebsd-all-static.tar.gz
+      checksum: 14cdca07045a53b2c69647f1255cbc2f9fe322ddf6040c2e1a6ba36aa482cdf2
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-x86_64-freebsd-all-static.tar.gz
     dynamic:
-      checksum: db00a48cbfebe8ec730e1869d8fc47cc986f895f2baab61a659eaa270280f88f
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-x86_64-freebsd-all-dynamic.tar.gz
+      checksum: 0433b4cd9e0af92b8b4efdb797de43129f754b71a04c2313786d571866092675
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-x86_64-freebsd-all-dynamic.tar.gz
   amd64-freebsd:
     static:
-      checksum: 9f02f723ceef3f5ebb68f226bb6f188b8f3e07551684b86f3eb37f918d549148
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-x86_64-freebsd-all-static.tar.gz
+      checksum: 14cdca07045a53b2c69647f1255cbc2f9fe322ddf6040c2e1a6ba36aa482cdf2
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-x86_64-freebsd-all-static.tar.gz
     dynamic:
-      checksum: db00a48cbfebe8ec730e1869d8fc47cc986f895f2baab61a659eaa270280f88f
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/7859eb4/appsignal-x86_64-freebsd-all-dynamic.tar.gz
+      checksum: 0433b4cd9e0af92b8b4efdb797de43129f754b71a04c2313786d571866092675
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/01362a4/appsignal-x86_64-freebsd-all-dynamic.tar.gz

--- a/lib/appsignal/version.rb
+++ b/lib/appsignal/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Appsignal
-  VERSION = "2.7.0".freeze
+  VERSION = "2.8.0.alpha.1".freeze
 end


### PR DESCRIPTION
## Bump agent to 01362a4

- Support memory host metrics collection for containers. When
  `running_in_container` is set to `true` or detected as such it will
  collect container runtime metrics rather than the container's parent
  host metrics.

🚨 PR will be used for the 2.8.0 alpha series to test it out. __DO NOT MERGE!__ 🚨 