### PR TITLE
Improve performance when garbage collection profiling is disabled

### DIFF
--- a/lib/appsignal/garbage_collection_profiler.rb
+++ b/lib/appsignal/garbage_collection_profiler.rb
@@ -47,4 +47,15 @@ module Appsignal
       self.class.lock
     end
   end
+
+  # {Appsignal::NilGarbageCollectionProfiler} is a dummy profiler
+  # that always returns 0 as the total time.
+  # Used when we don't want any profile information
+  #
+  # @api private
+  class NilGarbageCollectionProfiler
+    def total_time
+      0
+    end
+  end
 end

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -53,7 +53,8 @@ module Appsignal
       end
 
       def garbage_collection_profiler
-        @garbage_collection_profiler ||= Appsignal::GarbageCollectionProfiler.new
+        @garbage_collection_profiler ||=
+          Appsignal.config[:enable_gc_instrumentation] ? Appsignal::GarbageCollectionProfiler.new : NilGarbageCollectionProfiler.new
       end
     end
 

--- a/spec/lib/appsignal/garbage_collection_profiler_spec.rb
+++ b/spec/lib/appsignal/garbage_collection_profiler_spec.rb
@@ -64,3 +64,13 @@ describe Appsignal::GarbageCollectionProfiler do
     end
   end
 end
+
+describe Appsignal::NilGarbageCollectionProfiler do
+  let(:profiler) { described_class.new }
+
+  describe "#total_time" do
+    it "has a total time of 0" do
+      expect(profiler.total_time).to eq(0)
+    end
+  end
+end

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -672,6 +672,23 @@ describe Appsignal::Transaction do
       end
     end
 
+    describe "#garbage_collection_profiler" do
+      before { Appsignal::Transaction.instance_variable_set(:@garbage_collection_profiler, nil) }
+
+      it "returns the NilGarbageCollectionProfiler" do
+        expect(Appsignal::Transaction.garbage_collection_profiler).to be_a(Appsignal::NilGarbageCollectionProfiler)
+      end
+
+      context "when gc profiling is enabled" do
+        before { Appsignal.config.config_hash[:enable_gc_instrumentation] = true }
+        after { Appsignal.config.config_hash[:enable_gc_instrumentation] = false }
+
+        it "returns the GarbageCollectionProfiler" do
+          expect(Appsignal::Transaction.garbage_collection_profiler).to be_a(Appsignal::GarbageCollectionProfiler)
+        end
+      end
+    end
+
     describe "#start_event" do
       it "should start the event in the extension" do
         expect(transaction.ext).to receive(:start_event).with(0).and_call_original


### PR DESCRIPTION
When the garbage collection profiler is disabled, we still call the `total_time`
on `GarbageCollectionProfiler`. This contains a mutex lock, that might be slow.

This commit remedies this issue by switching to a `NilGarbageCollectionProfiler`
when cg profiling is disabled that immediately returns 0 whithout any locks.

* Add a `NilGarbageCollectionProfiler` that does not profile garbage collection
* Use the `NilGarbageCollectionProfiler` in `Transaction`
  when `config[:enable_gc_instrumentation]` is `false`