### PR TITLE
Load environment task before loading Appsignal config

### DIFF
--- a/lib/appsignal/integrations/capistrano/appsignal.cap
+++ b/lib/appsignal/integrations/capistrano/appsignal.cap
@@ -1,5 +1,5 @@
 namespace :appsignal do
-  task :deploy do
+  task deploy: :environment do
     appsignal_env = fetch(:appsignal_env, fetch(:stage, fetch(:rails_env, fetch(:rack_env, "production"))))
     user = fetch(:appsignal_user, ENV["USER"] || ENV["USERNAME"])
     revision = fetch(:appsignal_revision, fetch(:current_revision))

--- a/lib/appsignal/integrations/capistrano/capistrano_2_tasks.rb
+++ b/lib/appsignal/integrations/capistrano/capistrano_2_tasks.rb
@@ -10,7 +10,7 @@ module Appsignal
         after "deploy:migrations", "appsignal:deploy"
 
         namespace :appsignal do
-          task :deploy do
+          task deploy: :environment do
             env = fetch(:appsignal_env, fetch(:stage, fetch(:rails_env, fetch(:rack_env, "production"))))
             user = fetch(:appsignal_user, ENV["USER"] || ENV["USERNAME"])
             revision = fetch(:appsignal_revision, fetch(:current_revision))


### PR DESCRIPTION
Gems like dotenv need to be loaded before environment variables are set. This ensures that the config that is loaded is identical to when the app is booted.