### PR TITLE
Improve the installation script for Rails

### DIFF
--- a/lib/appsignal/cli/install.rb
+++ b/lib/appsignal/cli/install.rb
@@ -73,9 +73,9 @@ module Appsignal
         end
 
         def install_for_rails(config)
-          require File.expand_path(File.join(Dir.pwd, "config/application.rb"))
-
           puts "Installing for Ruby on Rails"
+
+          require File.expand_path(File.join(Dir.pwd, "config/application.rb"))
 
           config[:name] = Rails.application.class.parent_name
 


### PR DESCRIPTION
Print a message, "Installing for Ruby on Rails" before starting the installation process.

It will help to understand what goes wrong if the script detects Rails by a mistake and raises an exception like this one: https://gist.github.com/kostyadubinin/e2f5344b245d4278263ba87cd374370b

The script detects Rails by a mistake in this case:

- the application is written with Sinatra
- you don't use Bundler (not sure if this is required)
- the Rails gem is installed and `require "rails"` doesn't raise an error

When the script detects Rails by a mistake it tries to require `config/application.rb` (which doesn't exist) and raises an exception.