### PR TITLE
Remove unused extension send_params option

### DIFF
--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -166,7 +166,6 @@ module Appsignal
       ENV["_APPSIGNAL_IGNORE_ACTIONS"]               = config_hash[:ignore_actions].join(",")
       ENV["_APPSIGNAL_IGNORE_ERRORS"]                = config_hash[:ignore_errors].join(",")
       ENV["_APPSIGNAL_IGNORE_NAMESPACES"]            = config_hash[:ignore_namespaces].join(",")
-      ENV["_APPSIGNAL_SEND_PARAMS"]                  = config_hash[:send_params].to_s
       ENV["_APPSIGNAL_RUNNING_IN_CONTAINER"]         = config_hash[:running_in_container].to_s
       ENV["_APPSIGNAL_WORKING_DIR_PATH"]             = config_hash[:working_dir_path] if config_hash[:working_dir_path]
       ENV["_APPSIGNAL_WORKING_DIRECTORY_PATH"]       = config_hash[:working_directory_path] if config_hash[:working_directory_path]

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -432,7 +432,6 @@ describe Appsignal::Config do
       expect(ENV["_APPSIGNAL_IGNORE_ACTIONS"]).to               eq "action1,action2"
       expect(ENV["_APPSIGNAL_IGNORE_ERRORS"]).to                eq "ExampleStandardError,AnotherError"
       expect(ENV["_APPSIGNAL_IGNORE_NAMESPACES"]).to            eq "admin,private_namespace"
-      expect(ENV["_APPSIGNAL_SEND_PARAMS"]).to                  eq "true"
       expect(ENV["_APPSIGNAL_RUNNING_IN_CONTAINER"]).to         eq "false"
       expect(ENV["_APPSIGNAL_ENABLE_HOST_METRICS"]).to          eq "true"
       expect(ENV["_APPSIGNAL_ENABLE_MINUTELY_PROBES"]).to       eq "false"


### PR DESCRIPTION
It's not used for the config in the extension, so remove it to avoid
confusion.