### PR TITLE
Link gcc to extension .so library

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -23,6 +23,18 @@ def install
   elsif !find_executable("appsignal-agent", EXT_PATH)
     installation_failed "Aborting installation, appsignal-agent not found"
   else
+    with_static_link = [
+      Appsignal::System::LINUX_TARGET,
+      Appsignal::System::MUSL_TARGET
+    ].include?(PLATFORM)
+    if with_static_link
+      # Statically link libgcc and libgcc_s libraries.
+      # Dependencies of the libappsignal extension library.
+      # If the gem is installed on a host with build tools installed, but is
+      # run on one that isn't the missing libraries will cause the extension
+      # to fail on start.
+      $LDFLAGS += " -static-libgcc" # rubocop:disable Style/GlobalVars
+    end
     create_makefile "appsignal_extension"
     logger.info "Successfully created Makefile for appsignal extension"
   end

--- a/lib/appsignal/system.rb
+++ b/lib/appsignal/system.rb
@@ -7,7 +7,9 @@ module Appsignal
   #
   # @api private
   module System
+    LINUX_TARGET = "linux".freeze
     MUSL_TARGET = "linux-musl".freeze
+    FREEBSD_TARGET = "freebsd".freeze
     GEM_EXT_PATH = File.expand_path("../../../ext", __FILE__).freeze
 
     def self.heroku?
@@ -45,12 +47,12 @@ module Appsignal
       host_os = RbConfig::CONFIG["host_os"].downcase
       local_os =
         case host_os
-        when /linux/
-          "linux"
+        when /#{LINUX_TARGET}/
+          LINUX_TARGET
         when /darwin/
           "darwin"
-        when /freebsd/
-          "freebsd"
+        when /#{FREEBSD_TARGET}/
+          FREEBSD_TARGET
         else
           host_os
         end

--- a/spec/lib/appsignal/system_spec.rb
+++ b/spec/lib/appsignal/system_spec.rb
@@ -123,7 +123,7 @@ describe Appsignal::System do
       let(:os) { "freebsd11" }
       let(:ldd_output) { "ldd: illegal option -- -" }
 
-      it "returns the darwin build" do
+      it "returns the FreeBSD build" do
         is_expected.to eq("freebsd")
       end
     end


### PR DESCRIPTION
This fixes the missing `libgcc_s.so` error on AppSignal boot on (mostly
commonly) musl builds with a two stage deploy.

```
appsignal: Failed to load extension (Error loading shared library
libgcc_s.so.1: No such file or directory (needed by
/app/gem/ext/appsignal_extension.so) -
/app/gem/ext/appsignal_extension.so)
```

This was caused by the 2.7.x build having more dynamically linked
dependencies than the previous build. This was `libgcc_s`. Since it's
only available as a shared object file (`.so`) we can't specify
`-static` as an option to gcc. Instead, we need to add the
`-static-libgcc` option. Docs:
http://gcc.gnu.org/onlinedocs/gcc/Link-Options.html (search for
`-static-libgcc`).

Fixes:
https://docs.appsignal.com/support/known-issues/compilation-dependencies-required-at-runtime.html

For more information (private issue):
https://github.com/appsignal/appsignal-agent/issues/375


## TODO

- [x] Limit flag to Linux