### PR TITLE
Add new agent & extension diagnose report keys

### DIFF
--- a/ext/agent.yml
+++ b/ext/agent.yml
@@ -1,64 +1,64 @@
 ---
-version: 1bd6660
+version: '0830491'
 triples:
   x86_64-darwin:
     static:
-      checksum: 77371d3bc0a2933755ad637d5fad4b5695b7c509335a36d91c367e7de226a9c5
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-x86_64-darwin-all-static.tar.gz
+      checksum: e54dc97f43781c0227b2f15640060c7318153564105f48b835956a0a00271d7e
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-x86_64-darwin-all-static.tar.gz
     dynamic:
-      checksum: c8f2393bb50d45d027a698cc598de5be2ddc6ffe5f27971f8251f873a7b9640b
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-x86_64-darwin-all-dynamic.tar.gz
+      checksum: 1c52f2d2f9e2463470f261a0da28731bbf48e54693453f82bc07488bc77b7d8d
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-x86_64-darwin-all-dynamic.tar.gz
   universal-darwin:
     static:
-      checksum: 77371d3bc0a2933755ad637d5fad4b5695b7c509335a36d91c367e7de226a9c5
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-x86_64-darwin-all-static.tar.gz
+      checksum: e54dc97f43781c0227b2f15640060c7318153564105f48b835956a0a00271d7e
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-x86_64-darwin-all-static.tar.gz
     dynamic:
-      checksum: c8f2393bb50d45d027a698cc598de5be2ddc6ffe5f27971f8251f873a7b9640b
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-x86_64-darwin-all-dynamic.tar.gz
+      checksum: 1c52f2d2f9e2463470f261a0da28731bbf48e54693453f82bc07488bc77b7d8d
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-x86_64-darwin-all-dynamic.tar.gz
   i686-linux:
     static:
-      checksum: f256cda20f7b614d5286645257bf3d6861a106251c9c9ff009aa49582fc59231
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-i686-linux-all-static.tar.gz
+      checksum: 5d07d9ef6273c02328dd96334d69f8809ea00cd1e2f09b2ffa6765b530029b10
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-i686-linux-all-static.tar.gz
     dynamic:
-      checksum: 641cd67fd11f3a9dd0286ea790e5efa26b41eab95e3b482e36b2c4a002b00ec1
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-i686-linux-all-dynamic.tar.gz
+      checksum: '081715eeb42989e90a6a572f0911e1ad1afa89401af8686200a666a025293a7f'
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-i686-linux-all-dynamic.tar.gz
   x86-linux:
     static:
-      checksum: f256cda20f7b614d5286645257bf3d6861a106251c9c9ff009aa49582fc59231
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-i686-linux-all-static.tar.gz
+      checksum: 5d07d9ef6273c02328dd96334d69f8809ea00cd1e2f09b2ffa6765b530029b10
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-i686-linux-all-static.tar.gz
     dynamic:
-      checksum: 641cd67fd11f3a9dd0286ea790e5efa26b41eab95e3b482e36b2c4a002b00ec1
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-i686-linux-all-dynamic.tar.gz
+      checksum: '081715eeb42989e90a6a572f0911e1ad1afa89401af8686200a666a025293a7f'
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-i686-linux-all-dynamic.tar.gz
   i686-linux-musl:
     static:
-      checksum: f6290a6ccd8a700af66720fa5e99a99265c3f76f64fb841919a7ce061b04e7cc
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-i686-linux-musl-all-static.tar.gz
+      checksum: cc30d74b5f80ce334699459e69d38788156633e95343d448f1f16af3d06c4819
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-i686-linux-musl-all-static.tar.gz
   x86-linux-musl:
     static:
-      checksum: f6290a6ccd8a700af66720fa5e99a99265c3f76f64fb841919a7ce061b04e7cc
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-i686-linux-musl-all-static.tar.gz
+      checksum: cc30d74b5f80ce334699459e69d38788156633e95343d448f1f16af3d06c4819
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-i686-linux-musl-all-static.tar.gz
   x86_64-linux:
     static:
-      checksum: e2e91a85296bd68718e59cc72a27a224b399bd87ca309e562d1b27cc408c6c40
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-x86_64-linux-all-static.tar.gz
+      checksum: dbbf73b16afd49670f7ec4fd574ed17510c1c96d073faee1d496f56b49bc7515
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-x86_64-linux-all-static.tar.gz
     dynamic:
-      checksum: c65d49ff6454ebbe6ae9e495f4e9a30e45cc21e514bf9cb59e2459bdea8b8424
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-x86_64-linux-all-dynamic.tar.gz
+      checksum: c48b1e80cf6f5800d5a9d7efbff2bd922f8a781bac9ace19be31076e6025d67f
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-x86_64-linux-all-dynamic.tar.gz
   x86_64-linux-musl:
     static:
-      checksum: dff3eebc7bc3453984e1c58d8f11ae28fbf352561f44946cd1b381387c499a5a
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-x86_64-linux-musl-all-static.tar.gz
+      checksum: e0591c948590b6ef96b243a826dd176ec4466f326eef44b71a2a4322d9b6358d
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-x86_64-linux-musl-all-static.tar.gz
   x86_64-freebsd:
     static:
-      checksum: 27806c713ce7d594cf32bc290cc2aafdbbd604a2ee9b6edee7d19e8adb029792
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-x86_64-freebsd-all-static.tar.gz
+      checksum: f5e75c689cc25ec37315fb68c0c4d849f1b9987e675272652cb6ce3b3d785257
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-x86_64-freebsd-all-static.tar.gz
     dynamic:
-      checksum: f0a0e25a7eee558d1eda089a053a170884dc9be9ac93f0fe291d1047f33111d2
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-x86_64-freebsd-all-dynamic.tar.gz
+      checksum: 4a3ed63a2bbabfdd76453e0e38c5cfa74629c7674af544d3366f8d5b9ad57f42
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-x86_64-freebsd-all-dynamic.tar.gz
   amd64-freebsd:
     static:
-      checksum: 27806c713ce7d594cf32bc290cc2aafdbbd604a2ee9b6edee7d19e8adb029792
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-x86_64-freebsd-all-static.tar.gz
+      checksum: f5e75c689cc25ec37315fb68c0c4d849f1b9987e675272652cb6ce3b3d785257
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-x86_64-freebsd-all-static.tar.gz
     dynamic:
-      checksum: f0a0e25a7eee558d1eda089a053a170884dc9be9ac93f0fe291d1047f33111d2
-      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/1bd6660/appsignal-x86_64-freebsd-all-dynamic.tar.gz
+      checksum: 4a3ed63a2bbabfdd76453e0e38c5cfa74629c7674af544d3366f8d5b9ad57f42
+      download_url: https://appsignal-agent-releases.global.ssl.fastly.net/0830491/appsignal-x86_64-freebsd-all-dynamic.tar.gz

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -225,7 +225,8 @@ module Appsignal
           output = test["output"]
 
           print "  #{definition[:label]}: "
-          display_value = definition[:values][value]
+          display_value =
+            definition[:values] ? definition[:values][value] : value
           print display_value.nil? ? "-" : display_value
           print "\n    Error: #{error}" if error
           print "\n    Output: #{output}" if output
@@ -249,6 +250,10 @@ module Appsignal
                   :values => { true => "started", false => "not started" }
                 }
               },
+              "host" => {
+                "uid" => { :label => "Agent user id" },
+                "gid" => { :label => "Agent user group id" }
+              },
               "config" => {
                 "valid" => {
                   :label => "Agent config",
@@ -260,6 +265,11 @@ module Appsignal
                   :label => "Agent logger",
                   :values => { true => "started", false => "not started" }
                 }
+              },
+              "working_directory_stat" => {
+                "uid" => { :label => "Agent working directory user id" },
+                "gid" => { :label => "Agent working directory user group id" },
+                "mode" => { :label => "Agent working directory permissions" }
               },
               "lock_path" => {
                 "created" => {

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -205,13 +205,22 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :report => true do
     end
 
     describe "agent diagnostics" do
+      let(:working_directory_stat) { File.stat("/tmp/appsignal") }
+
       it "starts the agent in diagnose mode and outputs the report" do
         run
+        working_directory_stat = File.stat("/tmp/appsignal")
         expect(output).to include \
           "Agent diagnostics",
           "  Extension config: valid",
+          "  Agent started: started",
+          "  Agent user id: #{Process.uid}",
+          "  Agent user group id: #{Process.gid}",
           "  Agent config: valid",
           "  Agent logger: started",
+          "  Agent working directory user id: #{working_directory_stat.uid}",
+          "  Agent working directory user group id: #{working_directory_stat.gid}",
+          "  Agent working directory permissions: #{working_directory_stat.mode}",
           "  Agent lock path: writable"
       end
 
@@ -223,8 +232,17 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :report => true do
           },
           "agent" => {
             "boot" => { "started" => { "result" => true } },
+            "host" => {
+              "uid" => { "result" => Process.uid },
+              "gid" => { "result" => Process.gid }
+            },
             "config" => { "valid" => { "result" => true } },
             "logger" => { "started" => { "result" => true } },
+            "working_directory_stat" => {
+              "uid" => { "result" => working_directory_stat.uid },
+              "gid" => { "result" => working_directory_stat.gid },
+              "mode" => { "result" => working_directory_stat.mode }
+            },
             "lock_path" => { "created" => { "result" => true } }
           }
         )

--- a/spec/lib/appsignal/extension_spec.rb
+++ b/spec/lib/appsignal/extension_spec.rb
@@ -29,8 +29,11 @@ describe Appsignal::Extension do
             subject.start
           end
 
-          expect(output).to include \
-            "WARNING: Error when reading appsignal config, appsignal not starting"
+          expect(output).to match \
+            %r{
+              WARNING:\sError\swhen\sreading\sappsignal\sconfig,\s
+              appsignal\s\(as\s(\d{2,4})/(\d{2,4})\)\snot\sstarting
+            }x
         end
       end
 


### PR DESCRIPTION
Support display of new agent & extension diagnose report keys and
values. Drop the requirement of boolean values. If no value display
method is found, show the raw value.

~Requires https://github.com/appsignal/appsignal-agent/pull/386 to be shipped as a build and added to this PR for it to be merged.~ shipped!