### PR TITLE
Add diagnose command --[no-]send-report option

### DIFF
--- a/lib/appsignal/cli.rb
+++ b/lib/appsignal/cli.rb
@@ -82,6 +82,9 @@ module Appsignal
             o.on "--environment=<app_env>", "The environment to diagnose" do |arg|
               options[:environment] = arg
             end
+            o.on "--[no-]send-report", "Confirm sending the report to AppSignal automatically" do |arg|
+              options[:send_report] = arg
+            end
           end,
           "install" => OptionParser.new,
           "notify_of_deploy" => OptionParser.new do |o|

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -34,6 +34,12 @@ module Appsignal
     # @example With a specific environment
     #   appsignal diagnose --environment=production
     #
+    # @example Automatically send the diagnose report without prompting
+    #   appsignal diagnose --send-report
+    #
+    # @example Don't prompt about sending the report and don't sent it
+    #   appsignal diagnose --no-send-report
+    #
     # @see http://docs.appsignal.com/support/debugging.html Debugging AppSignal
     # @see http://docs.appsignal.com/ruby/command-line/diagnose.html
     #   AppSignal diagnose documentation
@@ -96,21 +102,32 @@ module Appsignal
 
           log_files
 
-          transmit_report_to_appsignal if send_report_to_appsignal?
+          transmit_report_to_appsignal if send_report_to_appsignal?(options)
         end
 
         private
 
-        def send_report_to_appsignal?
+        def send_report_to_appsignal?(options)
           puts "\nDiagnostics report"
           puts "  Do you want to send this diagnostics report to AppSignal?"
           puts "  If you share this diagnostics report you will be given\n" \
             "  a support token you can use to refer to your diagnotics \n" \
             "  report when you contact us at support@appsignal.com\n\n"
-          send_diagnostics = yes_or_no(
-            "  Send diagnostics report to AppSignal? (Y/n): ",
-            :default => "y"
-          )
+          send_diagnostics =
+            if options.key?(:send_report)
+              if options[:send_report]
+                puts "  Confirmed sending report using --send-report option."
+                true
+              else
+                puts "  Not sending report. (Specified with the --no-send-report option.)"
+                false
+              end
+            else
+              yes_or_no(
+                "  Send diagnostics report to AppSignal? (Y/n): ",
+                :default => "y"
+              )
+            end
           unless send_diagnostics
             puts "  Not sending diagnostics information to AppSignal."
             return false


### PR DESCRIPTION
This option allows users to (not) send the report without being
prompted. Useful for our support team to send this all in one command to
the user, so users don't have to confirm anything.

```
appsignal diagnose --send-report
appsignal diagnose --no-send-report
```

Also useful for non-interactive environments in which the command is
run.