### PR TITLE
Print deprecation warnings to STDOUT as well

### DIFF
--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -8,6 +8,8 @@ require "tmpdir"
 
 module Appsignal
   class Config
+    include Appsignal::Utils::DeprecationMessage
+
     DEFAULT_CONFIG = {
       :debug                          => false,
       :log                            => "file",
@@ -241,17 +243,21 @@ module Appsignal
         DEPRECATED_CONFIG_KEY_MAPPING.each do |old_key, new_key|
           old_config_value = config.delete(old_key)
           next unless old_config_value
-          logger.warn "Old configuration key found. Please update the "\
-            "'#{old_key}' to '#{new_key}'."
+          deprecation_message \
+            "Old configuration key found. Please update the "\
+            "'#{old_key}' to '#{new_key}'.",
+            logger
 
           next if config[new_key] # Skip if new key is already in use
           config[new_key] = old_config_value
         end
 
         if config.include?(:working_dir_path)
-          logger.warn "'working_dir_path' is deprecated, please use " \
-                      "'working_directory_path' instead and specify the " \
-                      "full path to the working directory"
+          deprecation_message \
+            "'working_dir_path' is deprecated, please use " \
+            "'working_directory_path' instead and specify the " \
+            "full path to the working directory",
+            logger
         end
       end
     end

--- a/lib/appsignal/event_formatter.rb
+++ b/lib/appsignal/event_formatter.rb
@@ -14,6 +14,8 @@ module Appsignal
   # @api private
   class EventFormatter
     class << self
+      include Appsignal::Utils::DeprecationMessage
+
       def formatters
         @@formatters ||= {}
       end
@@ -33,7 +35,7 @@ module Appsignal
         end
 
         if registered?(name, formatter)
-          Appsignal.logger.warn(
+          logger.warn(
             "Formatter for '#{name}' already registered, not registering "\
             "'#{formatter.name}'"
           )
@@ -82,18 +84,22 @@ module Appsignal
       rescue => ex
         formatter_classes.delete(name)
         formatters.delete(name)
-        Appsignal.logger.warn("'#{ex.message}' when initializing #{name} event formatter")
+        logger.warn("'#{ex.message}' when initializing #{name} event formatter")
       end
 
       def register_deprecated_formatter(name)
-        Appsignal.logger.warn(
+        deprecation_message \
           "Formatter for '#{name}' is using a deprecated registration " \
           "method. This event formatter will not be loaded. " \
           "Please update the formatter according to the documentation at: " \
-          "https://docs.appsignal.com/ruby/instrumentation/event-formatters.html"
-        )
+          "https://docs.appsignal.com/ruby/instrumentation/event-formatters.html",
+          logger
 
         deprecated_formatter_classes[name] = self
+      end
+
+      def logger
+        Appsignal.logger
       end
     end
 

--- a/lib/appsignal/utils.rb
+++ b/lib/appsignal/utils.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "appsignal/utils/deprecation_message"
 require "appsignal/utils/data"
 require "appsignal/utils/hash_sanitizer"
 require "appsignal/utils/json"

--- a/lib/appsignal/utils/deprecation_message.rb
+++ b/lib/appsignal/utils/deprecation_message.rb
@@ -1,0 +1,10 @@
+module Appsignal
+  module Utils
+    module DeprecationMessage
+      def deprecation_message(message, logger)
+        $stdout.puts "appsignal WARNING: #{message}"
+        logger.warn message
+      end
+    end
+  end
+end

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -228,8 +228,11 @@ describe Appsignal::Config do
     end
 
     describe "support for old config keys" do
+      let(:out_stream) { std_stream }
+      let(:output) { out_stream.read }
       let(:config) { project_fixture_config(env, {}, test_logger(log)) }
       let(:log) { StringIO.new }
+      before { capture_stdout(out_stream) { config } }
 
       describe ":api_key" do
         context "without :push_api_key" do
@@ -238,8 +241,10 @@ describe Appsignal::Config do
           it "sets the :push_api_key with the old :api_key value" do
             expect(config[:push_api_key]).to eq "def"
             expect(config.config_hash).to_not have_key :api_key
-            expect(log_contents(log)).to contains_log :warn,
-              "Old configuration key found. Please update the 'api_key' to 'push_api_key'"
+
+            message = "Old configuration key found. Please update the 'api_key' to 'push_api_key'"
+            expect(output).to include "appsignal WARNING: #{message}"
+            expect(log_contents(log)).to contains_log :warn, message
           end
         end
 
@@ -249,8 +254,10 @@ describe Appsignal::Config do
           it "ignores the :api_key config and deletes it" do
             expect(config[:push_api_key]).to eq "ghi"
             expect(config.config_hash).to_not have_key :api_key
-            expect(log_contents(log)).to contains_log :warn,
-              "Old configuration key found. Please update the 'api_key' to 'push_api_key'"
+
+            message = "Old configuration key found. Please update the 'api_key' to 'push_api_key'"
+            expect(output).to include "appsignal WARNING: #{message}"
+            expect(log_contents(log)).to contains_log :warn, message
           end
         end
       end
@@ -262,8 +269,10 @@ describe Appsignal::Config do
           it "sets :ignore_errors with the old :ignore_exceptions value" do
             expect(config[:ignore_errors]).to eq ["StandardError"]
             expect(config.config_hash).to_not have_key :ignore_exceptions
-            expect(log_contents(log)).to contains_log :warn,
-              "Old configuration key found. Please update the 'ignore_exceptions' to 'ignore_errors'"
+
+            message = "Old configuration key found. Please update the 'ignore_exceptions' to 'ignore_errors'"
+            expect(output).to include "appsignal WARNING: #{message}"
+            expect(log_contents(log)).to contains_log :warn, message
           end
         end
 
@@ -273,8 +282,10 @@ describe Appsignal::Config do
           it "ignores the :ignore_exceptions config" do
             expect(config[:ignore_errors]).to eq ["NoMethodError"]
             expect(config.config_hash).to_not have_key :ignore_exceptions
-            expect(log_contents(log)).to contains_log :warn,
-              "Old configuration key found. Please update the 'ignore_exceptions' to 'ignore_errors'"
+
+            message = "Old configuration key found. Please update the 'ignore_exceptions' to 'ignore_errors'"
+            expect(output).to include "appsignal WARNING: #{message}"
+            expect(log_contents(log)).to contains_log :warn, message
           end
         end
       end


### PR DESCRIPTION
This makes it more difficult to miss these deprecation warnings for our
users. Would be helpful to have them upgrade before we stop supporting
these deprecated methods.

Fixes #419 