### PR TITLE
Diagnose command also logs to logger

### DIFF
--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -188,6 +188,8 @@ module Appsignal
             initial_config
           )
           Appsignal.config.write_to_environment
+          Appsignal.start_logger
+          Appsignal.logger.info("Starting AppSignal diagnose")
         end
 
         def run_agent_diagnose_mode

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -107,6 +107,12 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
         "support@appsignal.com"
     end
 
+    it "logs to the log file" do
+      run
+      log_contents = File.read(config.log_file_path)
+      expect(log_contents).to contains_log :info, "Starting AppSignal diagnose"
+    end
+
     describe "report" do
       context "when user wants to send report" do
         it "sends report" do
@@ -811,7 +817,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
           it "log files fall back on system tmp directory" do
             expect(output).to include \
               %(log_dir_path: "#{system_tmp_dir}"\n    Writable?: true),
-              %(log_file_path: "#{system_tmp_log_file}"\n    Exists?: false)
+              %(log_file_path: "#{system_tmp_log_file}"\n    Writable?: true)
           end
 
           it "transmits path data in report" do
@@ -841,7 +847,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
             it "log files fall back on system tmp directory" do
               expect(output).to include \
                 %(log_dir_path: "#{system_tmp_dir}"\n    Writable?: true),
-                %(log_file_path: "#{system_tmp_log_file}"\n    Exists?: false)
+                %(log_file_path: "#{system_tmp_log_file}"\n    Writable?: true)
             end
 
             it "transmits path data in report" do
@@ -869,7 +875,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
               it "log files fall back on system tmp directory" do
                 expect(output).to include \
                   %(log_dir_path: "#{system_tmp_dir}"\n    Writable?: true),
-                  %(log_file_path: "#{system_tmp_log_file}"\n    Exists?: false)
+                  %(log_file_path: "#{system_tmp_log_file}"\n    Writable?: true)
               end
 
               it "transmits path data in report" do
@@ -886,7 +892,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
                   expect(output).to include \
                     %(root_path: "#{root_path}"\n    Writable?: true),
                     %(log_dir_path: "#{log_dir}"\n    Writable?: true),
-                    %(log_file_path: "#{log_file}"\n    Exists?: false)
+                    %(log_file_path: "#{log_file}"\n    Writable?: true)
                 end
 
                 it "transmits path data in report" do

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -693,7 +693,11 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
 
       context "when a directory is not configured" do
         let(:root_path) { File.join(tmp_dir, "writable_path") }
-        let(:config) { Appsignal::Config.new(root_path, "production", :log_file => nil) }
+        let(:config) do
+          silence(:allowed => ["Push api key not set after loading config"]) do
+            Appsignal::Config.new(root_path, "production", :log_file => nil)
+          end
+        end
         before do
           FileUtils.mkdir_p(File.join(root_path, "log"), :mode => 0o555)
           FileUtils.chmod(0o555, system_tmp_dir)
@@ -717,7 +721,11 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
       context "when a directory does not exist" do
         let(:root_path) { tmp_dir }
         let(:execution_path) { File.join(tmp_dir, "not_existing_dir") }
-        let(:config) { Appsignal::Config.new(execution_path, "production") }
+        let(:config) do
+          silence(:allowed => ["Push api key not set after loading config"]) do
+            Appsignal::Config.new(execution_path, "production")
+          end
+        end
         before do
           allow(Dir).to receive(:pwd).and_return(execution_path)
           run_within_dir tmp_dir
@@ -923,6 +931,11 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
                     FileUtils.touch(log_file)
                     FileUtils.chmod(0o444, log_file)
                     run_within_dir root_path
+                  end
+                  around do |example|
+                    silence(:allowed => ["Push api key not set after loading config"]) do
+                      example.run
+                    end
                   end
 
                   it "lists log file as not writable" do


### PR DESCRIPTION
Start the logger by calling `start_logger`. Log an info message to the
logger not only for the test, but also as a marker for the actual log
contents so we know where what comes from in real logs.

Update the tests to assert the log file has been created, rather that
"Exists?: false". The tests now create the log file, so it needs to
check a different type of output from the diagnose command, because
"Exists?: false" is only printed if the file doesn't exist.

Fixes #435 

## Silence logger output in tests

Now that the diagnose command starts the AppSignal logger it prints some
errors to STDOUT when no writable log file can be found. The config
prints a valid error, but it's part of the scenario we are testing.

Expand the `silence` helper to allow certain errors and wrap the
`Config.new` calls with the `silence` helper. This way we silence the
output in the tests while still triggering an error if a not allowed
error is logged.