### PR TITLE
Reduce number of TravisCI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ cache:
 
 rvm:
   - "2.0.0"
-  - "2.1.8"
-  - "2.2.4"
   - "2.3.0"
   - "2.4.0"
   - "2.5.1"
@@ -41,6 +39,10 @@ gemfile:
 matrix:
   fast_finish: true
   include:
+    - rvm: "2.1.8"
+      gemfile: "gemfiles/no_dependencies.gemfile"
+    - rvm: "2.2.4"
+      gemfile: "gemfiles/no_dependencies.gemfile"
     - rvm: "2.3.0"
       gemfile: "gemfiles/no_dependencies.gemfile"
       script: "bundle exec rubocop"
@@ -48,11 +50,7 @@ matrix:
     # Rails 5 doesn't support Ruby < 2.2
     - rvm: "2.0.0"
       gemfile: "gemfiles/rails-5.0.gemfile"
-    - rvm: "2.1.8"
-      gemfile: "gemfiles/rails-5.0.gemfile"
     - rvm: "2.0.0"
-      gemfile: "gemfiles/rails-5.1.gemfile"
-    - rvm: "2.1.8"
       gemfile: "gemfiles/rails-5.1.gemfile"
     - rvm: "2.5.1"
       gemfile: "gemfiles/rails-4.0.gemfile"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ cache:
 
 rvm:
   - "2.0.0"
-  - "2.3.0"
-  - "2.4.0"
-  - "2.5.1"
+  - "2.3.8"
+  - "2.4.5"
+  - "2.5.3"
   - "jruby-19mode"
 
 gemfile:
@@ -43,7 +43,7 @@ matrix:
       gemfile: "gemfiles/no_dependencies.gemfile"
     - rvm: "2.2.4"
       gemfile: "gemfiles/no_dependencies.gemfile"
-    - rvm: "2.3.0"
+    - rvm: "2.5.3"
       gemfile: "gemfiles/no_dependencies.gemfile"
       script: "bundle exec rubocop"
   exclude:
@@ -52,15 +52,15 @@ matrix:
       gemfile: "gemfiles/rails-5.0.gemfile"
     - rvm: "2.0.0"
       gemfile: "gemfiles/rails-5.1.gemfile"
-    - rvm: "2.5.1"
+    - rvm: "2.5.3"
       gemfile: "gemfiles/rails-4.0.gemfile"
-    - rvm: "2.5.1"
+    - rvm: "2.5.3"
       gemfile: "gemfiles/rails-4.1.gemfile"
 
   allow_failures:
-    - rvm: "2.4.0"
+    - rvm: "2.4.5"
       gemfile: "gemfiles/rails-4.0.gemfile"
-    - rvm: "2.4.0"
+    - rvm: "2.4.5"
       gemfile: "gemfiles/rails-4.1.gemfile"
 
 env:


### PR DESCRIPTION
Speed up the TravisCI build, by running less jobs.

For Ruby versions that are End Of Life, only run the `no_dependencies`
Gemfile. Except for Ruby 2.0, the oldest version we test against, test
as much as possible there so we know if all our  changes work on the
oldest version.

Note that Rubocop already checks if we use valid Ruby 1.9 syntax. So
syntax errors isn't what's being tested, just if it works at all on Ruby
2.0.

Reduces number of builds on Travis from 114 to __85__.

## Bump TravisCI Ruby versions

Use the latest patch release for every minor release for builds.