### PR TITLE
Improve diagnose report paths section and send contents of all files we diagnose

### DIFF
--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -433,10 +433,9 @@ module Appsignal
             "(file: #{ownership[:user]}:#{ownership[:uid]}, " \
             "process: #{process_user[:user]}:#{process_user[:uid]})"
           puts_value "Ownership?", owner, :level => 2
-          if path.key?(:content)
-            puts "    Contents (last 10 lines):"
-            puts path[:content]
-          end
+          return unless path.key?(:content)
+          puts "    Contents (last 10 lines):"
+          puts path[:content][0..10]
         end
 
         def print_empty_line

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -4,6 +4,8 @@ require "rbconfig"
 require "bundler/cli"
 require "bundler/cli/common"
 require "etc"
+require "appsignal/cli/diagnose/utils"
+require "appsignal/cli/diagnose/paths"
 
 module Appsignal
   class CLI
@@ -99,10 +101,10 @@ module Appsignal
 
           data[:process] = process_user
 
-          paths_section
+          paths_report = Paths.new
+          data[:paths] = paths_report.report
+          print_paths_section(paths_report)
           print_empty_line
-
-          log_files
 
           transmit_report_to_appsignal if send_report_to_appsignal?(options)
         end
@@ -327,7 +329,6 @@ module Appsignal
             puts_and_save :agent_version, "Agent version", Appsignal::Extension.agent_version
             puts_and_save :agent_architecture, "Agent architecture",
               Appsignal::System.installed_agent_architecture
-            puts_and_save :package_install_path, "Gem install path", gem_path
             puts_and_save :extension_loaded, "Extension loaded", Appsignal.extension_loaded
           end
         end
@@ -379,72 +380,13 @@ module Appsignal
           puts "      appsignal diagnose --environment=production"
         end
 
-        def paths_section
-          puts "Paths"
-          data_section :paths do
-            appsignal_paths.each do |name, path|
-              path_info = {
-                :path => path,
-                :configured => !path.nil?,
-                :exists => false,
-                :writable => false
-              }
-              save name, path_info
-
-              puts_value name, path.to_s.inspect
-
-              unless path_info[:configured]
-                puts_value "Configured?", "false", :level => 2
-                next
-              end
-              unless File.exist?(path)
-                puts_value "Exists?", "false", :level => 2
-                next
-              end
-
-              path_info[:exists] = true
-              path_info[:writable] = File.writable?(path)
-              puts_value "Writable?", path_info[:writable], :level => 2
-
-              file_owner = path_ownership(path)
-              path_info[:ownership] = file_owner
-              save name, path_info
-
-              owned = process_user[:uid] == file_owner[:uid]
-              owner = "#{owned} " \
-                "(file: #{file_owner[:user]}:#{file_owner[:uid]}, " \
-                "process: #{process_user[:user]}:#{process_user[:uid]})"
-              puts_value "Ownership?", owner, :level => 2
-            end
-          end
-        end
-
-        def path_ownership(path)
-          file_uid = File.stat(path).uid
-          {
-            :uid => file_uid,
-            :user => username_for_uid(file_uid)
-          }
-        end
-
         def process_user
           return @process_user if defined?(@process_user)
 
           process_uid = Process.uid
           @process_user = {
             :uid => process_uid,
-            :user => username_for_uid(process_uid)
-          }
-        end
-
-        def appsignal_paths
-          config = Appsignal.config
-          log_file_path = config.log_file_path
-          {
-            :working_dir => Dir.pwd,
-            :root_path => config.root_path,
-            :log_dir_path => log_file_path ? File.dirname(log_file_path) : "",
-            :log_file_path => log_file_path
+            :user => Utils.username_for_uid(process_uid)
           }
         end
 
@@ -466,55 +408,35 @@ module Appsignal
           end
         end
 
-        def log_files
-          puts "Log files"
-          data_section :logs do
-            install_log
-            print_empty_line
-            mkmf_log
+        def print_paths_section(report)
+          puts "Paths"
+          report_paths = report.paths
+          data[:paths].each do |name, file|
+            print_path_details report_paths[name][:label], file
           end
         end
 
-        def install_log
-          puts "  Extension install log"
-          filename = File.join("ext", "install.log")
-          log_info = log_file_info(File.join(gem_path, filename))
-          save filename, log_info
-          puts_log_file log_info
-        end
+        def print_path_details(name, path)
+          puts "  #{name}"
+          puts_value "Path", path[:path].to_s.inspect, :level => 2
 
-        def mkmf_log
-          puts "  Makefile install log"
-          filename = File.join("ext", "mkmf.log")
-          log_info = log_file_info(File.join(gem_path, filename))
-          save filename, log_info
-          puts_log_file log_info
-        end
-
-        def log_file_info(log_file)
-          {
-            :path => log_file,
-            :exists => File.exist?(log_file)
-          }.tap do |info|
-            next unless info[:exists]
-            info[:content] = File.read(log_file).split("\n")
+          unless path[:exists]
+            puts_value "Exists?", path[:exists], :level => 2
+            return
           end
-        end
 
-        def puts_log_file(log_info)
-          puts_value "Path", log_info[:path].to_s.inspect, :level => 2
-          if log_info[:exists]
-            puts "    Contents:"
-            puts log_info[:content].join("\n")
-          else
-            puts "    File not found."
+          puts_value "Writable?", path[:writable], :level => 2
+
+          ownership = path[:ownership]
+          owned = process_user[:uid] == ownership[:uid]
+          owner = "#{owned} " \
+            "(file: #{ownership[:user]}:#{ownership[:uid]}, " \
+            "process: #{process_user[:user]}:#{process_user[:uid]})"
+          puts_value "Ownership?", owner, :level => 2
+          if path.key?(:content)
+            puts "    Contents (last 10 lines):"
+            puts path[:content]
           end
-        end
-
-        def username_for_uid(uid)
-          passwd_struct = Etc.getpwuid(uid)
-          return unless passwd_struct
-          passwd_struct.name
         end
 
         def print_empty_line
@@ -527,11 +449,6 @@ module Appsignal
           true
         rescue LoadError
           false
-        end
-
-        def gem_path
-          @gem_path ||= \
-            Bundler::CLI::Common.select_spec("appsignal").full_gem_path.strip
         end
       end
     end

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -97,6 +97,8 @@ module Appsignal
           check_api_key
           print_empty_line
 
+          data[:process] = process_user
+
           paths_section
           print_empty_line
 
@@ -379,7 +381,6 @@ module Appsignal
 
         def paths_section
           puts "Paths"
-          data[:process] = process_user
           data_section :paths do
             appsignal_paths.each do |name, path|
               path_info = {

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -79,26 +79,26 @@ module Appsignal
         def run(options = {})
           $stdout.sync = true
           header
-          empty_line
+          print_empty_line
 
           library_information
-          empty_line
+          print_empty_line
 
           host_information
-          empty_line
+          print_empty_line
 
           configure_appsignal(options)
           run_agent_diagnose_mode
-          empty_line
+          print_empty_line
 
           config
-          empty_line
+          print_empty_line
 
           check_api_key
-          empty_line
+          print_empty_line
 
           paths_section
-          empty_line
+          print_empty_line
 
           log_files
 
@@ -469,7 +469,7 @@ module Appsignal
           puts "Log files"
           data_section :logs do
             install_log
-            empty_line
+            print_empty_line
             mkmf_log
           end
         end
@@ -516,7 +516,7 @@ module Appsignal
           passwd_struct.name
         end
 
-        def empty_line
+        def print_empty_line
           puts "\n"
         end
 

--- a/lib/appsignal/cli/diagnose/paths.rb
+++ b/lib/appsignal/cli/diagnose/paths.rb
@@ -2,6 +2,8 @@ module Appsignal
   class CLI
     class Diagnose
       class Paths
+        BYTES_TO_READ_FOR_FILES = 2 * 1024 * 1024 # 2 Mebibytes
+
         def report
           {}.tap do |hash|
             paths.each do |filename, config|
@@ -70,7 +72,12 @@ module Appsignal
               :gid => path_gid,
               :group => Utils.group_for_gid(path_gid)
             }
-            info[:content] = File.read(path).split("\n") if info[:type] == "file"
+            if info[:type] == "file"
+              info[:content] = Utils.read_file_content(
+                path,
+                BYTES_TO_READ_FOR_FILES
+              ).split("\n")
+            end
           end
         end
 

--- a/lib/appsignal/cli/diagnose/paths.rb
+++ b/lib/appsignal/cli/diagnose/paths.rb
@@ -1,0 +1,84 @@
+module Appsignal
+  class CLI
+    class Diagnose
+      class Paths
+        def report
+          {}.tap do |hash|
+            paths.each do |filename, config|
+              hash[filename] = path_stat(config[:path])
+            end
+          end
+        end
+
+        def paths
+          @paths ||=
+            begin
+              config = Appsignal.config
+              log_file_path = config.log_file_path
+              install_log_path = File.join("ext", "install.log")
+              makefile_log_path = File.join("ext", "mkmf.log")
+              {
+                :package_install_path => {
+                  :label => "AppSignal gem path",
+                  :path => gem_path
+                },
+                :working_dir => {
+                  :label => "Current working directory",
+                  :path => Dir.pwd
+                },
+                :root_path => {
+                  :label => "Root path",
+                  :path => config.root_path
+                },
+                :log_dir_path => {
+                  :label => "Log directory",
+                  :path => log_file_path ? File.dirname(log_file_path) : ""
+                },
+                install_log_path => {
+                  :label => "Extension install log",
+                  :path => File.join(gem_path, install_log_path)
+                },
+                makefile_log_path => {
+                  :label => "Makefile install log",
+                  :path => File.join(gem_path, makefile_log_path)
+                },
+                "appsignal.log" => {
+                  :label => "AppSignal log",
+                  :path => log_file_path
+                }
+              }
+            end
+        end
+
+        private
+
+        def path_stat(path)
+          {
+            :path => path,
+            :exists => File.exist?(path)
+          }.tap do |info|
+            next unless info[:exists]
+            stat = File.stat(path)
+            info[:type] = stat.directory? ? "directory" : "file"
+            info[:mode] = format("%o", stat.mode)
+            info[:writable] = stat.writable?
+            path_uid = stat.uid
+            path_gid = stat.gid
+            info[:ownership] = {
+              :uid => path_uid,
+              :user => Utils.username_for_uid(path_uid),
+              :gid => path_gid,
+              :group => Utils.group_for_gid(path_gid)
+            }
+            info[:content] = File.read(path).split("\n") if info[:type] == "file"
+          end
+        end
+
+        def gem_path
+          @gem_path ||= \
+            Bundler::CLI::Common.select_spec("appsignal").full_gem_path.strip
+        end
+      end
+    end
+  end
+end

--- a/lib/appsignal/cli/diagnose/utils.rb
+++ b/lib/appsignal/cli/diagnose/utils.rb
@@ -13,6 +13,23 @@ module Appsignal
           return unless passwd_struct
           passwd_struct.name
         end
+
+        def self.read_file_content(path, bytes_to_read)
+          file_size = File.size(path)
+          if bytes_to_read > file_size
+            # When the file is smaller than the bytes_to_read
+            # Read the whole file
+            offset = 0
+            length = file_size
+          else
+            # When the file is smaller than the bytes_to_read
+            # Read the last X bytes_to_read
+            length = bytes_to_read
+            offset = file_size - bytes_to_read
+          end
+
+          IO.binread(path, length, offset)
+        end
       end
     end
   end

--- a/lib/appsignal/cli/diagnose/utils.rb
+++ b/lib/appsignal/cli/diagnose/utils.rb
@@ -1,0 +1,19 @@
+module Appsignal
+  class CLI
+    class Diagnose
+      class Utils
+        def self.username_for_uid(uid)
+          passwd_struct = Etc.getpwuid(uid)
+          return unless passwd_struct
+          passwd_struct.name
+        end
+
+        def self.group_for_gid(gid)
+          passwd_struct = Etc.getgrgid(gid)
+          return unless passwd_struct
+          passwd_struct.name
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/appsignal/cli/diagnose/utils_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose/utils_spec.rb
@@ -1,0 +1,37 @@
+require "appsignal/cli/diagnose/utils"
+
+describe Appsignal::CLI::Diagnose::Utils do
+  describe ".read_file_content" do
+    let(:path) { File.join(spec_system_tmp_dir, "test_file.txt") }
+    let(:bytes_to_read) { 100 }
+    subject { described_class.read_file_content(path, bytes_to_read) }
+    before do
+      File.open path, "w+" do |f|
+        f.write file_contents
+      end
+    end
+
+    context "when file is bigger than read size" do
+      let(:file_contents) do
+        "".tap do |s|
+          100.times do |i|
+            s << "line #{i}\n"
+          end
+        end
+      end
+
+      it "returns the last X bytes" do
+        is_expected
+          .to eq(file_contents[(file_contents.length - bytes_to_read)..file_contents.length])
+      end
+    end
+
+    context "when file is smaller than read size" do
+      let(:file_contents) { "line 1\n" }
+
+      it "returns the whole file content" do
+        is_expected.to eq(file_contents)
+      end
+    end
+  end
+end

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -927,10 +927,11 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
 
         context "when file exists" do
           let(:contents) do
-            [
-              "log line 1",
-              "log line 2"
-            ]
+            [].tap do |lines|
+              1..12.times do |i|
+                lines << "log line #{i}"
+              end
+            end
           end
           before do
             File.open file_path, "a" do |f|
@@ -942,8 +943,12 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
           end
 
           it "outputs file location and content" do
-            expect(output).to include(%(Path: "#{file_path}"))
-            expect(output).to include(*contents)
+            expect(output).to include(
+              %(Path: "#{file_path}"),
+              "Contents (last 10 lines):"
+            )
+            expect(output).to include(*contents[0..10])
+            expect(output).to_not include(*contents[11])
           end
 
           it "transmits file data in report" do


### PR DESCRIPTION
Ruby implementation of https://github.com/appsignal/appsignal-server/issues/3649

## Move paths and files diagnose to separate classes

This cleans up the main diagnose class a bit so we can add other classes
for sub sections more easily. The main diagnose class will be primarily
report construction from separate classes and printing the output to the
terminal.

The new paths setup will merge directories and files and as a report
section. It will read the file contents if the path is about a file.
This means the `appsignal.log` file contents will now be send to
AppSignal servers.

Directories and files now have the exact same data structure which makes
it easier to print them to the terminal and parse them in the AppSignal
admin.

Moved the `library.package_install_path` path to
`paths.package_install_path` so we also perform all the directory checks
on the gem install path.

New additions to the data structure:
- `type` - type of path ("directory" / "file")
- `mode` - file permissions (in addition to only sending `writable`)
- `ownership`
  - `gid` - group id of the path
  - `group` - group name of the path

Refactored some specs to not test the `Appsignal::Config#log_file_path`
logic again in the `diagnose_spec.rb`.

## Only show the last 10 lines of a file in terminal

Otherwise a file with 10K lines completely fills the user's terminal.
The last 10 lines give an indication. The user can send the full report
to us or inspect the files themselves for the full content.

## Only read the last 2 Mebibyte of a diagnose file

Not much more information is gained than 2 Mebibytes of data. Cut the
file contents off somewhere.

Only read the last part of the file as log files append to a file and
thus the newest logs are at the end of the file.