### PR TITLE
Track config options sources

### DIFF
--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -42,8 +42,8 @@ module Appsignal
     # @example Don't prompt about sending the report and don't sent it
     #   appsignal diagnose --no-send-report
     #
-    # @see http://docs.appsignal.com/support/debugging.html Debugging AppSignal
-    # @see http://docs.appsignal.com/ruby/command-line/diagnose.html
+    # @see https://docs.appsignal.com/support/debugging.html Debugging AppSignal
+    # @see https://docs.appsignal.com/ruby/command-line/diagnose.html
     #   AppSignal diagnose documentation
     # @since 1.1.0
     class Diagnose
@@ -316,7 +316,7 @@ module Appsignal
           puts "=" * 80
           puts "Use this information to debug your configuration."
           puts "More information is available on the documentation site."
-          puts "http://docs.appsignal.com/"
+          puts "https://docs.appsignal.com/"
           puts "Send this output to support@appsignal.com if you need help."
           puts "=" * 80
         end

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -380,7 +380,7 @@ module Appsignal
           option = :env
           option_sources = sources_for_option(option)
           sources_label = config_sources_label(option, option_sources)
-          print "  Environment: #{env}"
+          print "  Environment: #{format_config_option(env)}"
 
           if env == ""
             puts "\n    Warning: No environment set, no config loaded!"
@@ -396,7 +396,7 @@ module Appsignal
           config.config_hash.each do |key, value|
             option_sources = sources_for_option(key)
             sources_label = config_sources_label(key, option_sources)
-            puts "  #{key}: #{value}#{sources_label}"
+            puts "  #{key}: #{format_config_option(value)}#{sources_label}"
           end
 
           puts "\nRead more about how the diagnose config output is rendered\n"\
@@ -421,11 +421,23 @@ module Appsignal
               max_source_length = sources.map(&:length).max + 1 # 1 is for ":"
               sources.each do |source|
                 source_label = "#{source}:".ljust(max_source_length)
-                a << "      #{source_label} #{data[:config][:sources][source][option]}"
+                value = data[:config][:sources][source][option]
+                a << "      #{source_label} #{format_config_option(value)}"
               end
             end.join("\n")
           else
             " (Not configured)"
+          end
+        end
+
+        def format_config_option(value)
+          case value
+          when NilClass
+            "nil"
+          when String
+            value.inspect
+          else
+            value
           end
         end
 

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -93,7 +93,7 @@ module Appsignal
           run_agent_diagnose_mode
           print_empty_line
 
-          config
+          print_config_section
           print_empty_line
 
           check_api_key
@@ -358,26 +358,38 @@ module Appsignal
           end
         end
 
-        def config
+        def print_config_section
           puts "Configuration"
-          data_section :config do
-            puts_environment
-
-            Appsignal.config.config_hash.each do |key, value|
-              puts_and_save key, key, value
-            end
-          end
+          config = Appsignal.config
+          data[:config] = {
+            :config => config.config_hash.merge(:env => config.env),
+            :sources => {
+              :default => Appsignal::Config::DEFAULT_CONFIG,
+              :system => config.system_config,
+              :initial => config.initial_config,
+              :file => config.file_config,
+              :env => config.env_config
+            }
+          }
+          print_environment(config)
+          print_config_options(config)
         end
 
-        def puts_environment
-          env = Appsignal.config.env
-          puts_and_save :env, "Environment", env
+        def print_environment(config)
+          env = config.env
+          puts_value "Environment", env
 
           return unless env == ""
           puts "    Warning: No environment set, no config loaded!"
           puts "    Please make sure appsignal diagnose is run within your "
           puts "    project directory with an environment."
           puts "      appsignal diagnose --environment=production"
+        end
+
+        def print_config_options(config)
+          config.config_hash.each do |key, value|
+            puts "  #{key}: #{value}"
+          end
         end
 
         def process_user

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -362,7 +362,7 @@ module Appsignal
           puts "Configuration"
           config = Appsignal.config
           data[:config] = {
-            :config => config.config_hash.merge(:env => config.env),
+            :options => config.config_hash.merge(:env => config.env),
             :sources => {
               :default => Appsignal::Config::DEFAULT_CONFIG,
               :system => config.system_config,

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -84,27 +84,68 @@ module Appsignal
       :ignore_exceptions => :ignore_errors
     }.freeze
 
-    attr_reader :root_path, :env, :initial_config, :config_hash
+    # @attribute [r] system_config
+    #   Config detected on the system level.
+    #   Used in diagnose report.
+    #   @api private
+    #   @return [Hash]
+    # @!attribute [r] initial_config
+    #   Config detected on the system level.
+    #   Used in diagnose report.
+    #   @api private
+    #   @return [Hash]
+    # @!attribute [r] file_config
+    #   Config loaded from `config/appsignal.yml` config file.
+    #   Used in diagnose report.
+    #   @api private
+    #   @return [Hash]
+    # @!attribute [r] env_config
+    #   Config loaded from the system environment.
+    #   Used in diagnose report.
+    #   @api private
+    #   @return [Hash]
+    # @!attribute [r] config_hash
+    #   Config used by the AppSignal gem.
+    #   Combined Hash of the {system_config}, {initial_config}, {file_config},
+    #   {env_config} attributes.
+    #   @see #[]
+    #   @see #[]=
+    #   @api private
+    #   @return [Hash]
+
+    attr_reader :root_path, :env, :config_hash, :system_config,
+      :initial_config, :file_config, :env_config
     attr_accessor :logger
 
     def initialize(root_path, env, initial_config = {}, logger = Appsignal.logger)
       @root_path      = root_path
-      @env            = ENV.fetch("APPSIGNAL_APP_ENV".freeze, env.to_s)
-      @initial_config = initial_config
       @logger         = logger
       @valid          = false
       @config_hash    = Hash[DEFAULT_CONFIG]
+      @env =
+        if ENV.key?("APPSIGNAL_APP_ENV".freeze)
+          env_loaded_from_env = ENV["APPSIGNAL_APP_ENV".freeze]
+        else
+          env_loaded_from_initial = env.to_s
+        end
 
       # Set config based on the system
-      detect_from_system
+      @system_config = detect_from_system
+      merge(system_config)
       # Initial config
-      merge(@config_hash, initial_config)
+      @initial_config = initial_config
+      merge(initial_config)
       # Load the config file if it exists
-      load_from_disk
+      @file_config = load_from_disk || {}
+      merge(file_config)
       # Load config from environment variables
-      load_from_environment
+      @env_config = load_from_environment
+      merge(env_config)
       # Validate that we have a correct config
       validate
+      # Track origin of env
+      @initial_config[:env] = env_loaded_from_initial if env_loaded_from_initial
+      @env_config[:env] = env_loaded_from_env if env_loaded_from_env
     end
 
     # @api private
@@ -209,10 +250,12 @@ module Appsignal
     end
 
     def detect_from_system
-      config_hash[:log] = "stdout" if Appsignal::System.heroku?
+      {}.tap do |hash|
+        hash[:log] = "stdout" if Appsignal::System.heroku?
 
-      # Make active by default if APPSIGNAL_PUSH_API_KEY is present
-      config_hash[:active] = true if ENV["APPSIGNAL_PUSH_API_KEY"]
+        # Make active by default if APPSIGNAL_PUSH_API_KEY is present
+        hash[:active] = true if ENV["APPSIGNAL_PUSH_API_KEY"]
+      end
     end
 
     def load_from_disk
@@ -226,11 +269,10 @@ module Appsignal
             hash[key.to_sym] = value # convert keys to symbols
           end
 
-        config_for_this_env = maintain_backwards_compatibility(config_for_this_env)
-
-        merge(@config_hash, config_for_this_env)
+        maintain_backwards_compatibility(config_for_this_env)
       else
         @logger.error "Not loading from config file: config for '#{env}' not found"
+        nil
       end
     end
 
@@ -297,15 +339,15 @@ module Appsignal
         config[ENV_TO_KEY_MAPPING[var]] = env_var.split(",")
       end
 
-      merge(@config_hash, config)
+      config
     end
 
-    def merge(original_config, new_config)
+    def merge(new_config)
       new_config.each do |key, value|
-        unless original_config[key].nil?
+        unless config_hash[key].nil?
           @logger.debug("Config key '#{key}' is being overwritten")
         end
-        original_config[key] = value
+        config_hash[key] = value
       end
     end
   end

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -122,11 +122,12 @@ module Appsignal
       @logger         = logger
       @valid          = false
       @config_hash    = Hash[DEFAULT_CONFIG]
+      env_loaded_from_initial = env.to_s
       @env =
         if ENV.key?("APPSIGNAL_APP_ENV".freeze)
           env_loaded_from_env = ENV["APPSIGNAL_APP_ENV".freeze]
         else
-          env_loaded_from_initial = env.to_s
+          env_loaded_from_initial
         end
 
       # Set config based on the system

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -104,7 +104,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
       run
       expect(output).to include \
         "AppSignal diagnose",
-        "http://docs.appsignal.com/",
+        "https://docs.appsignal.com/",
         "support@appsignal.com"
     end
 

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -578,7 +578,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
         it "transmits validation in report" do
           default_config = hash_with_string_keys(Appsignal::Config::DEFAULT_CONFIG)
           expect(received_report["config"]).to eq(
-            "config" => default_config.merge("env" => ""),
+            "options" => default_config.merge("env" => ""),
             "sources" => {
               "default" => default_config,
               "system" => {},
@@ -696,7 +696,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
             .merge(additional_initial_config)
             .merge(config.config_hash)
           expect(received_report["config"]).to match(
-            "config" => hash_with_string_keys(final_config),
+            "options" => hash_with_string_keys(final_config),
             "sources" => {
               "default" => hash_with_string_keys(Appsignal::Config::DEFAULT_CONFIG),
               "system" => {},
@@ -723,7 +723,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
 
         it "transmits config in report" do
           expect(received_report["config"]).to match(
-            "config" => hash_with_string_keys(config.config_hash).merge("env" => "foobar"),
+            "options" => hash_with_string_keys(config.config_hash).merge("env" => "foobar"),
             "sources" => {
               "default" => hash_with_string_keys(Appsignal::Config::DEFAULT_CONFIG),
               "system" => {},

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -31,7 +31,7 @@ describe Appsignal::Config do
           end
 
           it "sets the environment as loaded through the env_config" do
-            expect(config.initial_config).to eq({})
+            expect(config.initial_config).to eq(:env => env)
             expect(config.env_config).to eq(:env => env_env)
             expect(config.config_hash).to_not have_key(:env)
           end

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -1,28 +1,39 @@
 describe Appsignal::Config do
   describe "#initialize" do
-    subject { config.env }
-
     describe "environment" do
       context "when environment is nil" do
-        let(:config) { described_class.new("", "") }
+        let(:config) { described_class.new("", nil) }
 
         it "sets an empty string" do
-          expect(subject).to eq("")
+          expect(config.env).to eq("")
         end
       end
 
       context "when environment is given" do
+        let(:env) { "my_env" }
         let(:config) { described_class.new("", "my_env") }
 
         it "sets the environment" do
-          expect(subject).to eq("my_env")
+          expect(config.env).to eq(env)
+        end
+
+        it "sets the environment as loaded through the initial_config" do
+          expect(config.initial_config).to eq(:env => env)
+          expect(config.config_hash).to_not have_key(:env)
         end
 
         context "with APPSIGNAL_APP_ENV environment variable" do
-          before { ENV["APPSIGNAL_APP_ENV"] = "my_env_env" }
+          let(:env_env) { "my_env_env" }
+          before { ENV["APPSIGNAL_APP_ENV"] = env_env }
 
           it "uses the environment variable" do
-            expect(subject).to eq("my_env_env")
+            expect(config.env).to eq(env_env)
+          end
+
+          it "sets the environment as loaded through the env_config" do
+            expect(config.initial_config).to eq({})
+            expect(config.env_config).to eq(:env => env_env)
+            expect(config.config_hash).to_not have_key(:env)
           end
         end
       end
@@ -40,6 +51,11 @@ describe Appsignal::Config do
 
         it "becomes active" do
           expect(subject).to be_truthy
+        end
+
+        it "sets the push_api_key as loaded through the env_config" do
+          expect(config.env_config).to eq(:push_api_key => "abc")
+          expect(config.system_config).to eq(:active => true)
         end
       end
 
@@ -59,27 +75,36 @@ describe Appsignal::Config do
         it "is set to stdout" do
           expect(subject).to eq("stdout")
         end
+
+        it "sets the log as loaded through the system" do
+          expect(config.system_config).to eq(:log => "stdout")
+        end
       end
 
       context "when not running on Heroku" do
         it "is set to file" do
           expect(subject).to eq("file")
         end
+
+        it "does not set log as loaded through the system" do
+          expect(config.system_config).to eq({})
+        end
       end
     end
   end
 
   describe "initial config" do
-    let(:config) do
-      described_class.new(
-        "non-existing-path",
-        "production",
+    let(:initial_config) do
+      {
         :push_api_key => "abc",
         :name => "TestApp",
         :active => true,
         :revision => "v2.5.1",
         :request_headers => []
-      )
+      }
+    end
+    let(:config) do
+      described_class.new("non-existing-path", "production", initial_config)
     end
 
     it "merges with the default config" do
@@ -112,6 +137,10 @@ describe Appsignal::Config do
         :revision                       => "v2.5.1",
         :request_headers                => []
       )
+    end
+
+    it "sets the initial_config" do
+      expect(config.initial_config).to eq(initial_config)
     end
 
     describe "overriding system detected config" do
@@ -181,6 +210,16 @@ describe Appsignal::Config do
     it "does not log an error" do
       expect_any_instance_of(Logger).to_not receive(:error)
       config
+    end
+
+    it "sets the file_config" do
+      # config found in spec/support/project_fixture/config/appsignal.yml
+      expect(config.file_config).to match(
+        :active => true,
+        :push_api_key => "abc",
+        :name => "TestApp",
+        :request_headers => kind_of(Array)
+      )
     end
 
     describe "overriding system and defaults config" do
@@ -301,6 +340,24 @@ describe Appsignal::Config do
         :debug => true
       )
     end
+    let(:env_config) do
+      {
+        :running_in_container => true,
+        :push_api_key => "aaa-bbb-ccc",
+        :active => true,
+        :name => "App name",
+        :debug => true,
+        :ignore_actions => %w[action1 action2],
+        :ignore_errors => %w[ExampleStandardError AnotherError],
+        :ignore_namespaces => %w[admin private_namespace],
+        :instrument_net_http => false,
+        :instrument_redis => false,
+        :instrument_sequel => false,
+        :files_world_accessible => false,
+        :request_headers => %w[accept accept-charset],
+        :revision => "v2.5.1"
+      }
+    end
     before do
       ENV["APPSIGNAL_RUNNING_IN_CONTAINER"]    = "true"
       ENV["APPSIGNAL_PUSH_API_KEY"]            = "aaa-bbb-ccc"
@@ -321,21 +378,7 @@ describe Appsignal::Config do
     it "overrides config with environment values" do
       expect(config.valid?).to be_truthy
       expect(config.active?).to be_truthy
-
-      expect(config[:running_in_container]).to be_truthy
-      expect(config[:push_api_key]).to eq "aaa-bbb-ccc"
-      expect(config[:active]).to eq(true)
-      expect(config[:name]).to eq "App name"
-      expect(config[:debug]).to eq(true)
-      expect(config[:ignore_actions]).to eq %w[action1 action2]
-      expect(config[:ignore_errors]).to eq %w[ExampleStandardError AnotherError]
-      expect(config[:ignore_namespaces]).to eq %w[admin private_namespace]
-      expect(config[:instrument_net_http]).to eq(false)
-      expect(config[:instrument_redis]).to eq(false)
-      expect(config[:instrument_sequel]).to eq(false)
-      expect(config[:files_world_accessible]).to eq(false)
-      expect(config[:request_headers]).to eq(%w[accept accept-charset])
-      expect(config[:revision]).to eq("v2.5.1")
+      expect(config.config_hash).to include(env_config)
     end
 
     context "with mixed case `true` env variables values" do
@@ -348,6 +391,10 @@ describe Appsignal::Config do
         expect(config[:debug]).to eq(true)
         expect(config[:instrument_sequel]).to eq(true)
       end
+    end
+
+    it "sets the env_config" do
+      expect(config.env_config).to eq(env_config)
     end
   end
 


### PR DESCRIPTION
Fixes #424

For diagnose purposes it's useful to know from what source the config
option is set. For example, this helps debugging file config being
overwritten by the system environment.

Change the report format to include all the sources as well as the final
config used by the gem.

Update how the config is loaded in Config#initialize to work the same
way for every source. Change `#merge` to directly update the
`config_hash`, no need to pass it along if we already which config we're
updating.

Looks like there were no specs for the config section in the transmitted
report. Added that now with the new structure.


## Print config option sources in diagnose report

This allows users to track back on their own, based on the output, where
the config options are coming from.

Helps with debugging where a particular option gets set.

## Format config options in diagnose output

- Print strings as strings, with quotes around them: `name: "my_app"`
- Print `nil` values as `nil`, like `true` and `false`, rather than
  empty strings.
- Array and all other types will be formatted the same.

## How the config section is printed now

```
Configuration
  Environment: "development" (Loaded from: initial)
  debug: true
    Sources:
      default: false
      file:    true
  log: "file"
  ignore_actions: []
  ignore_errors: []
  ignore_namespaces: []
  filter_parameters: []
  filter_session_data: []
  send_params: true
  request_headers: ["HTTP_ACCEPT", "HTTP_ACCEPT_CHARSET", "HTTP_ACCEPT_ENCODING", "HTTP_ACCEPT_LANGUAGE", "HTTP_CACHE_CONTROL", "HTTP_CONNECTION", "CONTENT_LENGTH", "PATH_INFO", "HTTP_RANGE", "REQUEST_METHOD", "REQUEST_URI", "SERVER_NAME", "SERVER_PORT", "SERVER_PROTOCOL"]
  endpoint: "https://push.appsignal.com"
  instrument_net_http: true
  instrument_redis: true
  instrument_sequel: true
  skip_session_data: false
  enable_frontend_error_catching: false
  frontend_error_catching_path: "/appsignal_error_catcher"
  enable_allocation_tracking: true
  enable_gc_instrumentation: false
  enable_host_metrics: true
  enable_minutely_probes: false
  ca_file_path: "/Users/tombruijn/appsignal/gem/resources/cacert.pem"
  dns_servers: []
  files_world_accessible: true
  push_api_key: "" (Loaded from: file)
  name: "Sinatra test" (Loaded from: file)
  active: true (Loaded from: file)
```