### PR TITLE
Print last 10 lines of a file in diagnose report

### DIFF
--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -496,7 +496,7 @@ module Appsignal
           puts_value "Ownership?", owner, :level => 2
           return unless path.key?(:content)
           puts "    Contents (last 10 lines):"
-          puts path[:content][0..10]
+          puts path[:content].last(10)
         end
 
         def print_empty_line

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -1072,7 +1072,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
         context "when file exists" do
           let(:contents) do
             [].tap do |lines|
-              1..12.times do |i|
+              (1..12).each do |i|
                 lines << "log line #{i}"
               end
             end
@@ -1091,8 +1091,8 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
               %(Path: "#{file_path}"),
               "Contents (last 10 lines):"
             )
-            expect(output).to include(*contents[0..10])
-            expect(output).to_not include(*contents[11])
+            expect(output).to include(*contents.last(10).join("\n"))
+            expect(output).to_not include(*contents.first(2).join("\n"))
           end
 
           it "transmits file data in report" do


### PR DESCRIPTION
It actually printed the first 10, which is not what we wanted.
Also update the tests to more accurately test the file contents, it now
makes sure "line x\n" is present in the output.

PR only for build.