### PR TITLE
Fix TravisCI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ matrix:
 
 env:
   global:
+    - "RUNNING_IN_CI=true"
     - "RAILS_ENV=test"
     - "JRUBY_OPTS=''" # Workaround https://github.com/travis-ci/travis-ci/issues/6471
 

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -1028,11 +1028,12 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
           end
 
           it "transmits path data in report" do
+            mode = ENV["RUNNING_IN_CI"] ? "40775" : "40755"
             expect(received_report["paths"]["root_path"]).to eq(
               "path" => root_path,
               "exists" => true,
               "type" => "directory",
-              "mode" => "40755",
+              "mode" => mode,
               "writable" => true,
               "ownership" => {
                 "uid" => Process.uid,


### PR DESCRIPTION
Something must have changed in the default permissions for the app
directory. It's now being reported as 40775, rather than 40755 (the
directory default).

Update the test to test for another value on TravisCI to make the build
work again.