### PR TITLE
Store extension installation details in report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,10 +26,10 @@ bundle_and_spec_all_rvm
 ext/libappsignal.*
 ext/appsignal-agent
 ext/appsignal.h
-ext/appsignal.architecture
 ext/appsignal.version
 ext/Makefile
 ext/*.bundle
 ext/*.o
 ext/*.so
+ext/*.report
 pkg/

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
 - "./support/bundler_wrapper exec rake extension:install"
 script: "./support/bundler_wrapper exec rake test"
 after_failure:
-- find ./ext -name install.log -exec cat {} \;
+- find ./ext -name install.report -exec cat {} \;
 - find ./ext -name mkmf.log -exec cat {} \;
 matrix:
   fast_finish: true

--- a/Rakefile
+++ b/Rakefile
@@ -303,7 +303,7 @@ namespace :extension do
           appsignal_extension.o \
           appsignal_extension.so \
           appsignal_extension.bundle \
-          install.log \
+          install.report \
           libappsignal.* \
           appsignal.version \
           Makefile \

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -24,7 +24,7 @@ travis: # Default `.travis.yml` contents
     - "./support/bundler_wrapper exec rake extension:install"
   script: "./support/bundler_wrapper exec rake test"
   after_failure:
-    - "find ./ext -name install.log -exec cat {} \\;"
+    - "find ./ext -name install.report -exec cat {} \\;"
     - "find ./ext -name mkmf.log -exec cat {} \\;"
 
   matrix:

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -1,4 +1,3 @@
-require File.expand_path("../../lib/appsignal/version.rb", __FILE__)
 require File.expand_path("../base.rb", __FILE__)
 
 task :default do

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -1,27 +1,35 @@
 require File.expand_path("../base.rb", __FILE__)
 
+def local_build?
+  File.exist?(ext_path("appsignal-agent")) &&
+    (
+      File.exist?(ext_path("libappsignal.dylib")) ||
+      File.exist?(ext_path("libappsignal.so"))
+    ) &&
+    File.exist?(ext_path("appsignal.h"))
+end
+
 task :default do
   begin
-    logger.info "Installing appsignal agent #{Appsignal::VERSION} for Ruby #{RUBY_VERSION} on #{RUBY_PLATFORM}"
-    write_agent_architecture
+    library_type = "dynamic"
+    report["language"]["implementation"] = "jruby"
+    report["build"]["library_type"] = library_type
     next unless check_architecture
     arch_config = AGENT_CONFIG["triples"][ARCH]
 
-    unless File.exist?(ext_path("appsignal-agent")) &&
-        (
-          File.exist?(ext_path("libappsignal.dylib")) ||
-          File.exist?(ext_path("libappsignal.so"))
-        ) &&
-        File.exist?(ext_path("appsignal.h"))
-      archive = download_archive(arch_config, "dynamic")
+    if local_build?
+      report["build"]["source"] = "local"
+    else
+      archive = download_archive(arch_config, library_type)
       next unless archive
-      next unless verify_archive(archive, arch_config, "dynamic")
+      next unless verify_archive(archive, arch_config, library_type)
       unarchive(archive)
     end
-  rescue => ex
-    installation_failed "Exception while installing: #{ex}"
-    ex.backtrace.each do |line|
-      logger.error line
-    end
+    successful_installation
+  rescue => error
+    fail_installation_with_error(error)
+  ensure
+    create_dummy_makefile unless installation_succeeded?
+    write_report
   end
 end

--- a/ext/base.rb
+++ b/ext/base.rb
@@ -5,6 +5,7 @@ require "open-uri"
 require "zlib"
 require "yaml"
 require "rubygems/package"
+require File.expand_path("../../lib/appsignal/version.rb", __FILE__)
 require File.expand_path("../../lib/appsignal/system.rb", __FILE__)
 
 EXT_PATH     = File.expand_path("..", __FILE__).freeze

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -1,4 +1,3 @@
-require File.expand_path("../../lib/appsignal/version.rb", __FILE__)
 require File.expand_path("../base.rb", __FILE__)
 
 def install # rubocop:disable Metrics/CyclomaticComplexity

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -1,17 +1,24 @@
 require File.expand_path("../base.rb", __FILE__)
 
-def install # rubocop:disable Metrics/CyclomaticComplexity
-  logger.info "Installing appsignal agent #{Appsignal::VERSION} for Ruby #{RUBY_VERSION} on #{RUBY_PLATFORM}"
-  write_agent_architecture
+def local_build?
+  File.exist?(ext_path("appsignal-agent")) &&
+    File.exist?(ext_path("libappsignal.a")) &&
+    File.exist?(ext_path("appsignal.h"))
+end
+
+def install
+  library_type = "static"
+  report["language"]["implementation"] = "ruby"
+  report["build"]["library_type"] = library_type
   return unless check_architecture
   arch_config = AGENT_CONFIG["triples"][ARCH]
 
-  unless File.exist?(ext_path("appsignal-agent")) &&
-      File.exist?(ext_path("libappsignal.a")) &&
-      File.exist?(ext_path("appsignal.h"))
-    archive = download_archive(arch_config, "static")
+  if local_build?
+    report["build"]["source"] = "local"
+  else
+    archive = download_archive(arch_config, library_type)
     return unless archive
-    return unless verify_archive(archive, arch_config, "static")
+    return unless verify_archive(archive, arch_config, library_type)
     unarchive(archive)
   end
 
@@ -20,15 +27,13 @@ def install # rubocop:disable Metrics/CyclomaticComplexity
     Appsignal::System::MUSL_TARGET
   ].include?(PLATFORM)
 
-  logger.info "Creating makefile"
   require "mkmf"
-
   link_libraries if is_linux_system
 
   if !have_library("appsignal", "appsignal_start", "appsignal.h")
-    installation_failed "Aborting installation, libappsignal.a or appsignal.h not found"
+    abort_installation("Library libappsignal.a or appsignal.h not found")
   elsif !find_executable("appsignal-agent", EXT_PATH)
-    installation_failed "Aborting installation, appsignal-agent not found"
+    abort_installation("File appsignal-agent not found")
   else
     if is_linux_system
       # Statically link libgcc and libgcc_s libraries.
@@ -37,15 +42,16 @@ def install # rubocop:disable Metrics/CyclomaticComplexity
       # run on one that isn't the missing libraries will cause the extension
       # to fail on start.
       $LDFLAGS += " -static-libgcc" # rubocop:disable Style/GlobalVars
+      report["build"]["flags"]["LDFLAGS"] = $LDFLAGS # rubocop:disable Style/GlobalVars
     end
     create_makefile "appsignal_extension"
-    logger.info "Successfully created Makefile for appsignal extension"
+    successful_installation
   end
-rescue => ex
-  installation_failed "Exception while installing: #{ex}"
-  ex.backtrace.each do |line|
-    logger.error line
-  end
+rescue => error
+  fail_installation_with_error(error)
+ensure
+  create_dummy_makefile unless installation_succeeded?
+  write_report
 end
 
 # Ruby 2.6 requires us to statically link more libraries we use in our
@@ -53,26 +59,28 @@ end
 # and musl builds.
 def link_libraries
   if RbConfig::CONFIG["THREAD_MODEL"] == "pthread"
-    logger.info "Linking extension against 'pthread' library"
     # Link gem extension against pthread library
     have_library "pthread"
-    have_required_function "pthread_create"
+    have_required_function "pthread", "pthread_create"
   end
 
   # Links gem extension against the `dl` library. This is needed when Ruby is
   # not linked against `dl` itself, so link it on the gem extension.
-  logger.info "Linking extension against 'dl' library"
   have_library "dl"
   # Check if functions are available now from the linked library
   %w[dlopen dlclose dlsym].each do |func|
-    have_required_function func
+    have_required_function "dl", func
   end
 end
 
-def have_required_function(func) # rubocop:disable Naming/PredicateName
-  return if have_func(func)
+def have_required_function(library, func) # rubocop:disable Naming/PredicateName
+  if have_func(func)
+    report["build"]["dependencies"][library] = "linked"
+    return
+  end
 
-  installation_failed "Aborting installation, missing function '#{func}'"
+  report["build"]["dependencies"][library] = "not linked"
+  abort_installation("Missing function '#{func}'")
   # Exit with true/0/success because the AppSignal installation should never
   # break a build
   exit

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -82,6 +82,8 @@ module Appsignal
           print_empty_line
 
           library_information
+          data[:installation] = fetch_installation_report
+          print_installation_report
           print_empty_line
 
           host_information
@@ -325,10 +327,91 @@ module Appsignal
             save :language, "ruby"
             puts_and_save :package_version, "Gem version", Appsignal::VERSION
             puts_and_save :agent_version, "Agent version", Appsignal::Extension.agent_version
-            puts_and_save :agent_architecture, "Agent architecture",
-              Appsignal::System.installed_agent_architecture
             puts_and_save :extension_loaded, "Extension loaded", Appsignal.extension_loaded
           end
+        end
+
+        def fetch_installation_report
+          raw_report = File.read(File.expand_path("../../../../ext/install.report", __FILE__))
+          method = YAML.respond_to?(:safe_load) ? :safe_load : :load
+          YAML.send(
+            method,
+            raw_report,
+            [Time]
+          )
+        rescue => e
+          {
+            "parsing_error" => {
+              "error" => "#{e.class}: #{e}",
+              "backtrace" => e.backtrace
+            }.tap do |r|
+              r["raw"] = raw_report if raw_report
+            end
+          }
+        end
+
+        def print_installation_report
+          puts "\nExtension installation report"
+          install_report = data[:installation]
+          if install_report.key? "parsing_error"
+            print_installation_report_parsing_error(install_report)
+            return
+          end
+
+          print_installation_result_report(install_report)
+          print_installation_language_report(install_report)
+          print_installation_download_report(install_report)
+          print_installation_build_report(install_report)
+          print_installation_host_report(install_report)
+        end
+
+        def print_installation_report_parsing_error(report)
+          report = report["parsing_error"]
+          puts "  Error found while parsing the report."
+          puts "  Error: #{report["error"]}"
+          puts "  Raw report:\n#{report["raw"]}" if report["raw"]
+        end
+
+        def print_installation_result_report(report)
+          report = report.fetch("download", {})
+          puts "  Installation result"
+          puts "    Status: #{report["status"]}"
+          puts "    Message: #{report["message"]}" if report["message"]
+          puts "    Error: #{report["error"]}" if report["error"]
+        end
+
+        def print_installation_language_report(report)
+          report = report.fetch("language", {})
+          puts "  Language details"
+          puts "    Implementation: #{report["implementation"]}"
+          puts "    Ruby version: #{report["version"]}"
+        end
+
+        def print_installation_download_report(report)
+          report = report.fetch("download", {})
+          puts "  Download details"
+          puts "    Download URL: #{report["download_url"]}"
+          puts "    Checksum: #{report["checksum"]}"
+        end
+
+        def print_installation_build_report(report)
+          report = report.fetch("build", {})
+          puts "  Build details"
+          puts "    Install time: #{report["time"]}"
+          puts "    Architecture: #{report["architecture"]}"
+          puts "    Target: #{report["target"]}"
+          puts "    Musl override: #{report["musl_override"]}"
+          puts "    Library type: #{report["library_type"]}"
+          puts "    Source: #{report["source"]}" if report["source"] != "remote"
+          puts "    Dependencies: #{report["dependencies"]}"
+          puts "    Flags: #{report["flags"]}"
+        end
+
+        def print_installation_host_report(report)
+          report = report.fetch("host", {})
+          puts "  Host details"
+          puts "    Root user: #{report["root_user"]}"
+          puts "    Dependencies: #{report["dependencies"]}"
         end
 
         def host_information
@@ -349,7 +432,7 @@ module Appsignal
             save :heroku, Appsignal::System.heroku?
 
             save :root, Process.uid.zero?
-            puts_value "root user",
+            puts_value "Root user",
               Process.uid.zero? ? "true (not recommended)" : "false"
             puts_and_save :running_in_container, "Running in container",
               Appsignal::Extension.running_in_container?

--- a/lib/appsignal/cli/diagnose/paths.rb
+++ b/lib/appsignal/cli/diagnose/paths.rb
@@ -17,7 +17,6 @@ module Appsignal
             begin
               config = Appsignal.config
               log_file_path = config.log_file_path
-              install_log_path = File.join("ext", "install.log")
               makefile_log_path = File.join("ext", "mkmf.log")
               {
                 :package_install_path => {
@@ -35,10 +34,6 @@ module Appsignal
                 :log_dir_path => {
                   :label => "Log directory",
                   :path => log_file_path ? File.dirname(log_file_path) : ""
-                },
-                install_log_path => {
-                  :label => "Extension install log",
-                  :path => File.join(gem_path, install_log_path)
                 },
                 makefile_log_path => {
                   :label => "Makefile install log",

--- a/lib/appsignal/extension.rb
+++ b/lib/appsignal/extension.rb
@@ -12,8 +12,8 @@ begin
   end
 rescue LoadError => err
   Appsignal.logger.error(
-    "Failed to load extension (#{err}), please check the install.log file in " \
-    "the ext directory of the gem and email us at support@appsignal.com"
+    "Failed to load extension (#{err}), please run `appsignal diagnose` " \
+      "and email us at support@appsignal.com"
   )
   Appsignal.extension_loaded = false
 end

--- a/spec/lib/appsignal/system_spec.rb
+++ b/spec/lib/appsignal/system_spec.rb
@@ -19,41 +19,6 @@ describe Appsignal::System do
     end
   end
 
-  describe ".installed_agent_architecture" do
-    let(:const_name) { "GEM_EXT_PATH".freeze }
-    let(:tmp_ext_dir) { File.join(tmp_dir, "ext") }
-    let(:architecture_file) { File.join(Appsignal::System::GEM_EXT_PATH, "appsignal.architecture") }
-    around do |example|
-      original_gem_ext_path = Appsignal::System.const_get(const_name)
-      Appsignal::System.send(:remove_const, const_name)
-      Appsignal::System.const_set(const_name, tmp_ext_dir)
-      example.run
-      Appsignal::System.send(:remove_const, const_name)
-      Appsignal::System.const_set(const_name, original_gem_ext_path)
-    end
-    after { FileUtils.rm_rf(tmp_ext_dir) }
-    subject { described_class.installed_agent_architecture }
-
-    context "with an ext/appsignal.architecture file" do
-      before do
-        FileUtils.mkdir_p(Appsignal::System::GEM_EXT_PATH)
-        File.open(architecture_file, "w") do |file|
-          file.write "foo"
-        end
-      end
-
-      it "returns the contents of the file" do
-        expect(subject).to eq("foo")
-      end
-    end
-
-    context "without an ext/appsignal.architecture file" do
-      it "returns nil" do
-        expect(subject).to be_nil
-      end
-    end
-  end
-
   describe ".agent_platform" do
     let(:os) { "linux-gnu" }
     let(:ldd_output) { "" }


### PR DESCRIPTION
~Before we merge this we need to be able to reproduce this report in Elixir.~ -> https://github.com/appsignal/appsignal-elixir/pull/433
Server PR: https://github.com/appsignal/appsignal-server/pull/3917

---

This report allows us to see what the environment was when the AppSignal
extension was installed, so we can compare it to the diagnose report
generated by `appsignal diagnose` afterwards.

Basic information, such as information about Ruby, the chosen agent and
extension build.

Combine the information from the `install.log` and
`appsignal.architecture` files in one file that stores more easily
parseable metadata.

It's especially good to know if the `LDFLAGS` were set or not during
installation. Helps track down if it was correctly installed for this
issue:
https://docs.appsignal.com/support/known-issues/compilation-dependencies-required-at-runtime.html

## Screenshots

![image](https://user-images.githubusercontent.com/282402/51410647-86e03c00-1b65-11e9-9fcd-453ddf2d8042.png)
