### PR TITLE
Remove diagnose command bundler dependency

### DIFF
--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "rbconfig"
-require "bundler/cli"
-require "bundler/cli/common"
 require "etc"
 require "appsignal/cli/diagnose/utils"
 require "appsignal/cli/diagnose/paths"

--- a/lib/appsignal/cli/diagnose/paths.rb
+++ b/lib/appsignal/cli/diagnose/paths.rb
@@ -81,9 +81,10 @@ module Appsignal
           end
         end
 
+        # Returns the AppSignal gem installation path. The root directory of
+        # this gem.
         def gem_path
-          @gem_path ||= \
-            Bundler::CLI::Common.select_spec("appsignal").full_gem_path.strip
+          File.expand_path("../../../../../", __FILE__)
         end
       end
     end

--- a/spec/lib/appsignal/cli/diagnose/paths_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose/paths_spec.rb
@@ -1,0 +1,16 @@
+require "bundler/cli"
+require "bundler/cli/common"
+require "appsignal/cli/diagnose/paths"
+
+describe Appsignal::CLI::Diagnose::Paths do
+  describe "#paths" do
+    before { Appsignal.config = project_fixture_config }
+
+    it "returns gem installation path as package_install_path" do
+      expect(described_class.new.paths[:package_install_path]).to eq(
+        :label => "AppSignal gem path",
+        :path => Bundler::CLI::Common.select_spec("appsignal").full_gem_path.strip
+      )
+    end
+  end
+end

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -1,3 +1,5 @@
+require "bundler/cli"
+require "bundler/cli/common"
 require "appsignal/cli"
 
 describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_input do
@@ -1140,10 +1142,9 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
         it_behaves_like "diagnose file" do
           let(:filename) { File.join("ext", "install.log") }
           before do
-            expect(Bundler::CLI::Common).to receive(:select_spec)
-              .with("appsignal")
+            expect_any_instance_of(Appsignal::CLI::Diagnose::Paths).to receive(:gem_path)
               .at_least(:once)
-              .and_return(double(:full_gem_path => parent_directory))
+              .and_return(parent_directory)
           end
         end
 
@@ -1157,10 +1158,9 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
         it_behaves_like "diagnose file" do
           let(:filename) { File.join("ext", "mkmf.log") }
           before do
-            expect(Bundler::CLI::Common).to receive(:select_spec)
-              .with("appsignal")
+            expect_any_instance_of(Appsignal::CLI::Diagnose::Paths).to receive(:gem_path)
               .at_least(:once)
-              .and_return(double(:full_gem_path => parent_directory))
+              .and_return(parent_directory)
           end
         end
 


### PR DESCRIPTION
It isn't part of our runtime dependencies. For users that don't have
bundler installed the "require bundler" statements would cause a
`LoadError`.

Add a test to verify the gem path is actually the gem path bundler
returns, but find out the path using `File.expand_path` and navigating
up the directory tree.