### PR TITLE
Fix TravisCI builds for older gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,6 @@ cache:
     - vendor/bundle
 
 rvm:
-  - "2.0.0"
-  - "2.3.8"
-  - "2.4.5"
-  - "2.5.3"
-  - "2.6.0"
   - "jruby-19mode"
 
 gemfile:
@@ -76,6 +71,7 @@ env:
 
 before_install:
   - "gem update --system 2.7.8"
+  - "gem uninstall bundler --all"
   - "gem install bundler --version 1.17.3"
 before_script:
   - "bundle exec rake extension:install"

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ env:
 
 before_install:
   - "gem update --system 2.7.8"
-  - "gem uninstall bundler --all"
+  - "gem uninstall bundler --all --executables"
   - "gem install bundler --version 1.17.3"
 before_script:
   - "bundle exec rake extension:install"

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ env:
 
 before_install:
   - "gem update --system 2.7.8"
-  - "gem update bundler"
+  - "gem install bundler --version 1.17.3"
 before_script:
   - "bundle exec rake extension:install"
 after_failure:


### PR DESCRIPTION
Lock bundler version to pre 2.0, because some builds (like padrino,
rails 3 & 4 and resque) have a `< 2.0` requirement.

This needs to be fixed in a better way to allow us to also test against
bundler 2.0, but this is the quickest fix now.