### PR TITLE
Build custom .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,86 +1,148 @@
+# DO NOT EDIT
+# This is a generated file by the `rake travis:generate` task.
+# See `build_matrix.yml` for the build matrix.
+# Generate this file with `rake travis:generate`.
+---
 sudo: false
-
 branches:
   only:
-    - "master"
-    - "develop"
-
+  - master
+  - develop
 language: ruby
 cache:
   directories:
-    - vendor/bundle
-
-rvm:
-  - "2.0.0"
-  - "2.3.8"
-  - "2.4.5"
-  - "2.5.3"
-  - "2.6.0"
-  - "jruby-19mode"
-
-gemfile:
-  - "gemfiles/capistrano2.gemfile"
-  - "gemfiles/capistrano3.gemfile"
-  - "gemfiles/no_dependencies.gemfile"
-  - "gemfiles/padrino.gemfile"
-  - "gemfiles/rails-3.2.gemfile"
-  - "gemfiles/rails-4.0.gemfile"
-  - "gemfiles/rails-4.1.gemfile"
-  - "gemfiles/rails-4.2.gemfile"
-  - "gemfiles/rails-5.0.gemfile"
-  - "gemfiles/rails-5.1.gemfile"
-  - "gemfiles/resque.gemfile"
-  - "gemfiles/sequel.gemfile"
-  - "gemfiles/sequel-435.gemfile"
-  - "gemfiles/sinatra.gemfile"
-  - "gemfiles/grape.gemfile"
-  - "gemfiles/webmachine.gemfile"
-  - "gemfiles/que.gemfile"
-
+  - vendor/bundle
+env:
+  global:
+  - RUNNING_IN_CI=true
+  - RAILS_ENV=test
+  - JRUBY_OPTS=''
+before_install:
+- "./support/install_deps"
+install: "./support/bundler_wrapper install --jobs=3 --retry=3"
+before_script:
+- "./support/bundler_wrapper exec rake extension:install"
+script: "./support/bundler_wrapper exec rake test"
+after_failure:
+- find ./ext -name install.log -exec cat {} \;
+- find ./ext -name mkmf.log -exec cat {} \;
 matrix:
   fast_finish: true
   include:
-    - rvm: "2.1.8"
-      gemfile: "gemfiles/no_dependencies.gemfile"
-    - rvm: "2.2.4"
-      gemfile: "gemfiles/no_dependencies.gemfile"
-    - rvm: "2.5.3"
-      gemfile: "gemfiles/no_dependencies.gemfile"
-      script: "bundle exec rubocop"
-  exclude:
-    # Rails 5 doesn't support Ruby < 2.2
-    - rvm: "2.0.0"
-      gemfile: "gemfiles/rails-5.0.gemfile"
-    - rvm: "2.0.0"
-      gemfile: "gemfiles/rails-5.1.gemfile"
-    - rvm: "2.5.3"
-      gemfile: "gemfiles/rails-4.0.gemfile"
-    - rvm: "2.5.3"
-      gemfile: "gemfiles/rails-4.1.gemfile"
-    - rvm: "2.6.0"
-      gemfile: "gemfiles/rails-4.0.gemfile"
-    - rvm: "2.6.0"
-      gemfile: "gemfiles/rails-4.1.gemfile"
-
-  allow_failures:
-    - rvm: "2.4.5"
-      gemfile: "gemfiles/rails-4.0.gemfile"
-    - rvm: "2.4.5"
-      gemfile: "gemfiles/rails-4.1.gemfile"
-
-env:
-  global:
-    - "RUNNING_IN_CI=true"
-    - "RAILS_ENV=test"
-    - "JRUBY_OPTS=''" # Workaround https://github.com/travis-ci/travis-ci/issues/6471
-
-before_install:
-  - "gem update --system 2.7.8"
-  - "gem update bundler"
-before_script:
-  - "bundle exec rake extension:install"
-after_failure:
-  - "find ./ext -name install.log -exec cat {} \\;"
-  - "find ./ext -name mkmf.log -exec cat {} \\;"
-
-script: "bundle exec rake test"
+  - rvm: 2.6.0
+    gemfile: gemfiles/no_dependencies.gemfile
+    before_script: ''
+    script:
+    - "./support/bundler_wrapper exec rake travis:validate"
+    - "./support/bundler_wrapper exec rubocop"
+  - rvm: 2.0.0
+    gemfile: gemfiles/no_dependencies.gemfile
+    env: _RUBYGEMS_VERSION=2.7.8 _BUNDLER_VERSION=latest
+  - rvm: 2.0.0
+    gemfile: gemfiles/capistrano2.gemfile
+    env: _RUBYGEMS_VERSION=2.7.8 _BUNDLER_VERSION=latest
+  - rvm: 2.0.0
+    gemfile: gemfiles/capistrano3.gemfile
+    env: _RUBYGEMS_VERSION=2.7.8 _BUNDLER_VERSION=latest
+  - rvm: 2.0.0
+    gemfile: gemfiles/grape.gemfile
+    env: _RUBYGEMS_VERSION=2.7.8 _BUNDLER_VERSION=latest
+  - rvm: 2.0.0
+    gemfile: gemfiles/padrino.gemfile
+    env: _RUBYGEMS_VERSION=2.7.8 _BUNDLER_VERSION=1.17.3
+  - rvm: 2.0.0
+    gemfile: gemfiles/que.gemfile
+    env: _RUBYGEMS_VERSION=2.7.8 _BUNDLER_VERSION=latest
+  - rvm: 2.0.0
+    gemfile: gemfiles/rails-3.2.gemfile
+    env: _RUBYGEMS_VERSION=2.7.8 _BUNDLER_VERSION=1.17.3
+  - rvm: 2.0.0
+    gemfile: gemfiles/rails-4.2.gemfile
+    env: _RUBYGEMS_VERSION=2.7.8 _BUNDLER_VERSION=1.17.3
+  - rvm: 2.0.0
+    gemfile: gemfiles/resque.gemfile
+    env: _RUBYGEMS_VERSION=2.7.8 _BUNDLER_VERSION=1.17.3
+  - rvm: 2.0.0
+    gemfile: gemfiles/sequel.gemfile
+    env: _RUBYGEMS_VERSION=2.7.8 _BUNDLER_VERSION=latest
+  - rvm: 2.0.0
+    gemfile: gemfiles/sequel-435.gemfile
+    env: _RUBYGEMS_VERSION=2.7.8 _BUNDLER_VERSION=latest
+  - rvm: 2.0.0
+    gemfile: gemfiles/sinatra.gemfile
+    env: _RUBYGEMS_VERSION=2.7.8 _BUNDLER_VERSION=latest
+  - rvm: 2.0.0
+    gemfile: gemfiles/webmachine.gemfile
+    env: _RUBYGEMS_VERSION=2.7.8 _BUNDLER_VERSION=latest
+  - rvm: 2.1.8
+    gemfile: gemfiles/no_dependencies.gemfile
+    env: _RUBYGEMS_VERSION=2.7.8 _BUNDLER_VERSION=latest
+  - rvm: 2.2.4
+    gemfile: gemfiles/no_dependencies.gemfile
+    env: _RUBYGEMS_VERSION=2.7.8 _BUNDLER_VERSION=latest
+  - rvm: 2.3.8
+    gemfile: gemfiles/no_dependencies.gemfile
+    env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=latest
+  - rvm: 2.4.5
+    gemfile: gemfiles/no_dependencies.gemfile
+    env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=latest
+  - rvm: 2.5.3
+    gemfile: gemfiles/no_dependencies.gemfile
+    env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=latest
+  - rvm: 2.5.3
+    gemfile: gemfiles/rails-4.2.gemfile
+    env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=1.17.3
+  - rvm: 2.5.3
+    gemfile: gemfiles/rails-5.2.gemfile
+    env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=latest
+  - rvm: 2.6.0
+    gemfile: gemfiles/no_dependencies.gemfile
+    env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=latest
+  - rvm: 2.6.0
+    gemfile: gemfiles/capistrano2.gemfile
+    env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=latest
+  - rvm: 2.6.0
+    gemfile: gemfiles/capistrano3.gemfile
+    env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=latest
+  - rvm: 2.6.0
+    gemfile: gemfiles/grape.gemfile
+    env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=latest
+  - rvm: 2.6.0
+    gemfile: gemfiles/padrino.gemfile
+    env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=1.17.3
+  - rvm: 2.6.0
+    gemfile: gemfiles/que.gemfile
+    env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=latest
+  - rvm: 2.6.0
+    gemfile: gemfiles/rails-5.0.gemfile
+    env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=latest
+  - rvm: 2.6.0
+    gemfile: gemfiles/rails-5.1.gemfile
+    env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=latest
+  - rvm: 2.6.0
+    gemfile: gemfiles/rails-5.2.gemfile
+    env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=latest
+  - rvm: 2.6.0
+    gemfile: gemfiles/resque.gemfile
+    env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=1.17.3
+  - rvm: 2.6.0
+    gemfile: gemfiles/sequel.gemfile
+    env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=latest
+  - rvm: 2.6.0
+    gemfile: gemfiles/sequel-435.gemfile
+    env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=latest
+  - rvm: 2.6.0
+    gemfile: gemfiles/sinatra.gemfile
+    env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=latest
+  - rvm: 2.6.0
+    gemfile: gemfiles/webmachine.gemfile
+    env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=latest
+  - rvm: jruby-19mode
+    gemfile: gemfiles/no_dependencies.gemfile
+    env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=latest
+  - rvm: jruby-19mode
+    gemfile: gemfiles/rails-4.2.gemfile
+    env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=1.17.3
+  - rvm: jruby-19mode
+    gemfile: gemfiles/rails-5.2.gemfile
+    env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=latest

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -1,0 +1,106 @@
+travis: # Default `.travis.yml` contents
+  sudo: false
+
+  branches:
+    only:
+      - "master"
+      - "develop"
+
+  language: ruby
+  cache:
+    directories:
+      - vendor/bundle
+
+  env:
+    global:
+      - "RUNNING_IN_CI=true"
+      - "RAILS_ENV=test"
+      - "JRUBY_OPTS=''" # Workaround https://github.com/travis-ci/travis-ci/issues/6471
+
+  before_install:
+    - "./support/install_deps"
+  install: "./support/bundler_wrapper install --jobs=3 --retry=3"
+  before_script:
+    - "./support/bundler_wrapper exec rake extension:install"
+  script: "./support/bundler_wrapper exec rake test"
+  after_failure:
+    - "find ./ext -name install.log -exec cat {} \\;"
+    - "find ./ext -name mkmf.log -exec cat {} \\;"
+
+  matrix:
+    fast_finish: true
+    include: # Builds based on the matrix below are added to this list
+      - rvm: "2.6.0"
+        gemfile: "gemfiles/no_dependencies.gemfile"
+        before_script: "" # Unset default: No need to install the extension
+        script:
+          - "./support/bundler_wrapper exec rake travis:validate"
+          - "./support/bundler_wrapper exec rubocop"
+
+matrix:
+  defaults:
+    rubygems: "latest"
+    bundler: "latest"
+
+  gemsets: # By default all gems are tested
+    none:
+      - "no_dependencies"
+    minimal:
+      - "no_dependencies"
+      - "rails-4.2"
+      - "rails-5.2"
+
+  ruby:
+    - ruby: "2.0.0"
+      rubygems: "2.7.8"
+    - ruby: "2.1.8"
+      rubygems: "2.7.8"
+      gems: "none"
+    - ruby: "2.2.4"
+      rubygems: "2.7.8"
+      gems: "none"
+    - ruby: "2.3.8"
+      gems: "none"
+    - ruby: "2.4.5"
+      gems: "none"
+    - ruby: "2.5.3"
+      gems: "minimal"
+    - ruby: "2.6.0"
+    - ruby: "jruby-19mode"
+      gems: "minimal"
+  gems:
+    - gem: "no_dependencies"
+    - gem: "capistrano2"
+    - gem: "capistrano3"
+    - gem: "grape"
+    - gem: "padrino"
+      bundler: "1.17.3"
+    - gem: "que"
+    - gem: "rails-3.2"
+      bundler: "1.17.3"
+      exclude:
+        ruby:
+          - "2.6.0"
+    - gem: "rails-4.2"
+      bundler: "1.17.3"
+      exclude:
+        ruby:
+          - "2.6.0"
+    - gem: "rails-5.0"
+      exclude:
+        ruby:
+          - "2.0.0"
+    - gem: "rails-5.1"
+      exclude:
+        ruby:
+          - "2.0.0"
+    - gem: "rails-5.2"
+      exclude:
+        ruby:
+          - "2.0.0"
+    - gem: "resque"
+      bundler: "1.17.3"
+    - gem: "sequel"
+    - gem: "sequel-435"
+    - gem: "sinatra"
+    - gem: "webmachine"

--- a/gemfiles/rails-5.2.gemfile
+++ b/gemfiles/rails-5.2.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~> 5.2.0'
+
+gemspec :path => '../'

--- a/support/bundler_wrapper
+++ b/support/bundler_wrapper
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eu
+
+case "${_BUNDLER_VERSION-"latest"}" in
+  "latest")
+    bundle $@
+  ;;
+  *)
+    bundle _${_BUNDLER_VERSION}_ $@
+  ;;
+esac

--- a/support/install_deps
+++ b/support/install_deps
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -eu
+
+case "${_RUBYGEMS_VERSION-"latest"}" in
+  "latest")
+    gem update --no-document --system
+  ;;
+  *)
+    gem update --no-document --system $_RUBYGEMS_VERSION
+  ;;
+esac
+
+case "${_BUNDLER_VERSION-"latest"}" in
+  "latest")
+    gem update bundler --no-document
+  ;;
+  *)
+    gem install bundler --no-document --version $_BUNDLER_VERSION
+  ;;
+esac


### PR DESCRIPTION
Attempt to fix #457 and fix #456 

---

To fix the builds on TravisCI we need a bit more flexibility to specify
the required RubyGems and Bundler versions.

For Padrino builds we need a Bundler version lower than 2.0 for example.
Some ActiveSupport (Rails) versions require Bundler < 2.0 as well.

This new matrix also decrease the number of jobs by choosing "gemsets"
per Ruby version. We don't have to test every Ruby version against every
gem combination. That's more the responsibility of the gems themselves.
And we do not have to support a combination if the gem itself doesn't.

By running `rake travis:generate` a new `.travis.yml` file is generated
we use to build against.

To ensure the build is using the latest intended build matrix, validate
the build matrix as the first job to see if the `.travis.yml` generated
differs from the committed version.