### PR TITLE
Minutely probes update

### DIFF
--- a/spec/lib/appsignal/minutely_spec.rb
+++ b/spec/lib/appsignal/minutely_spec.rb
@@ -42,9 +42,8 @@ describe Appsignal::Minutely do
       probe = Probe.new
       Appsignal::Minutely.probes << probe
       Appsignal::Minutely.start
-      sleep 0.01
 
-      expect(probe.calls).to be >= 2
+      wait_for("enough probe calls") { probe.calls >= 2 }
       expect(log).to include("Gathering minutely metrics with 1 probe")
       expect(log).to include("Gathering minutely metrics with Probe probe")
     end
@@ -56,16 +55,42 @@ describe Appsignal::Minutely do
         Appsignal::Minutely.probes << probe
         Appsignal::Minutely.probes << broken_probe
         Appsignal::Minutely.start
-        sleep 0.01
 
-        expect(probe.calls).to be >= 2
-        expect(broken_probe.calls).to be >= 2
+        wait_for("enough probe calls") { probe.calls >= 2 }
+        wait_for("enough broken_probe calls") { broken_probe.calls >= 2 }
 
         expect(log).to include("Gathering minutely metrics with 2 probes")
         expect(log).to include("Gathering minutely metrics with Probe probe")
         expect(log).to include("Gathering minutely metrics with BrokenProbe probe")
         expect(log).to include("Error in minutely thread (BrokenProbe): oh no!")
       end
+    end
+
+    # Wait for a condition to be met
+    #
+    # @example
+    #   # Perform threaded operation
+    #   wait_for("enough probe calls") { probe.calls >= 2 }
+    #   # Assert on result
+    #
+    # @param name [String] The name of the condition to check. Used in the
+    #   error when it fails.
+    # @yield Assertion to check.
+    # @yieldreturn [Boolean] True/False value that indicates if the condition
+    #   is met.
+    # @raise [StandardError] Raises error if the condition is not met after 5
+    #   seconds, 5_000 tries.
+    def wait_for(name)
+      max_wait = 5_000
+      i = 0
+      while i <= max_wait
+        break if yield
+        i += 1
+        sleep 0.001
+      end
+
+      return unless i == max_wait
+      raise "Waited 5 seconds for #{name} condition, but was not met."
     end
   end
 

--- a/spec/lib/appsignal/minutely_spec.rb
+++ b/spec/lib/appsignal/minutely_spec.rb
@@ -3,21 +3,21 @@ describe Appsignal::Minutely do
     Appsignal::Minutely.probes.clear
   end
 
-  it "should have a list of probes" do
+  it "has a list of probes" do
     expect(Appsignal::Minutely.probes).to be_instance_of(Array)
   end
 
   describe ".start" do
-    it "should call the probes periodically" do
-      probe = double
+    it "calls the probes every <wait_time>" do
+      probe = double(:name => "MyProbe")
       expect(probe).to receive(:call).at_least(:twice)
+      allow(Appsignal::Minutely).to receive(:wait_time).and_return(0.0001)
+
       Appsignal::Minutely.probes << probe
-      allow(Appsignal::Minutely).to receive(:wait_time).and_return(0.1)
-
       Appsignal::Minutely.start
-
-      sleep 0.5
+      sleep 0.01
     end
+
   end
 
   describe ".wait_time" do
@@ -28,7 +28,7 @@ describe Appsignal::Minutely do
   end
 
   describe ".add_gc_probe" do
-    it "should add the gc probe to the list" do
+    it "adds the GC probe to the probes list" do
       expect(Appsignal::Minutely.probes).to be_empty
 
       Appsignal::Minutely.add_gc_probe
@@ -40,7 +40,7 @@ describe Appsignal::Minutely do
 
   describe Appsignal::Minutely::GCProbe do
     describe "#call" do
-      it "should collect GC metrics" do
+      it "collects GC metrics" do
         expect(Appsignal).to receive(:set_process_gauge).at_least(8).times
 
         Appsignal::Minutely::GCProbe.new.call


### PR DESCRIPTION
## Allow minutely thread to continue if probe crashes

Just because one probe crashes doesn't mean the whole process should
stop.

If one probe crashes, don't crash the entire minutely probe thread. It
could have been a one time occurrence or some other external influence
causing the error.

## Remove doubles from Minutely spec

Just plain objects to track how many times a Probe was called rather
than relying on RSpec. Simpler code, easier to test. Less brittle for
what I want to write.

(Running into a RSpec OutsideOfExampleError in a future change.)

## Speed up the minutely probes spec

Decrease sleeps while still testing the same behavior. Speeds up these
tests.

## Add wait_for helper that checks conditions in spec

Only using `sleep X` is a little brittle as some machines are slower
than others. On faster machines you don't want to wait for the longest
time it can possibly take. So instead perform more checks in the helper
and set a maximum time after which it should have been completed.

The `wait_for` helper will check a condition for 5 seconds before giving
up and raising an error, causing the spec to fail.