### PR TITLE
Add default Sidekiq metrics

### DIFF
--- a/lib/appsignal/hooks/sidekiq.rb
+++ b/lib/appsignal/hooks/sidekiq.rb
@@ -12,7 +12,7 @@ module Appsignal
       end
 
       def install
-        Appsignal::Minutely.probes << SidekiqProbe.new
+        Appsignal::Minutely.probes.register :sidekiq, SidekiqProbe
 
         ::Sidekiq.configure_server do |config|
           config.server_middleware do |chain|
@@ -28,7 +28,7 @@ module Appsignal
       def initialize(config = {})
         @config = config
         @cache = {}
-        require "sidekiq/api" if Appsignal.config[:enable_minutely_probes]
+        require "sidekiq/api"
       end
 
       def call

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -431,6 +431,11 @@ describe Appsignal::Hooks::SidekiqPlugin, :with_yaml_parse_error => false do
     let(:error) { ExampleException }
 
     it "creates a transaction and adds the error" do
+      expect(Appsignal).to receive(:increment_counter)
+        .with("sidekiq_queue_job_count", 1, :queue => "default", :status => :failed)
+      expect(Appsignal).to receive(:increment_counter)
+        .with("sidekiq_queue_job_count", 1, :queue => "default", :status => :processed)
+
       expect do
         perform_job { raise error, "uh oh" }
       end.to raise_error(error)
@@ -466,6 +471,9 @@ describe Appsignal::Hooks::SidekiqPlugin, :with_yaml_parse_error => false do
 
   context "without an error" do
     it "creates a transaction with events" do
+      expect(Appsignal).to receive(:increment_counter)
+        .with("sidekiq_queue_job_count", 1, :queue => "default", :status => :processed)
+
       perform_job
 
       transaction_hash = transaction.to_h
@@ -541,6 +549,7 @@ describe Appsignal::Hooks::SidekiqHook do
 
   describe "#install" do
     before do
+      Appsignal.config = project_fixture_config
       class Sidekiq
         def self.middlewares
           @middlewares ||= Set.new
@@ -561,6 +570,129 @@ describe Appsignal::Hooks::SidekiqHook do
       described_class.new.install
 
       expect(Sidekiq.middlewares).to include(Appsignal::Hooks::SidekiqPlugin)
+    end
+
+    context "when enable_minutely_probes is true" do
+      it "loads Sidekiq::API" do
+        Appsignal.config[:enable_minutely_probes] = true
+        expect(defined?(Sidekiq::API)).to be_falsy
+        described_class.new.install
+        expect(defined?(Sidekiq::API)).to be_truthy
+      end
+    end
+
+    context "when enable_minutely_probes is false" do
+      it "does not load Sidekiq::API" do
+        expect(defined?(Sidekiq::API)).to be_falsy
+        described_class.new.install
+        expect(defined?(Sidekiq::API)).to be_falsy
+      end
+    end
+  end
+end
+
+describe Appsignal::Hooks::SidekiqProbe do
+  describe "#call" do
+    let(:probe) { described_class.new }
+    before do
+      Appsignal.config = project_fixture_config
+      class Sidekiq
+        def self.redis_info
+          {
+            "connected_clients" => 2,
+            "used_memory" => 1024,
+            "used_memory_rss" => 512
+          }
+        end
+
+        class Stats
+          class << self
+            attr_reader :calls
+
+            def count_call
+              @calls ||= -1
+              @calls += 1
+            end
+          end
+
+          def workers_size
+            # First method called, so count it towards a call
+            self.class.count_call
+            24
+          end
+
+          def processes_size
+            25
+          end
+
+          # Return two different values for two separate calls.
+          # This allows us to test the delta of the value send as a gauge.
+          def processed
+            [10, 15][self.class.calls]
+          end
+
+          # Return two different values for two separate calls.
+          # This allows us to test the delta of the value send as a gauge.
+          def failed
+            [10, 13][self.class.calls]
+          end
+
+          def retry_size
+            12
+          end
+
+          # Return two different values for two separate calls.
+          # This allows us to test the delta of the value send as a gauge.
+          def dead_size
+            [10, 12][self.class.calls]
+          end
+
+          def scheduled_size
+            14
+          end
+
+          def enqueued
+            15
+          end
+        end
+
+        class Queue
+          Queue = Struct.new(:name, :size, :latency)
+
+          def self.all
+            [
+              Queue.new("default", 10, 12),
+              Queue.new("critical", 1, 2)
+            ]
+          end
+        end
+      end
+    end
+    after { Object.send(:remove_const, "Sidekiq") }
+
+    it "collects custom metrics" do
+      expect_gauge("worker_count", 24).twice
+      expect_gauge("process_count", 25).twice
+      expect_gauge("connection_count", 2).twice
+      expect_gauge("memory_usage", 1024).twice
+      expect_gauge("memory_usage_rss", 512).twice
+      expect_gauge("job_count", 5, :status => :processed) # Gauge delta
+      expect_gauge("job_count", 3, :status => :failed) # Gauge delta
+      expect_gauge("job_count", 12, :status => :retry_queue).twice
+      expect_gauge("job_count", 2, :status => :died) # Gauge delta
+      expect_gauge("job_count", 14, :status => :scheduled).twice
+      expect_gauge("job_count", 15, :status => :enqueued).twice
+      expect_gauge("queue_length", 10, :queue => "default").twice
+      expect_gauge("queue_latency", 12, :queue => "default").twice
+      expect_gauge("queue_length", 1, :queue => "critical").twice
+      expect_gauge("queue_latency", 2, :queue => "critical").twice
+      # Call probe twice so we can calculate the delta for some gauge values
+      probe.call
+      probe.call
+    end
+
+    def expect_gauge(key, value, tags = {})
+      expect(Appsignal).to receive(:set_gauge).with("sidekiq_#{key}", value, tags).and_call_original
     end
   end
 end

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -571,23 +571,6 @@ describe Appsignal::Hooks::SidekiqHook do
 
       expect(Sidekiq.middlewares).to include(Appsignal::Hooks::SidekiqPlugin)
     end
-
-    context "when enable_minutely_probes is true" do
-      it "loads Sidekiq::API" do
-        Appsignal.config[:enable_minutely_probes] = true
-        expect(defined?(Sidekiq::API)).to be_falsy
-        described_class.new.install
-        expect(defined?(Sidekiq::API)).to be_truthy
-      end
-    end
-
-    context "when enable_minutely_probes is false" do
-      it "does not load Sidekiq::API" do
-        expect(defined?(Sidekiq::API)).to be_falsy
-        described_class.new.install
-        expect(defined?(Sidekiq::API)).to be_falsy
-      end
-    end
   end
 end
 
@@ -681,6 +664,12 @@ describe Appsignal::Hooks::SidekiqProbe do
       end
     end
     after { Object.send(:remove_const, "Sidekiq") }
+
+    it "loads Sidekiq::API" do
+      expect(defined?(Sidekiq::API)).to be_falsy
+      probe
+      expect(defined?(Sidekiq::API)).to be_truthy
+    end
 
     it "collects custom metrics" do
       expect_gauge("worker_count", 24).twice

--- a/spec/support/stubs/sidekiq/api.rb
+++ b/spec/support/stubs/sidekiq/api.rb
@@ -1,0 +1,4 @@
+class Sidekiq
+  class API
+  end
+end


### PR DESCRIPTION
Track more Sidekiq specific metrics by default and send them as custom
metrics. This makes it easy to set up a new Sidekiq metrics dashboard on
AppSignal.com to track more fine grained how every worker is performing.

Some Sidekiq stats are absolute counters, values that only go up over
time and are not about what has been processed in the last timeframe. To
send data about what has been processed since the minutely probe last
checked, keep track of what the previous probe call recorded and
subtract that from the new value. That way we get the delta (difference)
of those two values and can send that to AppSignal.

The cache is stored with a separately given cache_key to the
`gauge_delta` helper method, because creating our own based on the
metric key name and tags is much slower. It has to convert a Hash to
something that can be used as a cache key, which will always take
longer, and will slow down even more the more tags are used.

The metrics send as deltas from themselves:

- processed
- failed
- dead

Some keys are also not named 1 to 1 copies of the Sidekiq keys. First we
make all our keys singular. Then some other changes:

- dead -> died (jobs died since the last probe)
- retry -> retry_queue (they are not currently being retried, but are
  queued to be retried)

Part of https://github.com/appsignal/appsignal-server/issues/3926

## TODO

- [x] What happens when both a Rails process and Sidekiq worker run at the same time with this probe?
  - gauges will be safe to send, as we send one values, not a sum like for counters. We need to test if it's the minutely probe system is safe for counters.

## Dashboard YAML

```yml
-
  title: Sidekiq
  graphs:
    -
      title: 'Overall job status'
      line_label: '%name% - %hostname% - %status%'
      kind: gauge
      format: number
      fields:
        - sidekiq_job_count
      tags:
        status: '*'
        hostname: '*'
    -
      title: 'Job status per queue'
      line_label: '%name% - %queue% - %status%'
      kind: count
      format: number
      fields:
        - sidekiq_queue_job_count
      tags:
        queue: '*'
        status: '*'
    -
      title: 'Throughput per job'
      line_label: '%name% - %namespace% - %action%'
      kind: count
      format: number
      fields:
        - transaction_duration
      tags:
        namespace: '*'
        action: '*'
    -
      title: 'Duration per job'
      line_label: '%name% - %namespace% - %action%'
      kind: measurement
      format: duration
      fields:
        - transaction_duration
      tags:
        namespace: '*'
        action: '*'
    -
      title: 'Queue length'
      line_label: '%name% - %hostname% - %queue%'
      kind: gauge
      format: number
      fields:
        - sidekiq_queue_length
      tags:
        queue: '*'
        hostname: '*'
    -
      title: 'Queue latency'
      line_label: '%name% - %hostname% - %queue%'
      kind: gauge
      format: duration
      fields:
        - sidekiq_queue_latency
      tags:
        queue: '*'
        hostname: '*'
    -
      title: 'Worker / Processes count'
      line_label: '%name% - %hostname%'
      kind: gauge
      format: number
      fields:
        - sidekiq_worker_count
        - sidekiq_process_count
      tags:
        hostname: '*'
    -
      title: 'Connection count'
      line_label: '%name% - %hostname%'
      kind: gauge
      format: number
      fields:
        - sidekiq_connection_count
      tags:
        hostname: '*'
    -
      title: 'Memory usage'
      line_label: '%name% - %hostname%'
      kind: gauge
      format: size
      format_input: byte
      fields:
        - sidekiq_memory_usage
        - sidekiq_memory_usage_rss
      tags:
        hostname: '*'
```