### PR TITLE
Ensure only one Minutely thread can run at a time

### DIFF
--- a/lib/appsignal/minutely.rb
+++ b/lib/appsignal/minutely.rb
@@ -11,7 +11,8 @@ module Appsignal
       end
 
       def start
-        Thread.new do
+        stop
+        @@thread = Thread.new do
           loop do
             logger = Appsignal.logger
             logger.debug("Gathering minutely metrics with #{probes.count} probes")
@@ -27,6 +28,10 @@ module Appsignal
             sleep(Appsignal::Minutely.wait_time)
           end
         end
+      end
+
+      def stop
+        defined?(@@thread) && @@thread.kill
       end
 
       def wait_time


### PR DESCRIPTION
In the test suite, whenever `Minutely.start` is called a new thread is
started that loops all the probes.

While this usually doesn't happen in an app, in the test suite a
minutely thread is started for every test that calls `Minutely.start`.
This will become worse when we enable minutely probes by default, one
will start for all specs that call `Appsignal.start`, which are a lot
more specs than call `Minutely.start` now.