### PR TITLE
Change probe registration method to use names

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -130,7 +130,7 @@ module Appsignal
 
           if config[:enable_gc_instrumentation]
             GC::Profiler.enable
-            Appsignal::Minutely.add_gc_probe
+            Appsignal::Minutely.register_garbage_collection_probe
           end
 
           Appsignal::Minutely.start if config[:enable_minutely_probes]

--- a/lib/appsignal/minutely.rb
+++ b/lib/appsignal/minutely.rb
@@ -1,28 +1,126 @@
 # frozen_string_literal: true
 
 module Appsignal
-  # @api private
   class Minutely
-    class << self
-      # List of probes. Probes can be lamdba's or objects that
-      # respond to call.
-      def probes
-        @@probes ||= []
+    class ProbeCollection
+      include Appsignal::Utils::DeprecationMessage
+
+      def initialize
+        @probes = {}
       end
 
+      # @return [Integer] Number of probes that are registered.
+      def count
+        probes.count
+      end
+
+      # Clears all probes from the list.
+      # @return [void]
+      def clear
+        probes.clear
+      end
+
+      # Fetch a probe using its name.
+      # @param key [Symbol/String] The name of the probe to fetch.
+      # @return [Object] Returns the registered probe.
+      def [](key)
+        probes[key]
+      end
+
+      # @param probe [Object] Any object that listens to the `call` method will
+      #   be used as a probe.
+      # @deprecated Use {#register} instead.
+      # @return [void]
+      def <<(probe)
+        deprecation_message "Deprecated `Appsignal::Minute.probes <<` " \
+          "call. Please use `Appsignal::Minutely.probes.register` instead.",
+          logger
+        register probe.object_id, probe
+      end
+
+      # Register a new minutely probe.
+      #
+      # Supported probe types are:
+      #
+      # - Lambda - A lambda is an object that listens to a `call` method call.
+      #   This `call` method is called every minute.
+      # - Class instance - A class instance object is an object that listens to
+      #   a `call` method call. The `call` method is called every minute.
+      #
+      # @example Register a new probe
+      #   Appsignal::Minutely.probes.register :my_probe, lambda {}
+      #
+      # @example Overwrite an existing registered probe
+      #   Appsignal::Minutely.probes.register :my_probe, lambda {}
+      #   Appsignal::Minutely.probes.register :my_probe, lambda { puts "hello" }
+      #
+      # @example Add a lambda as a probe
+      #   Appsignal::Minutely.probes.register :my_probe, lambda { puts "hello" }
+      #   # "hello" # printed every minute
+      #
+      # @example Add a probe instance
+      #   class MyProbe
+      #     def initialize
+      #       puts "started"
+      #     end
+      #
+      #     def call
+      #       puts "called"
+      #     end
+      #   end
+      #
+      #   Appsignal::Minutely.probes.register :my_probe, MyProbe.new
+      #   # "started" # printed immediately
+      #   # "called" # printed every minute
+      #
+      # @param name [Symbol/String] Name of the probe. Can be used with {[]}.
+      #   This name will be used in errors in the log and allows overwriting of
+      #   probes by registering new ones with the same name.
+      # @param probe [Object] Any object that listens to the `call` method will
+      #   be used as a probe.
+      # @return [void]
+      def register(name, probe)
+        if probes.key?(name)
+          logger.debug "A probe with the name `#{name}` is already " \
+            "registered. Overwriting the entry with the new probe."
+        end
+        probes[name] = probe
+      end
+
+      # @api private
+      def each(&block)
+        probes.each(&block)
+      end
+
+      private
+
+      attr_reader :probes
+
+      def logger
+        Appsignal.logger
+      end
+    end
+
+    class << self
+      # @see ProbeCollection
+      # @return [ProbeCollection] Returns list of probes.
+      def probes
+        @@probes ||= ProbeCollection.new
+      end
+
+      # @api private
       def start
         stop
         @@thread = Thread.new do
           loop do
             logger = Appsignal.logger
             logger.debug("Gathering minutely metrics with #{probes.count} probes")
-            probes.each do |probe|
+            probes.each do |name, probe|
               begin
-                name = probe.class.name
-                logger.debug("Gathering minutely metrics with #{name} probe")
+                logger.debug("Gathering minutely metrics with '#{name}' probe")
                 probe.call
               rescue => ex
-                logger.error("Error in minutely thread (#{name}): #{ex}")
+                logger.error("Error in minutely probe '#{name}': #{ex}")
               end
             end
             sleep(Appsignal::Minutely.wait_time)
@@ -30,16 +128,19 @@ module Appsignal
         end
       end
 
+      # @api private
       def stop
         defined?(@@thread) && @@thread.kill
       end
 
+      # @api private
       def wait_time
         60 - Time.now.sec
       end
 
-      def add_gc_probe
-        probes << GCProbe.new
+      # @api private
+      def register_garbage_collection_probe
+        probes.register :garbage_collection, GCProbe.new
       end
     end
 

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -95,7 +95,7 @@ describe Appsignal do
         end
 
         it "should add the gc probe to minutely" do
-          expect(Appsignal::Minutely).to receive(:add_gc_probe)
+          expect(Appsignal::Minutely).to receive(:register_garbage_collection_probe)
           Appsignal.start
         end
       end
@@ -117,7 +117,7 @@ describe Appsignal do
         end
 
         it "should not add the gc probe to minutely" do
-          expect(Appsignal::Minutely).not_to receive(:add_gc_probe)
+          expect(Appsignal::Minutely).not_to receive(:register_garbage_collection_probe)
           Appsignal.start
         end
       end


### PR DESCRIPTION
Register a minutely probe with a name so it's easier identifiable and
can be overwritten by another probe.

```ruby
probe = lambda { Appsignal.set_gauge "my_gauge", 10 }

# This is deprecated now
Appsignal::Minutely.probes << probe

# Please use this new method of registering probes
Appsignal::Minutely.probes.register :my_probe, probe
```

This allows users to overwrite any of our probes with a new instance
that has custom config for the probe, in case the default config does
not work for their scenario.

This will allow users to quickly get the probe to work and not have to
rely on us to ship a new gem before they can test a certain probe.