### PR TITLE
Enable minutely probes by default

### DIFF
--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -36,7 +36,7 @@ module Appsignal
       :enable_allocation_tracking     => true,
       :enable_gc_instrumentation      => false,
       :enable_host_metrics            => true,
-      :enable_minutely_probes         => false,
+      :enable_minutely_probes         => true,
       :ca_file_path                   => File.expand_path(File.join("../../../resources/cacert.pem"), __FILE__),
       :dns_servers                    => [],
       :files_world_accessible         => true
@@ -214,7 +214,6 @@ module Appsignal
       ENV["_APPSIGNAL_WORKING_DIR_PATH"]             = config_hash[:working_dir_path] if config_hash[:working_dir_path]
       ENV["_APPSIGNAL_WORKING_DIRECTORY_PATH"]       = config_hash[:working_directory_path] if config_hash[:working_directory_path]
       ENV["_APPSIGNAL_ENABLE_HOST_METRICS"]          = config_hash[:enable_host_metrics].to_s
-      ENV["_APPSIGNAL_ENABLE_MINUTELY_PROBES"]       = config_hash[:enable_minutely_probes].to_s
       ENV["_APPSIGNAL_HOSTNAME"]                     = config_hash[:hostname].to_s
       ENV["_APPSIGNAL_PROCESS_NAME"]                 = $PROGRAM_NAME
       ENV["_APPSIGNAL_CA_FILE_PATH"]                 = config_hash[:ca_file_path].to_s

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -130,7 +130,7 @@ describe Appsignal::Config do
         :enable_allocation_tracking     => true,
         :enable_gc_instrumentation      => false,
         :enable_host_metrics            => true,
-        :enable_minutely_probes         => false,
+        :enable_minutely_probes         => true,
         :ca_file_path                   => File.join(resources_dir, "cacert.pem"),
         :dns_servers                    => [],
         :files_world_accessible         => true,
@@ -492,7 +492,6 @@ describe Appsignal::Config do
       expect(ENV["_APPSIGNAL_IGNORE_NAMESPACES"]).to            eq "admin,private_namespace"
       expect(ENV["_APPSIGNAL_RUNNING_IN_CONTAINER"]).to         eq "false"
       expect(ENV["_APPSIGNAL_ENABLE_HOST_METRICS"]).to          eq "true"
-      expect(ENV["_APPSIGNAL_ENABLE_MINUTELY_PROBES"]).to       eq "false"
       expect(ENV["_APPSIGNAL_HOSTNAME"]).to                     eq ""
       expect(ENV["_APPSIGNAL_PROCESS_NAME"]).to                 include "rspec"
       expect(ENV["_APPSIGNAL_CA_FILE_PATH"]).to                 eq File.join(resources_dir, "cacert.pem")


### PR DESCRIPTION
We want to offer more metrics by default by adding default minutely
probes. For those to work without any work for the user enable them by
default.

Users will still be able to disable them by setting the
`enable_minutely_probes` to `false`.

I also removed the `_APPSIGNAL_ENABLE_MINUTELY_PROBES` env variable send
to the extension because it's unused by it.