### PR TITLE
Ensure the minutely probe is stopped during tests

### DIFF
--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -218,7 +218,8 @@ describe Appsignal::Config do
         :active => true,
         :push_api_key => "abc",
         :name => "TestApp",
-        :request_headers => kind_of(Array)
+        :request_headers => kind_of(Array),
+        :enable_minutely_probes => false
       )
     end
 

--- a/spec/lib/appsignal/minutely_spec.rb
+++ b/spec/lib/appsignal/minutely_spec.rb
@@ -1,11 +1,5 @@
 describe Appsignal::Minutely do
-  before do
-    Appsignal::Minutely.stop
-    Appsignal::Minutely.probes.clear
-  end
-  after do
-    Appsignal::Minutely.stop
-  end
+  before { Appsignal::Minutely.probes.clear }
 
   it "returns a ProbeCollection" do
     expect(Appsignal::Minutely.probes)

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -90,12 +90,14 @@ describe Appsignal do
         unless Appsignal::System.jruby?
           it "installs the allocation event hook" do
             expect(Appsignal::Extension).to receive(:install_allocation_event_hook)
+              .and_call_original
             Appsignal.start
           end
         end
 
         it "should add the gc probe to minutely" do
           expect(Appsignal::Minutely).to receive(:register_garbage_collection_probe)
+            .and_call_original
           Appsignal.start
         end
       end

--- a/spec/support/project_fixture/config/appsignal.yml
+++ b/spec/support/project_fixture/config/appsignal.yml
@@ -8,6 +8,7 @@ default: &defaults
     "REQUEST_METHOD", "REQUEST_URI", "SERVER_NAME", "SERVER_PORT",
     "SERVER_PROTOCOL", "HTTP_USER_AGENT"
   ]
+  enable_minutely_probes: false
 
 production:
   <<: *defaults


### PR DESCRIPTION
On JRuby the timings seem different which is why tests are failing with:

```
RuntimeError: can't add a new key into hash during iteration
```

while initializing the probes while no probe should be running.

This is probably because the probes are now enabled by default and not
all tests stop the probe. This change ensures that no probe is continued
after a test and none is active before another test runs.

PR only for build.