### PR TITLE
Add Minutely probe for Unicorn

### DIFF
--- a/lib/appsignal/hooks/unicorn.rb
+++ b/lib/appsignal/hooks/unicorn.rb
@@ -12,6 +12,7 @@ module Appsignal
       end
 
       def install
+        Appsignal::Minutely.probes.register :unicorn, UnicornProbe
         # Make sure that appsignal is started and the last transaction
         # in a worker gets flushed.
         #
@@ -35,6 +36,14 @@ module Appsignal
             Appsignal.stop("unicorn")
             close_without_appsignal
           end
+        end
+      end
+    end
+
+    class UnicornProbe
+      def call
+        ObjectSpace.each_object(Unicorn::HttpServer) do |s|
+          Appsignal.set_gauge("unicorn_worker_count", s.worker_processes)
         end
       end
     end

--- a/spec/lib/appsignal/hooks/unicorn_spec.rb
+++ b/spec/lib/appsignal/hooks/unicorn_spec.rb
@@ -50,3 +50,29 @@ describe Appsignal::Hooks::UnicornHook do
     end
   end
 end
+
+describe Appsignal::Hooks::UnicornProbe do
+  describe "#call" do
+    let(:probe) { described_class.new }
+
+    before do
+      module Unicorn
+        class HttpServer
+          def worker_processes
+            3
+          end
+        end
+      end
+      Unicorn::HttpServer.new
+    end
+    after(:context) { Object.send(:remove_const, :Unicorn) }
+
+    it "sends back the amount of activer workers" do
+      expect(Appsignal).to receive(:set_gauge)
+        .with("unicorn_worker_count", 3)
+        .and_call_original
+
+      probe.call
+    end
+  end
+end


### PR DESCRIPTION
This adds a probe that will send the amount of active workers as a
custom metric.

The dashboard that can be used for this would look like this:

```yaml
-
  title: Unicorn
  graphs:
    -
      title: 'Worker count'
      line_label: Workers
      kind: gauge
      format: number
      fields:
        - unicorn_workers
```