### PR TITLE
Fix Rails6 deprecation warning

### DIFF
--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -182,7 +182,7 @@ module Appsignal
           if rails_app?
             data[:app][:rails] = true
             current_path = Rails.root
-            initial_config[:name] = Rails.application.class.parent_name
+            initial_config[:name] = detected_rails_app_name
             initial_config[:log_path] = current_path.join("log")
           end
 

--- a/lib/appsignal/cli/helpers.rb
+++ b/lib/appsignal/cli/helpers.rb
@@ -5,6 +5,15 @@ module Appsignal
     module Helpers
       private
 
+      def detected_rails_app_name
+        rails_class = Rails.application.class
+        if rails_class.respond_to? :module_parent_name # Rails 6
+          rails_class.module_parent_name
+        else # Older Rails versions
+          rails_class.parent_name
+        end
+      end
+
       def colorize(text, color)
         return text if Gem.win_platform?
 

--- a/lib/appsignal/cli/install.rb
+++ b/lib/appsignal/cli/install.rb
@@ -77,8 +77,7 @@ module Appsignal
 
           require File.expand_path(File.join(Dir.pwd, "config/application.rb"))
 
-          config[:name] = Rails.application.class.parent_name
-
+          config[:name] = detected_rails_app_name
           name_overwritten = yes_or_no("  Your app's name is: '#{config[:name]}' \n  Do you want to change how this is displayed in AppSignal? (y/n): ")
           puts
           if name_overwritten

--- a/spec/lib/appsignal/cli/install_spec.rb
+++ b/spec/lib/appsignal/cli/install_spec.rb
@@ -243,7 +243,12 @@ describe Appsignal::CLI::Install do
 
   if rails_present?
     context "with rails" do
-      let(:installation_instructions) { ["Installing for Ruby on Rails"] }
+      let(:installation_instructions) do
+        [
+          "Installing for Ruby on Rails",
+          "Your app's name is: 'MyApp'"
+        ]
+      end
       let(:app_name) { "MyApp" }
       let(:config_dir) { File.join(tmp_dir, "config") }
       let(:environments_dir) { File.join(config_dir, "environments") }


### PR DESCRIPTION
Use `module_parent_name` rather than `parent_name` for Rails app name
detection. Prevents a deprecation warning from being printed.

```
DEPRECATION WARNING: `Module#parent_name` has been renamed to
  `module_parent_name`. `parent_name` is deprecated and will be removed
  in Rails 6.1. (called from install_for_rails at
  <path>/appsignal/gem/lib/appsignal/cli/install.rb:80)
```

Part of #464 