### PR TITLE
Fix YAML deprecation warning

### DIFF
--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -332,13 +332,9 @@ module Appsignal
         end
 
         def fetch_installation_report
-          raw_report = File.read(File.expand_path("../../../../ext/install.report", __FILE__))
-          method = YAML.respond_to?(:safe_load) ? :safe_load : :load
-          YAML.send(
-            method,
-            raw_report,
-            [Time]
-          )
+          path = File.expand_path("../../../../ext/install.report", __FILE__)
+          raw_report = File.read(path)
+          Utils.parse_yaml(raw_report)
         rescue => e
           {
             "parsing_error" => {

--- a/lib/appsignal/cli/diagnose/utils.rb
+++ b/lib/appsignal/cli/diagnose/utils.rb
@@ -30,6 +30,23 @@ module Appsignal
 
           IO.binread(path, length, offset)
         end
+
+        def self.parse_yaml(contents)
+          arguments = [contents]
+          if YAML.respond_to? :safe_load
+            method = :safe_load
+            arguments << \
+              if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.6.0")
+                # Use keyword params for Ruby 2.6 and up
+                { :permitted_classes => [Time] }
+              else
+                [Time]
+              end
+          else
+            method = :load
+          end
+          YAML.send(method, *arguments)
+        end
       end
     end
   end


### PR DESCRIPTION
On Ruby 2.6 the Psych/YAML Ruby class prefers keyword arguments. Update
the code to use keyword arguments on newer Rubies.

```
<path>/appsignal/gem/lib/appsignal/cli/diagnose.rb:337:
  Passing permitted_classes with the 2nd argument of Psych.safe_load is
  deprecated. Use keyword argument like Psych.safe_load(yaml,
  permitted_classes: ...) instead.
```

Also remove the `permitted_classes` argument value from being passed to
`YAML.load`. The second argument on `YAML.load` is `filename`, not
`permitted_classes`, so omit it entirely for Ruby 2.0 and lower.

Part of #464 