### PR TITLE
Fix Ruby 2.6 ERB deprecation warnings

### DIFF
--- a/lib/appsignal/cli/helpers.rb
+++ b/lib/appsignal/cli/helpers.rb
@@ -14,6 +14,10 @@ module Appsignal
         end
       end
 
+      def ruby_2_6_or_up?
+        Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.6.0")
+      end
+
       def colorize(text, color)
         return text if Gem.win_platform?
 

--- a/lib/appsignal/cli/install.rb
+++ b/lib/appsignal/cli/install.rb
@@ -248,12 +248,19 @@ module Appsignal
         end
 
         def write_config_file(data)
-          template = ERB.new(
-            File.read(File.join(File.dirname(__FILE__), "../../../resources/appsignal.yml.erb")),
-            nil,
-            "-"
+          filename = File.join(
+            File.dirname(__FILE__),
+            "../../../resources/appsignal.yml.erb"
           )
-
+          file_contents = File.read(filename)
+          arguments = [file_contents]
+          if ruby_2_6_or_up?
+            arguments << { :trim_mode => "-" }
+          else
+            arguments << nil
+            arguments << "-"
+          end
+          template = ERB.new(*arguments)
           config = template.result(OpenStruct.new(data).instance_eval { binding })
 
           FileUtils.mkdir_p(File.join(Dir.pwd, "config"))


### PR DESCRIPTION
On Ruby 2.6 the ERB Ruby class prefers keyword arguments for its
initializer. Update the code to use keyword arguments on newer Rubies.

Drop the `safe_level` argument on Ruby 2.6 as we passed in `nil` before
only to set the third `trim_mode` argument.

```
<path>/appsignal-ruby/lib/appsignal/cli/install.rb:252: warning: Passing
  safe_level with the 2nd argument of ERB.new is deprecated. Do not use
  it, and specify other arguments as keyword arguments.

<path>/appsignal-ruby/lib/appsignal/cli/install.rb:252: warning: Passing
  trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword
  argument like ERB.new(str, trim_mode: ...) instead.
```

Part of #464 