### PR TITLE
Support send_error to yield the transaction

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -334,11 +334,22 @@ module Appsignal
     #     Appsignal.send_error(e, :key => "value")
     #   end
     #
+    # @example Add more metadata to transaction
+    #   Appsignal.send_error(e, :key => "value") do |transaction|
+    #     transaction.params(:search_query => params[:search_query])
+    #     transaction.set_action("my_action_name")
+    #     transaction.set_namespace("my_namespace")
+    #   end
+    #
     # @param error [Exception] The error to send to AppSignal.
     # @param tags [Hash{String, Symbol => String, Symbol, Integer}] Additional
     #   tags to add to the error. See also {.tag_request}.
     # @param namespace [String] The namespace in which the error occurred.
     #   See also {.set_namespace}.
+    # @yield [transaction] yields block to allow modification of the
+    #   transaction before its send.
+    # @yieldparam transaction [Transaction] yields the AppSignal transaction
+    #   used to send the error.
     # @return [void]
     #
     # @see http://docs.appsignal.com/ruby/instrumentation/exception-handling.html
@@ -359,6 +370,7 @@ module Appsignal
       )
       transaction.set_tags(tags) if tags
       transaction.set_error(error)
+      yield transaction if block_given?
       transaction.complete
     end
     alias :send_exception :send_error

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -347,7 +347,7 @@ module Appsignal
     # @param namespace [String] The namespace in which the error occurred.
     #   See also {.set_namespace}.
     # @yield [transaction] yields block to allow modification of the
-    #   transaction before its send.
+    #   transaction before it's send.
     # @yieldparam transaction [Transaction] yields the AppSignal transaction
     #   used to send the error.
     # @return [void]

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -652,6 +652,29 @@ describe Appsignal do
 
         after { Appsignal.send_error(error, nil, namespace) }
       end
+
+      context "when given a block" do
+        it "yields the transaction and allows additional metadata to be set" do
+          captured_transaction = nil
+          Appsignal.send_error(StandardError.new("my_error")) do |transaction|
+            captured_transaction = transaction
+            transaction.set_action("my_action")
+            transaction.set_namespace("my_namespace")
+
+            # Don't flush the transaction, so we can inspect it
+            expect(transaction).to receive(:complete)
+          end
+          expect(captured_transaction.to_h).to include(
+            "namespace" => "my_namespace",
+            "action" => "my_action",
+            "error" => {
+              "name" => "StandardError",
+              "message" => "my_error",
+              "backtrace" => kind_of(String) # TODO: should be Array
+            }
+          )
+        end
+      end
     end
 
     describe ".listen_for_error" do


### PR DESCRIPTION
This allows users to add more metadata to the transaction before its
send to AppSignal, such as action name, namespace, etc.

```ruby
Appsignal.send_error(StandardError.new("my_error")) do |transaction|
  transaction.set_action("my_action")
  transaction.set_namespace("my_namespace")
end
```

Closes #407 