### PR TITLE
Fix rails6 deprecation warning parent_name

### DIFF
--- a/lib/appsignal/integrations/railtie.rb
+++ b/lib/appsignal/integrations/railtie.rb
@@ -17,7 +17,7 @@ module Appsignal
         Appsignal.config = Appsignal::Config.new(
           Rails.root,
           Rails.env,
-          :name => Rails.application.class.parent_name,
+          :name => detected_rails_app_name,
           :log_path => Rails.root.join("log")
         )
 
@@ -37,6 +37,15 @@ module Appsignal
         end
 
         Appsignal.start
+      end
+
+      def self.detected_rails_app_name
+        rails_class = Rails.application.class
+        if rails_class.respond_to? :module_parent_name # Rails 6
+          rails_class.module_parent_name
+        else # Older Rails versions
+          rails_class.parent_name
+        end
       end
     end
   end


### PR DESCRIPTION
Fix remainder of deprecated parent_name use - see https://github.com/appsignal/appsignal-ruby/pull/478

```sh
DEPRECATION WARNING: `Module#parent_name` has been renamed to `module_parent_name`. `parent_name` is deprecated and will be removed in Rails 6.1. (called from initialize_appsignal at ~/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/appsignal-ruby-c5edf8e00a7b/lib/appsignal/integrations/railtie.rb:20)
~/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/appsignal-ruby-c5edf8e00a7b/lib/appsignal/integrations/railtie.rb:20:in `initialize_appsignal'
  ~/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/bundler/gems/appsignal-ruby-c5edf8e00a7b/lib/appsignal/integrations/railtie.rb:12:in `block in <class:Railtie>'
 
```