### PR TITLE
Move Rails name helper to a helper module

### DIFF
--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -182,7 +182,8 @@ module Appsignal
           if rails_app?
             data[:app][:rails] = true
             current_path = Rails.root
-            initial_config[:name] = detected_rails_app_name
+            initial_config[:name] =
+              Appsignal::Utils::RailsHelper.detected_rails_app_name
             initial_config[:log_path] = current_path.join("log")
           end
 

--- a/lib/appsignal/cli/helpers.rb
+++ b/lib/appsignal/cli/helpers.rb
@@ -1,18 +1,11 @@
 # frozen_string_literal: true
 
+require "appsignal/utils/rails_helper"
+
 module Appsignal
   class CLI
     module Helpers
       private
-
-      def detected_rails_app_name
-        rails_class = Rails.application.class
-        if rails_class.respond_to? :module_parent_name # Rails 6
-          rails_class.module_parent_name
-        else # Older Rails versions
-          rails_class.parent_name
-        end
-      end
 
       def ruby_2_6_or_up?
         Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.6.0")

--- a/lib/appsignal/cli/install.rb
+++ b/lib/appsignal/cli/install.rb
@@ -77,7 +77,7 @@ module Appsignal
 
           require File.expand_path(File.join(Dir.pwd, "config/application.rb"))
 
-          config[:name] = detected_rails_app_name
+          config[:name] = Appsignal::Utils::RailsHelper.detected_rails_app_name
           name_overwritten = yes_or_no("  Your app's name is: '#{config[:name]}' \n  Do you want to change how this is displayed in AppSignal? (y/n): ")
           puts
           if name_overwritten

--- a/lib/appsignal/integrations/railtie.rb
+++ b/lib/appsignal/integrations/railtie.rb
@@ -2,6 +2,7 @@
 
 Appsignal.logger.info("Loading Rails (#{Rails.version}) integration")
 
+require "appsignal/utils/rails_helper"
 require "appsignal/rack/rails_instrumentation"
 
 module Appsignal
@@ -17,7 +18,7 @@ module Appsignal
         Appsignal.config = Appsignal::Config.new(
           Rails.root,
           Rails.env,
-          :name => detected_rails_app_name,
+          :name => Appsignal::Utils::RailsHelper.detected_rails_app_name,
           :log_path => Rails.root.join("log")
         )
 
@@ -37,15 +38,6 @@ module Appsignal
         end
 
         Appsignal.start
-      end
-
-      def self.detected_rails_app_name
-        rails_class = Rails.application.class
-        if rails_class.respond_to? :module_parent_name # Rails 6
-          rails_class.module_parent_name
-        else # Older Rails versions
-          rails_class.parent_name
-        end
       end
     end
   end

--- a/lib/appsignal/utils/rails_helper.rb
+++ b/lib/appsignal/utils/rails_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Appsignal
+  module Utils
+    module RailsHelper
+      def self.detected_rails_app_name
+        rails_class = Rails.application.class
+        if rails_class.respond_to? :module_parent_name # Rails 6
+          rails_class.module_parent_name
+        else # Older Rails versions
+          rails_class.parent_name
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
So we don't reimplement the logic for the CLIs and Railtie separately.

Follow up of #483 