### PR TITLE
Add Puma minutely probe

### DIFF
--- a/lib/appsignal/hooks/puma.rb
+++ b/lib/appsignal/hooks/puma.rb
@@ -77,7 +77,7 @@ module Appsignal
           counts[:max_threads] += stats[:max_threads]
         end
 
-        puma_gauge(counts[:backlog], :backlog)
+        puma_gauge(counts[:backlog], :connections_backlog)
         puma_gauge(counts[:running], :running)
         puma_gauge(counts[:pool_capacity], :pool_capacity)
         puma_gauge(counts[:max_threads], :max_threads)

--- a/lib/appsignal/hooks/puma.rb
+++ b/lib/appsignal/hooks/puma.rb
@@ -39,7 +39,6 @@ module Appsignal
     end
 
     class PumaProbe
-
       def initialize
         @hostname = Appsignal.config[:hostname] || Socket.gethostname
       end
@@ -85,6 +84,7 @@ module Appsignal
       end
 
       private
+
       attr_reader :hostname
 
       def puma_gauge(count, field, tags = {})

--- a/lib/appsignal/hooks/puma.rb
+++ b/lib/appsignal/hooks/puma.rb
@@ -39,7 +39,6 @@ module Appsignal
     end
 
     class PumaProbe
-      attr_reader :hostname
 
       def initialize
         @hostname = Appsignal.config[:hostname] || Socket.gethostname
@@ -84,6 +83,9 @@ module Appsignal
         puma_gauge(counts[:pool_capacity], :pool_capacity)
         puma_gauge(counts[:max_threads], :max_threads)
       end
+
+      private
+      attr_reader :hostname
 
       def puma_gauge(count, field, tags = {})
         Appsignal.set_gauge("puma_#{field}", count, tags.merge(:hostname => hostname))

--- a/lib/appsignal/hooks/puma.rb
+++ b/lib/appsignal/hooks/puma.rb
@@ -64,9 +64,9 @@ module Appsignal
             counts[:max_threads] += stat[:max_threads]
           end
 
-          gauge(:workers, stats[:workers], :kind => :count)
-          gauge(:workers, stats[:booted_workers], :kind => :booted)
-          gauge(:workers, stats[:old_workers], :kind => :old)
+          gauge(:workers, stats[:workers], :type => :count)
+          gauge(:workers, stats[:booted_workers], :type => :booted)
+          gauge(:workers, stats[:old_workers], :type => :old)
 
         else # Single worker
           counts[:backlog] += stats[:backlog]
@@ -75,10 +75,10 @@ module Appsignal
           counts[:max_threads] += stats[:max_threads]
         end
 
-        gauge(:connections_backlog, counts[:backlog])
-        gauge(:running, counts[:running])
+        gauge(:connection_backlog, counts[:backlog])
         gauge(:pool_capacity, counts[:pool_capacity])
-        gauge(:max_threads, counts[:max_threads])
+        gauge(:threads, counts[:running], :type => :running)
+        gauge(:threads, counts[:max_threads], :type => :max)
       end
 
       private

--- a/lib/appsignal/hooks/puma.rb
+++ b/lib/appsignal/hooks/puma.rb
@@ -7,20 +7,24 @@ module Appsignal
       register :puma
 
       def dependencies_present?
-        defined?(::Puma) &&
-          ::Puma.respond_to?(:cli_config) &&
-          ::Puma.cli_config
+        defined?(::Puma)
       end
 
       def install
-        ::Puma.cli_config.options[:before_worker_boot] ||= []
-        ::Puma.cli_config.options[:before_worker_boot] << proc do |_id|
-          Appsignal.forked
+        if ::Puma.respond_to?(:stats)
+          Appsignal::Minutely.probes.register :puma, PumaProbe
         end
 
-        ::Puma.cli_config.options[:before_worker_shutdown] ||= []
-        ::Puma.cli_config.options[:before_worker_shutdown] << proc do |_id|
-          Appsignal.stop("puma before_worker_shutdown")
+        if ::Puma.respond_to?(:cli_config) && ::Puma.cli_config
+          ::Puma.cli_config.options[:before_worker_boot] ||= []
+          ::Puma.cli_config.options[:before_worker_boot] << proc do |_id|
+            Appsignal.forked
+          end
+
+          ::Puma.cli_config.options[:before_worker_shutdown] ||= []
+          ::Puma.cli_config.options[:before_worker_shutdown] << proc do |_id|
+            Appsignal.stop("puma before_worker_shutdown")
+          end
         end
 
         ::Puma::Cluster.class_eval do
@@ -31,6 +35,58 @@ module Appsignal
             stop_workers_without_appsignal
           end
         end
+      end
+    end
+
+    class PumaProbe
+      attr_reader :hostname
+
+      def initialize
+        @hostname = Appsignal.config[:hostname] || Socket.gethostname
+      end
+
+      def call
+        return unless ::Puma.stats
+
+        stats = JSON.parse Puma.stats, :symbolize_names => true
+        counts = {
+          :backlog => 0,
+          :running => 0,
+          :pool_capacity => 0,
+          :max_threads => 0
+        }
+
+        # Multiple workers
+        if stats[:worker_status]
+          stats[:worker_status].each do |worker|
+            stat = worker[:last_status]
+
+            counts[:backlog] += stat[:backlog]
+            counts[:running] += stat[:running]
+            counts[:pool_capacity] += stat[:pool_capacity]
+            counts[:max_threads] += stat[:max_threads]
+          end
+
+          puma_gauge(stats[:workers], :workers, :kind => :count)
+          puma_gauge(stats[:booted_workers], :workers, :kind => :booted)
+          puma_gauge(stats[:old_workers], :workers, :kind => :old)
+
+        # Single worker
+        else
+          counts[:backlog] += stats[:backlog]
+          counts[:running] += stats[:running]
+          counts[:pool_capacity] += stats[:pool_capacity]
+          counts[:max_threads] += stats[:max_threads]
+        end
+
+        puma_gauge(counts[:backlog], :backlog)
+        puma_gauge(counts[:running], :running)
+        puma_gauge(counts[:pool_capacity], :pool_capacity)
+        puma_gauge(counts[:max_threads], :max_threads)
+      end
+
+      def puma_gauge(count, field, tags = {})
+        Appsignal.set_gauge("puma_#{field}", count, tags.merge(:hostname => hostname))
       end
     end
   end

--- a/spec/lib/appsignal/hooks/puma_spec.rb
+++ b/spec/lib/appsignal/hooks/puma_spec.rb
@@ -154,7 +154,7 @@ describe Appsignal::Hooks::PumaProbe do
         expect_gauge(2, :workers, :kind => :booted)
         expect_gauge(0, :workers, :kind => :old)
 
-        expect_gauge(0, :backlog)
+        expect_gauge(0, :connections_backlog)
         expect_gauge(10, :running)
         expect_gauge(10, :pool_capacity)
         expect_gauge(10, :max_threads)
@@ -177,7 +177,7 @@ describe Appsignal::Hooks::PumaProbe do
       after(:context) { Object.send(:remove_const, :Puma) }
 
       it "calls `puma_gauge` with the (summed) worker metrics" do
-        expect_gauge(0, :backlog)
+        expect_gauge(0, :connections_backlog)
         expect_gauge(5, :running)
         expect_gauge(5, :pool_capacity)
         expect_gauge(5, :max_threads)

--- a/spec/lib/appsignal/hooks/puma_spec.rb
+++ b/spec/lib/appsignal/hooks/puma_spec.rb
@@ -150,14 +150,14 @@ describe Appsignal::Hooks::PumaProbe do
       after(:context) { Object.send(:remove_const, :Puma) }
 
       it "calls `puma_gauge` with the (summed) worker metrics" do
-        expect_gauge(2, :workers, :type => :count)
-        expect_gauge(2, :workers, :type => :booted)
-        expect_gauge(0, :workers, :type => :old)
+        expect_gauge(:workers, 2, :type => :count)
+        expect_gauge(:workers, 2, :type => :booted)
+        expect_gauge(:workers, 0, :type => :old)
 
-        expect_gauge(0, :connection_backlog)
-        expect_gauge(10, :pool_capacity)
-        expect_gauge(10, :threads, :type => :running)
-        expect_gauge(10, :threads, :type => :max)
+        expect_gauge(:connection_backlog, 0)
+        expect_gauge(:pool_capacity, 10)
+        expect_gauge(:threads, 10, :type => :running)
+        expect_gauge(:threads, 10, :type => :max)
       end
     end
 
@@ -177,10 +177,10 @@ describe Appsignal::Hooks::PumaProbe do
       after(:context) { Object.send(:remove_const, :Puma) }
 
       it "calls `puma_gauge` with the (summed) worker metrics" do
-        expect_gauge(0, :connection_backlog)
-        expect_gauge(5, :pool_capacity)
-        expect_gauge(5, :threads, :type => :running)
-        expect_gauge(5, :threads, :type => :max)
+        expect_gauge(:connection_backlog, 0)
+        expect_gauge(:pool_capacity, 5)
+        expect_gauge(:threads, 5, :type => :running)
+        expect_gauge(:threads, 5, :type => :max)
       end
     end
 
@@ -200,7 +200,7 @@ describe Appsignal::Hooks::PumaProbe do
 
     after { probe.call }
 
-    def expect_gauge(value, key, tags = {})
+    def expect_gauge(key, value, tags = {})
       expect(Appsignal).to receive(:set_gauge)
         .with("puma_#{key}", value, expected_default_tags.merge(tags))
         .and_call_original

--- a/spec/lib/appsignal/hooks/puma_spec.rb
+++ b/spec/lib/appsignal/hooks/puma_spec.rb
@@ -2,6 +2,9 @@ describe Appsignal::Hooks::PumaHook do
   context "with puma" do
     before(:context) do
       class Puma
+        def self.stats
+        end
+
         def self.cli_config
           @cli_config ||= CliConfig.new
         end
@@ -41,6 +44,11 @@ describe Appsignal::Hooks::PumaHook do
 
         cluster.stop_workers
       end
+
+      it "adds the Puma minutely probe" do
+        probe = Appsignal::Minutely.probes[:puma]
+        expect(probe).to eql(Appsignal::Hooks::PumaProbe)
+      end
     end
 
     context "with nil hooks" do
@@ -75,6 +83,130 @@ describe Appsignal::Hooks::PumaHook do
       subject { described_class.new.dependencies_present? }
 
       it { is_expected.to be_falsy }
+    end
+  end
+end
+
+describe Appsignal::Hooks::PumaProbe do
+  before(:context) do
+    Appsignal.config = project_fixture_config
+  end
+  after(:context) do
+    Appsignal.config = nil
+  end
+
+  let(:probe) { Appsignal::Hooks::PumaProbe.new }
+
+  describe "hostname" do
+    it "returns the socket hostname" do
+      expect(probe.hostname).to eql(Socket.gethostname)
+    end
+
+    it "returns the configured host" do
+      Appsignal.config[:hostname] = "frontend1"
+
+      expect(probe.hostname).to eql("frontend1")
+    end
+  end
+
+  describe "#call" do
+    context "with multiple worker stats" do
+      before(:context) do
+        class Puma
+          def self.stats
+            {
+              "workers" => 2,
+              "booted_workers" => 2,
+              "old_workers" => 0,
+              "worker_status" => [
+                {
+                  "last_status" => {
+                    "backlog" => 0,
+                    "running" => 5,
+                    "pool_capacity" => 5,
+                    "max_threads" => 5
+                  }
+                },
+                {
+                  "last_status" => {
+                    "backlog" => 0,
+                    "running" => 5,
+                    "pool_capacity" => 5,
+                    "max_threads" => 5
+                  }
+                }
+              ]
+            }.to_json
+          end
+        end
+      end
+      after(:context) { Object.send(:remove_const, :Puma) }
+
+      it "calls `puma_gauge` with the (summed) worker metrics" do
+        expect(probe).to receive(:puma_gauge).with(2, :workers, :kind => :count)
+        expect(probe).to receive(:puma_gauge).with(2, :workers, :kind => :booted)
+        expect(probe).to receive(:puma_gauge).with(0, :workers, :kind => :old)
+
+        expect(probe).to receive(:puma_gauge).with(0, :backlog)
+        expect(probe).to receive(:puma_gauge).with(10, :running)
+        expect(probe).to receive(:puma_gauge).with(10, :pool_capacity)
+        expect(probe).to receive(:puma_gauge).with(10, :max_threads)
+      end
+    end
+
+    context "with single worker stats" do
+      before(:context) do
+        class Puma
+          def self.stats
+            {
+              "backlog" => 0,
+              "running" => 5,
+              "pool_capacity" => 5,
+              "max_threads" => 5
+            }.to_json
+          end
+        end
+      end
+      after(:context) { Object.send(:remove_const, :Puma) }
+
+      it "calls `puma_gauge` with the (summed) worker metrics" do
+        expect(probe).to receive(:puma_gauge).with(0, :backlog)
+        expect(probe).to receive(:puma_gauge).with(5, :running)
+        expect(probe).to receive(:puma_gauge).with(5, :pool_capacity)
+        expect(probe).to receive(:puma_gauge).with(5, :max_threads)
+      end
+    end
+
+    context "without stats" do
+      before(:context) do
+        class Puma
+          def self.stats
+          end
+        end
+      end
+      after(:context) { Object.send(:remove_const, :Puma) }
+
+      it "does not track metrics" do
+        expect(probe).to_not receive(:puma_gauge)
+      end
+    end
+
+    after { probe.call }
+  end
+
+  describe "#puma_gauge" do
+    it "prefixes the name with puma_ and adds hostname" do
+      expect(Appsignal).to receive(:set_gauge)
+        .with("puma_workers", 10, :hostname => probe.hostname)
+
+      probe.puma_gauge(10, "workers")
+    end
+
+    it "merges the hostname tag with given tags" do
+      expect(Appsignal).to receive(:set_gauge)
+        .with("puma_workers", 10, :kind => :idle, :hostname => probe.hostname)
+
+      probe.puma_gauge(10, "workers", :kind => :idle)
     end
   end
 end

--- a/spec/lib/appsignal/hooks/puma_spec.rb
+++ b/spec/lib/appsignal/hooks/puma_spec.rb
@@ -150,14 +150,14 @@ describe Appsignal::Hooks::PumaProbe do
       after(:context) { Object.send(:remove_const, :Puma) }
 
       it "calls `puma_gauge` with the (summed) worker metrics" do
-        expect_gauge(2, :workers, :kind => :count)
-        expect_gauge(2, :workers, :kind => :booted)
-        expect_gauge(0, :workers, :kind => :old)
+        expect_gauge(2, :workers, :type => :count)
+        expect_gauge(2, :workers, :type => :booted)
+        expect_gauge(0, :workers, :type => :old)
 
-        expect_gauge(0, :connections_backlog)
-        expect_gauge(10, :running)
+        expect_gauge(0, :connection_backlog)
         expect_gauge(10, :pool_capacity)
-        expect_gauge(10, :max_threads)
+        expect_gauge(10, :threads, :type => :running)
+        expect_gauge(10, :threads, :type => :max)
       end
     end
 
@@ -177,10 +177,10 @@ describe Appsignal::Hooks::PumaProbe do
       after(:context) { Object.send(:remove_const, :Puma) }
 
       it "calls `puma_gauge` with the (summed) worker metrics" do
-        expect_gauge(0, :connections_backlog)
-        expect_gauge(5, :running)
+        expect_gauge(0, :connection_backlog)
         expect_gauge(5, :pool_capacity)
-        expect_gauge(5, :max_threads)
+        expect_gauge(5, :threads, :type => :running)
+        expect_gauge(5, :threads, :type => :max)
       end
     end
 


### PR DESCRIPTION
* Detect if `::Puma` is defined and if it responds to `stats`.
* Install the probe
* Get the `::Puma.stats` if present, and parse the JSON
* Emit gauges for the stats, summing the details for each worker.

### To discuss

* [x] Do we want to emit the worker metrics (count/running etc). This will generate an empty graph on the dashboard if you run Puma with just one worker. 


```yaml
title: Puma metrics
description: Track Puma workers on this dashboard, see how many worker processes are running and what the used/available concurrency is for those workers. 
graphs:
  - title: Threads running/max/idle
    line_label: '%hostname% - %type%'
    metrics:
      - name: puma_threads
        fields:
          - GAUGE
        tags:
          hostname: '*'
          type: "*"
  - title: Connection backlog
    line_label: '%hostname%'
    metrics:
      - name: puma_connection_backlog
        fields:
          - GAUGE
        tags:
          hostname: '*'
  - title: Pool capacity
    line_label: '%hostname%'
    metrics:
      - name: puma_pool_capacity
        fields:
          - GAUGE
        tags:
          hostname: '*'

  - title: Puma worker info
    line_label: '%hostname% - %kind%'
    metrics:
      - name: puma_workers
        fields:
          - GAUGE
        tags:
          hostname: '*'
          type: '*'
```