### PR TITLE
Refactor EventFormatter specs

### DIFF
--- a/spec/support/helpers/log_helpers.rb
+++ b/spec/support/helpers/log_helpers.rb
@@ -1,4 +1,10 @@
 module LogHelpers
+  def capture_logs(&block)
+    log = std_stream
+    use_logger_with(log, &block)
+    log_contents(log)
+  end
+
   def use_logger_with(log)
     Appsignal.logger = test_logger(log)
     yield


### PR DESCRIPTION
To more explicit in test naming what is being tested and group them with
describe blocks for every public method.

Also add the missing case of the missing `format/2` method check.

PR only for build.