### PR TITLE
Log invalid EventFormatter registrations as errors

### DIFF
--- a/lib/appsignal/event_formatter.rb
+++ b/lib/appsignal/event_formatter.rb
@@ -84,7 +84,7 @@ module Appsignal
       rescue => ex
         formatter_classes.delete(name)
         formatters.delete(name)
-        logger.warn("'#{ex.message}' when initializing #{name} event formatter")
+        logger.error("'#{ex.message}' when initializing #{name} event formatter")
       end
 
       def register_deprecated_formatter(name)

--- a/spec/lib/appsignal/event_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter_spec.rb
@@ -63,24 +63,24 @@ describe Appsignal::EventFormatter do
     end
 
     context "when there is an error initializing the formatter" do
-      it "does not register the formatter and logs a warning" do
+      it "does not register the formatter and logs an error" do
         logs = capture_logs do
           described_class.register "mock.dependent", MockDependentFormatter
         end
         expect(klass.registered?("mock.dependent")).to be_falsy
-        expect(logs).to contains_log :warn, \
+        expect(logs).to contains_log :error, \
           "'uninitialized constant MockDependentFormatter::NonsenseDependency' " \
           "when initializing mock.dependent event formatter"
       end
     end
 
     context "when formatter has no format/2 method" do
-      it "does not register the formatter and logs a warning" do
+      it "does not register the formatter and logs an error" do
         logs = capture_logs do
           described_class.register "mock.incorrect", IncorrectFormatMockFormatter
         end
         expect(klass.registered?("mock.incorrect")).to be_falsy
-        expect(logs).to contains_log :warn, \
+        expect(logs).to contains_log :error, \
           "'IncorrectFormatMockFormatter does not have a format(payload) " \
           "method' when initializing mock.incorrect event formatter"
       end


### PR DESCRIPTION
When a problem occurred during registration, log it as an error instead
of a warning. An error indicates better that something went wrong and
the registration was not successful. A warning is a bit more vague about
that.