### PR TITLE
Use guards for checks rather than if-statements

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -99,13 +99,3 @@ Style/ClassVars:
 Style/DoubleNegation:
   Exclude:
     - 'lib/appsignal.rb'
-
-# Offense count: 5
-# Configuration parameters: MinBodyLength.
-Style/GuardClause:
-  Exclude:
-    - 'lib/appsignal.rb'
-    - 'lib/appsignal/event_formatter.rb'
-    - 'lib/appsignal/event_formatter/moped/query_formatter.rb'
-    - 'lib/appsignal/hooks.rb'
-    - 'lib/appsignal/marker.rb'

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -223,6 +223,10 @@ module Appsignal
     # @return [void]
     # @since 0.7.0
     def start_logger(path_arg = nil)
+      if path_arg
+        logger.info("Setting the path in start_logger has no effect anymore, set it in the config instead")
+      end
+
       if config && config[:log] == "file" && config.log_file_path
         start_file_logger(config.log_file_path)
       else
@@ -237,10 +241,6 @@ module Appsignal
         end
 
       logger << @in_memory_log.string if @in_memory_log
-
-      if path_arg
-        logger.info("Setting the path in start_logger has no effect anymore, set it in the config instead")
-      end
     end
 
     # Returns if the C-extension was loaded properly.

--- a/lib/appsignal/event_formatter.rb
+++ b/lib/appsignal/event_formatter.rb
@@ -75,12 +75,11 @@ module Appsignal
 
       def initialize_formatter(name, formatter)
         format_method = formatter.instance_method(:format)
-        if format_method && format_method.arity == 1
-          formatter_classes[name] = formatter
-          formatters[name] = formatter.new
-        else
+        if !format_method || format_method.arity != 1
           raise "#{formatter} does not have a format(payload) method"
         end
+        formatter_classes[name] = formatter
+        formatters[name] = formatter.new
       rescue => ex
         formatter_classes.delete(name)
         formatters.delete(name)

--- a/lib/appsignal/event_formatter/moped/query_formatter.rb
+++ b/lib/appsignal/event_formatter/moped/query_formatter.rb
@@ -6,65 +6,66 @@ module Appsignal
     module Moped
       class QueryFormatter
         def format(payload)
-          if payload[:ops] && !payload[:ops].empty?
-            op = payload[:ops].first
-            case op.class.to_s
-            when "Moped::Protocol::Command"
-              [
-                "Command", {
-                  :database => op.full_collection_name,
-                  :selector => sanitize(op.selector, true, :mongodb)
-                }.inspect
-              ]
-            when "Moped::Protocol::Query"
-              [
-                "Query", {
-                  :database => op.full_collection_name,
-                  :selector => sanitize(op.selector, false, :mongodb),
-                  :flags    => op.flags,
-                  :limit    => op.limit,
-                  :skip     => op.skip,
-                  :fields   => op.fields
-                }.inspect
-              ]
-            when "Moped::Protocol::Delete"
-              [
-                "Delete", {
-                  :database => op.full_collection_name,
-                  :selector => sanitize(op.selector, false, :mongodb),
-                  :flags    => op.flags
-                }.inspect
-              ]
-            when "Moped::Protocol::Insert"
-              [
-                "Insert", {
-                  :database   => op.full_collection_name,
-                  :documents  => sanitize(op.documents, true, :mongodb),
-                  :count      => op.documents.count,
-                  :flags      => op.flags
-                }.inspect
-              ]
-            when "Moped::Protocol::Update"
-              [
-                "Update",
-                {
-                  :database => op.full_collection_name,
-                  :selector => sanitize(op.selector, false, :mongodb),
-                  :update   => sanitize(op.update, true, :mongodb),
-                  :flags    => op.flags
-                }.inspect
-              ]
-            when "Moped::Protocol::KillCursors"
-              [
-                "KillCursors",
-                { :number_of_cursor_ids => op.number_of_cursor_ids }.inspect
-              ]
-            else
-              [
-                op.class.to_s.sub("Moped::Protocol::", ""),
-                { :database => op.full_collection_name }.inspect
-              ]
-            end
+          return unless payload[:ops]
+          return if payload[:ops].empty?
+
+          op = payload[:ops].first
+          case op.class.to_s
+          when "Moped::Protocol::Command"
+            [
+              "Command", {
+                :database => op.full_collection_name,
+                :selector => sanitize(op.selector, true, :mongodb)
+              }.inspect
+            ]
+          when "Moped::Protocol::Query"
+            [
+              "Query", {
+                :database => op.full_collection_name,
+                :selector => sanitize(op.selector, false, :mongodb),
+                :flags    => op.flags,
+                :limit    => op.limit,
+                :skip     => op.skip,
+                :fields   => op.fields
+              }.inspect
+            ]
+          when "Moped::Protocol::Delete"
+            [
+              "Delete", {
+                :database => op.full_collection_name,
+                :selector => sanitize(op.selector, false, :mongodb),
+                :flags    => op.flags
+              }.inspect
+            ]
+          when "Moped::Protocol::Insert"
+            [
+              "Insert", {
+                :database   => op.full_collection_name,
+                :documents  => sanitize(op.documents, true, :mongodb),
+                :count      => op.documents.count,
+                :flags      => op.flags
+              }.inspect
+            ]
+          when "Moped::Protocol::Update"
+            [
+              "Update",
+              {
+                :database => op.full_collection_name,
+                :selector => sanitize(op.selector, false, :mongodb),
+                :update   => sanitize(op.update, true, :mongodb),
+                :flags    => op.flags
+              }.inspect
+            ]
+          when "Moped::Protocol::KillCursors"
+            [
+              "KillCursors",
+              { :number_of_cursor_ids => op.number_of_cursor_ids }.inspect
+            ]
+          else
+            [
+              op.class.to_s.sub("Moped::Protocol::", ""),
+              { :database => op.full_collection_name }.inspect
+            ]
           end
         end
 

--- a/lib/appsignal/hooks.rb
+++ b/lib/appsignal/hooks.rb
@@ -29,14 +29,15 @@ module Appsignal
       end
 
       def try_to_install(name)
-        if dependencies_present? && !installed?
-          Appsignal.logger.info("Installing #{name} hook")
-          begin
-            install
-            @installed = true
-          rescue => ex
-            Appsignal.logger.error("Error while installing #{name} hook: #{ex}")
-          end
+        return unless dependencies_present?
+        return if installed?
+
+        Appsignal.logger.info("Installing #{name} hook")
+        begin
+          install
+          @installed = true
+        rescue => ex
+          Appsignal.logger.error("Error while installing #{name} hook: #{ex}")
         end
       end
 

--- a/lib/appsignal/marker.rb
+++ b/lib/appsignal/marker.rb
@@ -53,11 +53,10 @@ module Appsignal
         "revision: #{marker_data[:revision]}, user: #{marker_data[:user]}"
 
       response = transmitter.transmit(marker_data)
-      if response.code == "200"
-        puts "AppSignal has been notified of this deploy!"
-      else
+      unless response.code == "200"
         raise "#{response.code} at #{transmitter.uri}"
       end
+      puts "AppSignal has been notified of this deploy!"
     rescue => e
       puts "Something went wrong while trying to notify AppSignal: #{e}"
     end

--- a/spec/lib/appsignal/event_formatter/moped/query_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/moped/query_formatter_spec.rb
@@ -16,6 +16,12 @@ describe Appsignal::EventFormatter::Moped::QueryFormatter do
       it { is_expected.to be_nil }
     end
 
+    context "when ops is nil in the payload" do
+      let(:payload) { { :ops => nil } }
+
+      it { is_expected.to be_nil }
+    end
+
     context "Moped::Protocol::Command" do
       let(:op) do
         double(

--- a/spec/lib/appsignal/event_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter_spec.rb
@@ -13,13 +13,16 @@ end
 class MockFormatterDouble < MockFormatter
 end
 
-class MissingFormatMockFormatter < Appsignal::EventFormatter
-  def transform(_payload)
-  end
+class MissingFormatMockFormatter
 end
 
 class IncorrectFormatMockFormatter < Appsignal::EventFormatter
   def format
+  end
+end
+
+class IncorrectFormatMock2Formatter < Appsignal::EventFormatter
+  def format(_payload, _foo = nil)
   end
 end
 
@@ -74,15 +77,41 @@ describe Appsignal::EventFormatter do
       end
     end
 
-    context "when formatter has no format/2 method" do
-      it "does not register the formatter and logs an error" do
-        logs = capture_logs do
-          described_class.register "mock.incorrect", IncorrectFormatMockFormatter
+    context "when formatter has no format/1 method" do
+      context "when the formatter has no format method" do
+        it "does not register the formatter and logs an error" do
+          logs = capture_logs do
+            described_class.register "mock.missing", MissingFormatMockFormatter
+          end
+          expect(klass.registered?("mock.missing")).to be_falsy
+          expect(logs).to contains_log :error, \
+            "'MissingFormatMockFormatter does not have a format(payload) " \
+            "method' when initializing mock.missing event formatter"
         end
-        expect(klass.registered?("mock.incorrect")).to be_falsy
-        expect(logs).to contains_log :error, \
-          "'IncorrectFormatMockFormatter does not have a format(payload) " \
-          "method' when initializing mock.incorrect event formatter"
+      end
+
+      context "when the formatter has an format/0 method" do
+        it "does not register the formatter and logs an error" do
+          logs = capture_logs do
+            described_class.register "mock.incorrect", IncorrectFormatMockFormatter
+          end
+          expect(klass.registered?("mock.incorrect")).to be_falsy
+          expect(logs).to contains_log :error, \
+            "'IncorrectFormatMockFormatter does not have a format(payload) " \
+            "method' when initializing mock.incorrect event formatter"
+        end
+      end
+
+      context "when formatter has an format/2 method" do
+        it "does not register the formatter and logs an error" do
+          logs = capture_logs do
+            described_class.register "mock.incorrect", IncorrectFormatMock2Formatter
+          end
+          expect(klass.registered?("mock.incorrect")).to be_falsy
+          expect(logs).to contains_log :error, \
+            "'IncorrectFormatMock2Formatter does not have a format(payload) " \
+            "method' when initializing mock.incorrect event formatter"
+        end
       end
     end
 


### PR DESCRIPTION
If statements indent the entire block while it's only a small check that
needs to be performed. Use guards instead to exit methods early or by
print warnings earlier.