### PR TITLE
Log error backtraces in minutely probes

### DIFF
--- a/lib/appsignal/minutely.rb
+++ b/lib/appsignal/minutely.rb
@@ -145,7 +145,8 @@ module Appsignal
                 logger.debug("Gathering minutely metrics with '#{name}' probe")
                 probe.call
               rescue => ex
-                logger.error("Error in minutely probe '#{name}': #{ex}")
+                logger.error "Error in minutely probe '#{name}': #{ex}\n"
+                logger.debug ex.backtrace.join("\n")
               end
             end
             sleep(Appsignal::Minutely.wait_time)

--- a/spec/lib/appsignal/minutely_spec.rb
+++ b/spec/lib/appsignal/minutely_spec.rb
@@ -87,6 +87,9 @@ describe Appsignal::Minutely do
         expect(log).to contains_log(:debug, "Gathering minutely metrics with 2 probes")
         expect(log).to contains_log(:debug, "Gathering minutely metrics with 'my_probe' probe")
         expect(log).to contains_log(:debug, "Gathering minutely metrics with 'broken_probe' probe")
+        expect(log).to contains_log(:error, "Error in minutely probe 'broken_probe': oh no!")
+        gem_path = File.expand_path("../../../../", __FILE__) # Start of backtrace
+        expect(log).to contains_log(:debug, gem_path)
       end
     end
 


### PR DESCRIPTION
When an error occurs in a minutely probe log the entire backtrace of the
error to make it easier to track down where an error originated from.