### PR TITLE
Fix Puma.stats calls

### DIFF
--- a/lib/appsignal/hooks/puma.rb
+++ b/lib/appsignal/hooks/puma.rb
@@ -44,9 +44,10 @@ module Appsignal
       end
 
       def call
-        return unless ::Puma.stats
+        puma_stats = fetch_puma_stats
+        return unless puma_stats
 
-        stats = JSON.parse Puma.stats, :symbolize_names => true
+        stats = JSON.parse puma_stats, :symbolize_names => true
         counts = {
           :backlog => 0,
           :running => 0,
@@ -87,6 +88,11 @@ module Appsignal
 
       def gauge(field, count, tags = {})
         Appsignal.set_gauge("puma_#{field}", count, tags.merge(:hostname => hostname))
+      end
+
+      def fetch_puma_stats
+        ::Puma.stats
+      rescue NoMethodError # rubocop:disable Lint/HandleExceptions
       end
     end
   end


### PR DESCRIPTION
In some scenarios this results in the following error:

```
[2019-03-27T20:57:30 (process) #17250][ERROR] Error in minutely probe 'puma': undefined method `stats' for nil:NilClass
/Users/tombruijn/.gem/ruby/2.5.3/gems/puma-3.12.1/lib/puma.rb:21:in `stats'
/Users/tombruijn/appsignal/gem/lib/appsignal/hooks/puma.rb:47:in `call'
/Users/tombruijn/appsignal/gem/lib/appsignal/minutely.rb:146:in `block (3 levels) in start'
/Users/tombruijn/appsignal/gem/lib/appsignal/minutely.rb:143:in `each'
/Users/tombruijn/appsignal/gem/lib/appsignal/minutely.rb:143:in `block (2 levels) in start'
/Users/tombruijn/appsignal/gem/lib/appsignal/minutely.rb:140:in `loop'
/Users/tombruijn/appsignal/gem/lib/appsignal/minutely.rb:140:in `block in start'
```

Make sure that we always call the top-level constant of the Puma class,
and not accidentally some other class.

## TODO

- [x] Accurately reproduce the issue causing the error in the log. Can reproduce on Puma 3.12.1