### PR TITLE
Update local build test script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,7 @@ Gemfile.lock
 gemfiles/*.lock
 .DS_Store
 .ruby-version
-bundle_and_spec_all_rbenv
-bundle_and_spec_all_rvm
+bundle_and_spec_all_*
 ext/libappsignal.*
 ext/appsignal-agent
 ext/appsignal.h

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # DO NOT EDIT
-# This is a generated file by the `rake travis:generate` task.
+# This is a generated file by the `rake build_matrix:travis:generate` task.
 # See `build_matrix.yml` for the build matrix.
-# Generate this file with `rake travis:generate`.
+# Generate this file with `rake build_matrix:travis:generate`.
 ---
 sudo: false
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,9 +90,6 @@ matrix:
     gemfile: gemfiles/no_dependencies.gemfile
     env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=latest
   - rvm: 2.5.3
-    gemfile: gemfiles/rails-4.2.gemfile
-    env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=1.17.3
-  - rvm: 2.5.3
     gemfile: gemfiles/rails-5.2.gemfile
     env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=latest
   - rvm: 2.6.0
@@ -143,9 +140,6 @@ matrix:
   - rvm: jruby-19mode
     gemfile: gemfiles/no_dependencies.gemfile
     env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=latest
-  - rvm: jruby-19mode
-    gemfile: gemfiles/rails-4.2.gemfile
-    env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=1.17.3
   - rvm: jruby-19mode
     gemfile: gemfiles/rails-5.2.gemfile
     env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=latest

--- a/README.md
+++ b/README.md
@@ -230,9 +230,9 @@ BUNDLE_GEMFILE=gemfiles/sinatra.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/webmachine.gemfile bundle exec rspec
 ```
 
-If you have either [RVM][rvm] or [rbenv][rbenv] installed you can also use
-`rake generate_bundle_and_spec_all` to generate a script that runs specs for
-all Ruby versions and gem combinations we support.
+If you have either [RVM][rvm], [rbenv][rbenv] or [chruby][chruby] installed you
+can also use `rake build_matrix:local:generate` to generate a script that runs
+specs for all Ruby versions and gem combinations we support.
 
 We run the suite against all of the Gemfiles mentioned above and on
 a number of different Ruby versions.
@@ -286,3 +286,4 @@ the most out of using AppSignal.
 [semver]: http://semver.org/
 [rvm]: http://rvm.io/
 [rbenv]: https://github.com/rbenv/rbenv
+[chruby]: https://github.com/postmodern/chruby/

--- a/Rakefile
+++ b/Rakefile
@@ -39,62 +39,69 @@ VERSION_MANAGERS = {
   :rvm => ->(version) { "rvm use --default #{version.split("-").first}" }
 }.freeze
 
-namespace :travis do
-  task :generate do
-    yaml = YAML.load_file("build_matrix.yml")
-    matrix = yaml["matrix"]
-    defaults = matrix["defaults"]
-    gems = matrix["gems"]
+namespace :build_matrix do
+  namespace :travis do
+    task :generate do
+      yaml = YAML.load_file("build_matrix.yml")
+      matrix = yaml["matrix"]
+      defaults = matrix["defaults"]
 
-    builds = []
-    matrix["ruby"].each do |ruby|
-      ruby_version = ruby["ruby"]
-      gemset =
-        if ruby["gems"]
-          # Only a specific gemset for this Ruby
-          selected_gems = matrix["gemsets"].fetch(ruby["gems"])
-          gems.select { |g| selected_gems.include?(g["gem"]) }
-        else
-          # All gems for this Ruby
-          gems
+      builds = []
+      matrix["ruby"].each do |ruby|
+        ruby_version = ruby["ruby"]
+        gemset_for_ruby(ruby, matrix).each do |gem|
+          next if excluded_for_ruby?(gem, ruby)
+
+          env = ""
+          rubygems = gem["rubygems"] || ruby["rubygems"] || defaults["rubygems"]
+          env = "_RUBYGEMS_VERSION=#{rubygems}" if rubygems
+          bundler = gem["bundler"] || ruby["bundler"] || defaults["bundler"]
+          env += " _BUNDLER_VERSION=#{bundler}" if bundler
+
+          builds << {
+            "rvm" => ruby_version,
+            "gemfile" => "gemfiles/#{gem["gem"]}.gemfile",
+            "env" => env
+          }
         end
-      gemset.each do |gem|
-        # Don't add build if ignored for this combination of Ruby and gem
-        next if (gem.dig("exclude", "ruby") || []).include?(ruby_version)
+      end
+      travis = yaml["travis"]
+      travis["matrix"]["include"] = travis["matrix"]["include"] + builds
 
-        env = ""
-        rubygems = gem["rubygems"] || ruby["rubygems"] || defaults["rubygems"]
-        env = "_RUBYGEMS_VERSION=#{rubygems}" if rubygems
-        bundler = gem["bundler"] || ruby["bundler"] || defaults["bundler"]
-        env += " _BUNDLER_VERSION=#{bundler}" if bundler
+      header = "# DO NOT EDIT\n" \
+        "# This is a generated file by the `rake build_matrix:travis:generate` task.\n" \
+        "# See `build_matrix.yml` for the build matrix.\n" \
+        "# Generate this file with `rake build_matrix:travis:generate`.\n"
+      generated_yaml = header + YAML.dump(travis)
+      File.write(".travis.yml", generated_yaml)
+      puts "Generated `.travis.yml`"
+      puts "Build count: #{builds.length}"
+    end
 
-        builds << {
-          "rvm" => ruby_version,
-          "gemfile" => "gemfiles/#{gem["gem"]}.gemfile",
-          "env" => env
-        }
+    task :validate => :generate do
+      `git status | grep .travis.yml 2>&1`
+      if $?.exitstatus.zero? # rubocop:disable Style/SpecialGlobalVars
+        puts "The `.travis.yml` is modified. The changes were not committed."
+        puts "Please run `rake build_matrix:travis:generate` and commit the changes."
+        exit 1
       end
     end
-    travis = yaml["travis"]
-    travis["matrix"]["include"] = travis["matrix"]["include"] + builds
-
-    header = "# DO NOT EDIT\n" \
-      "# This is a generated file by the `rake travis:generate` task.\n" \
-      "# See `build_matrix.yml` for the build matrix.\n" \
-      "# Generate this file with `rake travis:generate`.\n"
-    generated_yaml = header + YAML.dump(travis)
-    File.write(".travis.yml", generated_yaml)
-    puts "Generated `.travis.yml`"
-    puts "Build count: #{builds.length}"
   end
 
-  task :validate => :generate do
-    `git status | grep .travis.yml 2>&1`
-    if $?.exitstatus.zero? # rubocop:disable Style/SpecialGlobalVars
-      puts "The `.travis.yml` is modified. The changes were not committed."
-      puts "Please run `rake travis:generate` and commit the changes."
-      exit 1
+  def gemset_for_ruby(ruby, matrix)
+    gems = matrix["gems"]
+    if ruby["gems"]
+      # Only a specific gemset for this Ruby
+      selected_gems = matrix["gemsets"].fetch(ruby["gems"])
+      gems.select { |g| selected_gems.include?(g["gem"]) }
+    else
+      # All gems for this Ruby
+      gems
     end
+  end
+
+  def excluded_for_ruby?(gem, ruby)
+    (gem.dig("exclude", "ruby") || []).include?(ruby["ruby"])
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,10 @@ require "rubygems/package_task"
 require "fileutils"
 
 VERSION_MANAGERS = {
+  :chruby => {
+    :env => "#!/bin/bash\nsource /usr/local/opt/chruby/share/chruby/chruby.sh",
+    :switch_command => ->(version) { "chruby #{version}" }
+  },
   :rbenv => {
     :env => "#!/bin/bash",
     :switch_command => ->(version) { "rbenv local #{version}" }

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -47,8 +47,8 @@ matrix:
       - "no_dependencies"
     minimal:
       - "no_dependencies"
-      - "rails-4.2"
       - "rails-5.2"
+      - "rails-6.2"
 
   ruby:
     - ruby: "2.0.0"

--- a/gemfiles/capistrano2.gemfile
+++ b/gemfiles/capistrano2.gemfile
@@ -3,5 +3,10 @@ source 'https://rubygems.org'
 gem 'capistrano', '< 3.0'
 gem 'net-ssh', '2.9.2'
 gem 'rack', '~> 1.6'
+if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.1.0")
+  gem 'public_suffix', "~> 2.0.0"
+else
+  gem 'public_suffix'
+end
 
 gemspec :path => '../'

--- a/gemfiles/capistrano3.gemfile
+++ b/gemfiles/capistrano3.gemfile
@@ -4,5 +4,10 @@ gem 'capistrano', '~> 3.0'
 gem 'i18n', '~> 1.2.0'
 gem 'net-ssh', '2.9.2'
 gem 'rack', '~> 1.6'
+if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.1.0")
+  gem 'public_suffix', "~> 2.0.0"
+else
+  gem 'public_suffix'
+end
 
 gemspec :path => '../'

--- a/gemfiles/grape.gemfile
+++ b/gemfiles/grape.gemfile
@@ -3,5 +3,10 @@ source 'https://rubygems.org'
 gem 'grape', '0.14.0'
 gem 'rack', '~> 1.6'
 gem 'activesupport', '~> 4.2'
+if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.1.0")
+  gem 'public_suffix', "~> 2.0.0"
+else
+  gem 'public_suffix'
+end
 
 gemspec :path => '../'

--- a/gemfiles/no_dependencies.gemfile
+++ b/gemfiles/no_dependencies.gemfile
@@ -1,5 +1,10 @@
 source 'https://rubygems.org'
 
 gem 'rack', '~> 1.6'
+if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.1.0")
+  gem 'public_suffix', "~> 2.0.0"
+else
+  gem 'public_suffix'
+end
 
 gemspec :path => '../'

--- a/gemfiles/padrino.gemfile
+++ b/gemfiles/padrino.gemfile
@@ -3,5 +3,10 @@ source 'https://rubygems.org'
 gem 'padrino', '~> 0.13.0'
 gem 'rack', '~> 1.6'
 gem 'activesupport', '~> 4.2'
+if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.1.0")
+  gem 'public_suffix', "~> 2.0.0"
+else
+  gem 'public_suffix'
+end
 
 gemspec :path => '../'

--- a/gemfiles/que.gemfile
+++ b/gemfiles/que.gemfile
@@ -1,5 +1,10 @@
 source 'https://rubygems.org'
 
 gem 'que'
+if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.1.0")
+  gem 'public_suffix', "~> 2.0.0"
+else
+  gem 'public_suffix'
+end
 
 gemspec :path => '../'

--- a/gemfiles/rails-3.2.gemfile
+++ b/gemfiles/rails-3.2.gemfile
@@ -2,5 +2,10 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 3.2.14'
 gem 'test-unit'
+if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.1.0")
+  gem 'public_suffix', "~> 2.0.0"
+else
+  gem 'public_suffix'
+end
 
 gemspec :path => '../'

--- a/gemfiles/rails-4.0.gemfile
+++ b/gemfiles/rails-4.0.gemfile
@@ -2,5 +2,10 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 4.0.0'
 gem 'mime-types', '~> 2.6'
+if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.1.0")
+  gem 'public_suffix', "~> 2.0.0"
+else
+  gem 'public_suffix'
+end
 
 gemspec :path => '../'

--- a/gemfiles/rails-4.1.gemfile
+++ b/gemfiles/rails-4.1.gemfile
@@ -2,5 +2,10 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 4.1.0'
 gem 'mime-types', '~> 2.6'
+if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.1.0")
+  gem 'public_suffix', "~> 2.0.0"
+else
+  gem 'public_suffix'
+end
 
 gemspec :path => '../'

--- a/gemfiles/rails-4.2.gemfile
+++ b/gemfiles/rails-4.2.gemfile
@@ -8,3 +8,8 @@ gemspec :path => '../'
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1.0")
   gem 'nokogiri', '~> 1.6.0'
 end
+if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.1.0")
+  gem 'public_suffix', "~> 2.0.0"
+else
+  gem 'public_suffix'
+end

--- a/gemfiles/resque.gemfile
+++ b/gemfiles/resque.gemfile
@@ -10,3 +10,8 @@ gemspec :path => '../'
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1.0")
   gem 'nokogiri', '~> 1.6.0'
 end
+if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.1.0")
+  gem 'public_suffix', "~> 2.0.0"
+else
+  gem 'public_suffix'
+end


### PR DESCRIPTION
## Move .travis.yml script to build_matrix namespace

So we can add more builds to this namespace and not have it be limited
to TravisCI.

## Add Rails 6 to minimal gemset to test

Add Rails 6 to minimal gemset, remove 4.2 as it's being EOL-ed soon.

## Add rake build_matrix:local:generate task

Rename the `generate_bundle_and_spec_all` task to
`build_matrix:local:generate`.

Update it to use the `build_matrix.yml` file and take into account all
the exceptions to the matrix.

## Add chruby support for local test script

I personally use chruby, so I'd like to be able to generate a test
script for it.

## Specify which version of public_suffix to use

In the tests we often trip over which version of public_suffix bundler
wants to use. In the 3.x release they dropped support for Ruby < 2.1, so
specify an older version of the gem when we test on a Ruby lower than
