### PR TITLE
Remove GCProbe

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -135,10 +135,7 @@ module Appsignal
             Appsignal::Extension.install_allocation_event_hook
           end
 
-          if config[:enable_gc_instrumentation]
-            GC::Profiler.enable
-            Appsignal::Minutely.register_garbage_collection_probe
-          end
+          GC::Profiler.enable if config[:enable_gc_instrumentation]
 
           Appsignal::Minutely.start if config[:enable_minutely_probes]
         else

--- a/lib/appsignal/minutely.rb
+++ b/lib/appsignal/minutely.rb
@@ -164,11 +164,6 @@ module Appsignal
         60 - Time.now.sec
       end
 
-      # @api private
-      def register_garbage_collection_probe
-        probes.register :garbage_collection, GCProbe.new
-      end
-
       private
 
       def initialize_probes
@@ -180,14 +175,6 @@ module Appsignal
 
       def probe_instances
         @@probe_instances ||= {}
-      end
-    end
-
-    class GCProbe
-      def call
-        GC.stat.each do |key, value|
-          Appsignal.set_process_gauge("gc.#{key}", value)
-        end
       end
     end
   end

--- a/spec/lib/appsignal/minutely_spec.rb
+++ b/spec/lib/appsignal/minutely_spec.rb
@@ -169,18 +169,6 @@ describe Appsignal::Minutely do
     end
   end
 
-  describe ".register_garbage_collection_probe" do
-    it "adds the GC probe to the probes list" do
-      expect(Appsignal::Minutely.probes.count).to eql(0)
-
-      Appsignal::Minutely.register_garbage_collection_probe
-
-      expect(Appsignal::Minutely.probes.count).to eql(1)
-      expect(Appsignal::Minutely.probes[:garbage_collection])
-        .to be_instance_of(Appsignal::Minutely::GCProbe)
-    end
-  end
-
   describe Appsignal::Minutely::ProbeCollection do
     let(:collection) { described_class.new }
 
@@ -264,16 +252,6 @@ describe Appsignal::Minutely do
           list << [name, p]
         end
         expect(list).to eql([[:my_probe, probe]])
-      end
-    end
-  end
-
-  describe Appsignal::Minutely::GCProbe do
-    describe "#call" do
-      it "collects GC metrics" do
-        expect(Appsignal).to receive(:set_process_gauge).at_least(8).times
-
-        Appsignal::Minutely::GCProbe.new.call
       end
     end
   end

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -94,12 +94,6 @@ describe Appsignal do
             Appsignal.start
           end
         end
-
-        it "should add the gc probe to minutely" do
-          expect(Appsignal::Minutely).to receive(:register_garbage_collection_probe)
-            .and_call_original
-          Appsignal.start
-        end
       end
 
       context "when allocation tracking and gc instrumentation have been disabled" do


### PR DESCRIPTION
We don't store metrics sent this way, so there's no use to running this
probe at the moment.

We deprecated the function that this method uses, which in turn creates
a lot of logs about a deprecated function call.