### PR TITLE
Only register ActionView event formatter in Rails

### DIFF
--- a/lib/appsignal/event_formatter/action_view/render_formatter.rb
+++ b/lib/appsignal/event_formatter/action_view/render_formatter.rb
@@ -22,11 +22,13 @@ module Appsignal
   end
 end
 
-Appsignal::EventFormatter.register(
-  "render_partial.action_view",
-  Appsignal::EventFormatter::ActionView::RenderFormatter
-)
-Appsignal::EventFormatter.register(
-  "render_template.action_view",
-  Appsignal::EventFormatter::ActionView::RenderFormatter
-)
+if defined?(Rails)
+  Appsignal::EventFormatter.register(
+    "render_partial.action_view",
+    Appsignal::EventFormatter::ActionView::RenderFormatter
+  )
+  Appsignal::EventFormatter.register(
+    "render_template.action_view",
+    Appsignal::EventFormatter::ActionView::RenderFormatter
+  )
+end

--- a/spec/lib/appsignal/event_formatter/action_view/render_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/action_view/render_formatter_spec.rb
@@ -1,43 +1,53 @@
-if DependencyHelper.rails_present?
-  require "action_view"
+describe Appsignal::EventFormatter::ActionView::RenderFormatter do
+  let(:klass) { Appsignal::EventFormatter::ActionView::RenderFormatter }
 
-  describe Appsignal::EventFormatter::ActionView::RenderFormatter do
-    before { allow(Rails.root).to receive(:to_s).and_return("/var/www/app/20130101") }
-    let(:klass) { Appsignal::EventFormatter::ActionView::RenderFormatter }
-    let(:formatter) { klass.new }
+  if DependencyHelper.rails_present?
+    require "action_view"
 
-    it "should register render_partial.action_view and render_template.action_view" do
-      expect(Appsignal::EventFormatter.registered?("render_partial.action_view", klass)).to be_truthy
-      expect(Appsignal::EventFormatter.registered?("render_template.action_view", klass)).to be_truthy
-    end
+    context "when in a Rails app" do
+      let(:formatter) { klass.new }
+      before { allow(Rails.root).to receive(:to_s).and_return("/var/www/app/20130101") }
 
-    describe "#root_path" do
-      subject { formatter.root_path }
+      it "registers render_partial.action_view and render_template.action_view" do
+        expect(Appsignal::EventFormatter.registered?("render_partial.action_view", klass)).to be_truthy
+        expect(Appsignal::EventFormatter.registered?("render_template.action_view", klass)).to be_truthy
+      end
 
-      it "returns Rails root path" do
-        is_expected.to eq "/var/www/app/20130101/"
+      describe "#root_path" do
+        subject { formatter.root_path }
+
+        it "returns Rails root path" do
+          is_expected.to eq "/var/www/app/20130101/"
+        end
+      end
+
+      describe "#format" do
+        subject { formatter.format(payload) }
+
+        context "with an identifier" do
+          let(:payload) { { :identifier => "/var/www/app/20130101/app/views/home/index/html.erb" } }
+
+          it { is_expected.to eq ["app/views/home/index/html.erb", nil] }
+        end
+
+        context "with a frozen identifier" do
+          let(:payload) { { :identifier => "/var/www/app/20130101/app/views/home/index/html.erb".freeze } }
+
+          it { is_expected.to eq ["app/views/home/index/html.erb", nil] }
+        end
+
+        context "without an identifier" do
+          let(:payload) { {} }
+
+          it { is_expected.to be_nil }
+        end
       end
     end
-
-    describe "#format" do
-      subject { formatter.format(payload) }
-
-      context "with an identifier" do
-        let(:payload) { { :identifier => "/var/www/app/20130101/app/views/home/index/html.erb" } }
-
-        it { is_expected.to eq ["app/views/home/index/html.erb", nil] }
-      end
-
-      context "with a frozen identifier" do
-        let(:payload) { { :identifier => "/var/www/app/20130101/app/views/home/index/html.erb".freeze } }
-
-        it { is_expected.to eq ["app/views/home/index/html.erb", nil] }
-      end
-
-      context "without an identifier" do
-        let(:payload) { {} }
-
-        it { is_expected.to be_nil }
+  else
+    context "when not in a Rails app" do
+      it "does not register the event formatter" do
+        expect(Appsignal::EventFormatter.registered?("render_partial.action_view", klass)).to be_falsy
+        expect(Appsignal::EventFormatter.registered?("render_template.action_view", klass)).to be_falsy
       end
     end
   end


### PR DESCRIPTION
In non-Rails apps we still registered the event formatter causing an
error to be logged as a warning.

```
[2019-01-31T14:11:22 (process) #15076][WARN] appsignal: 'uninitialized
  constant Appsignal::EventFormatter::ActionView::RenderFormatter::Rails'
  when initializing render_partial.action_view event formatter
[2019-01-31T14:11:22 (process) #15076][WARN] appsignal: 'uninitialized
  constant Appsignal::EventFormatter::ActionView::RenderFormatter::Rails'
  when initializing render_template.action_view event formatter
```

Make sure we only register the event formatter in Rails apps so we
don't cause hidden errors.

Fixes #465