### PR TITLE
Don't add cluster behavior in Puma single mode

### DIFF
--- a/lib/appsignal/hooks/puma.rb
+++ b/lib/appsignal/hooks/puma.rb
@@ -27,6 +27,8 @@ module Appsignal
           end
         end
 
+        return unless defined?(::Puma::Cluster)
+        # For clustered mode with multiple workers
         ::Puma::Cluster.class_eval do
           alias stop_workers_without_appsignal stop_workers
 


### PR DESCRIPTION
The following error was logged on `rails server` with the Puma
webserver:

```
[2019-03-28T16:40:50 (process) #8340][ERROR] Error while installing puma
  hook: uninitialized constant Puma::Cluster
```

This change makes sure we only add our behavior to `Puma::Cluster` if
Puma is in clustered mode. If it is not in clustered mode the class
constant doesn't exist and logs an error on AppSignal start up.

To prevent that from happening, add a check if `Puma::Cluster` is
actually available to us and only then add our behavior to the
`Puma::Cluster#stop_workers` method.

Fixes #500 