### PR TITLE
Convert Sidekiq latency from seconds to ms

### DIFF
--- a/lib/appsignal/hooks/sidekiq.rb
+++ b/lib/appsignal/hooks/sidekiq.rb
@@ -49,7 +49,8 @@ module Appsignal
 
         ::Sidekiq::Queue.all.each do |queue|
           gauge "queue_length", queue.size, :queue => queue.name
-          gauge "queue_latency", queue.latency, :queue => queue.name
+          # Convert latency from seconds to milliseconds
+          gauge "queue_latency", queue.latency * 1_000.0, :queue => queue.name
         end
       end
 

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -684,9 +684,9 @@ describe Appsignal::Hooks::SidekiqProbe do
       expect_gauge("job_count", 14, :status => :scheduled).twice
       expect_gauge("job_count", 15, :status => :enqueued).twice
       expect_gauge("queue_length", 10, :queue => "default").twice
-      expect_gauge("queue_latency", 12, :queue => "default").twice
+      expect_gauge("queue_latency", 12_000, :queue => "default").twice
       expect_gauge("queue_length", 1, :queue => "critical").twice
-      expect_gauge("queue_latency", 2, :queue => "critical").twice
+      expect_gauge("queue_latency", 2_000, :queue => "critical").twice
       # Call probe twice so we can calculate the delta for some gauge values
       probe.call
       probe.call


### PR DESCRIPTION
AppSignal's graphs rely on the value being in milliseconds to properly
show durations.
Sidekiq returns the latency in seconds rather than in milliseconds.

Update the latency gauge to send the value in milliseconds rather than
seconds.