### PR TITLE
Rename PLATFORM constant for JRuby installation

### DIFF
--- a/ext/base.rb
+++ b/ext/base.rb
@@ -10,8 +10,8 @@ require File.expand_path("../../lib/appsignal/system.rb", __FILE__)
 EXT_PATH     = File.expand_path("..", __FILE__).freeze
 AGENT_CONFIG = YAML.load(File.read(File.join(EXT_PATH, "agent.yml"))).freeze
 
-PLATFORM     = Appsignal::System.agent_platform
-ARCH         = "#{RbConfig::CONFIG["host_cpu"]}-#{PLATFORM}".freeze
+AGENT_PLATFORM = Appsignal::System.agent_platform
+ARCH = "#{RbConfig::CONFIG["host_cpu"]}-#{AGENT_PLATFORM}".freeze
 CA_CERT_PATH = File.join(EXT_PATH, "../resources/cacert.pem").freeze
 
 def ext_path(path)
@@ -37,7 +37,7 @@ def report
           "time" => Time.now.utc,
           "package_path" => File.dirname(__dir__),
           "architecture" => rbconfig["host_cpu"],
-          "target" => PLATFORM,
+          "target" => AGENT_PLATFORM,
           "musl_override" => Appsignal::System.force_musl_build?,
           "dependencies" => {},
           "flags" => {}

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -25,7 +25,7 @@ def install
   is_linux_system = [
     Appsignal::System::LINUX_TARGET,
     Appsignal::System::MUSL_TARGET
-  ].include?(PLATFORM)
+  ].include?(AGENT_PLATFORM)
 
   require "mkmf"
   link_libraries if is_linux_system


### PR DESCRIPTION
On JRuby there is already a `PLATFORM` constant, and it prints the
following warning on (manual) installation.

```
rake extension:install
ext/base.rb:13: warning: already initialized constant PLATFORM
```

Rename the constant to `AGENT_PLATFORM` so we don't overwrite the
`PLATFORM` on JRuby and fix the warning printed on (manual)
installation.

Fixes  #461