### PR TITLE
Log hostname in Sidekiq probe 

### DIFF
--- a/lib/appsignal/hooks/sidekiq.rb
+++ b/lib/appsignal/hooks/sidekiq.rb
@@ -28,6 +28,8 @@ module Appsignal
       def initialize(config = {})
         @config = config
         @cache = {}
+        config_string = " with config: #{config}" unless config.empty?
+        Appsignal.logger.debug("Initializing Sidekiq probe#{config_string}")
         require "sidekiq/api"
       end
 

--- a/lib/appsignal/hooks/sidekiq.rb
+++ b/lib/appsignal/hooks/sidekiq.rb
@@ -89,11 +89,15 @@ module Appsignal
         return @hostname if defined?(@hostname)
         if config.key?(:hostname)
           @hostname = config[:hostname]
+          Appsignal.logger.debug "Sidekiq probe: Using hostname config " \
+            "option #{@hostname.inspect} as hostname"
           return @hostname
         end
 
         host = nil
         ::Sidekiq.redis { |c| host = c.connection[:host] }
+        Appsignal.logger.debug "Sidekiq probe: Using Redis server hostname " \
+          "#{host.inspect} as hostname"
         @hostname = host
       end
     end

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -671,6 +671,11 @@ describe Appsignal::Hooks::SidekiqProbe do
       expect(defined?(Sidekiq::API)).to be_truthy
     end
 
+    it "logs on initialize" do
+      log = capture_logs { probe }
+      expect(log).to contains_log(:debug, "Initializing Sidekiq probe\n")
+    end
+
     it "collects custom metrics" do
       expect_gauge("worker_count", 24).twice
       expect_gauge("process_count", 25).twice
@@ -698,6 +703,11 @@ describe Appsignal::Hooks::SidekiqProbe do
 
       it "uses the redis hostname for the hostname tag" do
         allow(Appsignal).to receive(:set_gauge).and_call_original
+        log = capture_logs { probe }
+        expect(log).to contains_log(
+          :debug,
+          %(Initializing Sidekiq probe with config: {:hostname=>"#{redis_hostname}"})
+        )
         probe.call
         expect(Appsignal).to have_received(:set_gauge)
           .with(anything, anything, :hostname => redis_hostname).at_least(:once)

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -671,9 +671,20 @@ describe Appsignal::Hooks::SidekiqProbe do
       expect(defined?(Sidekiq::API)).to be_truthy
     end
 
-    it "logs on initialize" do
+    it "logs config on initialize" do
       log = capture_logs { probe }
       expect(log).to contains_log(:debug, "Initializing Sidekiq probe\n")
+    end
+
+    it "logs used hostname on call once" do
+      log = capture_logs { probe.call }
+      expect(log).to contains_log(
+        :debug,
+        %(Sidekiq probe: Using Redis server hostname "localhost" as hostname)
+      )
+      log = capture_logs { probe.call }
+      # Match more logs with incompelete message
+      expect(log).to_not contains_log(:debug, %(Sidekiq probe: ))
     end
 
     it "collects custom metrics" do
@@ -708,7 +719,11 @@ describe Appsignal::Hooks::SidekiqProbe do
           :debug,
           %(Initializing Sidekiq probe with config: {:hostname=>"#{redis_hostname}"})
         )
-        probe.call
+        log = capture_logs { probe.call }
+        expect(log).to contains_log(
+          :debug,
+          "Sidekiq probe: Using hostname config option #{redis_hostname.inspect} as hostname"
+        )
         expect(Appsignal).to have_received(:set_gauge)
           .with(anything, anything, :hostname => redis_hostname).at_least(:once)
       end


### PR DESCRIPTION
## Log Sidekiq probe config on initialize

This way we can debug what value for the hostname is being used and
when.

## Log hostname on Sidekiq probe call

This way we know which hostname is being used to tag metrics. This is
only called once as the hostname is stored in the `@hostname` instance
variable and its value is reused if already set in the
`SidekiqProbe#hostname` method.