### PR TITLE
Fix Bundler cache path for TravisCI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,16 @@ branches:
 language: ruby
 cache:
   directories:
-  - vendor/bundle
+  - "$TRAVIS_BUILD_DIR/vendor/cache"
 env:
   global:
+  - BUNDLE_PATH=$TRAVIS_BUILD_DIR/vendor/cache
   - RUNNING_IN_CI=true
   - RAILS_ENV=test
   - JRUBY_OPTS=''
 before_install:
 - "./support/install_deps"
-install: "./support/bundler_wrapper install --jobs=3 --retry=3"
+install: "./support/bundler_wrapper install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-$TRAVIS_BUILD_DIR/vendor/cache}"
 before_script:
 - "./support/bundler_wrapper exec rake extension:install"
 script: "./support/bundler_wrapper exec rake test"

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -9,17 +9,18 @@ travis: # Default `.travis.yml` contents
   language: ruby
   cache:
     directories:
-      - vendor/bundle
+      - "$TRAVIS_BUILD_DIR/vendor/cache"
 
   env:
     global:
+      - "BUNDLE_PATH=$TRAVIS_BUILD_DIR/vendor/cache"
       - "RUNNING_IN_CI=true"
       - "RAILS_ENV=test"
       - "JRUBY_OPTS=''" # Workaround https://github.com/travis-ci/travis-ci/issues/6471
 
   before_install:
     - "./support/install_deps"
-  install: "./support/bundler_wrapper install --jobs=3 --retry=3"
+  install: "./support/bundler_wrapper install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-$TRAVIS_BUILD_DIR/vendor/cache}"
   before_script:
     - "./support/bundler_wrapper exec rake extension:install"
   script: "./support/bundler_wrapper exec rake test"


### PR DESCRIPTION
The Bundle path wasn't set, so the TravisCI build cache did nothing,
cached nothing. Fix it by setting the `BUNDLE_PATH` environment variable
for all jobs in the build. Hopefully speeding up the jobs.