### PR TITLE
Add SUPPORT.md file to link to our support process

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,8 @@ we send a package to so far on our [Stroopwafles page][waffles-page].
 AppSignal. They will help you get set up, tweak your code and make sure you get
 the most out of using AppSignal.
 
+Also see our [SUPPORT.md file](SUPPORT.md).
+
 [appsignal]: https://appsignal.com
 [appsignal-sign-up]: https://appsignal.com/users/sign_up
 [contact]: mailto:support@appsignal.com

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,16 @@
+# Support
+
+[Contact us][contact] and speak directly with the engineers working on
+AppSignal. They will help you get set up, tweak your code and make sure you get
+the most out of using AppSignal. You can also find our documentation at
+[docs.appsignal.com](https://docs.appsignal.com/).
+
+We do not recommend creating an issue on the Ruby gem's GitHub project if it
+concerns your private app data. During the support process we'll need the
+AppSignal logs and other resources that contain your app's private data,
+something for which the public GitHub issue tracker is not suited.
+
+Please contact us on our website (appsignal.com)[https://appsignal.com/] or via
+email at [support@appsignal.com][contact].
+
+[contact]: mailto:support@appsignal.com


### PR DESCRIPTION
By adding this file GitHub will hint users new to our project where they
can find more support resources.

This will be in addition to any issue templates we may set up.

Source:
https://help.github.com/en/articles/adding-support-resources-to-your-project

[ci skip]