### PR TITLE
Remove class variables

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -89,11 +89,6 @@ Style/ClassAndModuleChildren:
   Exclude:
     - 'lib/appsignal/integrations/padrino.rb'
 
-# Offense count: 3
-Style/ClassVars:
-  Exclude:
-    - 'lib/appsignal/event_formatter.rb'
-
 # Offense count: 1
 Style/DoubleNegation:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -89,11 +89,10 @@ Style/ClassAndModuleChildren:
   Exclude:
     - 'lib/appsignal/integrations/padrino.rb'
 
-# Offense count: 6
+# Offense count: 3
 Style/ClassVars:
   Exclude:
     - 'lib/appsignal/event_formatter.rb'
-    - 'lib/appsignal/minutely.rb'
 
 # Offense count: 1
 Style/DoubleNegation:

--- a/lib/appsignal/event_formatter.rb
+++ b/lib/appsignal/event_formatter.rb
@@ -17,15 +17,15 @@ module Appsignal
       include Appsignal::Utils::DeprecationMessage
 
       def formatters
-        @@formatters ||= {}
+        @formatters ||= {}
       end
 
       def deprecated_formatter_classes
-        @@deprecated_formatter_classes ||= {}
+        @deprecated_formatter_classes ||= {}
       end
 
       def formatter_classes
-        @@formatter_classes ||= {}
+        @formatter_classes ||= {}
       end
 
       def register(name, formatter = nil)
@@ -94,7 +94,7 @@ module Appsignal
           "https://docs.appsignal.com/ruby/instrumentation/event-formatters.html",
           logger
 
-        deprecated_formatter_classes[name] = self
+        EventFormatter.deprecated_formatter_classes[name] = self
       end
 
       def logger

--- a/lib/appsignal/minutely.rb
+++ b/lib/appsignal/minutely.rb
@@ -129,14 +129,14 @@ module Appsignal
       # @see ProbeCollection
       # @return [ProbeCollection] Returns list of probes.
       def probes
-        @@probes ||= ProbeCollection.new
+        @probes ||= ProbeCollection.new
       end
 
       # @api private
       def start
         stop
         initialize_probes
-        @@thread = Thread.new do
+        @thread = Thread.new do
           sleep initial_wait_time
           loop do
             logger = Appsignal.logger
@@ -157,7 +157,7 @@ module Appsignal
 
       # @api private
       def stop
-        defined?(@@thread) && @@thread.kill
+        defined?(@thread) && @thread.kill
         probe_instances.clear
       end
 
@@ -182,7 +182,7 @@ module Appsignal
       end
 
       def probe_instances
-        @@probe_instances ||= {}
+        @probe_instances ||= {}
       end
     end
   end

--- a/spec/lib/appsignal/minutely_spec.rb
+++ b/spec/lib/appsignal/minutely_spec.rb
@@ -112,7 +112,7 @@ describe Appsignal::Minutely do
       expect(Appsignal::Minutely).to have_received(:initial_wait_time).once
       expect do
         # Fetch old thread
-        thread = Appsignal::Minutely.class_variable_get(:@@thread)
+        thread = Appsignal::Minutely.instance_variable_get(:@thread)
         Appsignal::Minutely.start
         thread && thread.join # Wait for old thread to exit
       end.to_not(change { alive_thread_counter.call })
@@ -153,7 +153,7 @@ describe Appsignal::Minutely do
 
     it "stops the minutely thread" do
       Appsignal::Minutely.start
-      thread = Appsignal::Minutely.class_variable_get(:@@thread)
+      thread = Appsignal::Minutely.instance_variable_get(:@thread)
       expect(%w[sleep run]).to include(thread.status)
       Appsignal::Minutely.stop
       thread.join
@@ -163,7 +163,7 @@ describe Appsignal::Minutely do
     it "clears the probe instances array" do
       Appsignal::Minutely.probes.register :my_probe, -> {}
       Appsignal::Minutely.start
-      thread = Appsignal::Minutely.class_variable_get(:@@thread)
+      thread = Appsignal::Minutely.instance_variable_get(:@thread)
       expect(Appsignal::Minutely.send(:probe_instances)).to_not be_empty
       Appsignal::Minutely.stop
       thread.join


### PR DESCRIPTION
## Remove class variables from Minutely probes class

We don't need class variables for the Minutely probes class and can
instead use class instance variables.

This means that sub classes from the `Minutely` class, of which there
are none, will no longer inherit the class variables. Instead the
`thread` and `probes` variables will only be available directly on the
`Minutely` class. Since there is only one (instance) of the class (the
class itself) there will be difference in usage.

## Remove class variables from EventFormatter class

We don't need class variables for the EventFormatter class and can
instead use class instance variables.

This means that sub classes from the `EventFormatter` class, which are
deprecated, will no longer inherit the class variables.

To make sure the deprecated method still works, for now, any child
class of `EventFormatter` will forward the call to the `EventFormatter`
class to make sure the event formatters list is only updated on the
`EventFormatter` class.