### PR TITLE
 Add dependency check to probes 

### DIFF
--- a/lib/appsignal/hooks/sidekiq.rb
+++ b/lib/appsignal/hooks/sidekiq.rb
@@ -25,6 +25,10 @@ module Appsignal
     class SidekiqProbe
       attr_reader :config
 
+      def self.dependencies_present?
+        Gem::Version.new(Redis::VERSION) >= Gem::Version.new("3.3.5")
+      end
+
       def initialize(config = {})
         @config = config
         @cache = {}

--- a/lib/appsignal/minutely.rb
+++ b/lib/appsignal/minutely.rb
@@ -140,7 +140,7 @@ module Appsignal
           sleep initial_wait_time
           loop do
             logger = Appsignal.logger
-            logger.debug("Gathering minutely metrics with #{probes.count} probes")
+            logger.debug("Gathering minutely metrics with #{probe_instances.count} probes")
             probe_instances.each do |name, probe|
               begin
                 logger.debug("Gathering minutely metrics with '#{name}' probe")
@@ -176,9 +176,25 @@ module Appsignal
 
       def initialize_probes
         probes.each do |name, probe|
-          instance = probe.respond_to?(:new) ? probe.new : probe
+          if probe.respond_to? :new
+            instance = probe.new
+            klass = probe
+          else
+            instance = probe
+            klass = instance.class
+          end
+          unless dependencies_present?(klass)
+            Appsignal.logger.debug "Skipping '#{name}' probe, " \
+              "#{klass}.dependency_present? returned falsy"
+            next
+          end
           probe_instances[name] = instance
         end
+      end
+
+      def dependencies_present?(probe)
+        return true unless probe.respond_to? :dependencies_present?
+        probe.dependencies_present?
       end
 
       def probe_instances

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -665,6 +665,30 @@ describe Appsignal::Hooks::SidekiqProbe do
     end
     after { Object.send(:remove_const, "Sidekiq") }
 
+    describe ".dependencies_present?" do
+      before do
+        class Redis; end
+        Redis.const_set(:VERSION, version)
+      end
+      after { Object.send(:remove_const, "Redis") }
+
+      context "when Redis version is < 3.3.5" do
+        let(:version) { "3.3.4" }
+
+        it "does not start probe" do
+          expect(described_class.dependencies_present?).to be_falsy
+        end
+      end
+
+      context "when Redis version is >= 3.3.5" do
+        let(:version) { "3.3.5" }
+
+        it "does not start probe" do
+          expect(described_class.dependencies_present?).to be_truthy
+        end
+      end
+    end
+
     it "loads Sidekiq::API" do
       expect(defined?(Sidekiq::API)).to be_falsy
       probe


### PR DESCRIPTION
Fixes https://github.com/appsignal/support/issues/4

## Add dependency check to probes

This allows us to check beforehand if a probe should be initialized and
run or not. We may not want this because the probe only works in
combination with a certain gem version, for example.

## Skip Sidekiq probe on old Redis gem versions

Redis gem < 3.3.5 does not have all the connection information we need
for a good fallback. Skip the entire probe if a user is using an old
Redis gem.