### PR TITLE
Rescue no user/group error

### DIFF
--- a/lib/appsignal/cli/diagnose/utils.rb
+++ b/lib/appsignal/cli/diagnose/utils.rb
@@ -6,12 +6,14 @@ module Appsignal
           passwd_struct = Etc.getpwuid(uid)
           return unless passwd_struct
           passwd_struct.name
+        rescue ArgumentError # rubocop:disable Lint/HandleExceptions
         end
 
         def self.group_for_gid(gid)
           passwd_struct = Etc.getgrgid(gid)
           return unless passwd_struct
           passwd_struct.name
+        rescue ArgumentError # rubocop:disable Lint/HandleExceptions
         end
 
         def self.read_file_content(path, bytes_to_read)

--- a/spec/lib/appsignal/cli/diagnose/utils_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose/utils_spec.rb
@@ -1,6 +1,46 @@
 require "appsignal/cli/diagnose/utils"
 
 describe Appsignal::CLI::Diagnose::Utils do
+  describe ".username_for_uid" do
+    subject { described_class.username_for_uid(uid) }
+
+    context "when user with id exists" do
+      let(:uid) { 0 }
+
+      it "returns username" do
+        is_expected.to be_kind_of(String)
+      end
+    end
+
+    context "when user with id does not exist" do
+      let(:uid) { -1 }
+
+      it "returns nil" do
+        is_expected.to be_nil
+      end
+    end
+  end
+
+  describe ".group_for_gid" do
+    subject { described_class.group_for_gid(uid) }
+
+    context "when group with id exists" do
+      let(:uid) { 0 }
+
+      it "returns group name" do
+        is_expected.to be_kind_of(String)
+      end
+    end
+
+    context "when group with id does not exist" do
+      let(:uid) { -3 }
+
+      it "returns nil" do
+        is_expected.to be_nil
+      end
+    end
+  end
+
   describe ".read_file_content" do
     let(:path) { File.join(spec_system_tmp_dir, "test_file.txt") }
     let(:bytes_to_read) { 100 }


### PR DESCRIPTION
Return `nil` rather than let the error bubble up.

When a user or group cannot be found it's usually a mounted volume from
a host system where the guest system does not know the user/group that
own the files/directories.

We can probably store this in a better way, e.g. a hash containing the
error and the arguments given, but this should be consistently set for
all values, not only this one. So we look at that in a future release.