### PR TITLE
Bump debug log to warning

### DIFF
--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -25,7 +25,7 @@ module Appsignal
           Thread.current[:appsignal_transaction] = Appsignal::Transaction.new(id, namespace, request, options)
         else
           # Otherwise, log the issue about trying to start another transaction
-          Appsignal.logger.debug "Trying to start new transaction with id " \
+          Appsignal.logger.warn "Trying to start new transaction with id " \
             "'#{id}', but a transaction with id '#{current.transaction_id}' " \
             "is already running. Using transaction '#{current.transaction_id}'."
 

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -64,7 +64,7 @@ describe Appsignal::Transaction do
 
         it "logs a debug message" do
           create_transaction("2")
-          expect(log_contents(log)).to contains_log :debug,
+          expect(log_contents(log)).to contains_log :warn,
             "Trying to start new transaction with id '2', but a " \
             "transaction with id '#{transaction_id}' is already " \
             "running. Using transaction '#{transaction_id}'."


### PR DESCRIPTION
This message can pop up a bunch of times, in order not to polute the
logs unneededly we log them now as warning.

Fixes: #489