### PR TITLE
Delay minutely probe initialization till first run

### DIFF
--- a/lib/appsignal/minutely.rb
+++ b/lib/appsignal/minutely.rb
@@ -135,9 +135,9 @@ module Appsignal
       # @api private
       def start
         stop
-        initialize_probes
         @@thread = Thread.new do
           sleep initial_wait_time
+          initialize_probes
           loop do
             logger = Appsignal.logger
             logger.debug("Gathering minutely metrics with #{probe_instances.count} probes")


### PR DESCRIPTION
If we initialize the probes immediately on `Appsignal.start` probes get
initialized before Rails initializers have run. This behavior broke when
we added probes that could be initialized.

Now the probes get initialized when the minutely probes thread gets run
for the first time, which is more than 30 seconds after the
app/AppSignal gem has started, see
`Appsignal::Minutely.initial_wait_time`.

Fixes #527