### PR TITLE
Remove __dir__ usage from extension installation

### DIFF
--- a/ext/base.rb
+++ b/ext/base.rb
@@ -35,7 +35,7 @@ def report
         },
         "build" => {
           "time" => Time.now.utc,
-          "package_path" => File.dirname(__dir__),
+          "package_path" => File.dirname(EXT_PATH),
           "architecture" => rbconfig["host_cpu"],
           "target" => AGENT_PLATFORM,
           "musl_override" => Appsignal::System.force_musl_build?,


### PR DESCRIPTION
The `__dir__` method was introduced in Ruby 2.0.
To support 1.9 we can't keep using it.

Instead use the `EXT_PATH` as a basis for the gem install path, which is
based on the `__FILE__` keyword that is available in Ruby 1.9.