### PR TITLE
Fix error in AS when transaction get completed

### DIFF
--- a/lib/appsignal/hooks/active_support_notifications.rb
+++ b/lib/appsignal/hooks/active_support_notifications.rb
@@ -30,16 +30,13 @@ module Appsignal
             # Events that start with a bang are internal to Rails
             instrument_this = name[0] != BANG
 
-            if instrument_this
-              transaction = Appsignal::Transaction.current
-              transaction.start_event
-            end
+            Appsignal::Transaction.current.start_event if instrument_this
 
             instrument_without_appsignal(name, payload, &block)
           ensure
             if instrument_this
               title, body, body_format = Appsignal::EventFormatter.format(name, payload)
-              transaction.finish_event(
+              Appsignal::Transaction.current.finish_event(
                 name.to_s,
                 title,
                 body,

--- a/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
@@ -2,12 +2,14 @@ describe Appsignal::Hooks::ActiveSupportNotificationsHook do
   if active_support_present?
     let(:notifier) { ActiveSupport::Notifications::Fanout.new }
     let(:as) { ActiveSupport::Notifications }
+    let!(:transaction) do
+      Appsignal::Transaction.create("uuid", Appsignal::Transaction::HTTP_REQUEST, "test")
+    end
     before :context do
       start_agent
     end
     before do
       as.notifier = notifier
-      Appsignal::Transaction.create("uuid", Appsignal::Transaction::HTTP_REQUEST, "test")
     end
 
     describe "#dependencies_present?" do
@@ -17,41 +19,71 @@ describe Appsignal::Hooks::ActiveSupportNotificationsHook do
     end
 
     it "instruments an ActiveSupport::Notifications.instrument event" do
-      expect(Appsignal::Transaction.current).to receive(:start_event)
-        .at_least(:once)
-      expect(Appsignal::Transaction.current).to receive(:finish_event)
-        .at_least(:once)
-        .with("sql.active_record", nil, "SQL", 1)
-
       return_value = as.instrument("sql.active_record", :sql => "SQL") do
         "value"
       end
 
       expect(return_value).to eq "value"
+      expect(transaction.to_h["events"]).to match([
+        {
+          "allocation_count" => kind_of(Integer),
+          "body" => "SQL",
+          "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
+          "child_allocation_count" => kind_of(Integer),
+          "child_duration" => kind_of(Float),
+          "child_gc_duration" => kind_of(Float),
+          "count" => 1,
+          "duration" => kind_of(Float),
+          "gc_duration" => kind_of(Float),
+          "name" => "sql.active_record",
+          "start" => kind_of(Float),
+          "title" => ""
+        }
+      ])
     end
 
     it "instruments an ActiveSupport::Notifications.instrument event with no registered formatter" do
-      expect(Appsignal::Transaction.current).to receive(:start_event)
-        .at_least(:once)
-      expect(Appsignal::Transaction.current).to receive(:finish_event)
-        .at_least(:once)
-        .with("no-registered.formatter", nil, nil, nil)
-
       return_value = as.instrument("no-registered.formatter", :key => "something") do
         "value"
       end
 
       expect(return_value).to eq "value"
+      expect(transaction.to_h["events"]).to match([
+        {
+          "allocation_count" => kind_of(Integer),
+          "body" => "",
+          "body_format" => Appsignal::EventFormatter::DEFAULT,
+          "child_allocation_count" => kind_of(Integer),
+          "child_duration" => kind_of(Float),
+          "child_gc_duration" => kind_of(Float),
+          "count" => 1,
+          "duration" => kind_of(Float),
+          "gc_duration" => kind_of(Float),
+          "name" => "no-registered.formatter",
+          "start" => kind_of(Float),
+          "title" => ""
+        }
+      ])
     end
 
-    it "should convert non-string names to strings" do
-      expect(Appsignal::Transaction.current).to receive(:start_event)
-        .at_least(:once)
-      expect(Appsignal::Transaction.current).to receive(:finish_event)
-        .at_least(:once)
-        .with("not_a_string", nil, nil, nil)
-
+    it "converts non-string names to strings" do
       as.instrument(:not_a_string) {}
+      expect(transaction.to_h["events"]).to match([
+        {
+          "allocation_count" => kind_of(Integer),
+          "body" => "",
+          "body_format" => Appsignal::EventFormatter::DEFAULT,
+          "child_allocation_count" => kind_of(Integer),
+          "child_duration" => kind_of(Float),
+          "child_gc_duration" => kind_of(Float),
+          "count" => 1,
+          "duration" => kind_of(Float),
+          "gc_duration" => kind_of(Float),
+          "name" => "not_a_string",
+          "start" => kind_of(Float),
+          "title" => ""
+        }
+      ])
     end
 
     it "does not instrument events whose name starts with a bang" do
@@ -67,33 +99,66 @@ describe Appsignal::Hooks::ActiveSupportNotificationsHook do
 
     context "when an error is raised in an instrumented block" do
       it "instruments an ActiveSupport::Notifications.instrument event" do
-        expect(Appsignal::Transaction.current).to receive(:start_event)
-          .at_least(:once)
-        expect(Appsignal::Transaction.current).to receive(:finish_event)
-          .at_least(:once)
-          .with("sql.active_record", nil, "SQL", 1)
-
         expect do
           as.instrument("sql.active_record", :sql => "SQL") do
             raise ExampleException, "foo"
           end
         end.to raise_error(ExampleException, "foo")
+
+        expect(transaction.to_h["events"]).to match([
+          {
+            "allocation_count" => kind_of(Integer),
+            "body" => "SQL",
+            "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
+            "child_allocation_count" => kind_of(Integer),
+            "child_duration" => kind_of(Float),
+            "child_gc_duration" => kind_of(Float),
+            "count" => 1,
+            "duration" => kind_of(Float),
+            "gc_duration" => kind_of(Float),
+            "name" => "sql.active_record",
+            "start" => kind_of(Float),
+            "title" => ""
+          }
+        ])
       end
     end
 
     context "when a message is thrown in an instrumented block" do
       it "instruments an ActiveSupport::Notifications.instrument event" do
-        expect(Appsignal::Transaction.current).to receive(:start_event)
-          .at_least(:once)
-        expect(Appsignal::Transaction.current).to receive(:finish_event)
-          .at_least(:once)
-          .with("sql.active_record", nil, "SQL", 1)
-
         expect do
           as.instrument("sql.active_record", :sql => "SQL") do
             throw :foo
           end
         end.to throw_symbol(:foo)
+
+        expect(transaction.to_h["events"]).to match([
+          {
+            "allocation_count" => kind_of(Integer),
+            "body" => "SQL",
+            "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
+            "child_allocation_count" => kind_of(Integer),
+            "child_duration" => kind_of(Float),
+            "child_gc_duration" => kind_of(Float),
+            "count" => 1,
+            "duration" => kind_of(Float),
+            "gc_duration" => kind_of(Float),
+            "name" => "sql.active_record",
+            "start" => kind_of(Float),
+            "title" => ""
+          }
+        ])
+      end
+    end
+
+    context "when a transaction is completed in an instrumented block" do
+      it "does not complete the ActiveSupport::Notifications.instrument event" do
+        expect(transaction).to receive(:complete)
+        as.instrument("sql.active_record", :sql => "SQL") do
+          Appsignal::Transaction.complete_current!
+        end
+
+        expect(transaction.to_h["events"]).to match([])
       end
     end
   else


### PR DESCRIPTION
If an AppSignal transaction is closed in an instrumentation block (which
shouldn't happen), the transaction can no longer be called to finish an
event.

```ruby
ActiveSupport::Notifications.instrument("foo") do
  Appsignal::Transaction.complete_current!
end
```

To fix the error that would occur, fetch the transaction again from
`Appsignal::Transaction.current` instead of using the `transaction`
variable that was available. If the transaction was closed inside the
instrumentation block, it will return a `NilTransaction` which will
ignore the method call instead of raising an error.