### PR TITLE
Fix error when transactions are completed in GenericInstrumentation

### DIFF
--- a/lib/appsignal/rack/generic_instrumentation.rb
+++ b/lib/appsignal/rack/generic_instrumentation.rb
@@ -22,7 +22,7 @@ module Appsignal
 
       def call_with_appsignal_monitoring(env)
         request = ::Rack::Request.new(env)
-        transaction = Appsignal::Transaction.create(
+        Appsignal::Transaction.create(
           SecureRandom.uuid,
           Appsignal::Transaction::HTTP_REQUEST,
           request
@@ -32,9 +32,10 @@ module Appsignal
             @app.call(env)
           end
         rescue Exception => error # rubocop:disable Lint/RescueException
-          transaction.set_error(error)
+          Appsignal::Transaction.current.set_error(error)
           raise error
         ensure
+          transaction = Appsignal::Transaction.current
           if env["appsignal.route"]
             transaction.set_action_if_nil(env["appsignal.route"])
           else

--- a/spec/lib/appsignal/rack/generic_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/generic_instrumentation_spec.rb
@@ -1,90 +1,125 @@
 describe Appsignal::Rack::GenericInstrumentation do
-  before :context do
-    start_agent
-  end
-
   let(:app) { double(:call => true) }
-  let(:env) { { :path => "/", :method => "GET" } }
+  let(:env) { { "path" => "/", "REQUEST_METHOD" => "GET" } }
   let(:options) { {} }
   let(:middleware) { Appsignal::Rack::GenericInstrumentation.new(app, options) }
+  before(:context) { start_agent }
 
   describe "#call" do
-    before do
-      allow(middleware).to receive(:raw_payload).and_return({})
-    end
+    let(:app) { lambda { |_args| :app_result } }
 
-    context "when appsignal is active" do
-      before { allow(Appsignal).to receive(:active?).and_return(true) }
+    context "when AppSignal is not active" do
+      before do
+        expect(Appsignal).to receive(:active?).and_return(false)
+      end
 
-      it "should call with monitoring" do
-        expect(middleware).to receive(:call_with_appsignal_monitoring).with(env)
+      it "calls the app and returns the result" do
+        expect(app).to receive(:call).with(env).and_call_original
+        expect(middleware.call(env)).to eql(:app_result)
+      end
+
+      it "does not create an AppSignal transaction" do
+        expect(Appsignal::Transaction).to_not receive(:create)
+        middleware.call(env)
       end
     end
 
-    context "when appsignal is not active" do
-      before { allow(Appsignal).to receive(:active?).and_return(false) }
-
-      it "should not call with monitoring" do
-        expect(middleware).to_not receive(:call_with_appsignal_monitoring)
+    context "when AppSignal is active" do
+      let(:transaction) do
+        Appsignal::Transaction.new(
+          "1",
+          Appsignal::Transaction::HTTP_REQUEST,
+          Rack::Request.new(env)
+        )
+      end
+      before do
+        allow(Appsignal::Transaction).to receive(:new)
+          .with(kind_of(String), Appsignal::Transaction::HTTP_REQUEST, anything, {}) { |_id, _type, rack_env|
+            expect(rack_env.env).to include(env)
+          }.and_return(transaction)
+        allow(transaction).to receive(:complete)
       end
 
-      it "should call the stack" do
-        expect(app).to receive(:call).with(env)
+      it "calls the app and returns the result" do
+        expect(app).to receive(:call).with(env).and_call_original
+        expect(middleware.call(env)).to eql(:app_result)
       end
-    end
 
-    after { middleware.call(env) }
-  end
+      it "creates a transaction with the request metadata" do
+        middleware.call(env)
+        expect(transaction).to match_transaction(
+          "id" => "1",
+          "events" => [
+            be_transaction_event(
+              "name" => "process_action.generic",
+              "title" => "",
+              "body" => "",
+              "body_format" => Appsignal::EventFormatter::DEFAULT
+            )
+          ],
+          "metadata" => { "method" => "GET", "path" => "" },
+          "namespace" => Appsignal::Transaction::HTTP_REQUEST
+        )
+      end
 
-  describe "#call_with_appsignal_monitoring", :error => false do
-    it "should create a transaction" do
-      expect(Appsignal::Transaction).to receive(:create).with(
-        kind_of(String),
-        Appsignal::Transaction::HTTP_REQUEST,
-        kind_of(Rack::Request)
-      ).and_return(double(:set_action_if_nil => nil, :set_http_or_background_queue_start => nil, :set_metadata => nil))
-    end
+      context "with a queue start header" do
+        before do
+          env.merge!("HTTP_X_QUEUE_START" => "946_681_200_001")
+        end
 
-    it "should call the app" do
-      expect(app).to receive(:call).with(env)
-    end
-
-    context "with an exception", :error => true do
-      let(:error) { ExampleException }
-      let(:app) do
-        double.tap do |d|
-          allow(d).to receive(:call).and_raise(error)
+        it "sets the queue start time" do
+          expect(transaction).to receive(:set_http_or_background_queue_start).and_call_original
+          middleware.call(env)
+          expect(transaction).to match_transaction(
+            "id" => "1",
+            "events" => [
+              be_transaction_event(
+                "name" => "process_action.generic",
+                "title" => "",
+                "body" => "",
+                "body_format" => Appsignal::EventFormatter::DEFAULT
+              )
+            ],
+            "metadata" => { "method" => "GET", "path" => "" },
+            "namespace" => Appsignal::Transaction::HTTP_REQUEST
+          )
         end
       end
 
-      it "records the exception" do
-        expect_any_instance_of(Appsignal::Transaction).to receive(:set_error).with(error)
-      end
-    end
-
-    it "should set the action to unknown" do
-      expect_any_instance_of(Appsignal::Transaction).to receive(:set_action_if_nil).with("unknown")
-    end
-
-    context "with a route specified in the env" do
-      before do
-        env["appsignal.route"] = "GET /"
+      context "without custom appsignal.route env" do
+        it "sets 'unknown' as the action name" do
+          middleware.call(env)
+          expect(transaction).to match_transaction(
+            "action" => "unknown"
+          )
+        end
       end
 
-      it "should set the action" do
-        expect_any_instance_of(Appsignal::Transaction).to receive(:set_action_if_nil).with("GET /")
+      context "with custom appsignal.route env" do
+        before { env.merge!("appsignal.route" => "action_name") }
+
+        it "uses appsignal.route value for action name" do
+          middleware.call(env)
+          expect(transaction).to match_transaction(
+            "action" => "action_name"
+          )
+        end
+      end
+
+      context "when an error occurs" do
+        let(:error) { ExampleException }
+        let(:app) { lambda { |_args| raise error, "error message" } }
+
+        it "uses appsignal.route value for action name" do
+          expect { middleware.call(env) }.to raise_error(error)
+          expect(transaction).to match_transaction(
+            "error" => be_transaction_error(
+              "name" => "ExampleException",
+              "message" => "error message"
+            )
+          )
+        end
       end
     end
-
-    it "should set metadata" do
-      expect_any_instance_of(Appsignal::Transaction).to receive(:set_metadata).twice
-    end
-
-    it "should set the queue start" do
-      expect_any_instance_of(Appsignal::Transaction).to receive(:set_http_or_background_queue_start)
-    end
-
-    after(:error => false) { middleware.call(env) }
-    after(:error => true) { expect { middleware.call(env) }.to raise_error(error) }
   end
 end

--- a/spec/lib/appsignal/rack/generic_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/generic_instrumentation_spec.rb
@@ -120,6 +120,21 @@ describe Appsignal::Rack::GenericInstrumentation do
           )
         end
       end
+
+      context "when transaction gets completed inside instrumentation" do
+        let(:app) { lambda { |_args| Appsignal::Transaction.complete_current! } }
+
+        it "does not track any transaction details" do
+          middleware.call(env)
+          expect(transaction).to match_transaction(
+            "id" => "1",
+            "action" => nil,
+            "events" => [],
+            "metadata" => {},
+            "namespace" => Appsignal::Transaction::HTTP_REQUEST
+          )
+        end
+      end
     end
   end
 end

--- a/spec/support/helpers/transaction_helpers.rb
+++ b/spec/support/helpers/transaction_helpers.rb
@@ -34,4 +34,33 @@ module TransactionHelpers
   def clear_current_transaction!
     Thread.current[:appsignal_transaction] = nil
   end
+
+  def be_transaction_error(attrs = {})
+    hash_including(
+      {
+        "name" => kind_of(String),
+        "message" => kind_of(String),
+        "backtrace" => kind_of(String)
+      }.merge(attrs)
+    )
+  end
+
+  def be_transaction_event(attrs = {})
+    hash_including(
+      {
+        "name" => kind_of(String),
+        "title" => kind_of(String),
+        "body" => kind_of(String),
+        "body_format" => kind_of(Integer),
+        "allocation_count" => kind_of(Integer),
+        "child_allocation_count" => kind_of(Integer),
+        "child_duration" => kind_of(Float),
+        "child_gc_duration" => kind_of(Float),
+        "count" => kind_of(Integer),
+        "duration" => kind_of(Float),
+        "gc_duration" => kind_of(Float),
+        "start" => kind_of(Float)
+      }.merge(attrs)
+    )
+  end
 end

--- a/spec/support/matchers/match_transaction.rb
+++ b/spec/support/matchers/match_transaction.rb
@@ -1,0 +1,18 @@
+RSpec::Matchers.define :match_transaction do |expected|
+  match do |actual|
+    @actual = actual.to_h
+    @expected = {
+      "action" => kind_of(String),
+      "error" => be_nil | be_kind_of(String),
+      "events" => kind_of(Array),
+      "id" => kind_of(String),
+      "metadata" => kind_of(Hash),
+      "namespace" => kind_of(String),
+      "sample_data" => kind_of(Hash),
+      "timestamp" => kind_of(Integer)
+    }.merge(expected)
+    expect(@actual).to match(@expected)
+  end
+
+  diffable
+end


### PR DESCRIPTION
https://app.intercom.io/a/apps/yzor8gyw/inbox/inbox/540654/conversations/22303038066

## Fix error when transactions are completed

If an AppSignal transaction is closed in an app using the
GenericInstrumentation middleware AppSignal would raise an error.

To fix the error that would occur, fetch the transaction again from
`Appsignal::Transaction.current` instead of using the `transaction`
variable that was available. If the transaction was closed inside the
instrumentation block, it will return a `NilTransaction` which will
ignore the method call instead of raising an error.

## Rewrite GenericInstrumentation specs

Use `transaction.to_h` for as much transaction data as possible rather
than listening for method calls.

Also create some reusable helpers for the `transaction.to_h` assertions
so we don't have to specify all the keys and values every time. When a
new field gets added we also only have to update the helpers and
relevant specs rather than all the specs that use `transaction.to_h`.