### PR TITLE
Add AppSignal transaction test helpers

### DIFF
--- a/spec/lib/appsignal/hooks/action_cable_spec.rb
+++ b/spec/lib/appsignal/hooks/action_cable_spec.rb
@@ -54,16 +54,12 @@ describe Appsignal::Hooks::ActionCableHook do
             .with(transaction_id, Appsignal::Transaction::ACTION_CABLE, kind_of(ActionDispatch::Request))
             .and_return(transaction)
           allow(Appsignal::Transaction).to receive(:current).and_return(transaction)
-          # Make sure sample data is added
-          expect(transaction.ext).to receive(:finish).and_return(true)
-          # Stub complete call, stops it from being cleared in the extension
-          # And allows us to call `#to_h` on it after it's been completed.
-          expect(transaction.ext).to receive(:complete)
 
           # Stub transmit call for subscribe/unsubscribe tests
           allow(connection).to receive(:websocket)
             .and_return(instance_double("ActionCable::Connection::WebSocket", :transmit => nil))
         end
+        around { |example| keep_transactions { example.run } }
 
         describe "#perform_action" do
           it "creates a transaction for an action" do

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -44,11 +44,6 @@ describe Appsignal::Hooks::SidekiqPlugin, :with_yaml_parse_error => false do
     start_agent
     Appsignal.logger = test_logger(log)
 
-    # Stub calls to extension, because that would remove the transaction
-    # from the extension.
-    allow_any_instance_of(Appsignal::Extension::Transaction).to receive(:finish).and_return(true)
-    allow_any_instance_of(Appsignal::Extension::Transaction).to receive(:complete)
-
     # Stub removal of current transaction from current thread so we can fetch
     # it later.
     expect(Appsignal::Transaction).to receive(:clear_current_transaction!) do
@@ -56,6 +51,7 @@ describe Appsignal::Hooks::SidekiqPlugin, :with_yaml_parse_error => false do
       test_store[:transaction] = transaction if transaction
     end
   end
+  around { |example| keep_transactions { example.run } }
   after :with_yaml_parse_error => false do
     expect(log_contents(log)).to_not contains_log(:warn, "Unable to load YAML")
   end

--- a/spec/lib/appsignal/integrations/que_spec.rb
+++ b/spec/lib/appsignal/integrations/que_spec.rb
@@ -59,9 +59,8 @@ if DependencyHelper.que_present?
             kind_of(Appsignal::Transaction::GenericRequest)
           ).and_return(transaction)
         allow(Appsignal::Transaction).to receive(:current).and_return(transaction)
-        expect(transaction.ext).to receive(:finish).and_return(true)
-        expect(transaction.ext).to receive(:complete)
       end
+      around { |example| keep_transactions { example.run } }
 
       subject { transaction.to_h }
 

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -154,13 +154,8 @@ describe Appsignal::Transaction do
   describe "#complete" do
     context "when transaction is being sampled" do
       it "samples data" do
-        expect(transaction.ext).to receive(:finish).and_return(true)
-        # Stub call to extension, because that would remove the transaction
-        # from the extension.
-        expect(transaction.ext).to receive(:complete)
-
         transaction.set_tags(:foo => "bar")
-        transaction.complete
+        keep_transactions { transaction.complete }
         expect(transaction.to_h["sample_data"]).to include(
           "tags" => { "foo" => "bar" }
         )
@@ -169,11 +164,8 @@ describe Appsignal::Transaction do
 
     context "when transaction is not being sampled" do
       it "does not sample data" do
-        expect(transaction).to_not receive(:sample_data)
-        expect(transaction.ext).to receive(:finish).and_return(false)
-        expect(transaction.ext).to receive(:complete).and_call_original
-
-        transaction.complete
+        keep_transactions(:sample => false) { transaction.complete }
+        expect(transaction.to_h["sample_data"]).to be_empty
       end
     end
 

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -650,13 +650,12 @@ describe Appsignal do
       context "when given a block" do
         it "yields the transaction and allows additional metadata to be set" do
           captured_transaction = nil
-          Appsignal.send_error(StandardError.new("my_error")) do |transaction|
-            captured_transaction = transaction
-            transaction.set_action("my_action")
-            transaction.set_namespace("my_namespace")
-
-            # Don't flush the transaction, so we can inspect it
-            expect(transaction).to receive(:complete)
+          keep_transactions do
+            Appsignal.send_error(StandardError.new("my_error")) do |transaction|
+              captured_transaction = transaction
+              transaction.set_action("my_action")
+              transaction.set_namespace("my_namespace")
+            end
           end
           expect(captured_transaction.to_h).to include(
             "namespace" => "my_namespace",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,16 +31,9 @@ if DependencyHelper.rails_present?
   end
 end
 require "appsignal"
-
-module Appsignal
-  class << self
-    remove_method :testing?
-
-    def testing?
-      true
-    end
-  end
-end
+# Include patches of AppSignal modules and classes to make test helpers
+# available.
+require File.join(DirectoryHelper.support_dir, "testing.rb")
 
 puts "Running specs in #{RUBY_VERSION} on #{RUBY_PLATFORM}\n\n"
 

--- a/spec/support/testing.rb
+++ b/spec/support/testing.rb
@@ -1,0 +1,77 @@
+module Appsignal
+  class << self
+    remove_method :testing?
+
+    def testing?
+      true
+    end
+  end
+
+  module Testing
+    class << self
+      attr_writer :keep_transactions
+      # @see TransactionHelpers#keep_transactions
+      def keep_transactions?
+        defined?(@keep_transactions) ? @keep_transactions : nil
+      end
+
+      attr_writer :sample_transactions
+      # @see TransactionHelpers#keep_transactions
+      def sample_transactions?
+        sample = defined?(@sample_transactions) ? @sample_transactions : nil
+        if sample.nil?
+          keep_transactions?
+        else
+          @sample_transactions
+        end
+      end
+    end
+  end
+
+  class Extension
+    class Transaction
+      alias original_finish finish
+
+      # Override default {Extension::Transaction#finish} behavior to always
+      # return true, which tells the transaction to add its sample data (unless
+      # used in combination with {TransactionHelpers#keep_transactions}
+      # `:sample => false`). This allows us to use
+      # {Appsignal::Transaction#to_h} without relying on the extension sampling
+      # behavior.
+      #
+      # @see TransactionHelpers#keep_transactions
+      def finish(*args)
+        return_value = original_finish(*args)
+        return_value = true if Appsignal::Testing.sample_transactions?
+        return_value
+      end
+
+      alias original_complete complete
+
+      # Override default {Extension::Transaction#complete} behavior to
+      # store the transaction JSON before the transaction is completed
+      # and it's no longer possible to request the transaction JSON.
+      #
+      # @see TransactionHelpers#keep_transactions
+      def complete
+        @transaction_json = to_json if Appsignal::Testing.keep_transactions?
+        original_complete
+      end
+
+      alias original_to_json to_json
+
+      # Override default {Extension::Transaction#to_json} behavior to
+      # return the stored the transaction JSON when the transaction was
+      # completed.
+      #
+      # @see TransactionHelpers#keep_transactions
+      def to_json
+        if defined? @transaction_json
+          @transaction_json
+        else
+          original_to_json
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When an AppSignal transaction gets completed it is no longer available
in the extension for it to return a JSON representation of it.

The Ruby Transaction class will get `null` back from the extension which
the `JSON` library can't parse, which raises an error.

This makes it difficult in specs to use the
`Appsignal::Transaction#to_h` helper to get a Ruby Hash based on the
extension transaction JSON. Specs that use the
`Appsignal::Transaction#to_h` helper previously stubbed the
`Appsignal::Extension::Transaction#complete` method call so it is
possible to fetch the JSON during the spec.

This is a cumbersome process which makes it difficult to use the `#to_h`
in specs. Something which we prefer to do as expecting method call is a
fragile assertion, especially when `and_call_original` is not used on
the expectation.

Instead of stubbing `Appsignal::Extension::Transaction` call on the
`finish` and `complete` methods override them and add some extra
behavior in the test environment. This extra behavior requests and
stores the transaction JSON representation before the `complete` call is
made to the extension. This means we have access to the JSON while also
completing the transaction in the extension.

Additionally it doesn't break the
`Appsignal::Extension::Transaction#finish` call, which is the case with
using the RSpec method call expectation. So it would still send all the
arguments of the `Appsignal::Extension::Transaction#finish` method to
the extension.

This can now be used with the `keep_transactions` spec helper. See the
diff of this commit for some examples.

This new testing helper is not active used by default for all specs as
it may have a performance impact when it applies to all transactions in
the test suite. Not all tests rely this behavior, so only use it in
those that need it.