### PR TITLE
Fix Object integration specs

### DIFF
--- a/spec/lib/appsignal/integrations/object_spec.rb
+++ b/spec/lib/appsignal/integrations/object_spec.rb
@@ -16,8 +16,8 @@ describe Object do
       context "when active" do
         let(:transaction) { http_request_transaction }
         before do
-          expect(Appsignal::Transaction).to receive(:current).at_least(:once).and_return(transaction)
           Appsignal.config = project_fixture_config
+          expect(Appsignal::Transaction).to receive(:current).at_least(:once).and_return(transaction)
         end
         after { Appsignal.config = nil }
 
@@ -137,9 +137,9 @@ describe Object do
       context "when active" do
         let(:transaction) { http_request_transaction }
         before do
+          Appsignal.config = project_fixture_config
           expect(Appsignal::Transaction).to receive(:current).at_least(:once)
             .and_return(transaction)
-          Appsignal.config = project_fixture_config
         end
         after { Appsignal.config = nil }
 


### PR DESCRIPTION
When a transaction is created before the config is set (even in a spec)
it fails on a missing configuration option, the
`enable_gc_instrumentation` option being requested in
`Appsignal::Transaction.garbage_collection_profiler`.

This spec doesn't fail when run in the entire test suite, because other
specs are run beforehand that set the `Appsignal.config` with *any*
value. It does fail when run on its own.

To make our test suite more resilient and allow it to run in a random
order in the future, fix the setup in this spec file.