### PR TITLE
Keep track of created transactions in test suite

### DIFF
--- a/spec/lib/appsignal/hooks/rake_spec.rb
+++ b/spec/lib/appsignal/hooks/rake_spec.rb
@@ -4,69 +4,70 @@ describe Appsignal::Hooks::RakeHook do
   let(:task) { Rake::Task.new("task:name", Rake::Application.new) }
   let(:arguments) { Rake::TaskArguments.new(["foo"], ["bar"]) }
   let(:generic_request) { Appsignal::Transaction::GenericRequest.new({}) }
-  before(:context) do
-    Appsignal.config = project_fixture_config
-    expect(Appsignal.active?).to be_truthy
-    Appsignal::Hooks.load_hooks
-  end
+  before(:context) { start_agent }
 
   describe "#execute" do
     context "without error" do
+      before { expect(Appsignal).to_not receive(:stop) }
+
+      def perform
+        task.execute(arguments)
+      end
+
       it "creates no transaction" do
-        expect(Appsignal::Transaction).to_not receive(:create)
+        expect(Appsignal::Transaction).to_not receive(:new)
+        expect { perform }.to_not(change { created_transactions })
       end
 
       it "calls the original task" do
-        expect(task).to receive(:execute_without_appsignal).with("foo")
+        expect(task).to receive(:execute_without_appsignal).with(arguments)
+        perform
       end
-
-      after { task.execute("foo") }
     end
 
     context "with error" do
       let(:error) { ExampleException }
-      let(:transaction) { background_job_transaction }
       before do
-        task.enhance { raise error }
-
-        expect(Appsignal::Transaction).to receive(:create).with(
-          kind_of(String),
-          Appsignal::Transaction::BACKGROUND_JOB,
-          kind_of(Appsignal::Transaction::GenericRequest)
-        ).and_return(transaction)
+        task.enhance { raise error, "my error message" }
+        # We don't call `and_call_original` here as we don't want AppSignal to
+        # stop and start for every spec.
+        expect(Appsignal).to receive(:stop).with("rake")
       end
 
-      it "sets the action" do
-        expect(transaction).to receive(:set_action).with("task:name")
+      def perform
+        keep_transactions do
+          expect { task.execute(arguments) }.to raise_error(error)
+        end
       end
 
-      it "sets the error" do
-        expect(transaction).to receive(:set_error).with(error)
-      end
+      it "creates a background job transaction" do
+        perform
 
-      it "completes the transaction and stops" do
-        expect(transaction).to receive(:complete).ordered
-        expect(Appsignal).to receive(:stop).with("rake").ordered
-      end
-
-      it "adds the task arguments to the request" do
-        expect(Appsignal::Transaction::GenericRequest).to receive(:new)
-          .with(:params => { :foo => "bar" })
-          .and_return(generic_request)
+        expect(last_transaction.to_h).to include(
+          "id" => kind_of(String),
+          "namespace" => Appsignal::Transaction::BACKGROUND_JOB,
+          "action" => "task:name",
+          "error" => {
+            "name" => "ExampleException",
+            "message" => "my error message",
+            "backtrace" => kind_of(String)
+          },
+          "sample_data" => hash_including(
+            "params" => { "foo" => "bar" }
+          )
+        )
       end
 
       context "when first argument is not a `Rake::TaskArguments`" do
         let(:arguments) { nil }
 
-        it "adds the first argument regardless" do
-          expect(Appsignal::Transaction::GenericRequest).to receive(:new)
-            .with(:params => nil)
-            .and_return(generic_request)
-        end
-      end
+        it "does not add the params to the transaction" do
+          perform
 
-      after do
-        expect { task.execute(arguments) }.to raise_error ExampleException
+          expect(last_transaction.to_h).to include(
+            "sample_data" => hash_excluding("params")
+          )
+        end
       end
     end
   end

--- a/spec/lib/appsignal/integrations/resque_spec.rb
+++ b/spec/lib/appsignal/integrations/resque_spec.rb
@@ -18,65 +18,64 @@ if DependencyHelper.resque_present?
           extend Appsignal::Integrations::ResquePlugin
 
           def self.perform
-            raise ExampleException
+            raise ExampleException, "my error message"
           end
         end
       end
 
       describe :around_perform_resque_plugin do
-        let(:transaction) { Appsignal::Transaction.new("1", "background", {}, {}) }
         let(:job) { ::Resque::Job.new("default", "class" => "TestJob") }
-        before do
-          allow(transaction).to receive(:complete).and_return(true)
-          allow(Appsignal::Transaction).to receive(:current).and_return(transaction)
-          expect(Appsignal).to receive(:stop)
-        end
+        before { expect(Appsignal).to receive(:stop) }
 
         context "without exception" do
           it "creates a new transaction" do
-            expect(Appsignal::Transaction).to receive(:create).and_return(transaction)
-          end
+            expect do
+              keep_transactions { job.perform }
+            end.to change { created_transactions.length }.by(1)
 
-          it "wraps it in a transaction with the correct params" do
-            expect(Appsignal).to receive(:monitor_transaction).with(
-              "perform_job.resque",
-              :class => "TestJob",
-              :method => "perform"
+            expect(last_transaction.to_h).to include(
+              "namespace" => Appsignal::Transaction::BACKGROUND_JOB,
+              "action" => "TestJob#perform",
+              "error" => nil,
+              "events" => [
+                hash_including(
+                  "name" => "perform_job.resque",
+                  "title" => "",
+                  "body" => "",
+                  "body_format" => Appsignal::EventFormatter::DEFAULT,
+                  "count" => 1,
+                  "duration" => kind_of(Float)
+                )
+              ]
             )
           end
-
-          it "closes the transaction" do
-            expect(transaction).to receive(:complete)
-          end
-
-          after { job.perform }
         end
 
         context "with exception" do
           let(:job) { ::Resque::Job.new("default", "class" => "BrokenTestJob") }
-          let(:transaction) do
-            Appsignal::Transaction.new(
-              SecureRandom.uuid,
-              Appsignal::Transaction::BACKGROUND_JOB,
-              Appsignal::Transaction::GenericRequest.new({})
-            )
-          end
-          before do
-            allow(Appsignal::Transaction).to receive(:current).and_return(transaction)
-            expect(Appsignal::Transaction).to receive(:create)
-              .with(
-                kind_of(String),
-                Appsignal::Transaction::BACKGROUND_JOB,
-                kind_of(Appsignal::Transaction::GenericRequest)
-              ).and_return(transaction)
+
+          def perform
+            keep_transactions do
+              expect do
+                job.perform
+              end.to raise_error(ExampleException, "my error message")
+            end
           end
 
           it "sets the exception on the transaction" do
-            expect(transaction).to receive(:set_error).with(ExampleException)
-          end
+            expect do
+              perform
+            end.to change { created_transactions.length }.by(1)
 
-          after do
-            expect { job.perform }.to raise_error(ExampleException)
+            expect(last_transaction.to_h).to include(
+              "namespace" => Appsignal::Transaction::BACKGROUND_JOB,
+              "action" => "BrokenTestJob#perform",
+              "error" => {
+                "name" => "ExampleException",
+                "message" => "my error message",
+                "backtrace" => kind_of(String)
+              }
+            )
           end
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -113,6 +113,7 @@ RSpec.configure do |config|
   end
 
   config.after do
+    Appsignal::Testing.clear!
     Thread.current[:appsignal_transaction] = nil
     stop_minutely_probes
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -114,7 +114,7 @@ RSpec.configure do |config|
 
   config.after do
     Appsignal::Testing.clear!
-    Thread.current[:appsignal_transaction] = nil
+    clear_current_transaction!
     stop_minutely_probes
   end
 

--- a/spec/support/helpers/transaction_helpers.rb
+++ b/spec/support/helpers/transaction_helpers.rb
@@ -29,6 +29,21 @@ module TransactionHelpers
     )
   end
 
+  # Returns the all {Appsignal::Transaction} objects created during this test
+  # run so far.
+  #
+  # @return [Array<Appsignal::Transaction>]
+  def created_transactions
+    Appsignal::Testing.transactions
+  end
+
+  # Returns the last created {Appsignal::Transaction}.
+  #
+  # @return [Appsignal::Transaction]
+  def last_transaction
+    created_transactions.last
+  end
+
   # Use when {Appsignal::Transaction.clear_current_transaction!} is stubbed to
   # clear the current transaction on the current thread.
   def clear_current_transaction!

--- a/spec/support/testing.rb
+++ b/spec/support/testing.rb
@@ -9,6 +9,14 @@ module Appsignal
 
   module Testing
     class << self
+      def transactions
+        @transactions ||= []
+      end
+
+      def clear!
+        transactions.clear
+      end
+
       attr_writer :keep_transactions
       # @see TransactionHelpers#keep_transactions
       def keep_transactions?
@@ -24,6 +32,22 @@ module Appsignal
         else
           @sample_transactions
         end
+      end
+    end
+  end
+
+  class Transaction
+    class << self
+      alias original_new new
+
+      # Override the {Appsignal::Transaction.new} method so we can track which
+      # transactions are created on the {Appsignal::Testing.transactions} list.
+      #
+      # @see TransactionHelpers#last_transaction
+      def new(*args)
+        transaction = original_new(*args)
+        Appsignal::Testing.transactions << transaction
+        transaction
       end
     end
   end


### PR DESCRIPTION
This allows us to know which transactions were created during a spec.

The convenience method for fetching the last created transaction will
help us avoid having to stub transaction creation and clearing methods.
We won't have to reimplement a method to fetch the created
transaction(s) in every spec file.

The `created_transactions` method will return all created transactions,
which will also help us detect if more than one transaction is being
created during a spec.

The `last_transaction` will always return the last created transaction,
if any.

---

The rest of the commits of this PR update specs to use these new helpers.