### PR TITLE
Assert if transactions were completed

### DIFF
--- a/spec/lib/appsignal/hooks/rake_spec.rb
+++ b/spec/lib/appsignal/hooks/rake_spec.rb
@@ -43,6 +43,7 @@ describe Appsignal::Hooks::RakeHook do
       it "creates a background job transaction" do
         perform
 
+        expect(last_transaction).to be_completed
         expect(last_transaction.to_h).to include(
           "id" => kind_of(String),
           "namespace" => Appsignal::Transaction::BACKGROUND_JOB,

--- a/spec/lib/appsignal/integrations/que_spec.rb
+++ b/spec/lib/appsignal/integrations/que_spec.rb
@@ -46,21 +46,21 @@ if DependencyHelper.que_present?
       end
       around { |example| keep_transactions { example.run } }
 
-      subject { last_transaction.to_h }
-
       context "success" do
         it "creates a transaction for a job" do
           expect do
             instance._run
           end.to change { created_transactions.length }.by(1)
 
-          expect(subject).to include(
+          expect(last_transaction).to be_completed
+          transaction_hash = last_transaction.to_h
+          expect(transaction_hash).to include(
             "action" => "MyQueJob#run",
             "id" => instance_of(String),
             "namespace" => Appsignal::Transaction::BACKGROUND_JOB
           )
-          expect(subject["error"]).to be_nil
-          expect(subject["events"].first).to include(
+          expect(transaction_hash["error"]).to be_nil
+          expect(transaction_hash["events"].first).to include(
             "allocation_count" => kind_of(Integer),
             "body" => "",
             "body_format" => Appsignal::EventFormatter::DEFAULT,
@@ -74,7 +74,7 @@ if DependencyHelper.que_present?
             "name" => "perform_job.que",
             "title" => ""
           )
-          expect(subject["sample_data"]).to include(
+          expect(transaction_hash["sample_data"]).to include(
             "params" => %w[1 birds],
             "metadata" => {
               "attempts" => 0,
@@ -99,17 +99,19 @@ if DependencyHelper.que_present?
             end.to raise_error(ExampleException)
           end.to change { created_transactions.length }.by(1)
 
-          expect(subject).to include(
+          expect(last_transaction).to be_completed
+          transaction_hash = last_transaction.to_h
+          expect(transaction_hash).to include(
             "action" => "MyQueJob#run",
             "id" => instance_of(String),
             "namespace" => Appsignal::Transaction::BACKGROUND_JOB
           )
-          expect(subject["error"]).to include(
+          expect(transaction_hash["error"]).to include(
             "backtrace" => kind_of(String),
             "name" => error.class.name,
             "message" => error.message
           )
-          expect(subject["sample_data"]).to include(
+          expect(transaction_hash["sample_data"]).to include(
             "params" => %w[1 birds],
             "metadata" => {
               "attempts" => 0,
@@ -130,17 +132,19 @@ if DependencyHelper.que_present?
 
           expect { instance._run }.to change { created_transactions.length }.by(1)
 
-          expect(subject).to include(
+          expect(last_transaction).to be_completed
+          transaction_hash = last_transaction.to_h
+          expect(transaction_hash).to include(
             "action" => "MyQueJob#run",
             "id" => instance_of(String),
             "namespace" => Appsignal::Transaction::BACKGROUND_JOB
           )
-          expect(subject["error"]).to include(
+          expect(transaction_hash["error"]).to include(
             "backtrace" => kind_of(String),
             "name" => error.class.name,
             "message" => error.message
           )
-          expect(subject["sample_data"]).to include(
+          expect(transaction_hash["sample_data"]).to include(
             "params" => %w[1 birds],
             "metadata" => {
               "attempts" => 0,

--- a/spec/lib/appsignal/integrations/resque_spec.rb
+++ b/spec/lib/appsignal/integrations/resque_spec.rb
@@ -33,6 +33,7 @@ if DependencyHelper.resque_present?
               keep_transactions { job.perform }
             end.to change { created_transactions.length }.by(1)
 
+            expect(last_transaction).to be_completed
             expect(last_transaction.to_h).to include(
               "namespace" => Appsignal::Transaction::BACKGROUND_JOB,
               "action" => "TestJob#perform",
@@ -67,6 +68,7 @@ if DependencyHelper.resque_present?
               perform
             end.to change { created_transactions.length }.by(1)
 
+            expect(last_transaction).to be_completed
             expect(last_transaction.to_h).to include(
               "namespace" => Appsignal::Transaction::BACKGROUND_JOB,
               "action" => "BrokenTestJob#perform",

--- a/spec/support/matchers/be_completed.rb
+++ b/spec/support/matchers/be_completed.rb
@@ -1,0 +1,5 @@
+RSpec::Matchers.define :be_completed do
+  match do |transaction|
+    values_match? transaction.ext._completed?, true
+  end
+end

--- a/spec/support/testing.rb
+++ b/spec/support/testing.rb
@@ -2,11 +2,13 @@ module Appsignal
   class << self
     remove_method :testing?
 
+    # @api private
     def testing?
       true
     end
   end
 
+  # @api private
   module Testing
     class << self
       def transactions
@@ -77,9 +79,19 @@ module Appsignal
       # and it's no longer possible to request the transaction JSON.
       #
       # @see TransactionHelpers#keep_transactions
+      # @see #_completed?
       def complete
+        @completed = true # see {#_completed?} method
         @transaction_json = to_json if Appsignal::Testing.keep_transactions?
         original_complete
+      end
+
+      # Returns true when the Transaction was completed.
+      # {Appsignal::Extension::Transaction.complete} was called.
+      #
+      # @return [Boolean] returns if the transaction was completed.
+      def _completed?
+        @completed || false
       end
 
       alias original_to_json to_json


### PR DESCRIPTION
Test if a transaction was actually completed in an integration. This
allows us to test if we're still starting and finishing whole
transactions. This was previously asserted by listening to the
`Appsignal::Transaction#complete` method call, which is fragile without
at least and `and_call_original` call.

This change tracks whether or not a transaction was completed by
listening for the `Appsignal::Extension::Transaction#complete` call and
setting an instance variable. The original logic remains intact.

If it was completed can be asked by calling
`Appsignal::Extension::Transaction#_complete?`.

Use the `be_completed` matcher on a transaction to assert if it was
completed or not. Hide the internal classes search in the matcher so we
don't have to repeat it in every spec. Updated specs that are fully over
to the new test helpers.