### PR TITLE
Refactor Appsignal::Testing helpers

### DIFF
--- a/spec/support/testing.rb
+++ b/spec/support/testing.rb
@@ -38,76 +38,76 @@ module Appsignal
     end
   end
 
-  class Transaction
-    class << self
-      alias original_new new
+  # @api private
+  module TransactionTestHelpers
+    # Override the {Appsignal::Transaction.new} method so we can track which
+    # transactions are created on the {Appsignal::Testing.transactions} list.
+    #
+    # @see TransactionHelpers#last_transaction
+    def new(*_args)
+      transaction = super
+      Appsignal::Testing.transactions << transaction
+      transaction
+    end
+  end
 
-      # Override the {Appsignal::Transaction.new} method so we can track which
-      # transactions are created on the {Appsignal::Testing.transactions} list.
-      #
-      # @see TransactionHelpers#last_transaction
-      def new(*args)
-        transaction = original_new(*args)
-        Appsignal::Testing.transactions << transaction
-        transaction
+  Appsignal::Transaction.extend TransactionTestHelpers
+
+  # @api private
+  module ExtensionTransactionTestHelpers
+    # Override default {Extension::Transaction#finish} behavior to always
+    # return true, which tells the transaction to add its sample data (unless
+    # used in combination with {TransactionHelpers#keep_transactions}
+    # `:sample => false`). This allows us to use
+    # {Appsignal::Transaction#to_h} without relying on the extension sampling
+    # behavior.
+    #
+    # @see TransactionHelpers#keep_transactions
+    def finish(*_args)
+      return_value = super
+      return_value = true if Appsignal::Testing.sample_transactions?
+      return_value
+    end
+
+    # Override default {Extension::Transaction#complete} behavior to
+    # store the transaction JSON before the transaction is completed
+    # and it's no longer possible to request the transaction JSON.
+    #
+    # @see TransactionHelpers#keep_transactions
+    # @see #_completed?
+    def complete
+      @completed = true # see {#_completed?} method
+      @transaction_json = to_json if Appsignal::Testing.keep_transactions?
+      super
+    end
+
+    # Returns true when the Transaction was completed.
+    # {Appsignal::Extension::Transaction.complete} was called.
+    #
+    # @return [Boolean] returns if the transaction was completed.
+    def _completed?
+      @completed || false
+    end
+
+    # Override default {Extension::Transaction#to_json} behavior to
+    # return the stored the transaction JSON when the transaction was
+    # completed.
+    #
+    # @see TransactionHelpers#keep_transactions
+    def to_json
+      if defined? @transaction_json
+        @transaction_json
+      else
+        super
       end
     end
   end
 
-  class Extension
-    class Transaction
-      alias original_finish finish
-
-      # Override default {Extension::Transaction#finish} behavior to always
-      # return true, which tells the transaction to add its sample data (unless
-      # used in combination with {TransactionHelpers#keep_transactions}
-      # `:sample => false`). This allows us to use
-      # {Appsignal::Transaction#to_h} without relying on the extension sampling
-      # behavior.
-      #
-      # @see TransactionHelpers#keep_transactions
-      def finish(*args)
-        return_value = original_finish(*args)
-        return_value = true if Appsignal::Testing.sample_transactions?
-        return_value
-      end
-
-      alias original_complete complete
-
-      # Override default {Extension::Transaction#complete} behavior to
-      # store the transaction JSON before the transaction is completed
-      # and it's no longer possible to request the transaction JSON.
-      #
-      # @see TransactionHelpers#keep_transactions
-      # @see #_completed?
-      def complete
-        @completed = true # see {#_completed?} method
-        @transaction_json = to_json if Appsignal::Testing.keep_transactions?
-        original_complete
-      end
-
-      # Returns true when the Transaction was completed.
-      # {Appsignal::Extension::Transaction.complete} was called.
-      #
-      # @return [Boolean] returns if the transaction was completed.
-      def _completed?
-        @completed || false
-      end
-
-      alias original_to_json to_json
-
-      # Override default {Extension::Transaction#to_json} behavior to
-      # return the stored the transaction JSON when the transaction was
-      # completed.
-      #
-      # @see TransactionHelpers#keep_transactions
-      def to_json
-        if defined? @transaction_json
-          @transaction_json
-        else
-          original_to_json
-        end
-      end
-    end
+  class Appsignal::Extension::Transaction # rubocop:disable Style/ClassAndModuleChildren
+    # Use prepend so we can be assured that our testing helper versions of
+    # methods are called first.
+    # Call `prepend` by reopening the class. We can't call `prepend` outside
+    # the class because it's a private method in Ruby 2.0.
+    prepend ExtensionTransactionTestHelpers
   end
 end


### PR DESCRIPTION
Use modules and include (prepend/extend) existing classes rather than
reopening classes and monkeypatching methods (aliasing the old method
and creating a new method that wraps around it.

With modules we can more explicitly load in the helper logic and
methods. It also allows us to do away with the aliasing of methods and
rather call `super` inside the methods we're enhancing with testing
logic.