### PR TITLE
Use base namespace to check Redis version

### DIFF
--- a/lib/appsignal/hooks/sidekiq.rb
+++ b/lib/appsignal/hooks/sidekiq.rb
@@ -26,7 +26,7 @@ module Appsignal
       attr_reader :config
 
       def self.dependencies_present?
-        Gem::Version.new(Redis::VERSION) >= Gem::Version.new("3.3.5")
+        Gem::Version.new(::Redis::VERSION) >= Gem::Version.new("3.3.5")
       end
 
       def initialize(config = {})


### PR DESCRIPTION
Fixes #542