### PR TITLE
Add more logging for errors in debug mode

### DIFF
--- a/lib/appsignal/hooks.rb
+++ b/lib/appsignal/hooks.rb
@@ -37,7 +37,9 @@ module Appsignal
           install
           @installed = true
         rescue => ex
-          Appsignal.logger.error("Error while installing #{name} hook: #{ex}")
+          logger = Appsignal.logger
+          logger.error("Error while installing #{name} hook: #{ex}")
+          logger.debug ex.backtrace.join("\n")
         end
       end
 

--- a/spec/lib/appsignal/hooks_spec.rb
+++ b/spec/lib/appsignal/hooks_spec.rb
@@ -68,6 +68,10 @@ describe Appsignal::Hooks do
     expect(Appsignal::Hooks.hooks[:mock_error_hook].installed?).to be_falsy
 
     expect(Appsignal.logger).to receive(:error).with("Error while installing mock_error_hook hook: error").once
+    expect(Appsignal.logger).to receive(:debug).once do |message|
+      # Start of the error backtrace as debug log
+      expect(message).to start_with(File.expand_path("../../../../", __FILE__))
+    end
 
     Appsignal::Hooks.load_hooks
 


### PR DESCRIPTION
When an error occurs we want to know the backtrace in debug mode so we
can track the problem down in more detail before having to be able to
reproduce it. The backtrace may help in reproducing it as well.