### PR TITLE
Deprecate notify_of_deploy command

### DIFF
--- a/lib/appsignal/cli/notify_of_deploy.rb
+++ b/lib/appsignal/cli/notify_of_deploy.rb
@@ -60,6 +60,8 @@ module Appsignal
     #   Terminology: Deploy marker
     class NotifyOfDeploy
       class << self
+        include Appsignal::Utils::DeprecationMessage
+
         # @param options [Hash]
         # @option options :environment [String] environment to load
         #   configuration for.
@@ -85,6 +87,14 @@ module Appsignal
             },
             config
           ).transmit
+
+          puts
+          message = "This command (appsignal notify_of_deploy) has been " \
+            "deprecated in favor of the `revision` config option. Please " \
+            "see our documentation for more information on the recommended " \
+            "method: " \
+            "https://docs.appsignal.com/application/markers/deploy-markers.html"
+          deprecation_message message, Appsignal.logger
         end
 
         private

--- a/spec/lib/appsignal/cli/notify_of_deploy_spec.rb
+++ b/spec/lib/appsignal/cli/notify_of_deploy_spec.rb
@@ -116,12 +116,22 @@ describe Appsignal::CLI::NotifyOfDeploy do
 
       context "with required options" do
         let(:options) { { :environment => "production", :revision => "aaaaa", :user => "thijs" } }
+        let(:log_stream) { std_stream }
+        let(:log) { log_contents(log_stream) }
+        before { Appsignal.logger = test_logger(log_stream) }
 
         it "notifies of a deploy" do
           run
           expect(output).to_not include_config_error
           expect(output).to_not include_missing_options([])
           expect(output).to include_deploy_notification_with(options)
+        end
+
+        it "prints a deprecation message" do
+          run
+          deprecation_message = "This command (appsignal notify_of_deploy) has been deprecated"
+          expect(output).to include("appsignal WARNING: #{deprecation_message}")
+          expect(log).to contains_log :warn, deprecation_message
         end
 
         context "with no app name configured" do


### PR DESCRIPTION
We recommend the revision method instead as described on this page:
https://docs.appsignal.com/application/markers/deploy-markers.html

Closes #414