### PR TITLE
In monitor_transaction, call the block always

### DIFF
--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -57,8 +57,9 @@ module Appsignal
       # @return [Object] the value of the given block is returned.
       # @since 0.10.0
       def monitor_transaction(name, env = {})
-        return yield unless active?
-
+        # Always verify input, even when Appsignal is not active.
+        # This makes it more likely invalid configuration
+        # gets flagged in test/dev environments
         if name.start_with?("perform_job".freeze)
           namespace = Appsignal::Transaction::BACKGROUND_JOB
           request   = Appsignal::Transaction::GenericRequest.new(env)
@@ -66,9 +67,12 @@ module Appsignal
           namespace = Appsignal::Transaction::HTTP_REQUEST
           request   = ::Rack::Request.new(env)
         else
-          logger.error("Unrecognized name '#{name}'")
+          logger.error("Unrecognized name '#{name}': names must start with either 'perform_job' (for jobs and tasks) or 'process_action' (for HTTP requests)")
           return yield
         end
+
+        return yield unless active?
+
         transaction = Appsignal::Transaction.create(
           SecureRandom.uuid,
           namespace,

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -58,8 +58,8 @@ module Appsignal
       # @since 0.10.0
       def monitor_transaction(name, env = {})
         # Always verify input, even when Appsignal is not active.
-        # This makes it more likely invalid configuration
-        # gets flagged in test/dev environments
+        # This makes it more likely invalid arguments get flagged in test/dev
+        # environments.
         if name.start_with?("perform_job".freeze)
           namespace = Appsignal::Transaction::BACKGROUND_JOB
           request   = Appsignal::Transaction::GenericRequest.new(env)
@@ -67,7 +67,9 @@ module Appsignal
           namespace = Appsignal::Transaction::HTTP_REQUEST
           request   = ::Rack::Request.new(env)
         else
-          logger.error("Unrecognized name '#{name}': names must start with either 'perform_job' (for jobs and tasks) or 'process_action' (for HTTP requests)")
+          logger.error "Unrecognized name '#{name}': names must start with " \
+            "either 'perform_job' (for jobs and tasks) or 'process_action' " \
+            "(for HTTP requests)"
           return yield
         end
 

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -67,7 +67,7 @@ module Appsignal
           request   = ::Rack::Request.new(env)
         else
           logger.error("Unrecognized name '#{name}'")
-          return
+          return yield
         end
         transaction = Appsignal::Transaction.create(
           SecureRandom.uuid,

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -359,6 +359,15 @@ describe Appsignal do
           end.to raise_error(error)
         end
       end
+
+      context "with an unmatched transaction name" do
+        it "still yields to the block, and raises a specific exception afterwards" do
+          expect(Appsignal).to receive(:active?).and_return(true)
+          expect do |blk|
+            Appsignal.monitor_transaction("unknown.sidekiq", &blk)
+          end.to yield_control
+        end
+      end
     end
 
     describe ".monitor_single_transaction" do

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -360,8 +360,8 @@ describe Appsignal do
         end
       end
 
-      context "with an unmatched transaction name" do
-        it "still yields to the block, and raises a specific exception afterwards" do
+      context "with an unknown event type" do
+        it "yields the given block" do
           expect do |blk|
             Appsignal.monitor_transaction("unknown.sidekiq", &blk)
           end.to yield_control

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -362,7 +362,6 @@ describe Appsignal do
 
       context "with an unmatched transaction name" do
         it "still yields to the block, and raises a specific exception afterwards" do
-          expect(Appsignal).to receive(:active?).and_return(true)
           expect do |blk|
             Appsignal.monitor_transaction("unknown.sidekiq", &blk)
           end.to yield_control


### PR DESCRIPTION
Follow up of #546

---

Original PR by @julik :

> Namely in cases when the name of the transaction is not recognised. Previously the block would be ignored and `nil` would be returned to the caller, which is not intuitive. This was exacerbated by the fact that when Appsignal was inactive the block _would_ end up being called - in test and dev.
> 
> This change makes sure that input is validated/transformed even when Appsignal is inactive, and that the block gets called even when the `name` argument is not matched.

