### PR TITLE
Improve Puma compatibility

### DIFF
--- a/lib/appsignal/hooks/puma.rb
+++ b/lib/appsignal/hooks/puma.rb
@@ -16,6 +16,11 @@ module Appsignal
         end
 
         if ::Puma.respond_to?(:cli_config) && ::Puma.cli_config
+          ::Puma.cli_config.options[:before_fork] ||= []
+          ::Puma.cli_config.options[:before_fork] << proc do |_id|
+            Appsignal::Minutely.start
+          end
+
           ::Puma.cli_config.options[:before_worker_boot] ||= []
           ::Puma.cli_config.options[:before_worker_boot] << proc do |_id|
             Appsignal.forked

--- a/spec/lib/appsignal/hooks/puma_spec.rb
+++ b/spec/lib/appsignal/hooks/puma_spec.rb
@@ -71,12 +71,14 @@ describe Appsignal::Hooks::PumaHook do
 
     context "with nil hooks" do
       before do
+        Puma.cli_config.options.delete(:before_fork)
         Puma.cli_config.options.delete(:before_worker_boot)
         Puma.cli_config.options.delete(:before_worker_shutdown)
         Appsignal::Hooks::PumaHook.new.install
       end
 
       it "should add a before shutdown worker callback" do
+        expect(Puma.cli_config.options[:before_fork].first).to be_a(Proc)
         expect(Puma.cli_config.options[:before_worker_boot].first).to be_a(Proc)
         expect(Puma.cli_config.options[:before_worker_shutdown].first).to be_a(Proc)
       end
@@ -84,12 +86,14 @@ describe Appsignal::Hooks::PumaHook do
 
     context "with existing hooks" do
       before do
+        Puma.cli_config.options[:before_fork] = []
         Puma.cli_config.options[:before_worker_boot] = []
         Puma.cli_config.options[:before_worker_shutdown] = []
         Appsignal::Hooks::PumaHook.new.install
       end
 
       it "should add a before shutdown worker callback" do
+        expect(Puma.cli_config.options[:before_fork].first).to be_a(Proc)
         expect(Puma.cli_config.options[:before_worker_boot].first).to be_a(Proc)
         expect(Puma.cli_config.options[:before_worker_shutdown].first).to be_a(Proc)
       end


### PR DESCRIPTION
Adding a `before_fork` proc that starts our Minutely Puma probe.

When `daemonize true` is set in the Puma config, this ensures that
a new minutely probe is started after daemonizing the process.

The probe needs to live in the "master" process,
to gather all the wanted metrics.

This doesn't cover all cases, just the one(s) where Puma is started
from it's own CLI.