### PR TITLE
Automatically set revision from Heroku Dyno Metadata

### DIFF
--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -251,7 +251,10 @@ module Appsignal
 
     def detect_from_system
       {}.tap do |hash|
-        hash[:log] = "stdout" if Appsignal::System.heroku?
+        if Appsignal::System.heroku?
+          hash[:log] = "stdout"
+          hash[:revision] = ENV["HEROKU_SLUG_COMMIT"]
+        end
 
         # Make active by default if APPSIGNAL_PUSH_API_KEY is present
         hash[:active] = true if ENV["APPSIGNAL_PUSH_API_KEY"]

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -77,7 +77,7 @@ describe Appsignal::Config do
         end
 
         it "sets the log as loaded through the system" do
-          expect(config.system_config).to eq(:log => "stdout")
+          expect(config.system_config).to match(hash_including(:log => "stdout"))
         end
       end
 
@@ -87,6 +87,36 @@ describe Appsignal::Config do
         end
 
         it "does not set log as loaded through the system" do
+          expect(config.system_config).to eq({})
+        end
+      end
+    end
+
+    describe ":revision" do
+      subject { config[:revision] }
+
+      context "when running on Heroku" do
+        let(:revision) { SecureRandom.hex(16) }
+
+        around { |example| recognize_as_heroku { example.run } }
+
+        before { ENV["HEROKU_SLUG_COMMIT"] = revision }
+
+        it "is set to the value of HEROKU_SLUG_COMMIT" do
+          expect(subject).to eq(revision)
+        end
+
+        it "sets revision as loaded through the system" do
+          expect(config.system_config).to match(hash_including(:revision => revision))
+        end
+      end
+
+      context "when not running on Heroku" do
+        it "is not set" do
+          expect(subject).to eq(nil)
+        end
+
+        it "does not set revision as loaded through the system" do
           expect(config.system_config).to eq({})
         end
       end


### PR DESCRIPTION
This changes `Appsignal::Config` so it automatically populates the revision setting on Heroku using the [dyno metadata](https://devcenter.heroku.com/articles/dyno-metadata) labs feature.