### PR TITLE
Add appsignal install --no-color option

### DIFF
--- a/lib/appsignal/cli.rb
+++ b/lib/appsignal/cli.rb
@@ -32,7 +32,7 @@ module Appsignal
             when :diagnose
               Appsignal::CLI::Diagnose.run(options)
             when :install
-              Appsignal::CLI::Install.run(argv.shift)
+              Appsignal::CLI::Install.run(argv.shift, options)
             when :notify_of_deploy
               Appsignal::CLI::NotifyOfDeploy.run(options)
             end
@@ -86,7 +86,11 @@ module Appsignal
               options[:send_report] = arg
             end
           end,
-          "install" => OptionParser.new,
+          "install" => OptionParser.new do |o|
+            o.on "--[no-]color", "Colorize the output of the diagnose command" do |arg|
+              options[:color] = arg
+            end
+          end,
           "notify_of_deploy" => OptionParser.new do |o|
             o.banner = "Usage: appsignal notify_of_deploy [options]"
 

--- a/lib/appsignal/cli/helpers.rb
+++ b/lib/appsignal/cli/helpers.rb
@@ -7,6 +7,15 @@ module Appsignal
     module Helpers
       private
 
+      COLOR_CODES = {
+        :red => 31,
+        :green => 32,
+        :yellow => 33,
+        :blue => 34,
+        :pink => 35,
+        :default => 0
+      }.freeze
+
       def ruby_2_6_or_up?
         Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.6.0")
       end
@@ -14,17 +23,10 @@ module Appsignal
       def colorize(text, color)
         return text if Gem.win_platform?
 
-        color_code =
-          case color
-          when :red then 31
-          when :green then 32
-          when :yellow then 33
-          when :blue then 34
-          when :pink then 35
-          else 0
-          end
+        reset_color_code = COLOR_CODES.fetch(:default)
+        color_code = COLOR_CODES.fetch(color, reset_color_code)
 
-        "\e[#{color_code}m#{text}\e[0m"
+        "\e[#{color_code}m#{text}\e[#{reset_color_code}m"
       end
 
       def periods

--- a/lib/appsignal/cli/helpers.rb
+++ b/lib/appsignal/cli/helpers.rb
@@ -20,7 +20,17 @@ module Appsignal
         Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.6.0")
       end
 
+      def coloring=(value)
+        @coloring = value
+      end
+
+      def coloring?
+        return true unless defined?(@coloring)
+        @coloring
+      end
+
       def colorize(text, color)
+        return text unless coloring?
         return text if Gem.win_platform?
 
         reset_color_code = COLOR_CODES.fetch(:default)

--- a/lib/appsignal/cli/install.rb
+++ b/lib/appsignal/cli/install.rb
@@ -13,7 +13,8 @@ module Appsignal
       EXCLUDED_ENVIRONMENTS = ["test"].freeze
 
       class << self
-        def run(push_api_key)
+        def run(push_api_key, options) # rubocop:disable Metrics/AbcSize
+          self.coloring = options.delete(:color) { true }
           $stdout.sync = true
 
           puts

--- a/spec/lib/appsignal/cli/helpers_spec.rb
+++ b/spec/lib/appsignal/cli/helpers_spec.rb
@@ -24,7 +24,7 @@ describe Appsignal::CLI::Helpers do
   describe ".colorize" do
     subject { cli.send(:colorize, "text", :green) }
 
-    context "on windows" do
+    context "when on windows" do
       before { allow(Gem).to receive(:win_platform?).and_return(true) }
 
       it "outputs plain string" do
@@ -32,7 +32,15 @@ describe Appsignal::CLI::Helpers do
       end
     end
 
-    context "not on windows" do
+    context "when coloring is set to false" do
+      before { cli.send(:coloring=, false) }
+
+      it "outputs plain string" do
+        expect(subject).to eq "text"
+      end
+    end
+
+    context "when not on windows" do
       before { allow(Gem).to receive(:win_platform?).and_return(false) }
 
       it "wraps text in color tags" do

--- a/spec/lib/appsignal/cli/helpers_spec.rb
+++ b/spec/lib/appsignal/cli/helpers_spec.rb
@@ -36,7 +36,7 @@ describe Appsignal::CLI::Helpers do
       before { allow(Gem).to receive(:win_platform?).and_return(false) }
 
       it "wraps text in color tags" do
-        expect(subject).to eq "\e[32mtext\e[0m"
+        expect(subject).to have_colorized_text(:green, "text")
       end
     end
   end

--- a/spec/lib/appsignal/cli/install_spec.rb
+++ b/spec/lib/appsignal/cli/install_spec.rb
@@ -9,6 +9,7 @@ describe Appsignal::CLI::Install do
   let(:config) { Appsignal::Config.new(tmp_dir, "") }
   let(:config_file_path) { File.join(tmp_dir, "config", "appsignal.yml") }
   let(:config_file) { File.read(config_file_path) }
+  let(:options) { {} }
   before do
     stub_api_validation_request
     # Stub calls to speed up tests
@@ -87,7 +88,7 @@ describe Appsignal::CLI::Install do
     Dir.chdir tmp_dir do
       prepare_cli_input
       capture_stdout(out_stream) do
-        run_cli(["install", push_api_key])
+        run_cli(["install", push_api_key], options)
       end
     end
   end
@@ -623,9 +624,32 @@ describe Appsignal::CLI::Install do
       it_behaves_like "push_api_key validation"
       it_behaves_like "demo data"
 
-      it "prints the instructions in color" do
-        run
-        expect(output).to have_colorized_text(:green, "## Starting AppSignal Installer      ##")
+      context "without color options" do
+        let(:options) { {} }
+
+        it "prints the instructions in color" do
+          run
+          expect(output).to have_colorized_text(:green, "## Starting AppSignal Installer      ##")
+        end
+      end
+
+      context "with --color option" do
+        let(:options) { { "color" => nil } }
+
+        it "prints the instructions in color" do
+          run
+          expect(output).to have_colorized_text(:green, "## Starting AppSignal Installer      ##")
+        end
+      end
+
+      context "with --no-color option" do
+        let(:options) { { "no-color" => nil } }
+
+        it "prints the instructions without special colors" do
+          run
+          expect(output).to include("Starting AppSignal Installer")
+          expect(output).to_not have_color_markers
+        end
       end
 
       it "prints a message about unknown framework" do

--- a/spec/lib/appsignal/cli/install_spec.rb
+++ b/spec/lib/appsignal/cli/install_spec.rb
@@ -623,6 +623,11 @@ describe Appsignal::CLI::Install do
       it_behaves_like "push_api_key validation"
       it_behaves_like "demo data"
 
+      it "prints the instructions in color" do
+        run
+        expect(output).to have_colorized_text(:green, "## Starting AppSignal Installer      ##")
+      end
+
       it "prints a message about unknown framework" do
         run
 

--- a/spec/support/helpers/cli_helpers.rb
+++ b/spec/support/helpers/cli_helpers.rb
@@ -10,7 +10,7 @@ module CLIHelpers
   def format_cli_arguments_and_options(command, options = {})
     [*command].tap do |o|
       options.each do |key, value|
-        o << "--#{key}=#{value}"
+        o << (value.nil? ? "--#{key}" : "--#{key}=#{value}")
       end
     end
   end

--- a/spec/support/matchers/have_colorized_text.rb
+++ b/spec/support/matchers/have_colorized_text.rb
@@ -11,3 +11,18 @@ RSpec::Matchers.define :have_colorized_text do |color, text|
   diffable
   attr_reader :expected
 end
+
+COLOR_TAG_MATCHER_REGEX = /\e\[(\d+)m/
+RSpec::Matchers.define :have_color_markers do
+  match do |actual|
+    actual =~ COLOR_TAG_MATCHER_REGEX
+  end
+
+  failure_message do
+    "expected that output contains color markers: /\\e[\\d+m/"
+  end
+
+  failure_message_when_negated do
+    "expected that output does not contain color markers: /\\e[\\d+m/"
+  end
+end

--- a/spec/support/matchers/have_colorized_text.rb
+++ b/spec/support/matchers/have_colorized_text.rb
@@ -1,0 +1,13 @@
+RSpec::Matchers.define :have_colorized_text do |color, text|
+  match do |actual|
+    color_codes = Appsignal::CLI::Helpers::COLOR_CODES
+    reset_color_code = color_codes.fetch(:default)
+    color_code = color_codes.fetch(color)
+
+    @expected = "\e[#{color_code}m#{text}\e[#{reset_color_code}m"
+    expect(actual).to include(@expected)
+  end
+
+  diffable
+  attr_reader :expected
+end


### PR DESCRIPTION
## Add appsignal install --no-color option

Allow users to run the command without it printing the output with
color. Helps with accessibility and on machines without color support.

It continues to default to `--color`, with color.

## Test for colorize in specs

Test if we actually colorize some output in our test suite.
Added a matcher to help with this.

To avoid repetition about color declarations and regular expressions to
match *any* color with the `\d` matcher, refactored the CLI::Helpers to
define a constant with the color definitions.
