### PR TITLE
Color diagnose environment warning in red

### DIFF
--- a/lib/appsignal/cli.rb
+++ b/lib/appsignal/cli.rb
@@ -85,6 +85,9 @@ module Appsignal
             o.on "--[no-]send-report", "Confirm sending the report to AppSignal automatically" do |arg|
               options[:send_report] = arg
             end
+            o.on "--[no-]color", "Colorize the output of the diagnose command" do |arg|
+              options[:color] = arg
+            end
           end,
           "install" => OptionParser.new do |o|
             o.on "--[no-]color", "Colorize the output of the diagnose command" do |arg|

--- a/spec/support/helpers/cli_helpers.rb
+++ b/spec/support/helpers/cli_helpers.rb
@@ -1,3 +1,5 @@
+require "appsignal/cli/helpers"
+
 module CLIHelpers
   def cli
     Appsignal::CLI
@@ -22,5 +24,17 @@ module CLIHelpers
   def prepare_cli_input
     # Prepare the input by rewinding the pointer in the StringIO
     $stdin.rewind
+  end
+
+  def colorize(*args)
+    ColorizeHelper.colorize(*args)
+  end
+end
+
+module ColorizeHelper
+  extend Appsignal::CLI::Helpers
+
+  def self.colorize(*_args)
+    super
   end
 end


### PR DESCRIPTION
Hopefully the red color will make it stand out more so users will retry
the command with the environment option set.

Next steps (in new PRs):

- Show env error at the end of the output? Tell users they need to rerun the command.
- More colorized output for diagnose report? (This only highlights: missing env, missing extension, (in)valid Push API key.)

## Screenshots

![image](https://user-images.githubusercontent.com/282402/62775746-d73ecd00-baa8-11e9-8ee9-29fedc73af70.png)

![image](https://user-images.githubusercontent.com/282402/62775816-11a86a00-baa9-11e9-934e-0b280a63d1aa.png)

![image](https://user-images.githubusercontent.com/282402/62775754-dad25400-baa8-11e9-8997-1f7a3e03ad20.png)

![image](https://user-images.githubusercontent.com/282402/62775761-df970800-baa8-11e9-9d59-cc71ad62e272.png)
