### PR TITLE
Add Ruby gem metadata for Rubygems.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ issues.
 
 - [AppSignal.com website][appsignal]
 - [Documentation][docs]
+- [Ruby doc][ruby-doc]
 - [Support][contact]
 
 [![Build Status](https://travis-ci.org/appsignal/appsignal-ruby.png?branch=master)](https://travis-ci.org/appsignal/appsignal-ruby)
@@ -275,6 +276,7 @@ Also see our [SUPPORT.md file](SUPPORT.md).
 [coc]: https://docs.appsignal.com/appsignal/code-of-conduct.html
 [waffles-page]: https://appsignal.com/waffles
 [docs]: http://docs.appsignal.com
+[ruby-doc]: https://www.rubydoc.info/gems/appsignal
 [contributing-guide]: http://docs.appsignal.com/appsignal/contributing.html
 [supported-systems]: http://docs.appsignal.com/support/operating-systems.html
 [integrations]: http://docs.appsignal.com/ruby/integrations/index.html

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ issues.
 
 - [AppSignal.com website][appsignal]
 - [Documentation][docs]
-- [Ruby doc][ruby-doc]
+- [Ruby code documentation][ruby-doc]
 - [Support][contact]
 
 [![Build Status](https://travis-ci.org/appsignal/appsignal-ruby.png?branch=master)](https://travis-ci.org/appsignal/appsignal-ruby)

--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -2,7 +2,7 @@
 
 require File.expand_path("../lib/appsignal/version", __FILE__)
 
-Gem::Specification.new do |gem|
+Gem::Specification.new do |gem| # rubocop:disable Metrics/BlockLength
   gem.authors = [
     "Robert Beekman",
     "Thijs Cadier"
@@ -24,6 +24,15 @@ Gem::Specification.new do |gem|
   # Default extension installer. Overridden by JRuby gemspec as defined in
   # `Rakefile`.
   gem.extensions            = %w[ext/extconf.rb]
+
+  gem.metadata = {
+    "bug_tracker_uri"   => "https://github.com/appsignal/appsignal-ruby/issues",
+    "changelog_uri"     =>
+      "https://github.com/appsignal/appsignal-ruby/blob/master/CHANGELOG.md",
+    "documentation_uri" => "https://docs.appsignal.com/ruby/",
+    "homepage_uri"      => "https://docs.appsignal.com/ruby/",
+    "source_code_uri"   => "https://github.com/appsignal/appsignal-ruby"
+  }
 
   gem.add_dependency "rack"
 


### PR DESCRIPTION
According to this spec:
https://guides.rubygems.org/specification-reference/#metadata

The links will show up here:
https://rubygems.org/gems/appsignal

Add the old documentation link to rubydoc.info to the README, so it's
also available from the project itself.