### PR TITLE
Fix Sequel install hook version detection mismatch.

### DIFF
--- a/lib/appsignal/hooks/sequel.rb
+++ b/lib/appsignal/hooks/sequel.rb
@@ -42,7 +42,7 @@ module Appsignal
 
       def install
         # Register the extension...
-        if ::Sequel::MAJOR >= 4 && ::Sequel::MINOR >= 35
+        if (::Sequel::MAJOR >= 4 && ::Sequel::MINOR >= 35) || ::Sequel::MAJOR >= 5
           ::Sequel::Database.register_extension(
             :appsignal_integration,
             Appsignal::Hooks::SequelLogConnectionExtension


### PR DESCRIPTION
The old detection only allowed version 4
of Sequel to use the new log extension
This commit adds version 5