### PR TITLE
Bump yard gem to 0.9.20

### DIFF
--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -42,5 +42,5 @@ Gem::Specification.new do |gem| # rubocop:disable Metrics/BlockLength
   gem.add_development_dependency "timecop"
   gem.add_development_dependency "webmock"
   gem.add_development_dependency "rubocop", "0.50.0"
-  gem.add_development_dependency "yard"
+  gem.add_development_dependency "yard", ">= 0.9.20"
 end


### PR DESCRIPTION
Resolves CVE 2019-1020001 - Moderate severity vulnerability.

Let's require users to at least install the version that fixes this CVE.