### PR TITLE
Make sure Que integration works with upcoming release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,6 +112,9 @@ matrix:
     gemfile: gemfiles/que.gemfile
     env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=latest
   - rvm: 2.6.0
+    gemfile: gemfiles/que_beta.gemfile
+    env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=latest
+  - rvm: 2.6.0
     gemfile: gemfiles/rails-5.0.gemfile
     env: _RUBYGEMS_VERSION=latest _BUNDLER_VERSION=latest
   - rvm: 2.6.0

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -76,6 +76,10 @@ matrix:
     - gem: "padrino"
       bundler: "1.17.3"
     - gem: "que"
+    - gem: "que_beta"
+      exclude:
+        ruby:
+          - "2.0.0"
     - gem: "rails-3.2"
       bundler: "1.17.3"
       exclude:

--- a/gemfiles/que_beta.gemfile
+++ b/gemfiles/que_beta.gemfile
@@ -1,0 +1,10 @@
+source 'https://rubygems.org'
+
+gem 'que', '1.0.0.beta3'
+if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.1.0")
+  gem 'public_suffix', "~> 2.0.0"
+else
+  gem 'public_suffix'
+end
+
+gemspec :path => '../'


### PR DESCRIPTION
We have to make a few changes to support the upcoming Que release:

* `attrs` is renamed to `que_attrs`
* `job_id` in the attributes is renamed to `id`
