### PR TITLE
Check set_error arguments for Exceptions

### DIFF
--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -201,7 +201,8 @@ module Appsignal
       )
         return unless active?
         unless error.is_a?(Exception)
-          logger.error("Can't send error, given value is not an exception")
+          logger.error "Appsignal.send_error: Cannot send error. The given " \
+            "value is not an exception: #{error.inspect}"
           return
         end
         transaction = Appsignal::Transaction.new(
@@ -256,9 +257,12 @@ module Appsignal
       #   Exception handling guide
       # @since 0.6.6
       def set_error(exception, tags = nil, namespace = nil)
-        return if !active? ||
-            Appsignal::Transaction.current.nil? ||
-            exception.nil?
+        unless exception.is_a?(Exception)
+          logger.error "Appsignal.set_error: Cannot set error. The given " \
+            "value is not an exception: #{exception.inspect}"
+          return
+        end
+        return if !active? || Appsignal::Transaction.current.nil?
         transaction = Appsignal::Transaction.current
         transaction.set_error(exception)
         transaction.set_tags(tags) if tags

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -264,6 +264,11 @@ module Appsignal
     end
 
     def set_error(error)
+      unless error.is_a?(Exception)
+        Appsignal.logger.error "Appsignal::Transaction#set_error: Cannot set error. " \
+          "The given value is not an exception: #{error.inspect}"
+        return
+      end
       return unless error
       return unless Appsignal.active?
 

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -630,7 +630,11 @@ describe Appsignal::Transaction do
 
     describe "#set_error" do
       let(:env) { http_request_env_with_data }
-      let(:error) { double(:error, :message => "test message", :backtrace => ["line 1"]) }
+      let(:error) do
+        e = ExampleStandardError.new("test message")
+        allow(e).to receive(:backtrace).and_return(["line 1"])
+        e
+      end
 
       it "should also respond to add_exception for backwords compatibility" do
         expect(transaction).to respond_to(:add_exception)
@@ -643,10 +647,24 @@ describe Appsignal::Transaction do
         transaction.set_error(error)
       end
 
+      context "when error is not an error" do
+        let(:error) { Object.new }
+
+        it "does not add the error" do
+          expect(Appsignal.logger).to receive(:error).with(
+            "Appsignal::Transaction#set_error: Cannot set error. " \
+            "The given value is not an exception: #{error.inspect}"
+          )
+          expect(transaction.ext).to_not receive(:set_error)
+
+          transaction.set_error(error)
+        end
+      end
+
       context "for a http request" do
         it "should set an error in the extension" do
           expect(transaction.ext).to receive(:set_error).with(
-            "RSpec::Mocks::Double",
+            "ExampleStandardError",
             "test message",
             Appsignal::Utils::Data.generate(["line 1"])
           )
@@ -656,7 +674,12 @@ describe Appsignal::Transaction do
       end
 
       context "when error message is nil" do
-        let(:error) { double(:error, :message => nil, :backtrace => ["line 1"]) }
+        let(:error) do
+          e = ExampleStandardError.new
+          allow(e).to receive(:message).and_return(nil)
+          allow(e).to receive(:backtrace).and_return(["line 1"])
+          e
+        end
 
         it "should not raise an error" do
           expect { transaction.set_error(error) }.to_not raise_error
@@ -664,7 +687,7 @@ describe Appsignal::Transaction do
 
         it "should set an error in the extension" do
           expect(transaction.ext).to receive(:set_error).with(
-            "RSpec::Mocks::Double",
+            "ExampleStandardError",
             "",
             Appsignal::Utils::Data.generate(["line 1"])
           )

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -657,8 +657,10 @@ describe Appsignal do
         let(:error) { double }
 
         it "logs an error message" do
-          expect(Appsignal.logger).to receive(:error)
-            .with("Can't send error, given value is not an exception")
+          expect(Appsignal.logger).to receive(:error).with(
+            "Appsignal.send_error: Cannot send error. " \
+              "The given value is not an exception: #{error.inspect}"
+          )
         end
 
         it "does not send the error" do
@@ -778,13 +780,19 @@ describe Appsignal do
           Appsignal.set_error(error)
         end
 
-        context "when the error is nil" do
-          it "does nothing" do
+        context "when the error is not an Exception" do
+          let(:error) { Object.new }
+
+          it "logs an error" do
+            expect(Appsignal.logger).to receive(:error).with(
+              "Appsignal.set_error: Cannot set error. " \
+                "The given value is not an exception: #{error.inspect}"
+            )
             expect(transaction).to_not receive(:set_error)
             expect(transaction).to_not receive(:set_tags)
             expect(transaction).to_not receive(:set_namespace)
 
-            Appsignal.set_error(nil)
+            Appsignal.set_error(error)
           end
         end
 


### PR DESCRIPTION
It was possible to pass in a non-Exception object to
`Appsignal.set_error` and `Appsignal::Transaction#set_error`.

This would then error on `object.backtrace` if the object didn't
implement a backtrace method.

Add additional checks and logging to these methods when the argument
isn't a valid Exception object instance. It's not possible to pass in
Exception classes either, these have the same problems as normal Ruby
objects as arguments.

Update `Appsignal.send_error` which did have these checks to log the
same kind of error message.