### PR TITLE
Handle errors in Rails installer

### DIFF
--- a/lib/appsignal/cli/install.rb
+++ b/lib/appsignal/cli/install.rb
@@ -81,17 +81,30 @@ module Appsignal
         end
 
         def configure_rails_app_name(config)
-          require Appsignal::Utils::RailsHelper.application_config_path
+          loaded =
+            begin
+              load Appsignal::Utils::RailsHelper.application_config_path
+              true
+            rescue LoadError, StandardError
+              false
+            end
 
-          config[:name] = Appsignal::Utils::RailsHelper.detected_rails_app_name
-          puts
-          name_overwritten = yes_or_no(
-            "  Your app's name is: '#{config[:name]}' \n  " \
-              "Do you want to change how this is displayed in AppSignal? " \
-              "(y/n): "
-          )
-          if name_overwritten
-            config[:name] = required_input("  Choose app's display name: ")
+          name_overwritten = false
+          if loaded
+            config[:name] = Appsignal::Utils::RailsHelper.detected_rails_app_name
+            puts
+            name_overwritten = yes_or_no(
+              "  Your app's name is: '#{config[:name]}' \n  " \
+                "Do you want to change how this is displayed in AppSignal? " \
+                "(y/n): "
+            )
+            if name_overwritten
+              config[:name] = required_input("  Choose app's display name: ")
+              puts
+            end
+          else
+            puts "  Unable to automatically detect your Rails app's name."
+            config[:name] = required_input("  Choose your app's display name for AppSignal.com: ")
             puts
           end
           name_overwritten

--- a/lib/appsignal/utils/rails_helper.rb
+++ b/lib/appsignal/utils/rails_helper.rb
@@ -11,6 +11,10 @@ module Appsignal
           rails_class.parent_name
         end
       end
+
+      def self.application_config_path
+        File.expand_path(File.join(Dir.pwd, "config/application.rb"))
+      end
     end
   end
 end

--- a/spec/lib/appsignal/cli/install_spec.rb
+++ b/spec/lib/appsignal/cli/install_spec.rb
@@ -16,6 +16,10 @@ describe Appsignal::CLI::Install do
     allow(described_class).to receive(:press_any_key)
     allow(Appsignal::Demo).to receive(:transmit).and_return(true)
   end
+  after do
+    FileUtils.rm_rf(tmp_dir)
+    FileUtils.mkdir_p(tmp_dir)
+  end
   around do |example|
     original_stdin = $stdin
     $stdin = StringIO.new
@@ -157,15 +161,9 @@ describe Appsignal::CLI::Install do
   shared_examples "capistrano install" do
     let(:capfile) { File.join(tmp_dir, "Capfile") }
     before do
-      FileUtils.mkdir_p(tmp_dir)
-
       enter_app_name "foo"
       add_cli_input "n"
       choose_environment_config
-    end
-    after do
-      FileUtils.rm_rf(tmp_dir)
-      FileUtils.mkdir_p(tmp_dir)
     end
 
     context "without Capfile" do
@@ -260,7 +258,6 @@ describe Appsignal::CLI::Install do
         FileUtils.touch(File.join(environments_dir, "development.rb"))
         FileUtils.touch(File.join(environments_dir, "staging.rb"))
         FileUtils.touch(File.join(environments_dir, "production.rb"))
-        enter_app_name app_name
       end
 
       describe "environments" do
@@ -408,6 +405,27 @@ describe Appsignal::CLI::Install do
             expect(output).to include(*installation_instructions)
             expect(output).to include_complete_install
           end
+        end
+      end
+
+      context "when there is no Rails application.rb file" do
+        before do
+          # Do not detect it as another framework for testing
+          allow(described_class).to receive(:framework_available?).and_call_original
+          allow(described_class).to receive(:framework_available?).with("sinatra").and_return(false)
+
+          File.delete(File.join(config_dir, "application.rb"))
+          expect(File.exist?(File.join(config_dir, "application.rb"))).to eql(false)
+        end
+
+        it "fails the installation" do
+          run
+
+          expect(output).to include("We could not detect which framework you are using.")
+          expect(output).to_not include("Installing for Ruby on Rails")
+          expect(output).to include_complete_install
+
+          expect(File.exist?(config_file_path)).to be(false)
         end
       end
     end

--- a/spec/lib/appsignal/cli/install_spec.rb
+++ b/spec/lib/appsignal/cli/install_spec.rb
@@ -428,6 +428,32 @@ describe Appsignal::CLI::Install do
           expect(File.exist?(config_file_path)).to be(false)
         end
       end
+
+      context "when failed to load the Rails application.rb file" do
+        before do
+          File.open(File.join(config_dir, "application.rb"), "w") do |file|
+            file.write("I am invalid code")
+          end
+        end
+
+        it "prompts the user to fill in an app name" do
+          enter_app_name app_name
+          choose_config_file
+          run
+
+          expect(output).to include("Installing for Ruby on Rails")
+          expect(output).to include("Unable to automatically detect your Rails app's name.")
+          expect(output).to include("Choose your app's display name for AppSignal.com:")
+          expect(output).to include_file_config
+          expect(output).to include_complete_install
+
+          expect(config_file).to configure_app_name(app_name)
+          expect(config_file).to configure_push_api_key(push_api_key)
+          expect(config_file).to configure_environment("development")
+          expect(config_file).to configure_environment("staging")
+          expect(config_file).to configure_environment("production")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #432
Part of #315 

## Handle missing application.rb for Rails installer

When an app is detected as a Rails app by the presence of the `rails`
gem we load the `config/application.rb` file, assuming it exists. Catch
the scenario where it doesn't.

It doesn't error anymore, but doesn't show the desired output perhaps,
it only ends the installer without prompting the user for a custom app
name. This should be picked up as part of #315.

Co-authored-by: Mark <birmanmark@gmail.com>

Followed up from #566 

## Handle Rails application.rb load errors in install

When the Rails' application.rb references code that isn't available to
the AppSignal installer, such as loading another gem, it results in a
`StandardError` subclass. When this occurs, or the file loading fails in
general with `LoadError` rescue the installation and prompt the user for
an app name.

I've changed the `require` call to a `load` call for the
`config/application.rb` file, because in our tests this file gets
required multiple times. The second time it's being required it won't be
loaded again, because it's already required.

To ensure the file is (attempted) to be loaded, use Ruby's `load`
instead. This will load the file again even if it's loaded already. This
will make our tests more accurate and shouldn't impact the installer
since the file is only loaded once in the installer.