### PR TITLE
Check for empty Push API key in config

### DIFF
--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -234,11 +234,12 @@ module Appsignal
           "#{endpoint_uri.scheme}://#{endpoint_uri.host}:#{endpoint_uri.port}"
         end
 
-      if config_hash[:push_api_key]
-        @valid = true
-      else
+      push_api_key = config_hash[:push_api_key] || ""
+      if push_api_key.strip.empty?
         @valid = false
-        @logger.error "Push api key not set after loading config"
+        @logger.error "Push API key not set after loading config"
+      else
+        @valid = true
       end
     end
 
@@ -253,8 +254,10 @@ module Appsignal
       {}.tap do |hash|
         hash[:log] = "stdout" if Appsignal::System.heroku?
 
-        # Make active by default if APPSIGNAL_PUSH_API_KEY is present
-        hash[:active] = true if ENV["APPSIGNAL_PUSH_API_KEY"]
+        # Make AppSignal active by default if APPSIGNAL_PUSH_API_KEY
+        # environment variable is present and not empty.
+        env_push_api_key = ENV["APPSIGNAL_PUSH_API_KEY"] || ""
+        hash[:active] = true unless env_push_api_key.strip.empty?
       end
     end
 

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -47,15 +47,43 @@ describe Appsignal::Config do
       subject { config[:active] }
 
       context "with APPSIGNAL_PUSH_API_KEY env variable" do
-        before { ENV["APPSIGNAL_PUSH_API_KEY"] = "abc" }
+        context "when not empty" do
+          before { ENV["APPSIGNAL_PUSH_API_KEY"] = "abc" }
 
-        it "becomes active" do
-          expect(subject).to be_truthy
+          it "becomes active" do
+            expect(subject).to be_truthy
+          end
+
+          it "sets the push_api_key as loaded through the env_config" do
+            expect(config.env_config).to eq(:push_api_key => "abc")
+            expect(config.system_config).to eq(:active => true)
+          end
         end
 
-        it "sets the push_api_key as loaded through the env_config" do
-          expect(config.env_config).to eq(:push_api_key => "abc")
-          expect(config.system_config).to eq(:active => true)
+        context "when empty string" do
+          before { ENV["APPSIGNAL_PUSH_API_KEY"] = "" }
+
+          it "does not becomes active" do
+            expect(subject).to be_falsy
+          end
+
+          it "sets the push_api_key as loaded through the env_config" do
+            expect(config.env_config).to eq(:push_api_key => "")
+            expect(config.system_config).to be_empty
+          end
+        end
+
+        context "when blank string" do
+          before { ENV["APPSIGNAL_PUSH_API_KEY"] = " " }
+
+          it "does not becomes active" do
+            expect(subject).to be_falsy
+          end
+
+          it "sets the push_api_key as loaded through the env_config" do
+            expect(config.env_config).to eq(:push_api_key => " ")
+            expect(config.system_config).to be_empty
+          end
         end
       end
 
@@ -264,7 +292,7 @@ describe Appsignal::Config do
         expect_any_instance_of(Logger).to receive(:error).once
           .with("Not loading from config file: config for 'nonsense' not found")
         expect_any_instance_of(Logger).to receive(:error).once
-          .with("Push api key not set after loading config")
+          .with("Push API key not set after loading config")
         config
       end
     end
@@ -715,6 +743,22 @@ describe Appsignal::Config do
 
       context "with missing push_api_key" do
         let(:push_api_key) { nil }
+
+        it "sets valid to false" do
+          is_expected.to eq(false)
+        end
+      end
+
+      context "with empty push_api_key" do
+        let(:push_api_key) { "" }
+
+        it "sets valid to false" do
+          is_expected.to eq(false)
+        end
+      end
+
+      context "with blank push_api_key" do
+        let(:push_api_key) { " " }
 
         it "sets valid to false" do
           is_expected.to eq(false)

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -30,7 +30,7 @@ describe Appsignal do
     context "with no config set beforehand" do
       it "should do nothing when config is not set and there is no valid config in the env" do
         expect(Appsignal.logger).to receive(:error).with(
-          "Push api key not set after loading config"
+          "Push API key not set after loading config"
         ).once
         expect(Appsignal.logger).to receive(:error).with(
           "Not starting, no valid config for this environment"


### PR DESCRIPTION
Don't make AppSignal active if the key is empty or only contains spaces.
This should make the active check more reliably as empty values are not considered valid.

For example:

```yaml
push_api_key: "<%= ENV['APPSIGNAL_PUSH_API_KEY'] %>"
```

This in the `config/appsignal.yml` file returns an empty string if the
Push API key is not set. But we did detect it as a valid value.