### PR TITLE
Add Puma plugin to start probe in main process

### DIFF
--- a/lib/puma/plugin/appsignal.rb
+++ b/lib/puma/plugin/appsignal.rb
@@ -1,0 +1,26 @@
+APPSIGNAL_PUMA_PLUGIN_LOADED = true
+
+# AppSignal Puma plugin
+#
+# This plugin ensures the minutely probe thread is started with the Puma
+# minutely probe in the Puma master process.
+#
+# The constant {APPSIGNAL_PUMA_PLUGIN_LOADED} is here to mark the Plugin as
+# loaded by the rest of the AppSignal gem. This ensures that the Puma minutely
+# probe is not also started in every Puma workers, which was the old behavior.
+# See {Appsignal::Hooks::PumaHook#install} for more information.
+#
+# For even more information:
+# https://docs.appsignal.com/ruby/integrations/puma.html
+Puma::Plugin.create do
+  def start(_launcher = nil)
+    in_background do
+      require "appsignal"
+      if ::Puma.respond_to?(:stats)
+        Appsignal::Minutely.probes.register :puma, Appsignal::Hooks::PumaProbe
+      end
+      Appsignal.start
+      Appsignal.start_logger
+    end
+  end
+end

--- a/lib/puma/plugin/appsignal.rb
+++ b/lib/puma/plugin/appsignal.rb
@@ -13,8 +13,8 @@ APPSIGNAL_PUMA_PLUGIN_LOADED = true
 # For even more information:
 # https://docs.appsignal.com/ruby/integrations/puma.html
 Puma::Plugin.create do
-  def start(_launcher = nil)
-    in_background do
+  def start(launcher = nil)
+    launcher.events.on_booted do
       require "appsignal"
       if ::Puma.respond_to?(:stats)
         Appsignal::Minutely.probes.register :puma, Appsignal::Hooks::PumaProbe

--- a/spec/lib/appsignal/minutely_spec.rb
+++ b/spec/lib/appsignal/minutely_spec.rb
@@ -1,4 +1,6 @@
 describe Appsignal::Minutely do
+  include WaitForHelper
+
   before { Appsignal::Minutely.probes.clear }
 
   it "returns a ProbeCollection" do
@@ -336,32 +338,5 @@ describe Appsignal::Minutely do
         expect(list).to eql([[:my_probe, probe]])
       end
     end
-  end
-
-  # Wait for a condition to be met
-  #
-  # @example
-  #   # Perform threaded operation
-  #   wait_for("enough probe calls") { probe.calls >= 2 }
-  #   # Assert on result
-  #
-  # @param name [String] The name of the condition to check. Used in the
-  #   error when it fails.
-  # @yield Assertion to check.
-  # @yieldreturn [Boolean] True/False value that indicates if the condition
-  #   is met.
-  # @raise [StandardError] Raises error if the condition is not met after 5
-  #   seconds, 5_000 tries.
-  def wait_for(name)
-    max_wait = 5_000
-    i = 0
-    while i <= max_wait
-      break if yield
-      i += 1
-      sleep 0.001
-    end
-
-    return unless i == max_wait
-    raise "Waited 5 seconds for #{name} condition, but was not met."
   end
 end

--- a/spec/lib/puma/appsignal_spec.rb
+++ b/spec/lib/puma/appsignal_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "Puma plugin" do
-  let(:probe) { Probe.new }
+  let(:probe) { MockProbe.new }
   before do
     module Puma
       def self.stats
@@ -22,18 +22,6 @@ RSpec.describe "Puma plugin" do
       end
     end
 
-    class Probe
-      attr_reader :calls
-
-      def initialize
-        @calls = 0
-      end
-
-      def call
-        @calls += 1
-      end
-    end
-
     Appsignal::Minutely.probes.clear
     ENV["APPSIGNAL_ENABLE_MINUTELY_PROBES"] = "true"
     Appsignal.config = project_fixture_config
@@ -47,7 +35,6 @@ RSpec.describe "Puma plugin" do
   after do
     Appsignal.config = nil
     Object.send :remove_const, :Puma
-    Object.send :remove_const, :Probe
     Object.send :remove_const, :APPSIGNAL_PUMA_PLUGIN_LOADED
   end
 

--- a/spec/lib/puma/appsignal_spec.rb
+++ b/spec/lib/puma/appsignal_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe "Puma plugin" do
+  include WaitForHelper
+
   let(:probe) { MockProbe.new }
   before do
     module Puma
@@ -74,18 +76,5 @@ RSpec.describe "Puma plugin" do
       # Minutely probes started and called
       wait_for("enough probe calls") { probe.calls >= 2 }
     end
-  end
-
-  def wait_for(name)
-    max_wait = 5_000
-    i = 0
-    while i <= max_wait
-      break if yield
-      i += 1
-      sleep 0.001
-    end
-
-    return unless i == max_wait
-    raise "Waited 5 seconds for #{name} condition, but was not met."
   end
 end

--- a/spec/lib/puma/appsignal_spec.rb
+++ b/spec/lib/puma/appsignal_spec.rb
@@ -1,0 +1,104 @@
+RSpec.describe "Puma plugin" do
+  let(:probe) { Probe.new }
+  before do
+    module Puma
+      def self.stats
+      end
+
+      class Plugin
+        class << self
+          attr_reader :plugin
+
+          def create(&block)
+            @plugin = Class.new(::Puma::Plugin)
+            @plugin.class_eval(&block)
+          end
+        end
+
+        def in_background(&block)
+          @in_background = block if block_given?
+          @in_background if defined?(@in_background)
+        end
+      end
+    end
+
+    class Probe
+      attr_reader :calls
+
+      def initialize
+        @calls = 0
+      end
+
+      def call
+        @calls += 1
+      end
+    end
+
+    Appsignal::Minutely.probes.clear
+    ENV["APPSIGNAL_ENABLE_MINUTELY_PROBES"] = "true"
+    Appsignal.config = project_fixture_config
+    # Speed up test time
+    allow(Appsignal::Minutely).to receive(:initial_wait_time).and_return(0.001)
+    allow(Appsignal::Minutely).to receive(:wait_time).and_return(0.001)
+
+    Appsignal::Minutely.probes.register :my_probe, probe
+    load File.expand_path("../lib/puma/plugin/appsignal.rb", APPSIGNAL_SPEC_DIR)
+  end
+  after do
+    Appsignal.config = nil
+    Object.send :remove_const, :Puma
+    Object.send :remove_const, :Probe
+    Object.send :remove_const, :APPSIGNAL_PUMA_PLUGIN_LOADED
+  end
+
+  it "registers the PumaProbe" do
+    expect(Appsignal::Minutely.probes[:my_probe]).to eql(probe)
+    expect(Appsignal::Minutely.probes[:puma]).to be_nil
+    plugin = Puma::Plugin.plugin.new
+    expect(plugin.in_background).to be_nil
+
+    plugin.start
+    expect(Appsignal::Minutely.probes[:puma]).to be_nil
+    expect(plugin.in_background).to_not be_nil
+
+    plugin.in_background.call
+    expect(Appsignal::Minutely.probes[:puma]).to eql(Appsignal::Hooks::PumaProbe)
+
+    # Minutely probes started and called
+    wait_for("enough probe calls") { probe.calls >= 2 }
+  end
+
+  context "without Puma.stats" do
+    before { Puma.singleton_class.send(:remove_method, :stats) }
+
+    it "does not register the PumaProbe" do
+      expect(Appsignal::Minutely.probes[:my_probe]).to eql(probe)
+      expect(Appsignal::Minutely.probes[:puma]).to be_nil
+      plugin = Puma::Plugin.plugin.new
+      expect(plugin.in_background).to be_nil
+
+      plugin.start
+      expect(Appsignal::Minutely.probes[:puma]).to be_nil
+      expect(plugin.in_background).to_not be_nil
+
+      plugin.in_background.call
+      expect(Appsignal::Minutely.probes[:puma]).to be_nil
+
+      # Minutely probes started and called
+      wait_for("enough probe calls") { probe.calls >= 2 }
+    end
+  end
+
+  def wait_for(name)
+    max_wait = 5_000
+    i = 0
+    while i <= max_wait
+      break if yield
+      i += 1
+      sleep 0.001
+    end
+
+    return unless i == max_wait
+    raise "Waited 5 seconds for #{name} condition, but was not met."
+  end
+end

--- a/spec/support/helpers/wait_for_helper.rb
+++ b/spec/support/helpers/wait_for_helper.rb
@@ -1,0 +1,28 @@
+module WaitForHelper
+  # Wait for a condition to be met
+  #
+  # @example
+  #   # Perform threaded operation
+  #   wait_for("enough probe calls") { probe.calls >= 2 }
+  #   # Assert on result
+  #
+  # @param name [String] The name of the condition to check. Used in the
+  #   error when it fails.
+  # @yield Assertion to check.
+  # @yieldreturn [Boolean] True/False value that indicates if the condition
+  #   is met.
+  # @raise [StandardError] Raises error if the condition is not met after 5
+  #   seconds, 5_000 tries.
+  def wait_for(name)
+    max_wait = 5_000
+    i = 0
+    while i <= max_wait
+      break if yield
+      i += 1
+      sleep 0.001
+    end
+
+    return unless i == max_wait
+    raise "Waited 5 seconds for #{name} condition, but was not met."
+  end
+end

--- a/spec/support/mocks/mock_probe.rb
+++ b/spec/support/mocks/mock_probe.rb
@@ -1,0 +1,11 @@
+class MockProbe
+  attr_reader :calls
+
+  def initialize
+    @calls = 0
+  end
+
+  def call
+    @calls += 1
+  end
+end


### PR DESCRIPTION
Add a new Puma plugin to start the Puma probe only in the Puma's main
process. The old solution started the Puma probe in every worker.
(Duplicate stats from X workers weren't an issue.) Puma only exposed the
worker stats in the main process, and the workers all reported `0` as
values.

As a fallback we detect if users have loaded the plugin with the
{APPSIGNAL_PUMA_PLUGIN_LOADED} constant. If it hasn't it will fall back
on the old behavior which works for non-cluster mode setups.

We prefer people use the AppSignal Puma plugin from now on. The fallback
on the old behavior is only there when users relied on our *magic*
integration. The minutely probe thread will still run in Puma workers,
for other non-Puma probes, but the Puma probe only runs in the Puma main
process.

To add the AppSignal plugin to Puma add this to your `config/puma.rb`
file (or other file location if you have configured the config file
location).

```
plugin :appsignal
```

Fixes https://github.com/appsignal/appsignal-ruby/issues/502

## TODO

- [x] Update docs - https://github.com/appsignal/appsignal-docs/pull/261
- [x] Make test components reusable
  - [x] `wait_for`
  - [x] `Probe`