### PR TITLE
Deprecate JSExceptionCatcher

### DIFF
--- a/lib/appsignal/rack/js_exception_catcher.rb
+++ b/lib/appsignal/rack/js_exception_catcher.rb
@@ -23,9 +23,15 @@ module Appsignal
     # @see http://docs.appsignal.com/front-end/error-handling.html
     # @api private
     class JSExceptionCatcher
+      include Appsignal::Utils::DeprecationMessage
+
       def initialize(app, _options = nil)
         Appsignal.logger.debug \
           "Initializing Appsignal::Rack::JSExceptionCatcher"
+        message = "The Appsignal::Rack::JSExceptionCatcher is deprecated. " \
+          "Please use the official AppSignal JavaScript integration instead. " \
+          "https://docs.appsignal.com/front-end/"
+        deprecation_message message, Appsignal.logger
         @app = app
       end
 


### PR DESCRIPTION
Instead recommend our JavaScript integration:
https://appsignal.com/javascript

Use the DeprecationMessage module so it gets logged as a warning as well
as printed to STDOUT so the warning is also visible to users that don't
check the `appsignal.log` file.

This middleware will be removed in Ruby gem 3.0.

Closes #564