### PR TITLE
Remove SSL version lock in transmitter

### DIFF
--- a/lib/appsignal/transmitter.rb
+++ b/lib/appsignal/transmitter.rb
@@ -78,7 +78,6 @@ module Appsignal
       client.tap do |http|
         if uri.scheme == "https"
           http.use_ssl     = true
-          http.ssl_version = :TLSv1
           http.verify_mode = OpenSSL::SSL::VERIFY_PEER
 
           ca_file = config[:ca_file_path]


### PR DESCRIPTION
By removing the version lock we will no longer be limited to TLSv1, this
has known security issues.

By not specifying it, it will work with TLSv1.2 as well.

The `ssl_version` option itself is also deprecated. Instead we could use
the `min_option` version, but we think the Ruby default should be good
enough and more future proof.