### PR TITLE
Fix wait_for helper

### DIFF
--- a/spec/support/helpers/wait_for_helper.rb
+++ b/spec/support/helpers/wait_for_helper.rb
@@ -16,13 +16,13 @@ module WaitForHelper
   def wait_for(name)
     max_wait = 5_000
     i = 0
-    while i <= max_wait
+    while i < max_wait
       break if yield
       i += 1
       sleep 0.001
     end
 
-    return unless i == max_wait
+    return unless i >= max_wait
     raise "Waited 5 seconds for #{name} condition, but was not met."
   end
 end


### PR DESCRIPTION
It would hide the error if the error would occur for 5000 retries.

It always iterated once more than the max retry count. Fix that, but
also make the assertion for showing the error also show the error when
it makes more iterations in the future, so that this doesn't happen
again.

[skip review]