### PR TITLE
Fix exception handling of config file issues

### DIFF
--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -284,7 +284,7 @@ module Appsignal
       message = "An error occured while loading the AppSignal config file." \
         " Skipping file config.\n" \
         "File: #{config_file.inspect}\n" \
-        "#{e.name}: #{e}"
+        "#{e.class.name}: #{e}"
       $stderr.puts "appsignal: #{message}"
       logger.error "#{message}\n#{e.backtrace.join("\n")}"
       nil

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -258,7 +258,7 @@ describe Appsignal::Config do
         message = "An error occured while loading the AppSignal config file. " \
           "Skipping file config.\n" \
           "File: #{File.join(config_path, "config", "appsignal.yml").inspect}\n" \
-          "NotExistingConstant: uninitialized constant NotExistingConstant\n"
+          "KeyError: key not found"
         expect(log).to contains_log :error, message
         expect(log).to include("/appsignal/config.rb:") # Backtrace
         expect(stdout.read).to_not include("appsignal:")

--- a/spec/support/fixtures/projects/broken/config/appsignal.yml
+++ b/spec/support/fixtures/projects/broken/config/appsignal.yml
@@ -1,1 +1,1 @@
-<%= NotExistingConstant.not_existing_method %>
+<%= ENV.fetch("I AM A KEY THAT DOES NOT EXIST") %>


### PR DESCRIPTION
When the `config/appsignal.yml` file would raise an error we print the
error name and error message.

Unfortunately do to the chosen test error it was not caught that
`Exception#name` is not an available method to ask for the Exception
class name. This would cause an error for other errors that were not an
`NameError`.
`NameError` does listen to the `#name` method, returning the constant
name that was missing in the test.

To fix this, update the class name call to the Exception class name,
instead of the Exception instance.