### PR TITLE
Add logger that can warn once, then use debug.

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 require "json"
-require "logger"
 require "securerandom"
 
+require "appsignal/logger"
 require "appsignal/helpers/instrumentation"
 require "appsignal/helpers/metrics"
 
@@ -195,7 +195,7 @@ module Appsignal
     end
 
     def logger
-      @logger ||= Logger.new(in_memory_log).tap do |l|
+      @logger ||= Appsignal::Logger.new(in_memory_log).tap do |l|
         l.level = Logger::INFO
         l.formatter = log_formatter("appsignal")
       end
@@ -294,12 +294,12 @@ module Appsignal
     private
 
     def start_stdout_logger
-      @logger = Logger.new($stdout)
+      @logger = Appsignal::Logger.new($stdout)
       logger.formatter = log_formatter("appsignal")
     end
 
     def start_file_logger(path)
-      @logger = Logger.new(path)
+      @logger = Appsignal::Logger.new(path)
       logger.formatter = log_formatter
     rescue SystemCallError => error
       start_stdout_logger

--- a/lib/appsignal/logger.rb
+++ b/lib/appsignal/logger.rb
@@ -7,13 +7,12 @@ require "set"
 # prevents the log from filling up with repeated messages.
 module Appsignal
   class Logger < ::Logger
-
     def seen_keys
       @seen_keys ||= Set.new
     end
 
     def warn_once_then_debug(key, message)
-      if seen_keys.add?(key) != nil
+      if !seen_keys.add?(key).nil?
         warn message
       else
         debug message

--- a/lib/appsignal/logger.rb
+++ b/lib/appsignal/logger.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "logger"
+require "set"
+
+# Subclass of logger with method to only log a warning once
+# prevents the log from filling up with repeated messages.
+module Appsignal
+  class Logger < ::Logger
+
+    def seen_keys
+      @seen_keys ||= Set.new
+    end
+
+    def warn_once_then_debug(key, message)
+      if seen_keys.add?(key) != nil
+        warn message
+      else
+        debug message
+      end
+    end
+  end
+end

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -25,7 +25,7 @@ module Appsignal
           Thread.current[:appsignal_transaction] = Appsignal::Transaction.new(id, namespace, request, options)
         else
           # Otherwise, log the issue about trying to start another transaction
-          Appsignal.logger.warn "Trying to start new transaction with id " \
+          Appsignal.logger.warn_once_then_debug :transaction_id, "Trying to start new transaction with id " \
             "'#{id}', but a transaction with id '#{current.transaction_id}' " \
             "is already running. Using transaction '#{current.transaction_id}'."
 

--- a/spec/lib/appsignal/logger_spec.rb
+++ b/spec/lib/appsignal/logger_spec.rb
@@ -1,0 +1,21 @@
+describe Appsignal::Logger do
+  let(:logger) { Appsignal::Logger.new(STDOUT) }
+
+  describe "#seen_keys" do
+    it "returns a Set" do
+      expect(logger.seen_keys).to be_a(Set)
+    end
+  end
+
+  describe "#warn_once_then_debug" do
+    it "only warns once, then uses debug" do
+      expect(logger).to receive(:warn).once.with("This is a log line")
+      expect(logger).to receive(:debug).twice.with("This is a log line")
+
+      3.times { logger.warn_once_then_debug(:key, "This is a log line") }
+
+      expect(logger).to receive(:warn).once.with("This is anoter log line")
+      logger.warn_once_then_debug(:other_key, "This is anoter log line")
+    end
+  end
+end

--- a/spec/lib/appsignal/logger_spec.rb
+++ b/spec/lib/appsignal/logger_spec.rb
@@ -1,5 +1,10 @@
 describe Appsignal::Logger do
-  let(:logger) { Appsignal::Logger.new(STDOUT) }
+  let(:log) { std_stream }
+  let(:logger) do
+    Appsignal::Logger.new(log).tap do |l|
+      l.formatter = logger_formatter
+    end
+  end
 
   describe "#seen_keys" do
     it "returns a Set" do
@@ -9,13 +14,12 @@ describe Appsignal::Logger do
 
   describe "#warn_once_then_debug" do
     it "only warns once, then uses debug" do
-      expect(logger).to receive(:warn).once.with("This is a log line")
-      expect(logger).to receive(:debug).twice.with("This is a log line")
+      message = "This is a log line"
+      3.times { logger.warn_once_then_debug(:key, message) }
 
-      3.times { logger.warn_once_then_debug(:key, "This is a log line") }
-
-      expect(logger).to receive(:warn).once.with("This is anoter log line")
-      logger.warn_once_then_debug(:other_key, "This is anoter log line")
+      logs = log_contents(log)
+      expect(logs.scan(/#{Regexp.escape(log_line(:WARN, message))}/).count).to eql(1)
+      expect(logs.scan(/#{Regexp.escape(log_line(:DEBUG, message))}/).count).to eql(2)
     end
   end
 end

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -1032,6 +1032,10 @@ describe Appsignal do
         it "amends in memory log to log file" do
           expect(log_file_contents).to include "[ERROR] appsignal: Log in memory"
         end
+
+        it "logs with an Appsignal::Logger" do
+          expect(Appsignal.logger).to be_a(Appsignal::Logger)
+        end
       end
 
       context "when the log file is not writable" do
@@ -1043,6 +1047,7 @@ describe Appsignal do
             initialize_config
             Appsignal.start_logger
             Appsignal.logger.error("Log to not writable log file")
+            expect(Appsignal.logger).to be_a(Appsignal::Logger)
           end
         end
 
@@ -1059,6 +1064,10 @@ describe Appsignal do
           expect(output).to include \
             "[WARN] appsignal: Unable to start logger with log path '#{log_file}'.",
             "[WARN] appsignal: Permission denied"
+        end
+
+        it "logs with an Appsignal::Logger" do
+          expect(Appsignal.logger).to be_a(Appsignal::Logger)
         end
       end
     end
@@ -1092,6 +1101,10 @@ describe Appsignal do
           "appsignal: Unable to log to '#{log_path}' "\
           "or the '#{Appsignal::Config.system_tmp_dir}' fallback."
       end
+
+      it "logs with an Appsignal::Logger" do
+        expect(Appsignal.logger).to be_a(Appsignal::Logger)
+      end
     end
 
     context "when on Heroku" do
@@ -1110,6 +1123,10 @@ describe Appsignal do
 
       it "amends in memory log to stdout" do
         expect(output).to include "[ERROR] appsignal: Log in memory"
+      end
+
+      it "logs with an Appsignal::Logger" do
+        expect(Appsignal.logger).to be_a(Appsignal::Logger)
       end
     end
 

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -1021,6 +1021,7 @@ describe Appsignal do
             Appsignal.start_logger
             Appsignal.logger.error("Log to file")
           end
+          expect(Appsignal.logger).to be_a(Appsignal::Logger)
         end
 
         it "logs to file" do
@@ -1031,10 +1032,6 @@ describe Appsignal do
 
         it "amends in memory log to log file" do
           expect(log_file_contents).to include "[ERROR] appsignal: Log in memory"
-        end
-
-        it "logs with an Appsignal::Logger" do
-          expect(Appsignal.logger).to be_a(Appsignal::Logger)
         end
       end
 
@@ -1065,10 +1062,6 @@ describe Appsignal do
             "[WARN] appsignal: Unable to start logger with log path '#{log_file}'.",
             "[WARN] appsignal: Permission denied"
         end
-
-        it "logs with an Appsignal::Logger" do
-          expect(Appsignal.logger).to be_a(Appsignal::Logger)
-        end
       end
     end
 
@@ -1082,6 +1075,7 @@ describe Appsignal do
           Appsignal.start_logger
           Appsignal.logger.error("Log to not writable log path")
         end
+        expect(Appsignal.logger).to be_a(Appsignal::Logger)
       end
       after do
         FileUtils.chmod 0o755, Appsignal::Config.system_tmp_dir
@@ -1101,10 +1095,6 @@ describe Appsignal do
           "appsignal: Unable to log to '#{log_path}' "\
           "or the '#{Appsignal::Config.system_tmp_dir}' fallback."
       end
-
-      it "logs with an Appsignal::Logger" do
-        expect(Appsignal.logger).to be_a(Appsignal::Logger)
-      end
     end
 
     context "when on Heroku" do
@@ -1114,6 +1104,7 @@ describe Appsignal do
           Appsignal.start_logger
           Appsignal.logger.error("Log to stdout")
         end
+        expect(Appsignal.logger).to be_a(Appsignal::Logger)
       end
       around { |example| recognize_as_heroku { example.run } }
 
@@ -1123,10 +1114,6 @@ describe Appsignal do
 
       it "amends in memory log to stdout" do
         expect(output).to include "[ERROR] appsignal: Log in memory"
-      end
-
-      it "logs with an Appsignal::Logger" do
-        expect(Appsignal.logger).to be_a(Appsignal::Logger)
       end
     end
 

--- a/spec/support/helpers/log_helpers.rb
+++ b/spec/support/helpers/log_helpers.rb
@@ -13,12 +13,19 @@ module LogHelpers
 
   def test_logger(log)
     Appsignal::Logger.new(log).tap do |logger|
-      logger.formatter =
-        proc do |severity, _datetime, _progname, msg|
-          # This format is used in the `contains_log` matcher.
-          "[#{severity}] #{msg}\n"
-        end
+      logger.formatter = logger_formatter
     end
+  end
+
+  def logger_formatter
+    proc do |severity, _datetime, _progname, msg|
+      log_line(severity, msg)
+    end
+  end
+
+  def log_line(severity, message)
+    # This format is used in the `contains_log` matcher.
+    "[#{severity}] #{message}\n"
   end
 
   def log_contents(log)

--- a/spec/support/helpers/log_helpers.rb
+++ b/spec/support/helpers/log_helpers.rb
@@ -12,7 +12,7 @@ module LogHelpers
   end
 
   def test_logger(log)
-    Logger.new(log).tap do |logger|
+    Appsignal::Logger.new(log).tap do |logger|
       logger.formatter =
         proc do |severity, _datetime, _progname, msg|
           # This format is used in the `contains_log` matcher.


### PR DESCRIPTION
Right now we use `logger.warn` for a number of messages that occur
very often in client apps.

To prevent a huge amount of log lines, this subclassed logger as a new
method called `warn_once_then_debug` to only "warn" once, then default to "debug".

Fixes #584