### PR TITLE
Add grape.skip_appsignal_error request env

### DIFF
--- a/lib/appsignal/integrations/grape.rb
+++ b/lib/appsignal/integrations/grape.rb
@@ -23,7 +23,8 @@ module Appsignal
         begin
           app.call(env)
         rescue Exception => error # rubocop:disable Lint/RescueException
-          transaction.set_error(error)
+          # Do not set error if "grape.skip_appsignal_error" is set to `true`.
+          transaction.set_error(error) unless env["grape.skip_appsignal_error"]
           raise error
         ensure
           request_method = request.request_method.to_s.upcase

--- a/spec/lib/appsignal/integrations/grape_spec.rb
+++ b/spec/lib/appsignal/integrations/grape_spec.rb
@@ -93,6 +93,16 @@ if DependencyHelper.grape_present?
             expect(transaction).to receive(:set_error).with(kind_of(ExampleException))
           end
 
+          context "with env['grape.skip_appsignal_error'] = true" do
+            before do
+              env["grape.skip_appsignal_error"] = true
+            end
+
+            it "does not add the error" do
+              expect(transaction).to_not receive(:set_error)
+            end
+          end
+
           after do
             expect { middleware.call(env) }.to raise_error ExampleException
           end


### PR DESCRIPTION
Listen to `grape.skip_appsignal_error` request env to ignore errors if
it's set to `true`. This way users can ignore errors in their
app for specific occurrences, not just ignore all occurrences with
the `ignore_errors` option.

This solution is the same as is available in Sinatra with
`sinatra.skip_appsignal_error`.

Closes #586