### PR TITLE
Add Rails 6 build to minimal gem set

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -354,6 +354,18 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+    - name: Ruby 2.5.7 for rails-6.0
+      env_vars:
+      - name: RUBY_VERSION
+        value: 2.5.7
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/rails-6.0.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
 - name: Ruby 2.6.5
   dependencies:
   - Validation

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -76,6 +76,7 @@ matrix:
     minimal:
       - "no_dependencies"
       - "rails-5.2"
+      - "rails-6.0"
 
   ruby:
     - ruby: "2.0.0-p648"
@@ -143,6 +144,7 @@ matrix:
           - "2.2.10"
           - "2.3.8"
           - "2.4.9"
+          - "jruby-9.1.17.0"
     - gem: "resque"
       bundler: "1.17.3"
     - gem: "sequel"


### PR DESCRIPTION
This adds it to the Ruby 2.5 builds.
For some reason the JRuby builds fails with the following Bundler error:

```
Resolving dependencies....
Bundler found conflicting requirements for the Ruby version:
  In rails-6.0.gemfile:
    Ruby java
    appsignal java was resolved to 2.10.3, which depends on
      Ruby (>= 1.9) java
    rails (~> 6.0.0) java was resolved to 6.0.2.1, which depends on
      Ruby (>= 2.5.0) java
```

[skip review]