### PR TITLE
Fix ruby names for builds 

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -15,7 +15,7 @@ auto_cancel:
 global_job_config:
   env_vars:
   - name: BUNDLE_PATH
-    value: "../.bundle"
+    value: "../.bundle/"
   - name: RUNNING_IN_CI
     value: 'true'
   - name: RAILS_ENV
@@ -29,12 +29,14 @@ global_job_config:
     - checkout
     - sem-version ruby $RUBY_VERSION
     - cache restore v1-bundler-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE),v1-bundler-$RUBY_VERSION
+    - cache restore v1-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE),v1-gems-$RUBY_VERSION
     - "./support/install_deps"
     - "./support/bundler_wrapper install --jobs=3 --retry=3"
   epilogue:
     on_pass:
       commands:
       - cache store v1-bundler-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE) .bundle
+      - cache store v1-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE) $HOME/.gem
 blocks:
 - name: Validation
   dependencies: []
@@ -60,7 +62,7 @@ blocks:
         value: gemfiles/no_dependencies.gemfile
       commands:
       - "./support/bundler_wrapper exec rubocop"
-- name: Ruby 1.9.3
+- name: Ruby 2.0.0-p648
   dependencies:
   - Validation
   task:
@@ -68,86 +70,66 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake extension:install"
     jobs:
-    - name: Ruby 1.9.3 for no_dependencies
+    - name: Ruby 2.0.0-p648 for no_dependencies
       env_vars:
       - name: RUBY_VERSION
-        value: 1.9.3
+        value: 2.0.0-p648
       - name: BUNDLE_GEMFILE
         value: gemfiles/no_dependencies.gemfile
       - name: _RUBYGEMS_VERSION
         value: 2.7.8
       - name: _BUNDLER_VERSION
-        value: latest
+        value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
-- name: Ruby 2.0.0
+- name: Ruby 2.0.0-p648 - Gems
   dependencies:
-  - Validation
+  - Ruby 2.0.0-p648
   task:
     prologue:
       commands:
       - "./support/bundler_wrapper exec rake extension:install"
     jobs:
-    - name: Ruby 2.0.0 for no_dependencies
+    - name: Ruby 2.0.0-p648 for capistrano2
       env_vars:
       - name: RUBY_VERSION
-        value: 2.0.0
-      - name: BUNDLE_GEMFILE
-        value: gemfiles/no_dependencies.gemfile
-      - name: _RUBYGEMS_VERSION
-        value: 2.7.8
-      - name: _BUNDLER_VERSION
-        value: latest
-      commands:
-      - "./support/bundler_wrapper exec rake test"
-- name: Ruby 2.0.0 - Gems
-  dependencies:
-  - Ruby 2.0.0
-  task:
-    prologue:
-      commands:
-      - "./support/bundler_wrapper exec rake extension:install"
-    jobs:
-    - name: Ruby 2.0.0 for capistrano2
-      env_vars:
-      - name: RUBY_VERSION
-        value: 2.0.0
+        value: 2.0.0-p648
       - name: BUNDLE_GEMFILE
         value: gemfiles/capistrano2.gemfile
       - name: _RUBYGEMS_VERSION
         value: 2.7.8
       - name: _BUNDLER_VERSION
-        value: latest
+        value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 2.0.0 for capistrano3
+    - name: Ruby 2.0.0-p648 for capistrano3
       env_vars:
       - name: RUBY_VERSION
-        value: 2.0.0
+        value: 2.0.0-p648
       - name: BUNDLE_GEMFILE
         value: gemfiles/capistrano3.gemfile
       - name: _RUBYGEMS_VERSION
         value: 2.7.8
       - name: _BUNDLER_VERSION
-        value: latest
+        value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 2.0.0 for grape
+    - name: Ruby 2.0.0-p648 for grape
       env_vars:
       - name: RUBY_VERSION
-        value: 2.0.0
+        value: 2.0.0-p648
       - name: BUNDLE_GEMFILE
         value: gemfiles/grape.gemfile
       - name: _RUBYGEMS_VERSION
         value: 2.7.8
       - name: _BUNDLER_VERSION
-        value: latest
+        value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 2.0.0 for padrino
+    - name: Ruby 2.0.0-p648 for padrino
       env_vars:
       - name: RUBY_VERSION
-        value: 2.0.0
+        value: 2.0.0-p648
       - name: BUNDLE_GEMFILE
         value: gemfiles/padrino.gemfile
       - name: _RUBYGEMS_VERSION
@@ -156,22 +138,22 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 2.0.0 for que
+    - name: Ruby 2.0.0-p648 for que
       env_vars:
       - name: RUBY_VERSION
-        value: 2.0.0
+        value: 2.0.0-p648
       - name: BUNDLE_GEMFILE
         value: gemfiles/que.gemfile
       - name: _RUBYGEMS_VERSION
         value: 2.7.8
       - name: _BUNDLER_VERSION
-        value: latest
+        value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 2.0.0 for rails-3.2
+    - name: Ruby 2.0.0-p648 for rails-3.2
       env_vars:
       - name: RUBY_VERSION
-        value: 2.0.0
+        value: 2.0.0-p648
       - name: BUNDLE_GEMFILE
         value: gemfiles/rails-3.2.gemfile
       - name: _RUBYGEMS_VERSION
@@ -180,10 +162,10 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 2.0.0 for rails-4.2
+    - name: Ruby 2.0.0-p648 for rails-4.2
       env_vars:
       - name: RUBY_VERSION
-        value: 2.0.0
+        value: 2.0.0-p648
       - name: BUNDLE_GEMFILE
         value: gemfiles/rails-4.2.gemfile
       - name: _RUBYGEMS_VERSION
@@ -192,10 +174,10 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 2.0.0 for resque
+    - name: Ruby 2.0.0-p648 for resque
       env_vars:
       - name: RUBY_VERSION
-        value: 2.0.0
+        value: 2.0.0-p648
       - name: BUNDLE_GEMFILE
         value: gemfiles/resque.gemfile
       - name: _RUBYGEMS_VERSION
@@ -204,55 +186,55 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 2.0.0 for sequel
+    - name: Ruby 2.0.0-p648 for sequel
       env_vars:
       - name: RUBY_VERSION
-        value: 2.0.0
+        value: 2.0.0-p648
       - name: BUNDLE_GEMFILE
         value: gemfiles/sequel.gemfile
       - name: _RUBYGEMS_VERSION
         value: 2.7.8
       - name: _BUNDLER_VERSION
-        value: latest
+        value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 2.0.0 for sequel-435
+    - name: Ruby 2.0.0-p648 for sequel-435
       env_vars:
       - name: RUBY_VERSION
-        value: 2.0.0
+        value: 2.0.0-p648
       - name: BUNDLE_GEMFILE
         value: gemfiles/sequel-435.gemfile
       - name: _RUBYGEMS_VERSION
         value: 2.7.8
       - name: _BUNDLER_VERSION
-        value: latest
+        value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 2.0.0 for sinatra
+    - name: Ruby 2.0.0-p648 for sinatra
       env_vars:
       - name: RUBY_VERSION
-        value: 2.0.0
+        value: 2.0.0-p648
       - name: BUNDLE_GEMFILE
         value: gemfiles/sinatra.gemfile
       - name: _RUBYGEMS_VERSION
         value: 2.7.8
       - name: _BUNDLER_VERSION
-        value: latest
+        value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 2.0.0 for webmachine
+    - name: Ruby 2.0.0-p648 for webmachine
       env_vars:
       - name: RUBY_VERSION
-        value: 2.0.0
+        value: 2.0.0-p648
       - name: BUNDLE_GEMFILE
         value: gemfiles/webmachine.gemfile
       - name: _RUBYGEMS_VERSION
         value: 2.7.8
       - name: _BUNDLER_VERSION
-        value: latest
+        value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
-- name: Ruby 2.1.8
+- name: Ruby 2.1.10
   dependencies:
   - Validation
   task:
@@ -260,19 +242,19 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake extension:install"
     jobs:
-    - name: Ruby 2.1.8 for no_dependencies
+    - name: Ruby 2.1.10 for no_dependencies
       env_vars:
       - name: RUBY_VERSION
-        value: 2.1.8
+        value: 2.1.10
       - name: BUNDLE_GEMFILE
         value: gemfiles/no_dependencies.gemfile
       - name: _RUBYGEMS_VERSION
         value: 2.7.8
       - name: _BUNDLER_VERSION
-        value: latest
+        value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
-- name: Ruby 2.2.4
+- name: Ruby 2.2.10
   dependencies:
   - Validation
   task:
@@ -280,16 +262,16 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake extension:install"
     jobs:
-    - name: Ruby 2.2.4 for no_dependencies
+    - name: Ruby 2.2.10 for no_dependencies
       env_vars:
       - name: RUBY_VERSION
-        value: 2.2.4
+        value: 2.2.10
       - name: BUNDLE_GEMFILE
         value: gemfiles/no_dependencies.gemfile
       - name: _RUBYGEMS_VERSION
         value: 2.7.8
       - name: _BUNDLER_VERSION
-        value: latest
+        value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
 - name: Ruby 2.3.8
@@ -312,7 +294,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-- name: Ruby 2.4.5
+- name: Ruby 2.4.9
   dependencies:
   - Validation
   task:
@@ -320,10 +302,10 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake extension:install"
     jobs:
-    - name: Ruby 2.4.5 for no_dependencies
+    - name: Ruby 2.4.9 for no_dependencies
       env_vars:
       - name: RUBY_VERSION
-        value: 2.4.5
+        value: 2.4.9
       - name: BUNDLE_GEMFILE
         value: gemfiles/no_dependencies.gemfile
       - name: _RUBYGEMS_VERSION
@@ -332,7 +314,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-- name: Ruby 2.5.3
+- name: Ruby 2.5.7
   dependencies:
   - Validation
   task:
@@ -340,10 +322,10 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake extension:install"
     jobs:
-    - name: Ruby 2.5.3 for no_dependencies
+    - name: Ruby 2.5.7 for no_dependencies
       env_vars:
       - name: RUBY_VERSION
-        value: 2.5.3
+        value: 2.5.7
       - name: BUNDLE_GEMFILE
         value: gemfiles/no_dependencies.gemfile
       - name: _RUBYGEMS_VERSION
@@ -352,18 +334,18 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-- name: Ruby 2.5.3 - Gems
+- name: Ruby 2.5.7 - Gems
   dependencies:
-  - Ruby 2.5.3
+  - Ruby 2.5.7
   task:
     prologue:
       commands:
       - "./support/bundler_wrapper exec rake extension:install"
     jobs:
-    - name: Ruby 2.5.3 for rails-5.2
+    - name: Ruby 2.5.7 for rails-5.2
       env_vars:
       - name: RUBY_VERSION
-        value: 2.5.3
+        value: 2.5.7
       - name: BUNDLE_GEMFILE
         value: gemfiles/rails-5.2.gemfile
       - name: _RUBYGEMS_VERSION

--- a/Rakefile
+++ b/Rakefile
@@ -17,9 +17,6 @@ VERSION_MANAGERS = {
   }
 }.freeze
 
-BUNDLE_DIR = ".bundle".freeze
-BUNDLE_PATH = "../#{BUNDLE_DIR}/".freeze
-
 def env_map(key, value)
   {
     "name" => key,

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -16,7 +16,7 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
   global_job_config:
     env_vars:
       - name: BUNDLE_PATH
-        value: "../.bundle"
+        value: "../.bundle/"
       - name: RUNNING_IN_CI
         value: "true"
       - name: RAILS_ENV
@@ -30,12 +30,14 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
         - checkout
         - sem-version ruby $RUBY_VERSION
         - cache restore v1-bundler-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE),v1-bundler-$RUBY_VERSION
+        - cache restore v1-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE),v1-gems-$RUBY_VERSION
         - ./support/install_deps
         - ./support/bundler_wrapper install --jobs=3 --retry=3
     epilogue:
       on_pass:
         commands:
           - cache store v1-bundler-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE) .bundle
+          - cache store v1-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE) $HOME/.gem
 
   blocks:
     - name: Validation
@@ -76,22 +78,22 @@ matrix:
       - "rails-5.2"
 
   ruby:
-    - ruby: "1.9.3"
+    - ruby: "2.0.0-p648"
       rubygems: "2.7.8"
+      bundler: "1.17.3"
+    - ruby: "2.1.10"
+      rubygems: "2.7.8"
+      bundler: "1.17.3"
       gems: "none"
-    - ruby: "2.0.0"
+    - ruby: "2.2.10"
       rubygems: "2.7.8"
-    - ruby: "2.1.8"
-      rubygems: "2.7.8"
-      gems: "none"
-    - ruby: "2.2.4"
-      rubygems: "2.7.8"
+      bundler: "1.17.3"
       gems: "none"
     - ruby: "2.3.8"
       gems: "none"
-    - ruby: "2.4.5"
+    - ruby: "2.4.9"
       gems: "none"
-    - ruby: "2.5.3"
+    - ruby: "2.5.7"
       gems: "minimal"
     - ruby: "2.6.5"
     - ruby: "2.7.0"
@@ -108,7 +110,7 @@ matrix:
     - gem: "que_beta"
       exclude:
         ruby:
-          - "2.0.0"
+          - "2.0.0-p648"
     - gem: "rails-3.2"
       bundler: "1.17.3"
       exclude:
@@ -124,23 +126,23 @@ matrix:
     - gem: "rails-5.0"
       exclude:
         ruby:
-          - "2.0.0"
+          - "2.0.0-p648"
     - gem: "rails-5.1"
       exclude:
         ruby:
-          - "2.0.0"
+          - "2.0.0-p648"
     - gem: "rails-5.2"
       exclude:
         ruby:
-          - "2.0.0"
+          - "2.0.0-p648"
     - gem: "rails-6.0"
       exclude:
         ruby:
-          - "2.0.0"
-          - "2.1.8"
-          - "2.2.4"
+          - "2.0.0-p648"
+          - "2.1.10"
+          - "2.2.10"
           - "2.3.8"
-          - "2.4.5"
+          - "2.4.9"
     - gem: "resque"
       bundler: "1.17.3"
     - gem: "sequel"


### PR DESCRIPTION
If specified just `2.0.0` it wouldn't switch to Ruby 2.0.0. It needs the
patch level to switch to the Ruby version.

Also cache the gems for each build so we shouldn't have to update
bundler and gem every build.

[skip review]