### PR TITLE
Fix Ruby 1.9 build

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -68,6 +68,26 @@ blocks:
         value: gemfiles/no_dependencies.gemfile
       commands:
       - "./support/bundler_wrapper exec rubocop"
+- name: Ruby 1.9.3-p551
+  dependencies:
+  - Validation
+  task:
+    prologue:
+      commands:
+      - "./support/bundler_wrapper exec rake extension:install"
+    jobs:
+    - name: Ruby 1.9.3-p551 for no_dependencies
+      env_vars:
+      - name: RUBY_VERSION
+        value: 1.9.3-p551
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/no_dependencies.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: 2.7.8
+      - name: _BUNDLER_VERSION
+        value: 1.17.3
+      commands:
+      - "./support/bundler_wrapper exec rake test"
 - name: Ruby 2.0.0-p648
   dependencies:
   - Validation

--- a/Rakefile
+++ b/Rakefile
@@ -364,7 +364,12 @@ end
 begin
   require "rspec/core/rake_task"
   desc "Run the AppSignal gem test suite."
-  RSpec::Core::RakeTask.new :test
+  RSpec::Core::RakeTask.new :test do |t|
+    is_jruby = defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
+    unless is_jruby
+      t.rspec_opts = "--exclude-pattern=spec/lib/appsignal/extension/jruby_spec.rb"
+    end
+  end
 rescue LoadError # rubocop:disable Lint/HandleExceptions
   # When running rake install, there is no RSpec yet.
 end

--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -39,9 +39,12 @@ Gem::Specification.new do |gem| # rubocop:disable Metrics/BlockLength
 
   gem.add_development_dependency "rake", "~> 11"
   gem.add_development_dependency "rspec", "~> 3.8"
-  gem.add_development_dependency "pry"
   gem.add_development_dependency "timecop"
   gem.add_development_dependency "webmock"
-  gem.add_development_dependency "rubocop", "0.50.0"
   gem.add_development_dependency "yard", ">= 0.9.20"
+  is_modern_ruby = Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.0.0")
+  if is_modern_ruby
+    gem.add_development_dependency "pry"
+    gem.add_development_dependency "rubocop", "0.50.0"
+  end
 end

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -83,6 +83,10 @@ matrix:
       - "rails-5.2"
 
   ruby:
+    - ruby: "1.9.3-p551"
+      rubygems: "2.7.8"
+      bundler: "1.17.3"
+      gems: "none"
     - ruby: "2.0.0-p648"
       rubygems: "2.7.8"
       bundler: "1.17.3"

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -337,7 +337,7 @@ module Appsignal
           path = File.expand_path("../../../../ext/install.report", __FILE__)
           raw_report = File.read(path)
           Utils.parse_yaml(raw_report)
-        rescue => e
+        rescue StandardError, Psych::SyntaxError => e # rubocop:disable Lint/ShadowedException
           {
             "parsing_error" => {
               "error" => "#{e.class}: #{e}",

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -248,7 +248,12 @@ module Appsignal
         Appsignal::Utils::Data.generate(data)
       )
     rescue RuntimeError => e
-      Appsignal.logger.error("Error generating data (#{e.class}: #{e.message}) for '#{data.inspect}'")
+      begin
+        inspected_data = data.inspect
+        Appsignal.logger.error("Error generating data (#{e.class}: #{e.message}) for '#{inspected_data}'")
+      rescue => e
+        Appsignal.logger.error("Error generating data (#{e.class}: #{e.message}). Can't inspect data.")
+      end
     end
 
     def sample_data

--- a/spec/lib/appsignal/auth_check_spec.rb
+++ b/spec/lib/appsignal/auth_check_spec.rb
@@ -39,7 +39,7 @@ describe Appsignal::AuthCheck do
       end
     end
 
-    context "when encountering an exception" do
+    context "when encountering an exception", :not_ruby19 do
       before { stubbed_request.to_timeout }
 
       it "raises an error" do

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -38,7 +38,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
         # Because this is saved on the class rather than an instance of the
         # class we need to clear it like this in case a certain test doesn't
         # generate a report.
-        cli_class.remove_instance_variable :@data
+        cli_class.send :remove_instance_variable, :@data
       end
 
       if DependencyHelper.rails_present?

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -568,7 +568,7 @@ describe Appsignal::Transaction do
       end
 
       context "when the data cannot be converted to JSON" do
-        it "does not update the sample data on the transaction" do
+        it "does not update the sample data on the transaction", :not_ruby19 do
           klass = Class.new do
             def to_s
               raise "foo" # Cause a deliberate error
@@ -579,6 +579,19 @@ describe Appsignal::Transaction do
           expect(transaction.to_h["sample_data"]).to eq({})
           expect(log_contents(log)).to contains_log :error,
             "Error generating data (RuntimeError: foo) for"
+        end
+
+        it "does not update the sample data on the transaction", :only_ruby19 do
+          klass = Class.new do
+            def to_s
+              raise "foo" # Cause a deliberate error
+            end
+          end
+          transaction.set_sample_data("params", klass.new => 1)
+
+          expect(transaction.to_h["sample_data"]).to eq({})
+          expect(log_contents(log)).to contains_log :error,
+            "Error generating data (RuntimeError: foo). Can't inspect data."
         end
       end
     end

--- a/spec/lib/appsignal/transmitter_spec.rb
+++ b/spec/lib/appsignal/transmitter_spec.rb
@@ -143,7 +143,9 @@ describe Appsignal::Transmitter do
     context "with a proxy" do
       let(:config) { project_fixture_config("production", :http_proxy => "http://localhost:8080") }
 
-      it { expect(subject).to be_instance_of(Net::HTTP) }
+      it "is of Net::HTTP class", :not_ruby19 do
+        expect(subject).to be_instance_of(Net::HTTP)
+      end
       it { expect(subject.proxy?).to be_truthy }
       it { expect(subject.proxy_address).to eq "localhost" }
       it { expect(subject.proxy_port).to eq 8080 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,6 @@ Bundler.require :default
 require "cgi"
 require "rack"
 require "rspec"
-require "pry"
 require "timecop"
 require "webmock/rspec"
 
@@ -30,6 +29,7 @@ if DependencyHelper.rails_present?
     require f
   end
 end
+require "pry" if DependencyHelper.dependency_present?("pry")
 require "appsignal"
 # Include patches of AppSignal modules and classes to make test helpers
 # available.
@@ -79,6 +79,20 @@ RSpec.configure do |config|
   config.before :context do
     FileUtils.rm_rf(tmp_dir)
     FileUtils.mkdir_p(spec_system_tmp_dir)
+  end
+
+  config.before :each, :only_ruby19 => true do
+    is_ruby19 = Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.0.0")
+    next if is_ruby19
+
+    skip "Skipping spec for Ruby only for Ruby 1.9"
+  end
+
+  config.before :each, :not_ruby19 => true do
+    is_ruby19 = Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.0.0")
+    next unless is_ruby19
+
+    skip "Skipping spec for Ruby 1.9"
   end
 
   config.before do

--- a/support/install_deps
+++ b/support/install_deps
@@ -2,7 +2,10 @@
 
 set -eu
 
-gem_args="--no-document --no-verbose"
+gem_args="--no-verbose"
+if [[ $(ruby --version) != "ruby 1.9.3"* ]]; then
+  gem_args+=" --no-document"
+fi
 
 case "${_RUBYGEMS_VERSION-"latest"}" in
   "latest")


### PR DESCRIPTION
Disable some gem dependencies for Ruby 1.9, like JRuby specs, pry and
rubocop. Things we wouldn't run on Ruby 1.9 anyway.

Skip specs that don't work on Ruby 1.9 and are too much work to make
work just for that case. The behavior works, just some details are
different.