### PR TITLE
Add check for correct Ruby version

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -28,6 +28,7 @@ global_job_config:
     commands:
     - checkout
     - sem-version ruby $RUBY_VERSION
+    - "./support/check_versions"
     - cache restore v1-bundler-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE),v1-bundler-$RUBY_VERSION
     - cache restore v1-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE),v1-gems-$RUBY_VERSION
     - "./support/install_deps"

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -29,6 +29,7 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
       commands:
         - checkout
         - sem-version ruby $RUBY_VERSION
+        - ./support/check_versions
         - cache restore v1-bundler-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE),v1-bundler-$RUBY_VERSION
         - cache restore v1-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE),v1-gems-$RUBY_VERSION
         - ./support/install_deps

--- a/support/check_versions
+++ b/support/check_versions
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -eu
+
+actual_ruby_version=$(ruby --version)
+if [[ "$actual_ruby_version" == *"jruby"* ]]; then
+  # Replace "-" from specified RUBY_VERSION string. Semaphore/rbenv version uses
+  # a dash, where `jruby --version` uses a space.
+  sanitized_ruby_version="${RUBY_VERSION//-/ }"
+else
+  # Strip "-" from specified RUBY_VERSION string. Semaphore/rbenv version uses
+  # a dash, where `ruby --version` does not.
+  sanitized_ruby_version="${RUBY_VERSION//-}"
+fi
+if [[ "$actual_ruby_version" == *"$sanitized_ruby_version"* ]]; then
+  echo "Ruby version is $RUBY_VERSION"
+  exit 0
+else
+  echo "Ruby version is:        $(ruby --version)"
+  echo "Ruby version should be: ${sanitized_ruby_version}"
+  exit 1
+fi


### PR DESCRIPTION
When using `sem version ruby $VERSION` and $VERSION isn't available on
the system it continues without failing the build.

To make sure we test against the right Ruby version, add our own check
to see if we're using the right Ruby version.