### PR TITLE
Remove public_suffix gem from gemfiles

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -14,6 +14,8 @@ auto_cancel:
     when: branch != 'master' AND branch != 'develop'
 global_job_config:
   env_vars:
+  - name: CACHE
+    value: v2
   - name: BUNDLE_PATH
     value: "../.bundle/"
   - name: RUNNING_IN_CI
@@ -29,15 +31,15 @@ global_job_config:
     - checkout
     - sem-version ruby $RUBY_VERSION
     - "./support/check_versions"
-    - cache restore v1-bundler-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE),v1-bundler-$RUBY_VERSION
-    - cache restore v1-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE),v1-gems-$RUBY_VERSION
+    - cache restore $CACHE-bundler-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE),$CACHE-bundler-$RUBY_VERSION
+    - cache restore $CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE),$CACHE-gems-$RUBY_VERSION
     - "./support/install_deps"
     - "./support/bundler_wrapper install --jobs=3 --retry=3"
   epilogue:
     on_pass:
       commands:
-      - cache store v1-bundler-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE) .bundle
-      - cache store v1-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE) $HOME/.gem
+      - cache store $CACHE-bundler-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE) .bundle
+      - cache store $CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE) $HOME/.gem
 blocks:
 - name: Validation
   dependencies: []

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -15,6 +15,8 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
 
   global_job_config:
     env_vars:
+      - name: CACHE
+        value: "v2"
       - name: BUNDLE_PATH
         value: "../.bundle/"
       - name: RUNNING_IN_CI
@@ -30,15 +32,15 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
         - checkout
         - sem-version ruby $RUBY_VERSION
         - ./support/check_versions
-        - cache restore v1-bundler-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE),v1-bundler-$RUBY_VERSION
-        - cache restore v1-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE),v1-gems-$RUBY_VERSION
+        - cache restore $CACHE-bundler-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE),$CACHE-bundler-$RUBY_VERSION
+        - cache restore $CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE),$CACHE-gems-$RUBY_VERSION
         - ./support/install_deps
         - ./support/bundler_wrapper install --jobs=3 --retry=3
     epilogue:
       on_pass:
         commands:
-          - cache store v1-bundler-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE) .bundle
-          - cache store v1-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE) $HOME/.gem
+          - cache store $CACHE-bundler-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE) .bundle
+          - cache store $CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE) $HOME/.gem
 
   blocks:
     - name: Validation

--- a/gemfiles/capistrano2.gemfile
+++ b/gemfiles/capistrano2.gemfile
@@ -3,10 +3,5 @@ source 'https://rubygems.org'
 gem 'capistrano', '< 3.0'
 gem 'net-ssh', '2.9.2'
 gem 'rack', '~> 1.6'
-if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.1.0")
-  gem 'public_suffix', "~> 2.0.0"
-else
-  gem 'public_suffix'
-end
 
 gemspec :path => '../'

--- a/gemfiles/capistrano3.gemfile
+++ b/gemfiles/capistrano3.gemfile
@@ -4,10 +4,5 @@ gem 'capistrano', '~> 3.0'
 gem 'i18n', '~> 1.2.0'
 gem 'net-ssh', '2.9.2'
 gem 'rack', '~> 1.6'
-if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.1.0")
-  gem 'public_suffix', "~> 2.0.0"
-else
-  gem 'public_suffix'
-end
 
 gemspec :path => '../'

--- a/gemfiles/grape.gemfile
+++ b/gemfiles/grape.gemfile
@@ -3,10 +3,5 @@ source 'https://rubygems.org'
 gem 'grape', '0.14.0'
 gem 'rack', '~> 1.6'
 gem 'activesupport', '~> 4.2'
-if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.1.0")
-  gem 'public_suffix', "~> 2.0.0"
-else
-  gem 'public_suffix'
-end
 
 gemspec :path => '../'

--- a/gemfiles/no_dependencies.gemfile
+++ b/gemfiles/no_dependencies.gemfile
@@ -1,10 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'rack', '~> 1.6'
-if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.1.0")
-  gem 'public_suffix', "~> 2.0.0"
-else
-  gem 'public_suffix'
-end
 
 gemspec :path => '../'

--- a/gemfiles/padrino.gemfile
+++ b/gemfiles/padrino.gemfile
@@ -2,10 +2,5 @@ source 'https://rubygems.org'
 
 gem 'padrino', '~> 0.13.0'
 gem 'rack', '~> 1.6'
-if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.1.0")
-  gem 'public_suffix', "~> 2.0.0"
-else
-  gem 'public_suffix'
-end
 
 gemspec :path => '../'

--- a/gemfiles/que.gemfile
+++ b/gemfiles/que.gemfile
@@ -1,10 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'que'
-if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.1.0")
-  gem 'public_suffix', "~> 2.0.0"
-else
-  gem 'public_suffix'
-end
 
 gemspec :path => '../'

--- a/gemfiles/que_beta.gemfile
+++ b/gemfiles/que_beta.gemfile
@@ -1,10 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'que', '1.0.0.beta3'
-if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.1.0")
-  gem 'public_suffix', "~> 2.0.0"
-else
-  gem 'public_suffix'
-end
 
 gemspec :path => '../'

--- a/gemfiles/rails-3.2.gemfile
+++ b/gemfiles/rails-3.2.gemfile
@@ -2,10 +2,5 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 3.2.14'
 gem 'test-unit'
-if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.1.0")
-  gem 'public_suffix', "~> 2.0.0"
-else
-  gem 'public_suffix'
-end
 
 gemspec :path => '../'

--- a/gemfiles/rails-4.0.gemfile
+++ b/gemfiles/rails-4.0.gemfile
@@ -2,10 +2,5 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 4.0.0'
 gem 'mime-types', '~> 2.6'
-if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.1.0")
-  gem 'public_suffix', "~> 2.0.0"
-else
-  gem 'public_suffix'
-end
 
 gemspec :path => '../'

--- a/gemfiles/rails-4.1.gemfile
+++ b/gemfiles/rails-4.1.gemfile
@@ -2,10 +2,5 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 4.1.0'
 gem 'mime-types', '~> 2.6'
-if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.1.0")
-  gem 'public_suffix', "~> 2.0.0"
-else
-  gem 'public_suffix'
-end
 
 gemspec :path => '../'

--- a/gemfiles/rails-4.2.gemfile
+++ b/gemfiles/rails-4.2.gemfile
@@ -8,8 +8,3 @@ gemspec :path => '../'
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1.0")
   gem 'nokogiri', '~> 1.6.0'
 end
-if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.1.0")
-  gem 'public_suffix', "~> 2.0.0"
-else
-  gem 'public_suffix'
-end

--- a/gemfiles/resque.gemfile
+++ b/gemfiles/resque.gemfile
@@ -9,8 +9,3 @@ gemspec :path => '../'
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1.0")
   gem 'nokogiri', '~> 1.6.0'
 end
-if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.1.0")
-  gem 'public_suffix', "~> 2.0.0"
-else
-  gem 'public_suffix'
-end


### PR DESCRIPTION
The gem is not explicitly used by our test suite. And whatever version
problems that would occur should be resolved by Bundler.

The build is green, so it looks like this check is no longer necessary.

[skip review]