### PR TITLE
Fix set auto action name with custom action

### DIFF
--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -218,7 +218,7 @@ module Appsignal
         from[:controller] || from[:class],
         from[:action] || from[:method]
       ]
-      set_action(group_and_action.compact.join("#"))
+      set_action_if_nil(group_and_action.compact.join("#"))
     end
 
     def set_queue_start(start)

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -441,30 +441,36 @@ describe Appsignal::Transaction do
 
     describe "#set_http_or_background_action" do
       context "for a hash with controller and action" do
-        let(:from) { { :controller => "HomeController", :action => "show" } }
-
-        it "should set the action" do
-          expect(transaction).to receive(:set_action).with("HomeController#show")
+        it "sets the action" do
+          transaction.set_http_or_background_action(
+            :controller => "HomeController",
+            :action => "show"
+          )
+          expect(transaction.to_h["action"]).to eql("HomeController#show")
         end
       end
 
       context "for a hash with just action" do
-        let(:from) { { :action => "show" } }
-
-        it "should set the action" do
-          expect(transaction).to receive(:set_action).with("show")
+        it "sets the action" do
+          transaction.set_http_or_background_action(:action => "show")
+          expect(transaction.to_h["action"]).to eql("show")
         end
       end
 
       context "for a hash with class and method" do
-        let(:from) { { :class => "Worker", :method => "perform" } }
-
-        it "should set the action" do
-          expect(transaction).to receive(:set_action).with("Worker#perform")
+        it "sets the action" do
+          transaction.set_http_or_background_action(:class => "Worker", :method => "perform")
+          expect(transaction.to_h["action"]).to eql("Worker#perform")
         end
       end
 
-      after { transaction.set_http_or_background_action(from) }
+      context "when action is already set" do
+        it "does not overwrite the set action" do
+          transaction.set_action("MyCustomAction#perform")
+          transaction.set_http_or_background_action(:class => "Worker", :method => "perform")
+          expect(transaction.to_h["action"]).to eql("MyCustomAction#perform")
+        end
+      end
     end
 
     describe "set_queue_start" do


### PR DESCRIPTION
When an action is already set on the transaction do not overwrite it
with the `set_http_or_background_action` helper method.

This allows users to configure the action name in
`Appsignal.monitor_transaction` blocks, using the
`set_http_or_background_action` helper method.

Reported in https://app.intercom.io/a/apps/yzor8gyw/inbox/inbox/540709/conversations/25943030689