### PR TITLE
Use Module.prepend for net_http on newer Rubies

### DIFF
--- a/lib/appsignal/integrations/net_http.rb
+++ b/lib/appsignal/integrations/net_http.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Appsignal
+  module Integrations
+    module NetHttpIntegration
+      def request(request, body = nil, &block)
+        Appsignal.instrument(
+          "request.net_http",
+          "#{request.method} #{use_ssl? ? "https" : "http"}://#{request["host"] || address}"
+        ) do
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/appsignal/system.rb
+++ b/lib/appsignal/system.rb
@@ -76,8 +76,14 @@ module Appsignal
       ldd_version && ldd_version[0]
     end
 
+    # @api private
     def self.jruby?
       RUBY_PLATFORM == "java"
+    end
+
+    # @api private
+    def self.ruby_2_or_up?
+      versionify(RUBY_VERSION) >= versionify("2.0")
     end
   end
 end

--- a/spec/lib/appsignal/system_spec.rb
+++ b/spec/lib/appsignal/system_spec.rb
@@ -93,4 +93,40 @@ describe Appsignal::System do
       end
     end
   end
+
+  describe ".ruby_2_or_up?" do
+    around do |example|
+      original_ruby_version = RUBY_VERSION
+      Object.send(:remove_const, "RUBY_VERSION")
+      Object.const_set("RUBY_VERSION", ruby_version)
+      example.run
+      Object.send(:remove_const, "RUBY_VERSION")
+      Object.const_set("RUBY_VERSION", original_ruby_version)
+    end
+    subject { described_class.ruby_2_or_up? }
+
+    context "when on Ruby 1.9" do
+      let(:ruby_version) { "1.9.3-p533" }
+
+      it "returns false" do
+        is_expected.to be(false)
+      end
+    end
+
+    context "when on Ruby 2.0" do
+      let(:ruby_version) { "2.0.0" }
+
+      it "returns true" do
+        is_expected.to be(true)
+      end
+    end
+
+    context "when on Ruby 2.x" do
+      let(:ruby_version) { "2.1.0" }
+
+      it "returns true" do
+        is_expected.to be(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
In combination with the `http_logger` gem the AppSignal integration
causes a `SystemStackError (stack level too deep)` error.

This is because the `http_logger` gem uses `Module.prepend` and the
AppSignal gem uses aliases to monkeypatch the Net::HTTP behavior.

By also switching to `Module.prepend`, which we should probably use
moving forward, this problem can be avoided.

The only issue is that `Module.prepend` is not available on Ruby 1.9, so
we need to make an exception for that while we support it. On Ruby 1.9
it will continue to use the alias approach to integrate AppSignal.

Fixes #583