### PR TITLE
 Use deprecation_message for deprecated methods 

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -6,6 +6,7 @@ require "securerandom"
 require "appsignal/logger"
 require "appsignal/helpers/instrumentation"
 require "appsignal/helpers/metrics"
+require "appsignal/utils/deprecation_message"
 
 # AppSignal for Ruby gem's main module.
 #
@@ -15,9 +16,9 @@ require "appsignal/helpers/metrics"
 # {Appsignal::Helpers::Metrics}) for ease of use.
 module Appsignal
   class << self
-    extend Gem::Deprecate
     include Helpers::Instrumentation
     include Helpers::Metrics
+    include Utils::DeprecationMessage
 
     # Accessor for the AppSignal configuration.
     # Return the current AppSignal configuration.
@@ -280,16 +281,18 @@ module Appsignal
 
     # @deprecated No replacement
     def is_ignored_error?(error) # rubocop:disable Naming/PredicateName
+      deprecation_message "Appsignal.is_ignored_error? is deprecated " \
+        "with no replacement and will be removed in version 3.0."
       Appsignal.config[:ignore_errors].include?(error.class.name)
     end
     alias :is_ignored_exception? :is_ignored_error?
-    deprecate :is_ignored_error?, :none, 2017, 3
 
     # @deprecated No replacement
     def is_ignored_action?(action) # rubocop:disable Naming/PredicateName
+      deprecation_message "Appsignal.is_ignored_action? is deprecated " \
+        "with no replacement and will be removed in version 3.0."
       Appsignal.config[:ignore_actions].include?(action)
     end
-    deprecate :is_ignored_action?, :none, 2017, 3
 
     private
 

--- a/lib/appsignal/cli/notify_of_deploy.rb
+++ b/lib/appsignal/cli/notify_of_deploy.rb
@@ -94,7 +94,7 @@ module Appsignal
             "see our documentation for more information on the recommended " \
             "method: " \
             "https://docs.appsignal.com/application/markers/deploy-markers.html"
-          deprecation_message message, Appsignal.logger
+          deprecation_message message
         end
 
         private

--- a/lib/appsignal/event_formatter.rb
+++ b/lib/appsignal/event_formatter.rb
@@ -91,8 +91,7 @@ module Appsignal
           "Formatter for '#{name}' is using a deprecated registration " \
           "method. This event formatter will not be loaded. " \
           "Please update the formatter according to the documentation at: " \
-          "https://docs.appsignal.com/ruby/instrumentation/event-formatters.html",
-          logger
+          "https://docs.appsignal.com/ruby/instrumentation/event-formatters.html"
 
         EventFormatter.deprecated_formatter_classes[name] = self
       end

--- a/lib/appsignal/minutely.rb
+++ b/lib/appsignal/minutely.rb
@@ -33,8 +33,7 @@ module Appsignal
       # @return [void]
       def <<(probe)
         deprecation_message "Deprecated `Appsignal::Minute.probes <<` " \
-          "call. Please use `Appsignal::Minutely.probes.register` instead.",
-          logger
+          "call. Please use `Appsignal::Minutely.probes.register` instead."
         register probe.object_id, probe
       end
 

--- a/lib/appsignal/rack/js_exception_catcher.rb
+++ b/lib/appsignal/rack/js_exception_catcher.rb
@@ -28,10 +28,9 @@ module Appsignal
       def initialize(app, _options = nil)
         Appsignal.logger.debug \
           "Initializing Appsignal::Rack::JSExceptionCatcher"
-        message = "The Appsignal::Rack::JSExceptionCatcher is deprecated. " \
-          "Please use the official AppSignal JavaScript integration instead. " \
-          "https://docs.appsignal.com/front-end/"
-        deprecation_message message, Appsignal.logger
+        deprecation_message "The Appsignal::Rack::JSExceptionCatcher is " \
+          "deprecated. Please use the official AppSignal JavaScript " \
+          "integration instead. https://docs.appsignal.com/front-end/"
         @app = app
       end
 

--- a/lib/appsignal/utils/deprecation_message.rb
+++ b/lib/appsignal/utils/deprecation_message.rb
@@ -1,7 +1,7 @@
 module Appsignal
   module Utils
     module DeprecationMessage
-      def deprecation_message(message, logger)
+      def deprecation_message(message, logger = Appsignal.logger)
         $stdout.puts "appsignal WARNING: #{message}"
         logger.warn message
       end

--- a/lib/appsignal/utils/deprecation_message.rb
+++ b/lib/appsignal/utils/deprecation_message.rb
@@ -2,7 +2,7 @@ module Appsignal
   module Utils
     module DeprecationMessage
       def deprecation_message(message, logger = Appsignal.logger)
-        $stdout.puts "appsignal WARNING: #{message}"
+        $stderr.puts "appsignal WARNING: #{message}"
         logger.warn message
       end
     end

--- a/spec/lib/appsignal/cli/notify_of_deploy_spec.rb
+++ b/spec/lib/appsignal/cli/notify_of_deploy_spec.rb
@@ -5,6 +5,8 @@ describe Appsignal::CLI::NotifyOfDeploy do
 
   let(:out_stream) { std_stream }
   let(:output) { out_stream.read }
+  let(:err_stream) { std_stream }
+  let(:stderr) { err_stream.read }
 
   define :include_deploy_notification do
     match do |log|
@@ -32,7 +34,7 @@ describe Appsignal::CLI::NotifyOfDeploy do
   end
 
   def run
-    capture_stdout(out_stream) do
+    capture_std_streams(out_stream, err_stream) do
       run_cli("notify_of_deploy", options)
     end
   end
@@ -130,7 +132,7 @@ describe Appsignal::CLI::NotifyOfDeploy do
         it "prints a deprecation message" do
           run
           deprecation_message = "This command (appsignal notify_of_deploy) has been deprecated"
-          expect(output).to include("appsignal WARNING: #{deprecation_message}")
+          expect(stderr).to include("appsignal WARNING: #{deprecation_message}")
           expect(log).to contains_log :warn, deprecation_message
         end
 

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -323,11 +323,11 @@ describe Appsignal::Config do
     end
 
     describe "support for old config keys" do
-      let(:out_stream) { std_stream }
-      let(:output) { out_stream.read }
+      let(:err_stream) { std_stream }
+      let(:stderr) { err_stream.read }
       let(:config) { project_fixture_config(env, {}, test_logger(log)) }
       let(:log) { StringIO.new }
-      before { capture_stdout(out_stream) { config } }
+      before { capture_std_streams(std_stream, err_stream) { config } }
 
       describe ":api_key" do
         context "without :push_api_key" do
@@ -338,7 +338,7 @@ describe Appsignal::Config do
             expect(config.config_hash).to_not have_key :api_key
 
             message = "Old configuration key found. Please update the 'api_key' to 'push_api_key'"
-            expect(output).to include "appsignal WARNING: #{message}"
+            expect(stderr).to include "appsignal WARNING: #{message}"
             expect(log_contents(log)).to contains_log :warn, message
           end
         end
@@ -351,7 +351,7 @@ describe Appsignal::Config do
             expect(config.config_hash).to_not have_key :api_key
 
             message = "Old configuration key found. Please update the 'api_key' to 'push_api_key'"
-            expect(output).to include "appsignal WARNING: #{message}"
+            expect(stderr).to include "appsignal WARNING: #{message}"
             expect(log_contents(log)).to contains_log :warn, message
           end
         end
@@ -366,7 +366,7 @@ describe Appsignal::Config do
             expect(config.config_hash).to_not have_key :ignore_exceptions
 
             message = "Old configuration key found. Please update the 'ignore_exceptions' to 'ignore_errors'"
-            expect(output).to include "appsignal WARNING: #{message}"
+            expect(stderr).to include "appsignal WARNING: #{message}"
             expect(log_contents(log)).to contains_log :warn, message
           end
         end
@@ -379,7 +379,7 @@ describe Appsignal::Config do
             expect(config.config_hash).to_not have_key :ignore_exceptions
 
             message = "Old configuration key found. Please update the 'ignore_exceptions' to 'ignore_errors'"
-            expect(output).to include "appsignal WARNING: #{message}"
+            expect(stderr).to include "appsignal WARNING: #{message}"
             expect(log_contents(log)).to contains_log :warn, message
           end
         end

--- a/spec/lib/appsignal/event_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter_spec.rb
@@ -116,7 +116,8 @@ describe Appsignal::EventFormatter do
     end
 
     context "when registering deprecated formatters" do
-      let(:stdout_stream) { std_stream }
+      let(:err_stream) { std_stream }
+      let(:stderr) { err_stream.read }
       let(:deprecated_formatter) do
         Class.new(Appsignal::EventFormatter) do
           register "mock.deprecated"
@@ -133,16 +134,16 @@ describe Appsignal::EventFormatter do
           "https://docs.appsignal.com/ruby/instrumentation/event-formatters.html"
 
         logs = capture_logs do
-          capture_stdout(stdout_stream) { deprecated_formatter }
+          capture_std_streams(std_stream, err_stream) { deprecated_formatter }
         end
         expect(logs).to contains_log :warn, message
-        expect(stdout_stream.read).to include "appsignal WARNING: #{message}"
+        expect(stderr).to include "appsignal WARNING: #{message}"
 
         expect(klass.deprecated_formatter_classes.keys).to include("mock.deprecated")
       end
 
       it "initializes deprecated formatters" do
-        capture_stdout(stdout_stream) { deprecated_formatter }
+        capture_std_streams(std_stream, err_stream) { deprecated_formatter }
         klass.initialize_deprecated_formatters
 
         expect(klass.registered?("mock.deprecated")).to be_truthy

--- a/spec/lib/appsignal/minutely_spec.rb
+++ b/spec/lib/appsignal/minutely_spec.rb
@@ -285,19 +285,19 @@ describe Appsignal::Minutely do
     end
 
     describe "#<<" do
-      let(:out_stream) { std_stream }
-      let(:output) { out_stream.read }
+      let(:err_stream) { std_stream }
+      let(:stderr) { err_stream.read }
       let(:log_stream) { std_stream }
       let(:log) { log_contents(log_stream) }
       before { Appsignal.logger = test_logger(log_stream) }
 
       it "adds the probe, but prints a deprecation warning" do
         probe = lambda {}
-        capture_stdout(out_stream) { collection << probe }
+        capture_std_streams(std_stream, err_stream) { collection << probe }
         deprecation_message = "Deprecated " \
           "`Appsignal::Minute.probes <<` call. Please use " \
           "`Appsignal::Minutely.probes.register` instead."
-        expect(output).to include "appsignal WARNING: #{deprecation_message}"
+        expect(stderr).to include "appsignal WARNING: #{deprecation_message}"
         expect(log).to contains_log :warn, deprecation_message
         expect(collection[probe.object_id]).to eql(probe)
       end

--- a/spec/lib/appsignal/rack/js_exception_catcher_spec.rb
+++ b/spec/lib/appsignal/rack/js_exception_catcher_spec.rb
@@ -11,18 +11,22 @@ describe Appsignal::Rack::JSExceptionCatcher do
   before { Appsignal.config = config }
 
   describe "#initialize" do
+    let(:out_stream) { std_stream }
+    let(:err_stream) { std_stream }
+    let(:output) { out_stream.read }
+    let(:stderr) { err_stream.read }
+
     it "logs to the logger" do
-      stdout = std_stream
-      stderr = std_stream
       log = capture_logs do
-        capture_std_streams(stdout, stderr) do
+        capture_std_streams(out_stream, err_stream) do
           Appsignal::Rack::JSExceptionCatcher.new(app, options)
         end
       end
       expect(log).to contains_log(:warn, deprecation_message)
       expect(log).to contains_log(:debug, "Initializing Appsignal::Rack::JSExceptionCatcher")
-      expect(stdout.read).to include "appsignal WARNING: #{deprecation_message}"
-      expect(stderr.read).to_not include("appsignal:")
+      expect(stderr).to include "appsignal WARNING: #{deprecation_message}"
+      expect(stderr).to_not include("appsignal:")
+      expect(output).to be_empty
     end
   end
 

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -949,7 +949,7 @@ describe Appsignal do
 
       it "outputs deprecated warning" do
         subject
-        expect(stderr).to include("Appsignal.is_ignored_error? is deprecated with no replacement.")
+        expect(stderr).to include("Appsignal.is_ignored_error? is deprecated with no replacement")
       end
 
       context "when error is not in the ignored list" do
@@ -981,7 +981,7 @@ describe Appsignal do
 
       it "outputs deprecated warning" do
         subject
-        expect(stderr).to include("Appsignal.is_ignored_action? is deprecated with no replacement.")
+        expect(stderr).to include("Appsignal.is_ignored_action? is deprecated with no replacement")
       end
 
       context "when action is not in the ingore list" do


### PR DESCRIPTION
Closes #600

## Use deprecation_message for deprecated methods

We were using `Gem::Deprecate` which may or may not change in the
future, see #599.

To be more future proof, use our own solution for deprecation messages
which logs it both to the STDERR of the program, but also the
AppSignal log file.

## Log deprecation_message to STDERR

Instead of STDOUT. This will make it the same behavior as
`Gem::Deprecate`, which also logs to STDERR.

It's better to log warnings and such to STDERR than STDOUT so it makes
clear it's not regular app output.

Update all specs to match this behavior change.

## Set deprecation_message logger to default logger

So we don't need to specify the logger for every deprecation message we
output when it's also logged to the default logger most of the time.
