### PR TITLE
Track queue time regardless of namespace

### DIFF
--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -228,6 +228,22 @@ module Appsignal
       Appsignal.logger.warn("Queue start value #{start} is too big")
     end
 
+    # Set the queue time based on the HTTP header or `:queue_start` env key
+    # value.
+    #
+    # This method will first try to read the queue time from the HTTP headers
+    # `X-Request-Start` or `X-Queue-Start`. Which are parsed by Rack as
+    # `HTTP_X_QUEUE_START` and `HTTP_X_REQUEST_START`.
+    # The header value is parsed by AppSignal as either milliseconds or
+    # microseconds.
+    #
+    # If no headers are found, or the value could not be parsed, it falls back
+    # on the `:queue_start` env key on this Transaction's {request} environment
+    # (called like `request.env[:queue_start]`). This value is parsed by
+    # AppSignal as seconds.
+    #
+    # @see https://docs.appsignal.com/ruby/instrumentation/request-queue-time.html
+    # @return [void]
     def set_http_or_background_queue_start
       start = http_queue_start || background_queue_start
       return unless start

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -229,11 +229,10 @@ module Appsignal
     end
 
     def set_http_or_background_queue_start
-      if namespace == HTTP_REQUEST
-        set_queue_start(http_queue_start)
-      elsif namespace == BACKGROUND_JOB
-        set_queue_start(background_queue_start)
-      end
+      start = http_queue_start || background_queue_start
+      return unless start
+
+      set_queue_start(start)
     end
 
     def set_metadata(key, value)
@@ -346,14 +345,14 @@ module Appsignal
     #
     # @return [nil] if no {#environment} is present.
     # @return [nil] if there is no `:queue_start` in the {#environment}.
-    # @return [Integer]
+    # @return [Integer] `:queue_start` time (in seconds) converted to milliseconds
     def background_queue_start
       env = environment
       return unless env
       queue_start = env[:queue_start]
       return unless queue_start
 
-      (queue_start.to_f * 1000.0).to_i
+      (queue_start.to_f * 1000.0).to_i # Convert seconds to milliseconds
     end
 
     # Returns HTTP queue start time in milliseconds.

--- a/spec/support/helpers/env_helpers.rb
+++ b/spec/support/helpers/env_helpers.rb
@@ -27,7 +27,7 @@ module EnvHelpers
       :priority => 1,
       :attempts => 0,
       :queue => "default",
-      :queue_start => fixed_time - 10.0
+      :queue_start => fixed_time
     }.merge(args)
   end
 end


### PR DESCRIPTION
We had a check that only kept track the queue time for the web and
background namespaces. Remove that check now that we allow users to use
custom namespaces.

Prefer the web namespace HTTP header method of setting the queue time
(for things like admin namespace) and fall back on the background
namespace method (setting the :queue_start value on the transaction
env).

Depending on the method with which the value is set a different
calculation to set the time in milliseconds is done.

- HTTP header: expected value is in either milliseconds or microseconds.
- `:queue_start` key value on the transaction env: expected value in in
   seconds.

Update specs to always return the same magnitude of value for every
test case. Some tests didn't call `.to_i` on the value set on the
HTTP header, which caused the value to be read a factor of 100 lower
than the test cases for the `:queue_start` env key value. Now all test
cases are using the same magnitude of value for the queue times. Also
commented which calculations are done one which lines to hopefully make
this more understandable in the future.

Fixes #378 