### PR TITLE
Clean bundle in CI jobs

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -36,7 +36,7 @@ global_job_config:
     - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE),$_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET,$_BUNDLER_CACHE-bundler-$RUBY_VERSION
     - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE),$_GEMS_CACHE-gems-$RUBY_VERSION
     - "./support/install_deps"
-    - "./support/bundler_wrapper install --jobs=3 --retry=3"
+    - "./support/bundler_wrapper install --jobs=3 --retry=3 --clean"
   epilogue:
     on_pass:
       commands:

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -37,7 +37,7 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
         - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE),$_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET,$_BUNDLER_CACHE-bundler-$RUBY_VERSION
         - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE),$_GEMS_CACHE-gems-$RUBY_VERSION
         - ./support/install_deps
-        - ./support/bundler_wrapper install --jobs=3 --retry=3
+        - ./support/bundler_wrapper install --jobs=3 --retry=3 --clean
     epilogue:
       on_pass:
         commands:


### PR DESCRIPTION
Our bundle on the CI keeps growing as we've seen in other projects
(https://github.com/appsignal/appsignal-server/pull/6106). Probably
because when a Ruby gem is upgraded the old version is not removed from
the bundle directory that is later cached by Semaphore.

To ensure our bundle is kept small call `bundle clean` after calling
`bundle install` by adding the `--clean` flag to `bundle install`.

This should speed up our tests by not having to wait for larger than
necessary caches to be downloaded and uploaded.

The `bundle clean` command describes itself as:

> Cleans up unused gems in your bundler directory

[skip review]