### PR TITLE
Fix checksum check failure logging

### DIFF
--- a/ext/base.rb
+++ b/ext/base.rb
@@ -142,14 +142,16 @@ def download_archive(type)
 end
 
 def verify_archive(archive, type)
-  if Digest::SHA256.hexdigest(archive.read) == ARCH_CONFIG[type]["checksum"]
+  expected_checksum = ARCH_CONFIG[type]["checksum"]
+  actual_checksum = Digest::SHA256.hexdigest(archive.read)
+  if actual_checksum == expected_checksum
     report["download"]["checksum"] = "verified"
     true
   else
     report["download"]["checksum"] = "invalid"
     abort_installation(
       "Checksum of downloaded archive could not be verified: " \
-        "Expected '#{ARCH_CONFIG[type]["checksum"]}', got '#{checksum}'."
+        "Expected '#{expected_checksum}', got '#{actual_checksum}'."
     )
   end
 end


### PR DESCRIPTION
The failure scenario for a failed checksum check referred to an
undefined variable called `checksum`.

Update the code to refer to actual existing variable by assigning the
values that are compared to variables.