### PR TITLE
Fix issue where Delayed Job job objects responding to Hash accessor assumes string return value

### DIFF
--- a/lib/appsignal/integrations/delayed_job_plugin.rb
+++ b/lib/appsignal/integrations/delayed_job_plugin.rb
@@ -62,7 +62,7 @@ module Appsignal
         return pound_split if pound_split.length == 2
 
         dot_split = default_name.split(".")
-        return dot_split if dot_split.length == 2
+        return default_name if dot_split.length == 2
 
         ["unknown"]
       end

--- a/lib/appsignal/integrations/delayed_job_plugin.rb
+++ b/lib/appsignal/integrations/delayed_job_plugin.rb
@@ -27,9 +27,8 @@ module Appsignal
           method_name = "perform"
         else
           # Delayed Job
-          args = extract_value(job.payload_object, :args, {})
-          class_and_method_name = extract_value(job.payload_object, :appsignal_name, job.name)
-          class_name, method_name = class_and_method_name.split("#")
+          args = extract_value(payload, :args, {})
+          class_name, method_name = class_and_method_name_from_object_or_hash(payload, job.name)
         end
 
         params = Appsignal::Utils::HashSanitizer.sanitize(
@@ -52,6 +51,20 @@ module Appsignal
         ) do
           block.call(job)
         end
+      end
+
+      def self.class_and_method_name_from_object_or_hash(payload, default_name)
+        # Attempt to find appsignal_name override
+        class_and_method_name = extract_value(payload, :appsignal_name, nil)
+        return class_and_method_name.split("#") if class_and_method_name.is_a?(String)
+
+        pound_split = default_name.split("#")
+        return pound_split if pound_split.length == 2
+
+        dot_split = default_name.split(".")
+        return dot_split if dot_split.length == 2
+
+        %w[unknown unknown]
       end
 
       def self.extract_value(object_or_hash, field, default_value = nil, convert_to_s = false)

--- a/spec/lib/appsignal/hooks/delayed_job_spec.rb
+++ b/spec/lib/appsignal/hooks/delayed_job_spec.rb
@@ -142,7 +142,7 @@ describe Appsignal::Hooks::DelayedJobHook do
 
           it "wraps it in a transaction using the class method job name" do
             perform
-            expect(last_transaction.to_h["action"]).to eql("CustomClassMethod#perform")
+            expect(last_transaction.to_h["action"]).to eql("CustomClassMethod.perform")
           end
         end
 


### PR DESCRIPTION
With our Delayed Job integration it's possible to override the job's class/method name by implementing
an `appsignal_name` method or setting the value in the Job Hash.

Our `extract_value` code first attempts to read the value from the Hash,
and then attempts to read it as an object accessor.

If objects respond to `[]` with something other than a String, this could crash the plugin.

This commit adds more checking of return values from `extract_value` and only attempts to set the
class/method if the return value is a String. Otherwise it will return the given default value,
or `unknown` if no valid default value is found.