### PR TITLE
Revert DelayedJob class/method name extraction method logic for Class methods

### DIFF
--- a/lib/appsignal/integrations/delayed_job_plugin.rb
+++ b/lib/appsignal/integrations/delayed_job_plugin.rb
@@ -62,7 +62,7 @@ module Appsignal
         return pound_split if pound_split.length == 2
 
         dot_split = default_name.split(".")
-        return dot_split if dot_split.length == 2
+        return default_name if dot_split.length == 2
 
         ["unknown"]
       end

--- a/spec/lib/appsignal/hooks/delayed_job_spec.rb
+++ b/spec/lib/appsignal/hooks/delayed_job_spec.rb
@@ -142,7 +142,7 @@ describe Appsignal::Hooks::DelayedJobHook do
 
           it "wraps it in a transaction using the class method job name" do
             perform
-            expect(last_transaction.to_h["action"]).to eql("CustomClassMethod#perform")
+            expect(last_transaction.to_h["action"]).to eql("CustomClassMethod.perform")
           end
         end
 


### PR DESCRIPTION
Revert DelayedJob class/method name extraction method for Class methods to generate the same results as before this fix.

Code downstream relies on the fact that class methods (`Foo.bar`) are emitted as `["Foo.bar", nil]` for class/method name.
This commit ensures that this behavior is re-implemented in the DelayedJob class/method name extraction logic to ensure that
we don't suddenly generate a ton of new incidents with different "action" names.