### PR TITLE
Set bundle clean flag

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -36,7 +36,8 @@ global_job_config:
     - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE),$_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET,$_BUNDLER_CACHE-bundler-$RUBY_VERSION
     - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE),$_GEMS_CACHE-gems-$RUBY_VERSION
     - "./support/install_deps"
-    - "./support/bundler_wrapper install --jobs=3 --retry=3 --clean"
+    - bundle config set clean 'true'
+    - "./support/bundler_wrapper install --jobs=3 --retry=3"
   epilogue:
     on_pass:
       commands:

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -37,7 +37,8 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
         - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE),$_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET,$_BUNDLER_CACHE-bundler-$RUBY_VERSION
         - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE),$_GEMS_CACHE-gems-$RUBY_VERSION
         - ./support/install_deps
-        - ./support/bundler_wrapper install --jobs=3 --retry=3 --clean
+        - bundle config set clean 'true'
+        - ./support/bundler_wrapper install --jobs=3 --retry=3
     epilogue:
       on_pass:
         commands:


### PR DESCRIPTION
`bundle install --clean` is deprecated. Instead set the flag as a config
option for bundler.

```
[DEPRECATED] The `--clean` flag is deprecated because it relies on being
remembered across bundler invocations, which bundler will no longer do
in future versions. Instead please use `bundle config set clean 'true'`,
and stop using this flag
```

[skip review]