### PR TITLE
Fix ResqueActiveJobPlugin specs

### DIFF
--- a/spec/lib/appsignal/integrations/resque_active_job_spec.rb
+++ b/spec/lib/appsignal/integrations/resque_active_job_spec.rb
@@ -1,4 +1,4 @@
-if DependencyHelper.resque_present? && DependencyHelper.active_job_present?
+if DependencyHelper.active_job_present?
   require "active_job"
 
   describe Appsignal::Integrations::ResqueActiveJobPlugin do


### PR DESCRIPTION
Remove Resque presence check, it's not present in the ActiveJob specs
for it. The DependencyHelper would check for a scenario that never
occurred.

This meant the tests were never run in either the Resque gemfile or
Rails gemfiles setups.

Since we don't need Resque in this spec, since we stub it out, remove
the DependencyHelper check.

[skip review]