### PR TITLE
Support queueing time metrics for ResqueActiveJob

### DIFF
--- a/lib/appsignal/integrations/resque_active_job.rb
+++ b/lib/appsignal/integrations/resque_active_job.rb
@@ -14,12 +14,18 @@ module Appsignal
               Appsignal.config[:filter_parameters]
             )
 
+            queue_start =
+              if job.respond_to?(:enqueued_at) && job.enqueued_at
+                Time.parse(job.enqueued_at).utc
+              end
+
             Appsignal.monitor_single_transaction(
               "perform_job.resque",
-              :class    => job.class.to_s,
-              :method   => "perform",
-              :params   => params,
-              :metadata => {
+              :class       => job.class.to_s,
+              :method      => "perform",
+              :params      => params,
+              :queue_start => queue_start,
+              :metadata    => {
                 :id       => job.job_id,
                 :queue    => job.queue_name
               }

--- a/spec/lib/appsignal/integrations/resque_active_job_spec.rb
+++ b/spec/lib/appsignal/integrations/resque_active_job_spec.rb
@@ -1,21 +1,18 @@
 if DependencyHelper.active_job_present?
   require "active_job"
+  require File.expand_path("lib/appsignal/integrations/resque_active_job.rb")
+
+  class TestActiveJob < ActiveJob::Base
+    include Appsignal::Integrations::ResqueActiveJobPlugin
+
+    def perform(_)
+    end
+  end
 
   describe Appsignal::Integrations::ResqueActiveJobPlugin do
-    let(:file) { File.expand_path("lib/appsignal/integrations/resque_active_job.rb") }
     let(:args) { "argument" }
     let(:job) { TestActiveJob.new(args) }
-    before do
-      load file
-      start_agent
-
-      class TestActiveJob < ActiveJob::Base
-        include Appsignal::Integrations::ResqueActiveJobPlugin
-
-        def perform(_)
-        end
-      end
-    end
+    before { start_agent }
 
     def perform
       keep_transactions do
@@ -137,6 +134,51 @@ if DependencyHelper.active_job_present?
                 "queue" => "default"
               }
             )
+          )
+        end
+      end
+    end
+
+    context "without queue time" do
+      it "does not add queue time to transaction" do
+        # TODO: Not available in transaction.to_h yet.
+        # https://github.com/appsignal/appsignal-agent/issues/293
+        expect(Appsignal).to receive(:monitor_single_transaction).with(
+          "perform_job.resque",
+          a_hash_including(:queue_start => nil)
+        ).and_call_original
+
+        perform
+        expect(last_transaction.to_h).to include(
+          "namespace" => Appsignal::Transaction::BACKGROUND_JOB,
+          "action" => "TestActiveJob#perform",
+          "events" => [
+            hash_including("name" => "perform_job.resque")
+          ]
+        )
+      end
+    end
+
+    if DependencyHelper.rails6_present?
+      context "with queue time" do
+        it "adds queue time to transction" do
+          queue_start = "2017-01-01 10:01:00UTC"
+          queue_start_time = Time.parse(queue_start)
+          # TODO: Not available in transaction.to_h yet.
+          # https://github.com/appsignal/appsignal-agent/issues/293
+          expect(Appsignal).to receive(:monitor_single_transaction).with(
+            "perform_job.resque",
+            a_hash_including(:queue_start => queue_start_time)
+          ).and_call_original
+          job.enqueued_at = queue_start
+
+          perform
+          expect(last_transaction.to_h).to include(
+            "namespace" => Appsignal::Transaction::BACKGROUND_JOB,
+            "action" => "TestActiveJob#perform",
+            "events" => [
+              hash_including("name" => "perform_job.resque")
+            ]
           )
         end
       end

--- a/spec/support/helpers/dependency_helper.rb
+++ b/spec/support/helpers/dependency_helper.rb
@@ -9,6 +9,11 @@ module DependencyHelper
     dependency_present? "rails"
   end
 
+  def rails6_present?
+    rails_present? &&
+      Gem.loaded_specs["rails"].version >= Gem::Version.new("6.0.0")
+  end
+
   def sequel_present?
     dependency_present? "sequel"
   end


### PR DESCRIPTION
ActiveJob now supports reporting on the time each job was enqueued, so
we can report this as the queue_start in our transaction.

Ref: https://api.rubyonrails.org/classes/ActiveJob/Core.html

This current implementation also supports previous Rails versions by
checking presence of the enqueued_at attribute.

---

Tom de Bruijn (@tombruijn): Refactor the specs to no longer use the
`load file` logic. Just require the integration file once at the
beginning of the spec. This fixes the new specs using
`expect(Appsignal).to receive(:monitor_single_transaction)`
to not fail on method calls leaking from previous specs.

Co-authored-by: Josh <josh@joshbeckman.org>