### PR TITLE
Add helpers for environment metadata collection

### DIFF
--- a/ext/agent.yml
+++ b/ext/agent.yml
@@ -1,70 +1,70 @@
 ---
-version: 6ced5a6
+version: 5f2eb28
 mirrors:
 - https://appsignal-agent-releases.global.ssl.fastly.net
 - https://d135dj0rjqvssy.cloudfront.net
 triples:
   x86_64-darwin:
     static:
-      checksum: dcc623a7eea18727c8628cf29d30e61379e543328a53d91bcf0c5751f3f9f313
+      checksum: eda58ee5909912ff67d56c994e4d3a2724838c6408abe24722ef193430c8d68b
       filename: appsignal-x86_64-darwin-all-static.tar.gz
     dynamic:
-      checksum: 63f2ba8289390df75b72f414ed026acca07f26ac52bd25cd679c6de776b53ca4
+      checksum: 39a1a9ff4b7201bdb51af46978b0636f281f3b9d21d6d2899cfee6c5102d74a4
       filename: appsignal-x86_64-darwin-all-dynamic.tar.gz
   universal-darwin:
     static:
-      checksum: dcc623a7eea18727c8628cf29d30e61379e543328a53d91bcf0c5751f3f9f313
+      checksum: eda58ee5909912ff67d56c994e4d3a2724838c6408abe24722ef193430c8d68b
       filename: appsignal-x86_64-darwin-all-static.tar.gz
     dynamic:
-      checksum: 63f2ba8289390df75b72f414ed026acca07f26ac52bd25cd679c6de776b53ca4
+      checksum: 39a1a9ff4b7201bdb51af46978b0636f281f3b9d21d6d2899cfee6c5102d74a4
       filename: appsignal-x86_64-darwin-all-dynamic.tar.gz
   i686-linux:
     static:
-      checksum: 8941c1d0a546da8f63bc65953afc439987616c62f2d5307856728ae4f2e0b2f5
+      checksum: 0630e6585a7b9644eadb43f338bb85ebfc5d6266f2e2a313dc3e87dd3020113d
       filename: appsignal-i686-linux-all-static.tar.gz
     dynamic:
-      checksum: ccb59ee85f8ba8790482db9de29be6936e92c395bb6306f0fecefbc4de50f78d
+      checksum: f74a7397822cb1005de2e7fe7843cb046a5fd95ccfede9c83633d693b87fd6a6
       filename: appsignal-i686-linux-all-dynamic.tar.gz
   x86-linux:
     static:
-      checksum: 8941c1d0a546da8f63bc65953afc439987616c62f2d5307856728ae4f2e0b2f5
+      checksum: 0630e6585a7b9644eadb43f338bb85ebfc5d6266f2e2a313dc3e87dd3020113d
       filename: appsignal-i686-linux-all-static.tar.gz
     dynamic:
-      checksum: ccb59ee85f8ba8790482db9de29be6936e92c395bb6306f0fecefbc4de50f78d
+      checksum: f74a7397822cb1005de2e7fe7843cb046a5fd95ccfede9c83633d693b87fd6a6
       filename: appsignal-i686-linux-all-dynamic.tar.gz
   i686-linux-musl:
     static:
-      checksum: 9cfe62cfd0559b900c37b256a2ffc95021007cf3f365152b62af74b55da465a9
+      checksum: f75b078520f94efeb47a2a31a7f3fe7c1d5024e64fdac9b1aad57b695c496475
       filename: appsignal-i686-linux-musl-all-static.tar.gz
   x86-linux-musl:
     static:
-      checksum: 9cfe62cfd0559b900c37b256a2ffc95021007cf3f365152b62af74b55da465a9
+      checksum: f75b078520f94efeb47a2a31a7f3fe7c1d5024e64fdac9b1aad57b695c496475
       filename: appsignal-i686-linux-musl-all-static.tar.gz
   x86_64-linux:
     static:
-      checksum: fe74119337cfb8353c64707e4689dc398df1adf2d4bb1bf7750e9a71cca39b3a
+      checksum: 82e9fcb56f3523b59879ebcd581b0f3caa01bb8cc20d8cfcc8f0b1d221eb5ad0
       filename: appsignal-x86_64-linux-all-static.tar.gz
     dynamic:
-      checksum: 6816b709ca388421906b178ae592f565ebc433b59cc50223de8c914e44c75d7a
+      checksum: 90f0d77e9508ac9f23742b5cd426bdcd34dde47edf3b67d11a526f95ccc014c5
       filename: appsignal-x86_64-linux-all-dynamic.tar.gz
   x86_64-linux-musl:
     static:
-      checksum: 5382a1b0933a2b4d8fae74f89c1af7a21176a1bc100bb245078a1b369b91caca
+      checksum: 2e58686b81a4afc441abf5e5cb59a3fb593a88449b88e1ae8c19627fa9e428ef
       filename: appsignal-x86_64-linux-musl-all-static.tar.gz
     dynamic:
-      checksum: e222dd4b09d5042e5315512353f987b1be0302c457285de0bfaeb911d72a8e3e
+      checksum: f0d1f069661a69dfc0ce3a1fa35da4cc88ec515797ff056ff4bdb859eab2f3c1
       filename: appsignal-x86_64-linux-musl-all-dynamic.tar.gz
   x86_64-freebsd:
     static:
-      checksum: b98fcf6490cb5d1485e96656992ee083f534ec43d67caf015f72b8f4cc6e8fa6
+      checksum: a1702083d3a87f827efb1b9adc20cd8a8fb81b81c4858b98feaf8c9bbe5e411f
       filename: appsignal-x86_64-freebsd-all-static.tar.gz
     dynamic:
-      checksum: 28e8cab256c3550e249e0768dc9cb0f352396e972186e1ccf9f2c02461a87345
+      checksum: 30d1f7676c3d1221f0857732988a6256d8bf13674cb0def121740b33710d0289
       filename: appsignal-x86_64-freebsd-all-dynamic.tar.gz
   amd64-freebsd:
     static:
-      checksum: b98fcf6490cb5d1485e96656992ee083f534ec43d67caf015f72b8f4cc6e8fa6
+      checksum: a1702083d3a87f827efb1b9adc20cd8a8fb81b81c4858b98feaf8c9bbe5e411f
       filename: appsignal-x86_64-freebsd-all-static.tar.gz
     dynamic:
-      checksum: 28e8cab256c3550e249e0768dc9cb0f352396e972186e1ccf9f2c02461a87345
+      checksum: 30d1f7676c3d1221f0857732988a6256d8bf13674cb0def121740b33710d0289
       filename: appsignal-x86_64-freebsd-all-dynamic.tar.gz

--- a/ext/appsignal_extension.c
+++ b/ext/appsignal_extension.c
@@ -639,6 +639,14 @@ static VALUE running_in_container() {
   return appsignal_running_in_container() == 1 ? Qtrue : Qfalse;
 }
 
+static VALUE set_environment_metadata(VALUE self, VALUE key, VALUE value) {
+  appsignal_set_environment_metadata(
+      make_appsignal_string(key),
+      make_appsignal_string(value)
+  );
+  return Qnil;
+}
+
 void Init_appsignal_extension(void) {
   Appsignal = rb_define_module("Appsignal");
   Extension = rb_define_class_under(Appsignal, "Extension", rb_cObject);
@@ -697,9 +705,10 @@ void Init_appsignal_extension(void) {
   // Get JSON content of a data
   rb_define_method(Data, "to_s", data_to_s, 0);
 
-  // Event hook installation
+  // Other helper methods
   rb_define_singleton_method(Extension, "install_allocation_event_hook", install_allocation_event_hook, 0);
   rb_define_singleton_method(Extension, "running_in_container?", running_in_container, 0);
+  rb_define_singleton_method(Extension, "set_environment_metadata", set_environment_metadata, 2);
 
   // Metrics
   rb_define_singleton_method(Extension, "set_gauge",              set_gauge,              3);

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -312,6 +312,7 @@ module Appsignal
   end
 end
 
+require "appsignal/environment"
 require "appsignal/system"
 require "appsignal/utils"
 require "appsignal/extension"

--- a/lib/appsignal/environment.rb
+++ b/lib/appsignal/environment.rb
@@ -1,0 +1,46 @@
+module Appsignal
+  # @api private
+  class Environment
+    # Add environment metadata.
+    #
+    # The key and value of the environment metadata must be a String, even if
+    # it's actually of another type.
+    #
+    # The value of the environment metadata is given as a block that captures
+    # errors that might be raised while fetching the value. It will not
+    # re-raise errors, but instead log them using the {Appsignal.logger}. This
+    # ensures AppSignal will not cause an error in the application when
+    # collecting this metadata.
+    #
+    # @example Reporting a key and value
+    #   Appsignal::Environment.report("ruby_version") { RUBY_VERSION }
+    #
+    # @example When a value is nil
+    #   Appsignal::Environment.report("ruby_version") { nil }
+    #   # Key and value do not get reported. A warning gets logged instead.
+    #
+    # @example When an error occurs
+    #   Appsignal::Environment.report("ruby_version") { raise "uh oh" }
+    #   # Error does not get reraised. A warning gets logged instead.
+    #
+    # @param key [String] The name of the key of the environment metadata value.
+    # @yieldreturn [String] The value of the key of the environment metadata.
+    # @return [void]
+    def self.report(key)
+      value =
+        begin
+          yield
+        rescue => e
+          Appsignal.logger.warn("Unable to report on environment metadata `#{key}`: #{e}")
+          return
+        end
+
+      unless value
+        Appsignal.logger.warn("Unable to report on environment metadata `#{key}`: Value is nil")
+        return
+      end
+
+      Appsignal::Extension.set_environment_metadata(key, value)
+    end
+  end
+end

--- a/lib/appsignal/extension/jruby.rb
+++ b/lib/appsignal/extension/jruby.rb
@@ -60,6 +60,9 @@ module Appsignal
           [:appsignal_string],
           :appsignal_string
         attach_function :appsignal_running_in_container, [], :bool
+        attach_function :appsignal_set_environment_metadata,
+          [:appsignal_string, :appsignal_string],
+          :void
 
         # Metrics methods
         attach_function :appsignal_set_gauge,
@@ -222,6 +225,13 @@ module Appsignal
 
       def running_in_container?
         appsignal_running_in_container
+      end
+
+      def set_environment_metadata(key, value)
+        appsignal_set_environment_metadata(
+          make_appsignal_string(key),
+          make_appsignal_string(value)
+        )
       end
 
       def set_gauge(key, value, tags)

--- a/spec/lib/appsignal/environment_spec.rb
+++ b/spec/lib/appsignal/environment_spec.rb
@@ -1,0 +1,60 @@
+describe Appsignal::Environment do
+  before(:context) { start_agent }
+  before do
+    allow(Appsignal::Extension).to receive(:set_environment_metadata)
+      .and_call_original
+  end
+
+  def report(key, &value_block)
+    described_class.report(key, &value_block)
+  end
+
+  def expect_environment_metadata(key, value)
+    expect(Appsignal::Extension).to have_received(:set_environment_metadata)
+      .with(key, value)
+  end
+
+  def expect_not_environment_metadata(key)
+    expect(Appsignal::Extension).to_not have_received(:set_environment_metadata)
+      .with(key, anything)
+  end
+
+  describe ".report" do
+    it "sends environment metadata to the extension" do
+      logs =
+        capture_logs do
+          report("_test_ruby_version") { "1.0.0" }
+          expect_environment_metadata("_test_ruby_version", "1.0.0")
+        end
+      expect(logs).to be_empty
+    end
+
+    context "when the value is nil" do
+      it "does not set the value" do
+        logs =
+          capture_logs do
+            report("_test_ruby_version") { nil }
+            expect_not_environment_metadata("_test_ruby_version")
+          end
+        expect(logs).to contains_log(
+          :warn,
+          "Unable to report on environment metadata `_test_ruby_version`: Value is nil"
+        )
+      end
+    end
+
+    context "when the value block raises an error" do
+      it "does not re-raise the error and writes it to the log" do
+        logs =
+          capture_logs do
+            report("_test_ruby_version") { raise "uh oh" }
+            expect_not_environment_metadata("_test_ruby_version")
+          end
+        expect(logs).to contains_log(
+          :warn,
+          "Unable to report on environment metadata `_test_ruby_version`: uh oh"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add extension function and helper method to send environment metadata
from the Ruby gem to the extension.

This data will be use to improve AppSignal by tracking what AppSignal
integrations, and versions of these integrations, are actually used.

This is the basic implementation of the functionality. Documentation
about what data is collected and what it is used for will follow later.

Required for https://github.com/appsignal/appsignal-agent/pull/556, but also requires a new agent release using https://github.com/appsignal/appsignal-agent/pull/556 to get a green build.
Closes https://github.com/appsignal/appsignal-agent/issues/547