### PR TITLE
Add environment metadata report method guards

### DIFF
--- a/lib/appsignal/environment.rb
+++ b/lib/appsignal/environment.rb
@@ -27,20 +27,41 @@ module Appsignal
     # @yieldreturn [String] The value of the key of the environment metadata.
     # @return [void]
     def self.report(key)
-      value =
-        begin
-          yield
-        rescue => e
-          Appsignal.logger.warn("Unable to report on environment metadata `#{key}`: #{e}")
+      key =
+        case key
+        when String
+          key
+        else
+          Appsignal.logger.error "Unable to report on environment metadata: " \
+            "Unsupported value type for #{key.inspect}"
           return
         end
 
-      unless value
-        Appsignal.logger.warn("Unable to report on environment metadata `#{key}`: Value is nil")
-        return
-      end
+      yielded_value =
+        begin
+          yield
+        rescue => e
+          Appsignal.logger.error \
+            "Unable to report on environment metadata #{key.inspect}:\n" \
+              "#{e.class}: #{e}"
+          return
+        end
+
+      value =
+        case yielded_value
+        when String
+          yielded_value
+        else
+          Appsignal.logger.error "Unable to report on environment metadata " \
+            "#{key.inspect}: Unsupported value type for " \
+            "#{yielded_value.inspect}"
+          return
+        end
 
       Appsignal::Extension.set_environment_metadata(key, value)
+    rescue => e
+      Appsignal.logger.error "Unable to report on environment metadata:\n" \
+        "#{e.class}: #{e}"
     end
   end
 end

--- a/lib/appsignal/environment.rb
+++ b/lib/appsignal/environment.rb
@@ -49,6 +49,8 @@ module Appsignal
 
       value =
         case yielded_value
+        when TrueClass, FalseClass
+          yielded_value.to_s
         when String
           yielded_value
         else

--- a/spec/lib/appsignal/environment_spec.rb
+++ b/spec/lib/appsignal/environment_spec.rb
@@ -58,6 +58,19 @@ describe Appsignal::Environment do
       end
     end
 
+    context "when the value is true or false" do
+      it "reports true or false as Strings" do
+        logs =
+          capture_logs do
+            report("_test_true") { true }
+            report("_test_false") { false }
+            expect_environment_metadata("_test_true", "true")
+            expect_environment_metadata("_test_false", "false")
+          end
+        expect(logs).to be_empty
+      end
+    end
+
     context "when the value is nil" do
       it "does not set the value" do
         logs =

--- a/spec/lib/appsignal/environment_spec.rb
+++ b/spec/lib/appsignal/environment_spec.rb
@@ -29,6 +29,35 @@ describe Appsignal::Environment do
       expect(logs).to be_empty
     end
 
+    context "when the key is a non String type" do
+      it "does not set the value" do
+        logs =
+          capture_logs do
+            report(:_test_symbol) { "1.0.0" }
+            expect_not_environment_metadata(:_test_symbol)
+            expect_not_environment_metadata("_test_symbol")
+          end
+        expect(logs).to contains_log(
+          :error,
+          "Unable to report on environment metadata: Unsupported value type for :_test_symbol"
+        )
+      end
+    end
+
+    context "when the key is nil" do
+      it "does not set the value" do
+        logs =
+          capture_logs do
+            report(nil) { "1" }
+            expect_not_environment_metadata(nil)
+          end
+        expect(logs).to contains_log(
+          :error,
+          "Unable to report on environment metadata: Unsupported value type for nil"
+        )
+      end
+    end
+
     context "when the value is nil" do
       it "does not set the value" do
         logs =
@@ -37,8 +66,9 @@ describe Appsignal::Environment do
             expect_not_environment_metadata("_test_ruby_version")
           end
         expect(logs).to contains_log(
-          :warn,
-          "Unable to report on environment metadata `_test_ruby_version`: Value is nil"
+          :error,
+          "Unable to report on environment metadata \"_test_ruby_version\": " \
+            "Unsupported value type for nil"
         )
       end
     end
@@ -47,12 +77,34 @@ describe Appsignal::Environment do
       it "does not re-raise the error and writes it to the log" do
         logs =
           capture_logs do
-            report("_test_ruby_version") { raise "uh oh" }
-            expect_not_environment_metadata("_test_ruby_version")
+            report("_test_error") { raise "uh oh" }
+            expect_not_environment_metadata("_test_error")
           end
         expect(logs).to contains_log(
-          :warn,
-          "Unable to report on environment metadata `_test_ruby_version`: uh oh"
+          :error,
+          "Unable to report on environment metadata \"_test_error\":\n" \
+            "RuntimeError: uh oh"
+        )
+      end
+    end
+
+    context "when something unforseen errors" do
+      it "does not re-raise the error and writes it to the log" do
+        klass = Class.new do
+          def inspect
+            raise "inspect error"
+          end
+        end
+
+        logs =
+          capture_logs do
+            report(klass.new) { raise "value error" }
+            expect(Appsignal::Extension).to_not have_received(:set_environment_metadata)
+          end
+        expect(logs).to contains_log(
+          :error,
+          "Unable to report on environment metadata:\n" \
+            "RuntimeError: inspect error"
         )
       end
     end


### PR DESCRIPTION
## Add more defensive checks on report metadata

Make sure that the keys and values that are send to the extension
function are of the String type. If another type of value is given it
can cause a segfault, crashing the entire application. Add logging for
every step that the value can be something else than a String.

Also capture and log errors that may occur during this process.

## Support boolean values in environment metadata

Cast booleans to a String. This is a simple operation that makes passing
along boolean values easier for code calling the report method. There it
doesn't need to be manually casted with `.to_s` or by passing it along
as a String `"true"`/`"false"`.

