### PR TITLE
Mention disabling enable_frontend_error_catching in JSExceptionCatcher deprecation message

### DIFF
--- a/lib/appsignal/rack/js_exception_catcher.rb
+++ b/lib/appsignal/rack/js_exception_catcher.rb
@@ -31,7 +31,7 @@ module Appsignal
         deprecation_message "The Appsignal::Rack::JSExceptionCatcher is " \
           "deprecated and will be removed in a future version. Please use " \
           "the official AppSignal JavaScript integration by disabling " \
-          "`enable_frontend_error_catching` in your configuration and" \
+          "`enable_frontend_error_catching` in your configuration and " \
           "installing AppSignal for Javascript instead. " \
           "(https://docs.appsignal.com/front-end/)"
         @app = app

--- a/lib/appsignal/rack/js_exception_catcher.rb
+++ b/lib/appsignal/rack/js_exception_catcher.rb
@@ -32,7 +32,7 @@ module Appsignal
           "deprecated and will be removed in a future version. Please use " \
           "the official AppSignal JavaScript integration by disabling " \
           "`enable_frontend_error_catching` in your configuration and " \
-          "installing AppSignal for Javascript instead. " \
+          "installing AppSignal for JavaScript instead. " \
           "(https://docs.appsignal.com/front-end/)"
         @app = app
       end

--- a/lib/appsignal/rack/js_exception_catcher.rb
+++ b/lib/appsignal/rack/js_exception_catcher.rb
@@ -29,8 +29,11 @@ module Appsignal
         Appsignal.logger.debug \
           "Initializing Appsignal::Rack::JSExceptionCatcher"
         deprecation_message "The Appsignal::Rack::JSExceptionCatcher is " \
-          "deprecated. Please use the official AppSignal JavaScript " \
-          "integration instead. https://docs.appsignal.com/front-end/"
+          "deprecated and will be removed in a future version. Please use " \
+          "the official AppSignal JavaScript integration by disabling " \
+          "`enable_frontend_error_catching` in your configuration and" \
+          "installing AppSignal for Javascript instead. " \
+          "(https://docs.appsignal.com/front-end/)"
         @app = app
       end
 

--- a/spec/lib/appsignal/rack/js_exception_catcher_spec.rb
+++ b/spec/lib/appsignal/rack/js_exception_catcher_spec.rb
@@ -8,7 +8,7 @@ describe Appsignal::Rack::JSExceptionCatcher do
       "deprecated and will be removed in a future version. Please use " \
       "the official AppSignal JavaScript integration by disabling " \
       "`enable_frontend_error_catching` in your configuration and " \
-      "installing AppSignal for Javascript instead. " \
+      "installing AppSignal for JavaScript instead. " \
       "(https://docs.appsignal.com/front-end/)"
   end
   before { Appsignal.config = config }

--- a/spec/lib/appsignal/rack/js_exception_catcher_spec.rb
+++ b/spec/lib/appsignal/rack/js_exception_catcher_spec.rb
@@ -4,9 +4,12 @@ describe Appsignal::Rack::JSExceptionCatcher do
   let(:config_options) { { :enable_frontend_error_catching => true } }
   let(:config)         { project_fixture_config("production", config_options) }
   let(:deprecation_message) do
-    "The Appsignal::Rack::JSExceptionCatcher is deprecated. " \
-      "Please use the official AppSignal JavaScript integration instead. " \
-      "https://docs.appsignal.com/front-end/"
+    "The Appsignal::Rack::JSExceptionCatcher is " \
+      "deprecated and will be removed in a future version. Please use " \
+      "the official AppSignal JavaScript integration by disabling " \
+      "`enable_frontend_error_catching` in your configuration and " \
+      "installing AppSignal for Javascript instead. " \
+      "(https://docs.appsignal.com/front-end/)"
   end
   before { Appsignal.config = config }
 
@@ -32,7 +35,9 @@ describe Appsignal::Rack::JSExceptionCatcher do
 
   describe "#call" do
     let(:catcher) do
-      silence { Appsignal::Rack::JSExceptionCatcher.new(app, options) }
+      silence :allowed => ["enable_frontend_error_catching"] do
+        Appsignal::Rack::JSExceptionCatcher.new(app, options)
+      end
     end
     after { catcher.call(env) }
 


### PR DESCRIPTION
As reported in [support](https://app.intercom.com/a/apps/yzor8gyw/inbox/inbox/540654/conversations/16410700000986) (private Intercom link), the deprecation message for JSExceptionCatcher doesn't explain the message is caused by enable_frontend_error_catching being turned on. This patch adds a note about disabling that configuration option.