### PR TITLE
Report Ruby environment metadata

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -322,6 +322,7 @@ module Appsignal
           RUBY_ENGINE_VERSION
         end
       end
+      Appsignal::Environment.report_supported_gems
     end
   end
 end

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -139,6 +139,8 @@ module Appsignal
           GC::Profiler.enable if config[:enable_gc_instrumentation]
 
           Appsignal::Minutely.start if config[:enable_minutely_probes]
+
+          collect_environment_metadata
         else
           logger.info("Not starting, not active for #{config.env}")
         end
@@ -308,6 +310,18 @@ module Appsignal
       start_stdout_logger
       logger.warn "Unable to start logger with log path '#{path}'."
       logger.warn error
+    end
+
+    def collect_environment_metadata
+      Appsignal::Environment.report("ruby_version") do
+        "#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"
+      end
+      Appsignal::Environment.report("ruby_engine") { RUBY_ENGINE }
+      if defined?(RUBY_ENGINE_VERSION)
+        Appsignal::Environment.report("ruby_engine_version") do
+          RUBY_ENGINE_VERSION
+        end
+      end
     end
   end
 end

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -134,9 +134,13 @@ module Appsignal
 
           if config[:enable_allocation_tracking] && !Appsignal::System.jruby?
             Appsignal::Extension.install_allocation_event_hook
+            Appsignal::Environment.report_enabled("allocation_tracking")
           end
 
-          GC::Profiler.enable if config[:enable_gc_instrumentation]
+          if config[:enable_gc_instrumentation]
+            GC::Profiler.enable
+            Appsignal::Environment.report_enabled("gc_instrumentation")
+          end
 
           Appsignal::Minutely.start if config[:enable_minutely_probes]
 

--- a/lib/appsignal/capistrano.rb
+++ b/lib/appsignal/capistrano.rb
@@ -3,6 +3,8 @@
 require "appsignal"
 require "capistrano/version"
 
+Appsignal::Environment.report_enabled("capistrano")
+
 if defined?(Capistrano::VERSION) && Gem::Version.new(Capistrano::VERSION) >= Gem::Version.new(3)
   # Capistrano 3+
   load File.expand_path("../integrations/capistrano/appsignal.cap", __FILE__)

--- a/lib/appsignal/environment.rb
+++ b/lib/appsignal/environment.rb
@@ -65,5 +65,55 @@ module Appsignal
       Appsignal.logger.error "Unable to report on environment metadata:\n" \
         "#{e.class}: #{e}"
     end
+
+    # @see report_supported_gems
+    SUPPORTED_GEMS = %w[
+      actioncable
+      activejob
+      capistrano
+      celluloid
+      data_mapper
+      delayed_job
+      mongo_ruby_driver
+      padrino
+      passenger
+      puma
+      que
+      rack
+      rails
+      rake
+      redis
+      resque
+      sequel
+      shoryuken
+      sidekiq
+      sinatra
+      unicorn
+      webmachine
+    ].freeze
+
+    # Report on the list of AppSignal supported gems
+    #
+    # This list is used to report if which AppSignal supported gems are present
+    # in this app and what version. This data will help AppSignal improve its
+    # support by knowing what gems and versions of gems it still needs to
+    # support or can drop support for.
+    #
+    # It will ask Bundler to report name and version information from the gems
+    # that are present in the app bundle.
+    def self.report_supported_gems
+      return unless defined?(Bundler) # Do nothing if Bundler is not present
+
+      bundle_gem_specs = ::Bundler.rubygems.all_specs
+      SUPPORTED_GEMS.each do |gem_name|
+        gem_spec = bundle_gem_specs.find { |spec| spec.name == gem_name }
+        next unless gem_spec
+
+        report("ruby_#{gem_name}_version") { gem_spec.version.to_s }
+      end
+    rescue => e
+      Appsignal.logger.error "Unable to report supported gems:\n" \
+        "#{e.class}: #{e}"
+    end
   end
 end

--- a/lib/appsignal/environment.rb
+++ b/lib/appsignal/environment.rb
@@ -115,5 +115,12 @@ module Appsignal
       Appsignal.logger.error "Unable to report supported gems:\n" \
         "#{e.class}: #{e}"
     end
+
+    def self.report_enabled(feature)
+      Appsignal::Environment.report("ruby_#{feature}_enabled") { true }
+    rescue => e
+      Appsignal.logger.error "Unable to report integration enabled:\n" \
+        "#{e.class}: #{e}"
+    end
   end
 end

--- a/lib/appsignal/hooks/net_http.rb
+++ b/lib/appsignal/hooks/net_http.rb
@@ -25,6 +25,8 @@ module Appsignal
             end
           end
         end
+
+        Appsignal::Environment.report_enabled("net_http")
       end
     end
   end

--- a/lib/appsignal/hooks/redis.rb
+++ b/lib/appsignal/hooks/redis.rb
@@ -26,6 +26,8 @@ module Appsignal
             end
           end
         end
+
+        Appsignal::Environment.report_enabled("redis")
       end
     end
   end

--- a/lib/appsignal/hooks/sequel.rb
+++ b/lib/appsignal/hooks/sequel.rb
@@ -56,6 +56,8 @@ module Appsignal
 
         # ... and automatically add it to future instances.
         ::Sequel::Database.extension(:appsignal_integration)
+
+        Appsignal::Environment.report_enabled("sequel")
       end
     end
   end

--- a/lib/appsignal/integrations/object.rb
+++ b/lib/appsignal/integrations/object.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+if defined?(Appsignal)
+  Appsignal::Environment.report_enabled("object_instrumentation")
+end
+
 class Object
   def self.appsignal_instrument_class_method(method_name, options = {})
     singleton_class.send \

--- a/lib/appsignal/integrations/resque_active_job.rb
+++ b/lib/appsignal/integrations/resque_active_job.rb
@@ -34,6 +34,8 @@ module Appsignal
             end
           end
         end
+
+        Appsignal::Environment.report("ruby_active_job_resque_enabled") { true }
       end
     end
   end

--- a/spec/lib/appsignal/environment_spec.rb
+++ b/spec/lib/appsignal/environment_spec.rb
@@ -139,4 +139,29 @@ describe Appsignal::Environment do
       end
     end
   end
+
+  describe ".report_enabled" do
+    it "reports a feature being enabled" do
+      logs = capture_logs { described_class.report_enabled("a_test") }
+
+      expect(logs).to be_empty
+      expect_environment_metadata("ruby_a_test_enabled", "true")
+    end
+
+    context "when something unforseen errors" do
+      it "does not re-raise the error and writes it to the log" do
+        klass = Class.new do
+          def to_s
+            raise "to_s error"
+          end
+        end
+
+        logs = capture_logs { described_class.report_enabled(klass.new) }
+        expect(logs).to contains_log(
+          :error,
+          "Unable to report integration enabled:\nRuntimeError: to_s error"
+        )
+      end
+    end
+  end
 end

--- a/spec/lib/appsignal/environment_spec.rb
+++ b/spec/lib/appsignal/environment_spec.rb
@@ -1,22 +1,11 @@
 describe Appsignal::Environment do
+  include EnvironmentMetadataHelper
+
   before(:context) { start_agent }
-  before do
-    allow(Appsignal::Extension).to receive(:set_environment_metadata)
-      .and_call_original
-  end
+  before { capture_environment_metadata_report_calls }
 
   def report(key, &value_block)
     described_class.report(key, &value_block)
-  end
-
-  def expect_environment_metadata(key, value)
-    expect(Appsignal::Extension).to have_received(:set_environment_metadata)
-      .with(key, value)
-  end
-
-  def expect_not_environment_metadata(key)
-    expect(Appsignal::Extension).to_not have_received(:set_environment_metadata)
-      .with(key, anything)
   end
 
   describe ".report" do

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -82,18 +82,22 @@ describe Appsignal do
           allow(GC::Profiler).to receive(:enable)
           Appsignal.config.config_hash[:enable_allocation_tracking] = true
           Appsignal.config.config_hash[:enable_gc_instrumentation] = true
+          capture_environment_metadata_report_calls
         end
 
         it "should enable Ruby's GC::Profiler" do
           expect(GC::Profiler).to receive(:enable)
           Appsignal.start
+          expect_environment_metadata("ruby_gc_instrumentation_enabled", "true")
         end
 
         unless Appsignal::System.jruby?
+
           it "installs the allocation event hook" do
             expect(Appsignal::Extension).to receive(:install_allocation_event_hook)
               .and_call_original
             Appsignal.start
+            expect_environment_metadata("ruby_allocation_tracking_enabled", "true")
           end
         end
       end
@@ -102,6 +106,7 @@ describe Appsignal do
         before do
           Appsignal.config.config_hash[:enable_allocation_tracking] = false
           Appsignal.config.config_hash[:enable_gc_instrumentation] = false
+          capture_environment_metadata_report_calls
         end
 
         it "should not enable Ruby's GC::Profiler" do
@@ -112,11 +117,13 @@ describe Appsignal do
         it "should not install the allocation event hook" do
           expect(Appsignal::Minutely).not_to receive(:install_allocation_event_hook)
           Appsignal.start
+          expect_not_environment_metadata("ruby_allocation_tracking_enabled")
         end
 
         it "should not add the gc probe to minutely" do
           expect(Appsignal::Minutely).not_to receive(:register_garbage_collection_probe)
           Appsignal.start
+          expect_not_environment_metadata("ruby_gc_instrumentation_enabled")
         end
       end
 

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -1,4 +1,6 @@
 describe Appsignal do
+  include EnvironmentMetadataHelper
+
   before do
     # Make sure we have a clean state because we want to test
     # initialization here.
@@ -137,6 +139,19 @@ describe Appsignal do
         it "should not start minutely" do
           expect(Appsignal::Minutely).to_not receive(:start)
           Appsignal.start
+        end
+      end
+
+      describe "environment metadata" do
+        before { capture_environment_metadata_report_calls }
+
+        it "collects and reports environment metadata" do
+          Appsignal.start
+          expect_environment_metadata("ruby_version", "#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}")
+          expect_environment_metadata("ruby_engine", RUBY_ENGINE)
+          if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.3.0")
+            expect_environment_metadata("ruby_engine_version", RUBY_ENGINE_VERSION)
+          end
         end
       end
     end

--- a/spec/support/helpers/environment_metdata_helper.rb
+++ b/spec/support/helpers/environment_metdata_helper.rb
@@ -1,0 +1,16 @@
+module EnvironmentMetadataHelper
+  def capture_environment_metadata_report_calls
+    allow(Appsignal::Extension).to receive(:set_environment_metadata)
+      .and_call_original
+  end
+
+  def expect_environment_metadata(key, value)
+    expect(Appsignal::Extension).to have_received(:set_environment_metadata)
+      .with(key, value)
+  end
+
+  def expect_not_environment_metadata(key)
+    expect(Appsignal::Extension).to_not have_received(:set_environment_metadata)
+      .with(key, anything)
+  end
+end


### PR DESCRIPTION
## Report Ruby environment metadata

Collect environment metadata about which Ruby version (1.9.3/2.7.1),
engine (MRI/JRuby/Rubinius) and engine version is loaded.

Move the spec helpers to capture calls to the extension's
`set_environment_metadata` to a module that can be included separately
in every spec that wants to assert calls to this method. We use this
method of capturing method calls because the extension does not have a
"getter" for the environment metadata.

## Report which AppSignal supported gems are present

Collect metadata (name and version) about gems AppSignal integrates
with.

Ask Bundler about the gems that are available in the app's "bundle", and
then loop over the SUPPORTED_GEMS constant to only report about the gems
AppSignal integrates with. This way we do not collect data about _all_
apps in an app's bundle, which can contain things like private gems we
do not want to report.

I decided to use the data available in Bundler, rather than asking every
gem separately by calling the value of a `VERSION` constant. There are a
lot of different ways these constants are defined (e.g. `VERSION`,
`VERSION_STRING`) and I even found a gem that did not have one at all.
Using this method we can be sure that all the data is reported in the
same way, and there's less change of the reporting breaking when a gem
updates how they define their `VERSION` constant.

Another problem with collecting the data in the integrations themselves
is that, some integrations for gems are not installed automatically.
The Capistrano integration for example only loads when `require`d by an
app's `Capfile`. And then only when that `Capfile` itself is loaded,
such as for a deploy. This would make the reporting for these kinds of
integrations less accurate because the time we store this data may be
shorter than it is called. Creating inaccurate reporting.

An alternative approach, or fallback, would be to ask Ruby which gems
are loaded at load time, but that has the same problem as the method
that only sets the metadata on load of an integration, so it was not
chosen.

Report the actioncable and activejob gems separately as they can be used
outside of Rails and still have the AppSignal instrumentation installed.

## Report which integrations are enabled

Some AppSignal integrations are not installed automatically, or can be
manually disabled with configuration options, e.g.
`instrument_net_http`. Report the usage of these integrations separately
using the `report_enabled` helper method.

This way we can make the distinction between an AppSignal supported gem
being present in an app's "bundle" and the integration actively using
that integration.

Using this method we can also report metadata about AppSignal
integrations that do not rely on a gem, such as the Object method
instrumentation integration.

## Report the enabled features

Some AppSignal features are not enabled by default, or can be manually
disabled with configuration options, e.g. `enable_allocation_tracking`.
Report if these features are enabled separately using the
`report_enabled` helper method.

---

Closes https://github.com/appsignal/appsignal-agent/issues/555 (private link)
Closes https://github.com/appsignal/appsignal-agent/issues/546 (private link)