### PR TITLE
Bump Ruby 2.7 build to 2.7.1

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -684,7 +684,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-- name: Ruby 2.7.0
+- name: Ruby 2.7.1
   dependencies:
   - Validation
   task:
@@ -692,10 +692,10 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake extension:install"
     jobs:
-    - name: Ruby 2.7.0 for no_dependencies
+    - name: Ruby 2.7.1 for no_dependencies
       env_vars:
       - name: RUBY_VERSION
-        value: 2.7.0
+        value: 2.7.1
       - name: GEMSET
         value: no_dependencies
       - name: BUNDLE_GEMFILE
@@ -706,18 +706,18 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-- name: Ruby 2.7.0 - Gems
+- name: Ruby 2.7.1 - Gems
   dependencies:
-  - Ruby 2.7.0
+  - Ruby 2.7.1
   task:
     prologue:
       commands:
       - "./support/bundler_wrapper exec rake extension:install"
     jobs:
-    - name: Ruby 2.7.0 for capistrano2
+    - name: Ruby 2.7.1 for capistrano2
       env_vars:
       - name: RUBY_VERSION
-        value: 2.7.0
+        value: 2.7.1
       - name: GEMSET
         value: capistrano2
       - name: BUNDLE_GEMFILE
@@ -728,10 +728,10 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 2.7.0 for capistrano3
+    - name: Ruby 2.7.1 for capistrano3
       env_vars:
       - name: RUBY_VERSION
-        value: 2.7.0
+        value: 2.7.1
       - name: GEMSET
         value: capistrano3
       - name: BUNDLE_GEMFILE
@@ -742,10 +742,10 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 2.7.0 for grape
+    - name: Ruby 2.7.1 for grape
       env_vars:
       - name: RUBY_VERSION
-        value: 2.7.0
+        value: 2.7.1
       - name: GEMSET
         value: grape
       - name: BUNDLE_GEMFILE
@@ -756,10 +756,10 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 2.7.0 for padrino
+    - name: Ruby 2.7.1 for padrino
       env_vars:
       - name: RUBY_VERSION
-        value: 2.7.0
+        value: 2.7.1
       - name: GEMSET
         value: padrino
       - name: BUNDLE_GEMFILE
@@ -770,10 +770,10 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 2.7.0 for que
+    - name: Ruby 2.7.1 for que
       env_vars:
       - name: RUBY_VERSION
-        value: 2.7.0
+        value: 2.7.1
       - name: GEMSET
         value: que
       - name: BUNDLE_GEMFILE
@@ -784,10 +784,10 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 2.7.0 for que_beta
+    - name: Ruby 2.7.1 for que_beta
       env_vars:
       - name: RUBY_VERSION
-        value: 2.7.0
+        value: 2.7.1
       - name: GEMSET
         value: que_beta
       - name: BUNDLE_GEMFILE
@@ -798,10 +798,10 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 2.7.0 for rails-5.0
+    - name: Ruby 2.7.1 for rails-5.0
       env_vars:
       - name: RUBY_VERSION
-        value: 2.7.0
+        value: 2.7.1
       - name: GEMSET
         value: rails-5.0
       - name: BUNDLE_GEMFILE
@@ -812,10 +812,10 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 2.7.0 for rails-5.1
+    - name: Ruby 2.7.1 for rails-5.1
       env_vars:
       - name: RUBY_VERSION
-        value: 2.7.0
+        value: 2.7.1
       - name: GEMSET
         value: rails-5.1
       - name: BUNDLE_GEMFILE
@@ -826,10 +826,10 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 2.7.0 for rails-5.2
+    - name: Ruby 2.7.1 for rails-5.2
       env_vars:
       - name: RUBY_VERSION
-        value: 2.7.0
+        value: 2.7.1
       - name: GEMSET
         value: rails-5.2
       - name: BUNDLE_GEMFILE
@@ -840,10 +840,10 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 2.7.0 for rails-6.0
+    - name: Ruby 2.7.1 for rails-6.0
       env_vars:
       - name: RUBY_VERSION
-        value: 2.7.0
+        value: 2.7.1
       - name: GEMSET
         value: rails-6.0
       - name: BUNDLE_GEMFILE
@@ -854,10 +854,10 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 2.7.0 for resque
+    - name: Ruby 2.7.1 for resque
       env_vars:
       - name: RUBY_VERSION
-        value: 2.7.0
+        value: 2.7.1
       - name: GEMSET
         value: resque
       - name: BUNDLE_GEMFILE
@@ -868,10 +868,10 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 2.7.0 for sequel
+    - name: Ruby 2.7.1 for sequel
       env_vars:
       - name: RUBY_VERSION
-        value: 2.7.0
+        value: 2.7.1
       - name: GEMSET
         value: sequel
       - name: BUNDLE_GEMFILE
@@ -882,10 +882,10 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 2.7.0 for sequel-435
+    - name: Ruby 2.7.1 for sequel-435
       env_vars:
       - name: RUBY_VERSION
-        value: 2.7.0
+        value: 2.7.1
       - name: GEMSET
         value: sequel-435
       - name: BUNDLE_GEMFILE
@@ -896,10 +896,10 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 2.7.0 for sinatra
+    - name: Ruby 2.7.1 for sinatra
       env_vars:
       - name: RUBY_VERSION
-        value: 2.7.0
+        value: 2.7.1
       - name: GEMSET
         value: sinatra
       - name: BUNDLE_GEMFILE
@@ -910,10 +910,10 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 2.7.0 for webmachine
+    - name: Ruby 2.7.1 for webmachine
       env_vars:
       - name: RUBY_VERSION
-        value: 2.7.0
+        value: 2.7.1
       - name: GEMSET
         value: webmachine
       - name: BUNDLE_GEMFILE

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -115,7 +115,7 @@ matrix:
     - ruby: "2.5.7"
       gems: "minimal"
     - ruby: "2.6.5"
-    - ruby: "2.7.0"
+    - ruby: "2.7.1"
     - ruby: "jruby-9.1.17.0"
       gems: "minimal"
   gems:
@@ -135,13 +135,13 @@ matrix:
       exclude:
         ruby:
           - "2.6.5"
-          - "2.7.0"
+          - "2.7.1"
     - gem: "rails-4.2"
       bundler: "1.17.3"
       exclude:
         ruby:
           - "2.6.5"
-          - "2.7.0"
+          - "2.7.1"
     - gem: "rails-5.0"
       exclude:
         ruby:


### PR DESCRIPTION
2.7.1 is the latest build that's out. We test against the latest patch
release, so bump the build to see if it still works against the latest
Ruby version.

[skip review]