### PR TITLE
Bump Padrino build

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -172,20 +172,6 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 2.0.0-p648 for padrino
-      env_vars:
-      - name: RUBY_VERSION
-        value: 2.0.0-p648
-      - name: GEMSET
-        value: padrino
-      - name: BUNDLE_GEMFILE
-        value: gemfiles/padrino.gemfile
-      - name: _RUBYGEMS_VERSION
-        value: 2.7.8
-      - name: _BUNDLER_VERSION
-        value: 1.17.3
-      commands:
-      - "./support/bundler_wrapper exec rake test"
     - name: Ruby 2.0.0-p648 for que
       env_vars:
       - name: RUBY_VERSION
@@ -527,7 +513,7 @@ blocks:
       - name: _RUBYGEMS_VERSION
         value: latest
       - name: _BUNDLER_VERSION
-        value: 1.17.3
+        value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
     - name: Ruby 2.6.5 for que
@@ -767,7 +753,7 @@ blocks:
       - name: _RUBYGEMS_VERSION
         value: latest
       - name: _BUNDLER_VERSION
-        value: 1.17.3
+        value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
     - name: Ruby 2.7.1 for que

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -124,7 +124,9 @@ matrix:
     - gem: "capistrano3"
     - gem: "grape"
     - gem: "padrino"
-      bundler: "1.17.3"
+      exclude:
+        ruby:
+          - "2.0.0-p648"
     - gem: "que"
     - gem: "que_beta"
       exclude:

--- a/gemfiles/padrino.gemfile
+++ b/gemfiles/padrino.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'padrino', '~> 0.13.0'
-gem 'rack', '~> 1.6'
+gem 'padrino', "~> 0.15"
+gem 'rack'
 
 gemspec :path => '../'

--- a/spec/lib/appsignal/integrations/padrino_spec.rb
+++ b/spec/lib/appsignal/integrations/padrino_spec.rb
@@ -142,7 +142,7 @@ if DependencyHelper.padrino_present?
               expect_a_transaction_to_be_created
               # Uses path for action name
               expect(transaction).to receive(:set_action_if_nil).with("PadrinoTestApp#unknown")
-              expect(response).to match_response(404, "<h1>Not Found</h1>")
+              expect(response).to match_response(404, "GET /404")
             end
           end
 


### PR DESCRIPTION
Update to the latest Padrino version. Previously it would build against
a 0.13 beta version.

Lift the old bundler version restriction. It should no longer be
necessary to run it against that old version.

[skip review]