### PR TITLE
Only restore CI caches on exact match

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -33,8 +33,8 @@ global_job_config:
     - checkout
     - sem-version ruby $RUBY_VERSION
     - "./support/check_versions"
-    - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE),$_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET,$_BUNDLER_CACHE-bundler-$RUBY_VERSION
-    - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE),$_GEMS_CACHE-gems-$RUBY_VERSION
+    - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+    - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
     - "./support/install_deps"
     - bundle config set clean 'true'
     - "./support/bundler_wrapper install --jobs=3 --retry=3"

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -34,8 +34,8 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
         - checkout
         - sem-version ruby $RUBY_VERSION
         - ./support/check_versions
-        - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE),$_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET,$_BUNDLER_CACHE-bundler-$RUBY_VERSION
-        - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE),$_GEMS_CACHE-gems-$RUBY_VERSION
+        - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+        - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
         - ./support/install_deps
         - bundle config set clean 'true'
         - ./support/bundler_wrapper install --jobs=3 --retry=3


### PR DESCRIPTION
When something in the cache key has changed, do not use an older cache.
This can cause problem with gem updates not being picked up.

When no cache is found the install process shouldn't slow down the build
a ton that we have to wait forever for it to complete. So we can take
the extra time there for stability overall.

[skip review]