### PR TITLE
Add support for Active Job priority

### DIFF
--- a/lib/appsignal/hooks/active_job.rb
+++ b/lib/appsignal/hooks/active_job.rb
@@ -46,7 +46,11 @@ module Appsignal
                 Appsignal.config[:filter_parameters]
               )
 
-            tags = { :queue => job["queue_name"] }
+            tags = {}
+            queue = job["queue_name"]
+            tags[:queue] = queue if queue
+            priority = job["priority"]
+            tags[:priority] = priority if priority
             provider_job_id = job["provider_job_id"]
             tags[:provider_job_id] = provider_job_id if provider_job_id
             transaction.set_tags(tags)


### PR DESCRIPTION
Adapters that use a priority system (Backburner, Delayed::Job and Que,
as Rails shipped adapters), will now report the priority for the job.

I couldn't find any docs for the `queue_with_priority` class method on
Active Job, but I found it defined as part of the
`ActiveJob::QueuePriority` module. The previously listed adapters do
call the `priority` method that this method sets, so it is used.