### PR TITLE
Fix diagnose installation result display

### DIFF
--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -371,7 +371,7 @@ module Appsignal
         end
 
         def print_installation_result_report(report)
-          report = report.fetch("download", {})
+          report = report.fetch("result", {})
           puts "  Installation result"
           puts "    Status: #{report["status"]}"
           puts "    Message: #{report["message"]}" if report["message"]


### PR DESCRIPTION
The diagnose command never displayed the extension installation result
properly. It would just print `nil` (shown an empty string).

```
  Installation result
    Status:
```

This was caused by the command reading from the "download" key, rather
than the "result" key, making it never return the actual result of the
extension installation.

Added tests to actually test for this output.