### PR TITLE
Use Sidekiq jid as transaction ID

### DIFF
--- a/lib/appsignal/hooks/sidekiq.rb
+++ b/lib/appsignal/hooks/sidekiq.rb
@@ -35,7 +35,7 @@ module Appsignal
       def call(_worker, item, _queue)
         job_status = nil
         transaction = Appsignal::Transaction.create(
-          SecureRandom.uuid,
+          item["jid"],
           Appsignal::Transaction::BACKGROUND_JOB,
           Appsignal::Transaction::GenericRequest.new(
             :queue_start => item["enqueued_at"]

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -76,9 +76,10 @@ describe Appsignal::Hooks::SidekiqPlugin, :with_yaml_parse_error => false do
     ]
   end
   let(:job_class) { "TestClass" }
+  let(:jid) { "b4a577edbccf1d805744efa9" }
   let(:item) do
     {
-      "jid"         => "b4a577edbccf1d805744efa9",
+      "jid"         => jid,
       "class"       => job_class,
       "retry_count" => 0,
       "queue"       => "default",
@@ -151,7 +152,7 @@ describe Appsignal::Hooks::SidekiqPlugin, :with_yaml_parse_error => false do
   context "when using the Sidekiq delayed extension" do
     let(:item) do
       {
-        "jid" => "efb140489485999d32b5504c",
+        "jid" => jid,
         "class" => "Sidekiq::Extensions::DelayedClass",
         "queue" => "default",
         "args" => [
@@ -191,7 +192,7 @@ describe Appsignal::Hooks::SidekiqPlugin, :with_yaml_parse_error => false do
   context "when using the Sidekiq ActiveRecord instance delayed extension" do
     let(:item) do
       {
-        "jid" => "efb140489485999d32b5504c",
+        "jid" => jid,
         "class" => "Sidekiq::Extensions::DelayedModel",
         "queue" => "default",
         "args" => [
@@ -243,7 +244,7 @@ describe Appsignal::Hooks::SidekiqPlugin, :with_yaml_parse_error => false do
 
       transaction_hash = transaction.to_h
       expect(transaction_hash).to include(
-        "id" => kind_of(String),
+        "id" => jid,
         "action" => "TestClass#perform",
         "error" => {
           "name" => "ExampleException",
@@ -277,7 +278,7 @@ describe Appsignal::Hooks::SidekiqPlugin, :with_yaml_parse_error => false do
 
       transaction_hash = transaction.to_h
       expect(transaction_hash).to include(
-        "id" => kind_of(String),
+        "id" => jid,
         "action" => "TestClass#perform",
         "error" => nil,
         "metadata" => {


### PR DESCRIPTION
For other integrations, such as Rails, we use the request ID or some
other library specific ID to set the transaction ID.

Sidekiq instead generates a new ID with `SecureRandom.uuid`. This makes
it difficult to match the transaction ID from Sidekiq logs or the web UI
to what is reported in the AppSignal UI.

We also filter out the `jid`, as it's part of the `EXCLUDED_JOB_KEYS`
constant in the AppSignal Sidekiq middleware.

I can't find a scenario where the jid isn't reported. It's been part of
Sidekiq since at least version 2. So I haven't implemented a fallback
for when the jid is missing.