### PR TITLE
Support Delayed::Job jobs without method name

### DIFF
--- a/lib/appsignal/integrations/delayed_job_plugin.rb
+++ b/lib/appsignal/integrations/delayed_job_plugin.rb
@@ -64,7 +64,7 @@ module Appsignal
         dot_split = default_name.split(".")
         return default_name if dot_split.length == 2
 
-        ["unknown"]
+        "#{default_name}#perform"
       end
 
       def self.extract_value(object_or_hash, field, default_value = nil, convert_to_s = false)

--- a/spec/lib/appsignal/hooks/delayed_job_spec.rb
+++ b/spec/lib/appsignal/hooks/delayed_job_spec.rb
@@ -227,25 +227,14 @@ describe Appsignal::Hooks::DelayedJobHook do
           end
         end
 
-        context "without job name" do
-          let(:job_data) do
-            { :name => "", :payload_object => payload_object }
-          end
-
-          it "wraps it in a transaction using the class method job name" do
-            perform
-            expect(last_transaction.to_h["action"]).to eql("unknown")
-          end
-        end
-
-        context "with invalid job name" do
+        context "with only job class name" do
           let(:job_data) do
             { :name => "Banana", :payload_object => payload_object }
           end
 
-          it "wraps it in a transaction using the class method job name" do
+          it "appends #perform to the class name" do
             perform
-            expect(last_transaction.to_h["action"]).to eql("unknown")
+            expect(last_transaction.to_h["action"]).to eql("Banana#perform")
           end
         end
 


### PR DESCRIPTION
In #637 we got the report that Structs that get enqueued with
`Delayed::Job.enqueue` get an action name of "unknown".

```
Delayed::Job.enqueue job_object
```

I've updated the action name logic to append `#perform` to the job name
as the last possible option for an action name. This fixes #637, and
eliminates the need to define a `appsignal_name` method in the job
objects that are enqueued with `Delayed::Job.enqueue`.

I haven't found a scenario where the action name as returned by
Delayed::Job in `job.name` is an empty string or `nil`, so I removed
that test case. If it does happen in some scenario I'm not aware of,
those jobs will be reported as `#perform` instead of `unknown`.

Fixes #637 