### PR TITLE
Use extend instead of method aliasing for testing

### DIFF
--- a/spec/support/testing.rb
+++ b/spec/support/testing.rb
@@ -38,22 +38,6 @@ module Appsignal
     end
   end
 
-  class Transaction
-    class << self
-      alias original_new new
-
-      # Override the {Appsignal::Transaction.new} method so we can track which
-      # transactions are created on the {Appsignal::Testing.transactions} list.
-      #
-      # @see TransactionHelpers#last_transaction
-      def new(*args)
-        transaction = original_new(*args)
-        Appsignal::Testing.transactions << transaction
-        transaction
-      end
-    end
-  end
-
   class Extension
     class Transaction
       alias original_finish finish
@@ -111,3 +95,19 @@ module Appsignal
     end
   end
 end
+
+module AppsignalTest
+  module Transaction
+    # Override the {Appsignal::Transaction.new} method so we can track which
+    # transactions are created on the {Appsignal::Testing.transactions} list.
+    #
+    # @see TransactionHelpers#last_transaction
+    def new(*_args)
+      transaction = super
+      Appsignal::Testing.transactions << transaction
+      transaction
+    end
+  end
+end
+
+Appsignal::Transaction.extend(AppsignalTest::Transaction)


### PR DESCRIPTION
In the AppSignal testing "module" we use for testing, extend the
`Appsignal::Transaction` class instead of aliasing the methods. This way
we can call `super` to call the original method instead of calling the
aliased `original_*` method. Less moving parts, which is better.

We can't do the same for the `Appsignal::Extension::Transaction` class
because we need to override the instance methods. For that we need to
use `Module.prepend`, which is only available in Ruby 2.0+, and that
would break the Ruby 1.9 build. So to change that we need to wait to
drop Ruby 1.9.

[skip review]