### PR TITLE
Print warnings using Kernel.warn

### DIFF
--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -321,7 +321,7 @@ module Appsignal
         " Skipping file config.\n" \
         "File: #{config_file.inspect}\n" \
         "#{e.class.name}: #{e}"
-      $stderr.puts "appsignal: #{message}"
+      Kernel.warn "appsignal: #{message}"
       logger.error "#{message}\n#{e.backtrace.join("\n")}"
       nil
     end

--- a/lib/appsignal/utils/deprecation_message.rb
+++ b/lib/appsignal/utils/deprecation_message.rb
@@ -2,7 +2,7 @@ module Appsignal
   module Utils
     module DeprecationMessage
       def self.message(message, logger = Appsignal.logger)
-        $stderr.puts "appsignal WARNING: #{message}"
+        Kernel.warn "appsignal WARNING: #{message}"
         logger.warn message
       end
 


### PR DESCRIPTION
When warnings are printed using Kernel.warn the app listens to the
`RUBYOPT="-W0"` flag to disable all warnings from an app.

This way the gem is more consistent with how Ruby prints warnings. It
still prints to STDERR, it just allows users more control over what
their app outputs.