### PR TITLE
Update deprecation message to use helper

### DIFF
--- a/lib/appsignal/auth_check.rb
+++ b/lib/appsignal/auth_check.rb
@@ -25,8 +25,10 @@ module Appsignal
     def initialize(config, logger = nil)
       @config = config
       if logger # rubocop:disable Style/GuardClause
-        warn "Deprecated: `logger` argument will be removed in the next " \
-          "major version."
+        Appsignal::Utils::DeprecationMessage.message \
+          "`Appsignal::AuthCheck.new`'s `logger` argument will be removed " \
+          "in the next major version. Please configure the logger " \
+          "using `Appsignal.logger`."
       end
     end
 

--- a/spec/lib/appsignal/auth_check_spec.rb
+++ b/spec/lib/appsignal/auth_check_spec.rb
@@ -28,6 +28,29 @@ describe Appsignal::AuthCheck do
     end.join("&")
   end
 
+  describe ".new" do
+    describe "with logger argument" do
+      let(:err_stream) { std_stream }
+      let(:stderr) { err_stream.read }
+      let(:log_stream) { std_stream }
+      let(:log) { log_contents(log_stream) }
+
+      it "logs and prints a deprecation message" do
+        Appsignal.logger = test_logger(log_stream)
+
+        capture_std_streams(std_stream, err_stream) do
+          Appsignal::AuthCheck.new(config, Appsignal.logger)
+        end
+
+        deprecation_message =
+          "`Appsignal::AuthCheck.new`'s `logger` argument " \
+          "will be removed in the next major version."
+        expect(stderr).to include "appsignal WARNING: #{deprecation_message}"
+        expect(log).to contains_log :warn, deprecation_message
+      end
+    end
+  end
+
   describe "#perform" do
     subject { auth_check.perform }
 


### PR DESCRIPTION
Instead of directly calling `Kernel.warn`, call the DeprecationMessage
helper so that it also logs to the AppSignal log file.

This way this deprecation message is consistent with the other
deprecation message the gem has.

[skip review]