### PR TITLE
Remove JRuby spec if statement

### DIFF
--- a/spec/lib/appsignal/extension/jruby_spec.rb
+++ b/spec/lib/appsignal/extension/jruby_spec.rb
@@ -1,42 +1,45 @@
-if Appsignal::System.jruby?
-  describe Appsignal::Extension::Jruby do
-    let(:extension) { Appsignal::Extension }
+describe "JRuby extension", :jruby do
+  let(:extension) { Appsignal::Extension }
+  let(:jruby_module) { Appsignal::Extension::Jruby }
 
-    describe "string conversions" do
-      it "keeps the same value during string type conversions" do
-        # UTF-8 string with NULL
-        # Tests if the conversions between the conversions without breaking on
-        # NULL terminated strings in C.
-        string = "Merry Christmas! \u0000 🎄"
+  it "creates a JRuby extension module" do
+    expect(Appsignal::Extension::Jruby).to be_kind_of(Module)
+  end
 
-        appsignal_string = extension.make_appsignal_string(string)
-        ruby_string = extension.make_ruby_string(appsignal_string)
+  describe "string conversions" do
+    it "keeps the same value during string type conversions" do
+      # UTF-8 string with NULL
+      # Tests if the conversions between the conversions without breaking on
+      # NULL terminated strings in C.
+      string = "Merry Christmas! \u0000 🎄"
 
-        expect(ruby_string).to eq("Merry Christmas! \u0000 🎄")
+      appsignal_string = extension.make_appsignal_string(string)
+      ruby_string = extension.make_ruby_string(appsignal_string)
+
+      expect(ruby_string).to eq("Merry Christmas! \u0000 🎄")
+    end
+  end
+
+  it "loads libappsignal with FFI" do
+    expect(jruby_module.ffi_libraries.map(&:name).first).to include "libappsignal"
+  end
+
+  describe ".lib_extension" do
+    subject { jruby_module.lib_extension }
+
+    context "when on a darwin system" do
+      before { expect(Appsignal::System).to receive(:agent_platform).and_return("darwin") }
+
+      it "returns the extension for darwin" do
+        is_expected.to eq "dylib"
       end
     end
 
-    it "loads libappsignal with FFI" do
-      expect(described_class.ffi_libraries.map(&:name).first).to include "libappsignal"
-    end
+    context "when on a linux system" do
+      before { expect(Appsignal::System).to receive(:agent_platform).and_return("linux") }
 
-    describe ".lib_extension" do
-      subject { described_class.lib_extension }
-
-      context "when on a darwin system" do
-        before { expect(Appsignal::System).to receive(:agent_platform).and_return("darwin") }
-
-        it "returns the extension for darwin" do
-          is_expected.to eq "dylib"
-        end
-      end
-
-      context "when on a linux system" do
-        before { expect(Appsignal::System).to receive(:agent_platform).and_return("linux") }
-
-        it "returns the lib extension for linux" do
-          is_expected.to eq "so"
-        end
+      it "returns the lib extension for linux" do
+        is_expected.to eq "so"
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,6 +65,7 @@ RSpec.configure do |config|
 
   config.example_status_persistence_file_path = "spec/examples.txt"
   config.fail_if_no_examples = true
+  config.filter_run_excluding(:jruby => !DependencyHelper.running_jruby?)
   config.mock_with :rspec do |mocks|
     mocks.syntax = :expect
   end


### PR DESCRIPTION
The spec is only loaded when we're on JRuby on the CI.

If the spec is run manually or locally by calling "rspec", filter it
out using the tag. This way we don't have to wrap specs in
if-statements all the time, if we use more tags.

[skip review]