### PR TITLE
Print error of AppSignal extension not loaded

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -100,6 +100,7 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
 - name: Ruby 2.0.0-p648
   dependencies:
   - Validation
@@ -122,6 +123,7 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
 - name: Ruby 2.0.0-p648 - Gems
   dependencies:
   - Ruby 2.0.0-p648
@@ -144,6 +146,7 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.0.0-p648 for capistrano3
       env_vars:
       - name: RUBY_VERSION
@@ -158,6 +161,7 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.0.0-p648 for grape
       env_vars:
       - name: RUBY_VERSION
@@ -172,6 +176,7 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.0.0-p648 for que
       env_vars:
       - name: RUBY_VERSION
@@ -186,6 +191,7 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.0.0-p648 for rails-3.2
       env_vars:
       - name: RUBY_VERSION
@@ -200,6 +206,7 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.0.0-p648 for rails-4.2
       env_vars:
       - name: RUBY_VERSION
@@ -214,6 +221,7 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.0.0-p648 for resque-1
       env_vars:
       - name: RUBY_VERSION
@@ -228,6 +236,7 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.0.0-p648 for sequel
       env_vars:
       - name: RUBY_VERSION
@@ -242,6 +251,7 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.0.0-p648 for sequel-435
       env_vars:
       - name: RUBY_VERSION
@@ -256,6 +266,7 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.0.0-p648 for sinatra
       env_vars:
       - name: RUBY_VERSION
@@ -270,6 +281,7 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.0.0-p648 for webmachine
       env_vars:
       - name: RUBY_VERSION
@@ -284,6 +296,7 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
 - name: Ruby 2.1.10
   dependencies:
   - Validation
@@ -306,6 +319,7 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
 - name: Ruby 2.2.10
   dependencies:
   - Validation
@@ -328,6 +342,7 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
 - name: Ruby 2.3.8
   dependencies:
   - Validation
@@ -350,6 +365,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
 - name: Ruby 2.4.9
   dependencies:
   - Validation
@@ -372,6 +388,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
 - name: Ruby 2.5.7
   dependencies:
   - Validation
@@ -394,6 +411,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
 - name: Ruby 2.5.7 - Gems
   dependencies:
   - Ruby 2.5.7
@@ -416,6 +434,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.5.7 for rails-6.0
       env_vars:
       - name: RUBY_VERSION
@@ -430,6 +449,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
 - name: Ruby 2.6.5
   dependencies:
   - Validation
@@ -452,6 +472,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
 - name: Ruby 2.6.5 - Gems
   dependencies:
   - Ruby 2.6.5
@@ -474,6 +495,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.5 for capistrano3
       env_vars:
       - name: RUBY_VERSION
@@ -488,6 +510,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.5 for grape
       env_vars:
       - name: RUBY_VERSION
@@ -502,6 +525,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.5 for padrino
       env_vars:
       - name: RUBY_VERSION
@@ -516,6 +540,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.5 for que
       env_vars:
       - name: RUBY_VERSION
@@ -530,6 +555,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.5 for que_beta
       env_vars:
       - name: RUBY_VERSION
@@ -544,6 +570,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.5 for rails-5.0
       env_vars:
       - name: RUBY_VERSION
@@ -558,6 +585,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.5 for rails-5.1
       env_vars:
       - name: RUBY_VERSION
@@ -572,6 +600,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.5 for rails-5.2
       env_vars:
       - name: RUBY_VERSION
@@ -586,6 +615,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.5 for rails-6.0
       env_vars:
       - name: RUBY_VERSION
@@ -600,6 +630,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.5 for resque-1
       env_vars:
       - name: RUBY_VERSION
@@ -614,6 +645,7 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.5 for resque-2
       env_vars:
       - name: RUBY_VERSION
@@ -628,6 +660,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.5 for sequel
       env_vars:
       - name: RUBY_VERSION
@@ -642,6 +675,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.5 for sequel-435
       env_vars:
       - name: RUBY_VERSION
@@ -656,6 +690,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.5 for sinatra
       env_vars:
       - name: RUBY_VERSION
@@ -670,6 +705,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.5 for webmachine
       env_vars:
       - name: RUBY_VERSION
@@ -684,6 +720,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
 - name: Ruby 2.7.1
   dependencies:
   - Validation
@@ -706,6 +743,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
 - name: Ruby 2.7.1 - Gems
   dependencies:
   - Ruby 2.7.1
@@ -728,6 +766,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.1 for capistrano3
       env_vars:
       - name: RUBY_VERSION
@@ -742,6 +781,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.1 for grape
       env_vars:
       - name: RUBY_VERSION
@@ -756,6 +796,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.1 for padrino
       env_vars:
       - name: RUBY_VERSION
@@ -770,6 +811,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.1 for que
       env_vars:
       - name: RUBY_VERSION
@@ -784,6 +826,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.1 for que_beta
       env_vars:
       - name: RUBY_VERSION
@@ -798,6 +841,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.1 for rails-5.0
       env_vars:
       - name: RUBY_VERSION
@@ -812,6 +856,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.1 for rails-5.1
       env_vars:
       - name: RUBY_VERSION
@@ -826,6 +871,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.1 for rails-5.2
       env_vars:
       - name: RUBY_VERSION
@@ -840,6 +886,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.1 for rails-6.0
       env_vars:
       - name: RUBY_VERSION
@@ -854,6 +901,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.1 for resque-1
       env_vars:
       - name: RUBY_VERSION
@@ -868,6 +916,7 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.1 for resque-2
       env_vars:
       - name: RUBY_VERSION
@@ -882,6 +931,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.1 for sequel
       env_vars:
       - name: RUBY_VERSION
@@ -896,6 +946,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.1 for sequel-435
       env_vars:
       - name: RUBY_VERSION
@@ -910,6 +961,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.1 for sinatra
       env_vars:
       - name: RUBY_VERSION
@@ -924,6 +976,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.1 for webmachine
       env_vars:
       - name: RUBY_VERSION
@@ -938,6 +991,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
 - name: Ruby jruby-9.1.17.0
   dependencies:
   - Validation
@@ -960,6 +1014,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
 - name: Ruby jruby-9.1.17.0 - Gems
   dependencies:
   - Ruby jruby-9.1.17.0
@@ -982,3 +1037,4 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -11,6 +11,8 @@ end
 
 task :default do
   begin
+    fail_install_on_purpose_in_test!
+
     library_type = "dynamic"
     report["language"]["implementation"] = "jruby"
     report["build"]["library_type"] = library_type

--- a/ext/base.rb
+++ b/ext/base.rb
@@ -183,3 +183,10 @@ end
 def http_proxy
   Gem.configuration[:http_proxy] || ENV["http_proxy"] || ENV["HTTP_PROXY"]
 end
+
+# Fail the installation on purpose in a specific test environment.
+def fail_install_on_purpose_in_test!
+  return unless ENV["_TEST_APPSIGNAL_EXTENSION_FAILURE"]
+
+  raise "AppSignal internal test failure"
+end

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -7,6 +7,8 @@ def local_build?
 end
 
 def install
+  fail_install_on_purpose_in_test!
+
   library_type = "static"
   report["language"]["implementation"] = "ruby"
   report["build"]["library_type"] = library_type

--- a/lib/appsignal/extension.rb
+++ b/lib/appsignal/extension.rb
@@ -10,11 +10,12 @@ begin
     require "appsignal_extension"
     Appsignal.extension_loaded = true
   end
-rescue LoadError => err
-  Appsignal.logger.error(
-    "Failed to load extension (#{err}), please run `appsignal diagnose` " \
-      "and email us at support@appsignal.com"
-  )
+rescue LoadError => error
+  error_message = "ERROR: AppSignal failed to load extension. " \
+    "Please run `appsignal diagnose` and email us at support@appsignal.com\n" \
+    "#{error.class}: #{error.message}"
+  Appsignal.logger.error(error_message)
+  Kernel.warn error_message
   Appsignal.extension_loaded = false
 end
 

--- a/lib/appsignal/extension/jruby.rb
+++ b/lib/appsignal/extension/jruby.rb
@@ -179,11 +179,12 @@ module Appsignal
           :appsignal_string
 
         Appsignal.extension_loaded = true
-      rescue LoadError => err
-        Appsignal.logger.error(
-          "Failed to load extension (#{err}), please email us at " \
-          "support@appsignal.com"
-        )
+      rescue LoadError => error
+        error_message = "ERROR: AppSignal failed to load extension. " \
+          "Please run `appsignal diagnose` and email us at support@appsignal.com\n" \
+          "#{error.class}: #{error.message}"
+        Appsignal.logger.error(error_message)
+        Kernel.warn error_message
         Appsignal.extension_loaded = false
       end
 

--- a/spec/lib/appsignal/extension_install_failure_spec.rb
+++ b/spec/lib/appsignal/extension_install_failure_spec.rb
@@ -1,0 +1,23 @@
+describe Appsignal::Extension, :extension_installation_failure do
+  context "when the extension library cannot be loaded" do
+    # This test breaks the installation on purpose and is not run by default.
+    # See `rake test:failure`. If this test was run, run `rake
+    # extension:install` again to fix the extension installation.
+    it "prints and logs an error" do
+      # ENV var to make sure installation fails on purpurse
+      ENV["_TEST_APPSIGNAL_EXTENSION_FAILURE"] = "true"
+      `rake extension:install` # Run installation
+
+      require "open3"
+      _stdout, stderr, _status = Open3.capture3("bin/appsignal --version")
+      expect(stderr).to include("ERROR: AppSignal failed to load extension")
+      error_message =
+        if DependencyHelper.running_jruby?
+          "cannot open shared object file"
+        else
+          "LoadError: cannot load such file"
+        end
+      expect(stderr).to include(error_message)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,7 +65,10 @@ RSpec.configure do |config|
 
   config.example_status_persistence_file_path = "spec/examples.txt"
   config.fail_if_no_examples = true
-  config.filter_run_excluding(:jruby => !DependencyHelper.running_jruby?)
+  config.filter_run_excluding(
+    :extension_installation_failure => true,
+    :jruby => !DependencyHelper.running_jruby?
+  )
   config.mock_with :rspec do |mocks|
     mocks.syntax = :expect
   end
@@ -112,6 +115,7 @@ RSpec.configure do |config|
     # in the diagnose task, so add it manually to the list of to-be cleaned up
     # keys.
     env_keys << "_APPSIGNAL_DIAGNOSE"
+    env_keys << "_TEST_APPSIGNAL_EXTENSION_FAILURE"
     env_keys.each do |key|
       # First set the ENV var to an empty string and then delete the key from
       # the env. We set the env var to an empty string first as JRuby doesn't

--- a/spec/support/testing.rb
+++ b/spec/support/testing.rb
@@ -40,7 +40,7 @@ module Appsignal
 
   class Extension
     class Transaction
-      alias original_finish finish
+      alias original_finish finish if method_defined? :finish
 
       # Override default {Extension::Transaction#finish} behavior to always
       # return true, which tells the transaction to add its sample data (unless
@@ -56,7 +56,7 @@ module Appsignal
         return_value
       end
 
-      alias original_complete complete
+      alias original_complete complete if method_defined? :complete
 
       # Override default {Extension::Transaction#complete} behavior to
       # store the transaction JSON before the transaction is completed
@@ -78,7 +78,7 @@ module Appsignal
         @completed || false
       end
 
-      alias original_to_json to_json
+      alias original_to_json to_json if method_defined? :to_json
 
       # Override default {Extension::Transaction#to_json} behavior to
       # return the stored the transaction JSON when the transaction was


### PR DESCRIPTION
When the gem's extension fails to install, we don't fail the
installation because we don't want AppSignal to prevent an app from
deploying or running even if it hasn't installed properly.

However, we do not show this to users in any way once the app has
started. The only way for users to find out is an absence of data being
reported, which is not a great indication, or to look for an
"appsignal.log" file which most people don't know exists.

To alert users that something went wrong, not only log the error, but
print it to STDERR, the warning output of the program. This way new
users will see when running "appsignal install" for the first time. And
existing users can see it when the app is booting.

Hopefully this also makes support a bit easier as users notice issues
sooner.

The app is not negatively affected by printing this error, but the issue
will become more visible to users.

I've tried to find a way to `gem install appsignal` to print a warning
or something when it fails to install, but rubygems seems to hide all
the output from STDOUT and STDERR. So we have to wait until the app has
started to print the error.