### PR TITLE
Proof of concept for fetching Puma metrics through the control app

### DIFF
--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |gem| # rubocop:disable Metrics/BlockLength
   }
 
   gem.add_dependency "rack"
+  gem.add_runtime_dependency "net_http_unix", '~> 0.2'
 
   gem.add_development_dependency "rake", "~> 11"
   gem.add_development_dependency "rspec", "~> 3.8"

--- a/lib/appsignal/hooks/puma.rb
+++ b/lib/appsignal/hooks/puma.rb
@@ -11,22 +11,6 @@ module Appsignal
       end
 
       def install
-        if ::Puma.respond_to?(:stats) && !defined?(APPSIGNAL_PUMA_PLUGIN_LOADED)
-          # Only install the minutely probe if a user isn't using our Puma
-          # plugin, which lives in `lib/puma/appsignal.rb`. This plugin defines
-          # the {APPSIGNAL_PUMA_PLUGIN_LOADED} constant.
-          #
-          # We prefer people use the AppSignal Puma plugin. This fallback is
-          # only there when users relied on our *magic* integration.
-          #
-          # Using the Puma plugin, the minutely probe thread will still run in
-          # Puma workers, for other non-Puma probes, but the Puma probe only
-          # runs in the Puma main process.
-          # For more information:
-          # https://docs.appsignal.com/ruby/integrations/puma.html
-          Appsignal::Minutely.probes.register :puma, ::Appsignal::Probes::PumaProbe
-        end
-
         return unless defined?(::Puma::Cluster)
         # For clustered mode with multiple workers
         ::Puma::Cluster.class_eval do

--- a/lib/puma/plugin/appsignal.rb
+++ b/lib/puma/plugin/appsignal.rb
@@ -1,27 +1,11 @@
-APPSIGNAL_PUMA_PLUGIN_LOADED = true
-
-# AppSignal Puma plugin
+# AppSignal Puma plugin (Deprecated)
 #
-# This plugin ensures the minutely probe thread is started with the Puma
-# minutely probe in the Puma master process.
-#
-# The constant {APPSIGNAL_PUMA_PLUGIN_LOADED} is here to mark the Plugin as
-# loaded by the rest of the AppSignal gem. This ensures that the Puma minutely
-# probe is not also started in every Puma workers, which was the old behavior.
-# See {Appsignal::Hooks::PumaHook#install} for more information.
-#
-# For even more information:
+# This plugin is deprecated, see the documentation below:
 # https://docs.appsignal.com/ruby/integrations/puma.html
 Puma::Plugin.create do
   def start(launcher = nil)
-    launcher.events.on_booted do
-      require "appsignal"
-      if ::Puma.respond_to?(:stats)
-        require "appsignal/probes/puma"
-        Appsignal::Minutely.probes.register :puma, Appsignal::Probes::PumaProbe
-      end
-      Appsignal.start
-      Appsignal.start_logger
-    end
+    deprecation_message "Deprecated Puma plugin: `:appsignal " \
+    "This plugin is deprecated, use the Puma minutely probe as" \
+    "described on: https://docs.appsignal.com/ruby/integrations/puma.html"
   end
 end


### PR DESCRIPTION
This is a proof of concept to discuss how to collect Puma metrics in every Puma mode (clustered/single etc.)

Currently we try to hook into Puma through a plugin, however
since this plugin runs on the "main" thread, when deploying a new
application and reloading Puma, AppSignal in the main thread isn't reloaded.

In theory this can cause a boot fight, where the agent booted from the main thread
differs from the worker threads with a newer AppSignal version,
see: https://github.com/appsignal/appsignal-ruby/issues/575
for more information.

Instead of trying to hook into Puma automagically, this pull changes
the behavior of the minutely probe and needs to be manually configured.

```ruby

Appsignal::Minutely.probes.register(
  :puma,
  Appsignal::Probes::PumaProbe(:path => "unix://./tmp/pids/pumactl.sock", :auth_token => "123")
)
```

It also requries the control app to be enabled in the Puma config.rb:

```ruby

activate_control_app "unix://./tmp/pids/pumactl.sock", { auth_token: "123" }

```

The metrics emitted here are the same as we collected in the main thread