### PR TITLE
Support #start and #finish on instrumenters

### DIFF
--- a/lib/appsignal/hooks/active_support_notifications.rb
+++ b/lib/appsignal/hooks/active_support_notifications.rb
@@ -44,6 +44,36 @@ module Appsignal
               )
             end
           end
+
+          alias start_without_appsignal start
+
+          def start(name, payload = {})
+            # Events that start with a bang are internal to Rails
+            instrument_this = name[0] != BANG
+
+            Appsignal::Transaction.current.start_event if instrument_this
+
+            start_without_appsignal(name, payload)
+          end
+
+          alias finish_without_appsignal finish
+
+          def finish(name, payload = {})
+            finish_without_appsignal(name, payload)
+
+            # Events that start with a bang are internal to Rails
+            instrument_this = name[0] != BANG
+
+            return unless instrument_this
+
+            title, body, body_format = Appsignal::EventFormatter.format(name, payload)
+            Appsignal::Transaction.current.finish_event(
+              name.to_s,
+              title,
+              body,
+              body_format
+            )
+          end
         end
       end
     end


### PR DESCRIPTION
Hey there. Currently any instrumentation done with `ActiveSupport::Instrumentation` using `#start` and `#finish` rather than `#instrument` doesn't work. Many libraries etc make use of this way of instrumenting, so it would be welcomed if it functioned correctly!

Would something along these lines work? I tested it a bit and it shows up correctly for me, but I don't know much about Appsignal internals, or if this would cause any problems.