### PR TITLE
Activesupport instrumentation refactor

### DIFF
--- a/lib/appsignal/hooks/active_support_notifications.rb
+++ b/lib/appsignal/hooks/active_support_notifications.rb
@@ -44,6 +44,36 @@ module Appsignal
               )
             end
           end
+
+          alias start_without_appsignal start
+
+          def start(name, payload = {})
+            # Events that start with a bang are internal to Rails
+            instrument_this = name[0] != BANG
+
+            Appsignal::Transaction.current.start_event if instrument_this
+
+            start_without_appsignal(name, payload)
+          end
+
+          alias finish_without_appsignal finish
+
+          def finish(name, payload = {})
+            finish_without_appsignal(name, payload)
+
+            # Events that start with a bang are internal to Rails
+            instrument_this = name[0] != BANG
+
+            return unless instrument_this
+
+            title, body, body_format = Appsignal::EventFormatter.format(name, payload)
+            Appsignal::Transaction.current.finish_event(
+              name.to_s,
+              title,
+              body,
+              body_format
+            )
+          end
         end
       end
     end

--- a/spec/lib/appsignal/hooks/active_support_notifications/finish_with_state_shared_examples.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications/finish_with_state_shared_examples.rb
@@ -1,0 +1,35 @@
+shared_examples "activesupport finish_with_state override" do
+  let(:instrumenter) { as.instrumenter }
+
+  it "instruments an ActiveSupport::Notifications.start/finish event with payload on finish" do
+    listeners_state = instrumenter.start("sql.active_record", {})
+    instrumenter.finish_with_state(listeners_state, "sql.active_record", :sql => "SQL")
+
+    expect(transaction.to_h["events"]).to match([
+      {
+        "allocation_count" => kind_of(Integer),
+        "body" => "SQL",
+        "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
+        "child_allocation_count" => kind_of(Integer),
+        "child_duration" => kind_of(Float),
+        "child_gc_duration" => kind_of(Float),
+        "count" => 1,
+        "duration" => kind_of(Float),
+        "gc_duration" => kind_of(Float),
+        "name" => "sql.active_record",
+        "start" => kind_of(Float),
+        "title" => ""
+      }
+    ])
+  end
+
+  it "does not instrument events whose name starts with a bang" do
+    expect(Appsignal::Transaction.current).not_to receive(:start_event)
+    expect(Appsignal::Transaction.current).not_to receive(:finish_event)
+
+    listeners_state = instrumenter.start("!sql.active_record", {})
+    instrumenter.finish_with_state(listeners_state, "!sql.active_record", :sql => "SQL")
+
+    expect(transaction.to_h["events"]).to be_empty
+  end
+end

--- a/spec/lib/appsignal/hooks/active_support_notifications/instrument_shared_examples.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications/instrument_shared_examples.rb
@@ -1,0 +1,145 @@
+shared_examples "activesupport instrument override" do
+  it "instruments an ActiveSupport::Notifications.instrument event" do
+    return_value = as.instrument("sql.active_record", :sql => "SQL") do
+      "value"
+    end
+
+    expect(return_value).to eq "value"
+    expect(transaction.to_h["events"]).to match([
+      {
+        "allocation_count" => kind_of(Integer),
+        "body" => "SQL",
+        "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
+        "child_allocation_count" => kind_of(Integer),
+        "child_duration" => kind_of(Float),
+        "child_gc_duration" => kind_of(Float),
+        "count" => 1,
+        "duration" => kind_of(Float),
+        "gc_duration" => kind_of(Float),
+        "name" => "sql.active_record",
+        "start" => kind_of(Float),
+        "title" => ""
+      }
+    ])
+  end
+
+  it "instruments an ActiveSupport::Notifications.instrument event with no registered formatter" do
+    return_value = as.instrument("no-registered.formatter", :key => "something") do
+      "value"
+    end
+
+    expect(return_value).to eq "value"
+    expect(transaction.to_h["events"]).to match([
+      {
+        "allocation_count" => kind_of(Integer),
+        "body" => "",
+        "body_format" => Appsignal::EventFormatter::DEFAULT,
+        "child_allocation_count" => kind_of(Integer),
+        "child_duration" => kind_of(Float),
+        "child_gc_duration" => kind_of(Float),
+        "count" => 1,
+        "duration" => kind_of(Float),
+        "gc_duration" => kind_of(Float),
+        "name" => "no-registered.formatter",
+        "start" => kind_of(Float),
+        "title" => ""
+      }
+    ])
+  end
+
+  it "converts non-string names to strings" do
+    as.instrument(:not_a_string) {}
+    expect(transaction.to_h["events"]).to match([
+      {
+        "allocation_count" => kind_of(Integer),
+        "body" => "",
+        "body_format" => Appsignal::EventFormatter::DEFAULT,
+        "child_allocation_count" => kind_of(Integer),
+        "child_duration" => kind_of(Float),
+        "child_gc_duration" => kind_of(Float),
+        "count" => 1,
+        "duration" => kind_of(Float),
+        "gc_duration" => kind_of(Float),
+        "name" => "not_a_string",
+        "start" => kind_of(Float),
+        "title" => ""
+      }
+    ])
+  end
+
+  it "does not instrument events whose name starts with a bang" do
+    expect(Appsignal::Transaction.current).not_to receive(:start_event)
+    expect(Appsignal::Transaction.current).not_to receive(:finish_event)
+
+    return_value = as.instrument("!sql.active_record", :sql => "SQL") do
+      "value"
+    end
+
+    expect(return_value).to eq "value"
+  end
+
+  context "when an error is raised in an instrumented block" do
+    it "instruments an ActiveSupport::Notifications.instrument event" do
+      expect do
+        as.instrument("sql.active_record", :sql => "SQL") do
+          raise ExampleException, "foo"
+        end
+      end.to raise_error(ExampleException, "foo")
+
+      expect(transaction.to_h["events"]).to match([
+        {
+          "allocation_count" => kind_of(Integer),
+          "body" => "SQL",
+          "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
+          "child_allocation_count" => kind_of(Integer),
+          "child_duration" => kind_of(Float),
+          "child_gc_duration" => kind_of(Float),
+          "count" => 1,
+          "duration" => kind_of(Float),
+          "gc_duration" => kind_of(Float),
+          "name" => "sql.active_record",
+          "start" => kind_of(Float),
+          "title" => ""
+        }
+      ])
+    end
+  end
+
+  context "when a message is thrown in an instrumented block" do
+    it "instruments an ActiveSupport::Notifications.instrument event" do
+      expect do
+        as.instrument("sql.active_record", :sql => "SQL") do
+          throw :foo
+        end
+      end.to throw_symbol(:foo)
+
+      expect(transaction.to_h["events"]).to match([
+        {
+          "allocation_count" => kind_of(Integer),
+          "body" => "SQL",
+          "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
+          "child_allocation_count" => kind_of(Integer),
+          "child_duration" => kind_of(Float),
+          "child_gc_duration" => kind_of(Float),
+          "count" => 1,
+          "duration" => kind_of(Float),
+          "gc_duration" => kind_of(Float),
+          "name" => "sql.active_record",
+          "start" => kind_of(Float),
+          "title" => ""
+        }
+      ])
+    end
+  end
+
+  context "when a transaction is completed in an instrumented block" do
+    it "does not complete the ActiveSupport::Notifications.instrument event" do
+      expect(transaction).to receive(:complete)
+      as.instrument("sql.active_record", :sql => "SQL") do
+        Appsignal::Transaction.complete_current!
+      end
+
+      expect(transaction.to_h["events"]).to match([])
+    end
+  end
+end

--- a/spec/lib/appsignal/hooks/active_support_notifications/start_finish_shared_examples.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications/start_finish_shared_examples.rb
@@ -1,0 +1,69 @@
+shared_examples "activesupport start finish override" do
+  let(:instrumenter) { as.instrumenter }
+
+  it "instruments an ActiveSupport::Notifications.start/finish event with payload on start ignores payload" do
+    instrumenter.start("sql.active_record", :sql => "SQL")
+    instrumenter.finish("sql.active_record", {})
+
+    expect(transaction.to_h["events"]).to match([
+      {
+        "allocation_count" => kind_of(Integer),
+        "body" => "",
+        "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
+        "child_allocation_count" => kind_of(Integer),
+        "child_duration" => kind_of(Float),
+        "child_gc_duration" => kind_of(Float),
+        "count" => 1,
+        "duration" => kind_of(Float),
+        "gc_duration" => kind_of(Float),
+        "name" => "sql.active_record",
+        "start" => kind_of(Float),
+        "title" => ""
+      }
+    ])
+  end
+
+  it "instruments an ActiveSupport::Notifications.start/finish event with payload on finish" do
+    instrumenter.start("sql.active_record", {})
+    instrumenter.finish("sql.active_record", :sql => "SQL")
+
+    expect(transaction.to_h["events"]).to match([
+      {
+        "allocation_count" => kind_of(Integer),
+        "body" => "SQL",
+        "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
+        "child_allocation_count" => kind_of(Integer),
+        "child_duration" => kind_of(Float),
+        "child_gc_duration" => kind_of(Float),
+        "count" => 1,
+        "duration" => kind_of(Float),
+        "gc_duration" => kind_of(Float),
+        "name" => "sql.active_record",
+        "start" => kind_of(Float),
+        "title" => ""
+      }
+    ])
+  end
+
+  it "does not instrument events whose name starts with a bang" do
+    expect(Appsignal::Transaction.current).not_to receive(:start_event)
+    expect(Appsignal::Transaction.current).not_to receive(:finish_event)
+
+    instrumenter.start("!sql.active_record", {})
+    instrumenter.finish("!sql.active_record", {})
+
+    expect(transaction.to_h["events"]).to be_empty
+  end
+
+  context "when a transaction is completed in an instrumented block" do
+    it "does not complete the ActiveSupport::Notifications.instrument event" do
+      expect(transaction).to receive(:complete)
+
+      instrumenter.start("sql.active_record", {})
+      Appsignal::Transaction.complete_current!
+      instrumenter.finish("sql.active_record", {})
+
+      expect(transaction.to_h["events"]).to match([])
+    end
+  end
+end

--- a/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
@@ -1,4 +1,4 @@
-require_relative "./active_support_notifications/instrument_shared_examples.rb"
+require_relative "./active_support_notifications/instrument_shared_examples"
 
 describe Appsignal::Hooks::ActiveSupportNotificationsHook do
   if active_support_present?
@@ -23,13 +23,13 @@ describe Appsignal::Hooks::ActiveSupportNotificationsHook do
     it_behaves_like "activesupport instrument override"
 
     if ::ActiveSupport::Notifications::Instrumenter.method_defined?(:start)
-      require_relative "./active_support_notifications/start_finish_shared_examples.rb"
+      require_relative "./active_support_notifications/start_finish_shared_examples"
 
       it_behaves_like "activesupport start finish override"
     end
 
     if ::ActiveSupport::Notifications::Instrumenter.method_defined?(:finish_with_state)
-      require_relative "./active_support_notifications/finish_with_state_shared_examples.rb"
+      require_relative "./active_support_notifications/finish_with_state_shared_examples"
 
       it_behaves_like "activesupport finish_with_state override"
     end

--- a/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
@@ -1,3 +1,5 @@
+require_relative "./active_support_notifications/instrument_shared_examples.rb"
+
 describe Appsignal::Hooks::ActiveSupportNotificationsHook do
   if active_support_present?
     let(:notifier) { ActiveSupport::Notifications::Fanout.new }
@@ -18,148 +20,18 @@ describe Appsignal::Hooks::ActiveSupportNotificationsHook do
       it { is_expected.to be_truthy }
     end
 
-    it "instruments an ActiveSupport::Notifications.instrument event" do
-      return_value = as.instrument("sql.active_record", :sql => "SQL") do
-        "value"
-      end
+    it_behaves_like "activesupport instrument override"
 
-      expect(return_value).to eq "value"
-      expect(transaction.to_h["events"]).to match([
-        {
-          "allocation_count" => kind_of(Integer),
-          "body" => "SQL",
-          "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
-          "child_allocation_count" => kind_of(Integer),
-          "child_duration" => kind_of(Float),
-          "child_gc_duration" => kind_of(Float),
-          "count" => 1,
-          "duration" => kind_of(Float),
-          "gc_duration" => kind_of(Float),
-          "name" => "sql.active_record",
-          "start" => kind_of(Float),
-          "title" => ""
-        }
-      ])
+    if ::ActiveSupport::Notifications::Instrumenter.method_defined?(:start)
+      require_relative "./active_support_notifications/start_finish_shared_examples.rb"
+
+      it_behaves_like "activesupport start finish override"
     end
 
-    it "instruments an ActiveSupport::Notifications.instrument event with no registered formatter" do
-      return_value = as.instrument("no-registered.formatter", :key => "something") do
-        "value"
-      end
+    if ::ActiveSupport::Notifications::Instrumenter.method_defined?(:finish_with_state)
+      require_relative "./active_support_notifications/finish_with_state_shared_examples.rb"
 
-      expect(return_value).to eq "value"
-      expect(transaction.to_h["events"]).to match([
-        {
-          "allocation_count" => kind_of(Integer),
-          "body" => "",
-          "body_format" => Appsignal::EventFormatter::DEFAULT,
-          "child_allocation_count" => kind_of(Integer),
-          "child_duration" => kind_of(Float),
-          "child_gc_duration" => kind_of(Float),
-          "count" => 1,
-          "duration" => kind_of(Float),
-          "gc_duration" => kind_of(Float),
-          "name" => "no-registered.formatter",
-          "start" => kind_of(Float),
-          "title" => ""
-        }
-      ])
-    end
-
-    it "converts non-string names to strings" do
-      as.instrument(:not_a_string) {}
-      expect(transaction.to_h["events"]).to match([
-        {
-          "allocation_count" => kind_of(Integer),
-          "body" => "",
-          "body_format" => Appsignal::EventFormatter::DEFAULT,
-          "child_allocation_count" => kind_of(Integer),
-          "child_duration" => kind_of(Float),
-          "child_gc_duration" => kind_of(Float),
-          "count" => 1,
-          "duration" => kind_of(Float),
-          "gc_duration" => kind_of(Float),
-          "name" => "not_a_string",
-          "start" => kind_of(Float),
-          "title" => ""
-        }
-      ])
-    end
-
-    it "does not instrument events whose name starts with a bang" do
-      expect(Appsignal::Transaction.current).not_to receive(:start_event)
-      expect(Appsignal::Transaction.current).not_to receive(:finish_event)
-
-      return_value = as.instrument("!sql.active_record", :sql => "SQL") do
-        "value"
-      end
-
-      expect(return_value).to eq "value"
-    end
-
-    context "when an error is raised in an instrumented block" do
-      it "instruments an ActiveSupport::Notifications.instrument event" do
-        expect do
-          as.instrument("sql.active_record", :sql => "SQL") do
-            raise ExampleException, "foo"
-          end
-        end.to raise_error(ExampleException, "foo")
-
-        expect(transaction.to_h["events"]).to match([
-          {
-            "allocation_count" => kind_of(Integer),
-            "body" => "SQL",
-            "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
-            "child_allocation_count" => kind_of(Integer),
-            "child_duration" => kind_of(Float),
-            "child_gc_duration" => kind_of(Float),
-            "count" => 1,
-            "duration" => kind_of(Float),
-            "gc_duration" => kind_of(Float),
-            "name" => "sql.active_record",
-            "start" => kind_of(Float),
-            "title" => ""
-          }
-        ])
-      end
-    end
-
-    context "when a message is thrown in an instrumented block" do
-      it "instruments an ActiveSupport::Notifications.instrument event" do
-        expect do
-          as.instrument("sql.active_record", :sql => "SQL") do
-            throw :foo
-          end
-        end.to throw_symbol(:foo)
-
-        expect(transaction.to_h["events"]).to match([
-          {
-            "allocation_count" => kind_of(Integer),
-            "body" => "SQL",
-            "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
-            "child_allocation_count" => kind_of(Integer),
-            "child_duration" => kind_of(Float),
-            "child_gc_duration" => kind_of(Float),
-            "count" => 1,
-            "duration" => kind_of(Float),
-            "gc_duration" => kind_of(Float),
-            "name" => "sql.active_record",
-            "start" => kind_of(Float),
-            "title" => ""
-          }
-        ])
-      end
-    end
-
-    context "when a transaction is completed in an instrumented block" do
-      it "does not complete the ActiveSupport::Notifications.instrument event" do
-        expect(transaction).to receive(:complete)
-        as.instrument("sql.active_record", :sql => "SQL") do
-          Appsignal::Transaction.complete_current!
-        end
-
-        expect(transaction.to_h["events"]).to match([])
-      end
+      it_behaves_like "activesupport finish_with_state override"
     end
   else
     describe "#dependencies_present?" do


### PR DESCRIPTION
Depending on the Ruby version `start`/`finish` or even `finish_with_state` is defined
in favor of `instrument`.

This commit updates the `install` method for ActiveSupport notifications
to conditionally load the required overrides.

Note that using start/finish behaves slightly differently from `instrument`
as `instrument` rescues any errors in the given block and ensures
the transaction is closed after the error. With start/finish you are not
able to replicate the same behavior as `finish` might never be called
if an error occurs between the `start` and `finish` calls.

I've moved the specs to`behave_like`, this way all cases are tested when they are applicable, and it splits up the tests in a logical way, hopefully reducing the giant test files for this hook a bit. 

 