### PR TITLE
Add breadcrumbs as sample data

### DIFF
--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -380,6 +380,38 @@ module Appsignal
       end
       alias :tag_job :tag_request
 
+      # Add breadcrumbs to the transaction.
+      #
+      # Breadcrumbs can be used to trace what path a user has taken
+      # before encounterin an error.
+      #
+      # Only the last 20 added breadcrumbs will be saved.
+      #
+      # @example
+      #   Appsignal.add_breadcrumb("Navigation", "http://blablabla.com", "", { :response => 200 }, Time.now.utc)
+      #   Appsignal.add_breadcrumb("Network", "[GET] http://blablabla.com", "", { :response => 500 })
+      #   Appsignal.add_breadcrumb("UI", "closed modal(change_password)", "User closed modal without actions")
+      #
+      # @param category [String] category of breadcrumb
+      #   e.g. "UI", "Network", "Navigation", "Console".
+      # @param action [String] name of breadcrumb
+      #   e.g "The user clicked a button", "HTTP 500 from http://blablabla.com"
+      # @option message [String]  optional message in string format
+      # @option metadata [Hash<String,String>]  key/value metadata in <string, string> format
+      # @option time [Time] time of breadcrumb, should respond to `.to_i` defaults to `Time.now.utc`
+      # @return [void]
+      #
+      # @see Transaction#add_breadcrumb
+      # @see http://docs.appsignal.com/ruby/instrumentation/breadcrumbs.html
+      #   Breadcrumb reference
+      # @since 2.12.0
+      def add_breadcrumb(category, action, message = "", metadata = {}, time = Time.now.utc)
+        return unless active?
+        transaction = Appsignal::Transaction.current
+        return false unless transaction
+        transaction.add_breadcrumb(category, action, message, metadata, time)
+      end
+
       # Instrument helper for AppSignal.
       #
       # For more help, read our custom instrumentation guide, listed under "See

--- a/spec/lib/appsignal/hooks/resque_spec.rb
+++ b/spec/lib/appsignal/hooks/resque_spec.rb
@@ -60,7 +60,10 @@ describe Appsignal::Hooks::ResqueHook do
           "error" => nil,
           "namespace" => namespace,
           "metadata" => {},
-          "sample_data" => { "tags" => { "queue" => queue } }
+          "sample_data" => {
+            "breadcrumbs" => [],
+            "tags" => { "queue" => queue }
+          }
         )
         expect(transaction_hash["events"].map { |e| e["name"] })
           .to eql(["perform.resque"])
@@ -84,7 +87,10 @@ describe Appsignal::Hooks::ResqueHook do
             },
             "namespace" => namespace,
             "metadata" => {},
-            "sample_data" => { "tags" => { "queue" => queue } }
+            "sample_data" => {
+              "breadcrumbs" => [],
+              "tags" => { "queue" => queue }
+            }
           )
         end
       end
@@ -118,6 +124,7 @@ describe Appsignal::Hooks::ResqueHook do
             "metadata" => {},
             "sample_data" => {
               "tags" => { "queue" => queue },
+              "breadcrumbs" => [],
               "params" => [
                 "foo",
                 {
@@ -174,6 +181,7 @@ describe Appsignal::Hooks::ResqueHook do
             "namespace" => namespace,
             "metadata" => {},
             "sample_data" => {
+              "breadcrumbs" => [],
               "tags" => { "queue" => queue }
               # Params will be set by the ActiveJob integration
             }

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -262,7 +262,8 @@ describe Appsignal::Hooks::SidekiqPlugin, :with_yaml_parse_error => false do
         "sample_data" => {
           "environment" => {},
           "params" => expected_args,
-          "tags" => {}
+          "tags" => {},
+          "breadcrumbs" => []
         }
       )
       expect_transaction_to_have_sidekiq_event(transaction_hash)
@@ -290,7 +291,8 @@ describe Appsignal::Hooks::SidekiqPlugin, :with_yaml_parse_error => false do
         "sample_data" => {
           "environment" => {},
           "params" => expected_args,
-          "tags" => {}
+          "tags" => {},
+          "breadcrumbs" => []
         }
       )
       # TODO: Not available in transaction.to_h yet.

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -491,6 +491,36 @@ describe Appsignal do
       end
     end
 
+    describe ".add_breadcrumb" do
+      before { allow(Appsignal::Transaction).to receive(:current).and_return(transaction) }
+
+      context "with transaction" do
+        let(:transaction) { double }
+        it "should call add_breadcrumb on transaction" do
+          expect(transaction).to receive(:add_breadcrumb)
+            .with("Network", "http", "User made network request", { :response => 200 }, fixed_time)
+        end
+
+        after do
+          Appsignal.add_breadcrumb(
+            "Network",
+            "http",
+            "User made network request",
+            { :response => 200 },
+            fixed_time
+          )
+        end
+      end
+
+      context "without transaction" do
+        let(:transaction) { nil }
+
+        it "should not call add_breadcrumb on transaction" do
+          expect(Appsignal.add_breadcrumb("Network", "http")).to be_falsy
+        end
+      end
+    end
+
     describe "custom stats" do
       let(:tags) { { :foo => "bar" } }
 


### PR DESCRIPTION
Add breadcrumbs as sample data

Breadcrumbs can be used to trace a (user's) path throughout the application to the point where the exception/performance issue happened. 

For example:

```ruby
Appsignal.add_breadcrumb("Navigation", "http://blablabla.com", "", { :response => 200 }, Time.now.utc)
Appsignal.add_breadcrumb("Network", "[GET] http://blablabla.com", "", { :response => 500 })
Appsignal.add_breadcrumb("UI", "closed modal(change_password)", "User closed modal without actions")
```
Only the last 20 breadcrumbs will be sent to the extension

* Add instrumentation helper method `add_breadcrumb`
* Add transaction method `add_breadcrumb`
