### PR TITLE
Add hook to capture and emit ActionMailer metrics

### DIFF
--- a/lib/appsignal/hooks.rb
+++ b/lib/appsignal/hooks.rb
@@ -96,6 +96,7 @@ module Appsignal
 end
 
 require "appsignal/hooks/action_cable"
+require "appsignal/hooks/action_mailer"
 require "appsignal/hooks/active_job"
 require "appsignal/hooks/active_support_notifications"
 require "appsignal/hooks/celluloid"

--- a/lib/appsignal/hooks/action_mailer.rb
+++ b/lib/appsignal/hooks/action_mailer.rb
@@ -1,0 +1,22 @@
+module Appsignal
+  class Hooks
+    class ActionMailerHook < Appsignal::Hooks::Hook
+      register :action_mailer
+
+      def dependencies_present?
+        defined?(::ActionMailer)
+      end
+
+      def install
+        ActiveSupport::Notifications
+          .subscribe("process.action_mailer") do |_, _, _, _, payload|
+          Appsignal.increment_counter(
+            :action_mailer_process,
+            1,
+            :mailer => payload[:mailer], :action => payload[:action]
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/appsignal/hooks/action_mailer_spec.rb
+++ b/spec/lib/appsignal/hooks/action_mailer_spec.rb
@@ -1,0 +1,54 @@
+describe Appsignal::Hooks::ActionMailerHook do
+  if DependencyHelper.action_mailer_present? &&
+      DependencyHelper.rails_version >= Gem::Version.new("4.0.0")
+    context "with ActionMailer" do
+      require "action_mailer"
+
+      class UserMailer < ActionMailer::Base
+        default :from => "test@example.com"
+
+        def welcome
+          mail(:to => "test@example.com", :subject => "ActionMailer test", :content_type => "text/html") do |format|
+            format.html { render :html => "This is a test" }
+          end
+        end
+      end
+      UserMailer.delivery_method = :test
+
+      describe ".dependencies_present?" do
+        subject { described_class.new.dependencies_present? }
+
+        it "returns true" do
+          is_expected.to be_truthy
+        end
+      end
+
+      describe ".install" do
+        before do
+          start_agent
+          expect(Appsignal.active?).to be_truthy
+        end
+
+        it "is subscribed to 'process.action_mailer' and processes instrumentation" do
+          expect(Appsignal).to receive(:increment_counter).with(
+            :action_mailer_process,
+            1,
+            :mailer => "UserMailer", :action => :welcome
+          )
+
+          UserMailer.welcome.deliver_now
+        end
+      end
+    end
+  else
+    context "without ActionMailer" do
+      describe ".dependencies_present?" do
+        subject { described_class.new.dependencies_present? }
+
+        it "returns false" do
+          is_expected.to be_falsy
+        end
+      end
+    end
+  end
+end

--- a/spec/support/helpers/dependency_helper.rb
+++ b/spec/support/helpers/dependency_helper.rb
@@ -37,6 +37,10 @@ module DependencyHelper
     dependency_present? "actioncable"
   end
 
+  def action_mailer_present?
+    dependency_present? "actionmailer"
+  end
+
   def active_job_present?
     dependency_present? "activejob"
   end


### PR DESCRIPTION
Used in the `ActionMailer` magic dashboard.

Subscribes to ActionMailer's `process.action_mailer` notifications
and emits `count` metrics for each call.