### PR TITLE
Fix the ERB instantiation for Ruby 3

### DIFF
--- a/gemfiles/resque-1.gemfile
+++ b/gemfiles/resque-1.gemfile
@@ -1,7 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'resque', "~> 1.27.0"
-gem 'sinatra'
-gem 'mime-types', '~> 2.6'
-
-gemspec :path => '../'

--- a/gemfiles/resque-2.gemfile
+++ b/gemfiles/resque-2.gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'resque', "~> 2.0"
 gem 'sinatra'
-gem 'mime-types', '~> 2.6'
 
 gemspec :path => '../'
 

--- a/gemfiles/webmachine.gemfile
+++ b/gemfiles/webmachine.gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'webmachine'
+gem 'webrick'
 
 gemspec :path => '../'

--- a/lib/appsignal/cli/install.rb
+++ b/lib/appsignal/cli/install.rb
@@ -279,10 +279,10 @@ module Appsignal
           )
           file_contents = File.read(filename)
           template = if ruby_2_6_or_up?
-            ERB.new(file_contents, trim_mode: "-")
-          else
-            ERB.new(file_contents, nil, "-")
-          end
+                       ERB.new(file_contents, :trim_mode => "-")
+                     else
+                       ERB.new(file_contents, nil, "-")
+                     end
           config = template.result(OpenStruct.new(data).instance_eval { binding })
 
           FileUtils.mkdir_p(File.join(Dir.pwd, "config"))

--- a/lib/appsignal/cli/install.rb
+++ b/lib/appsignal/cli/install.rb
@@ -278,14 +278,11 @@ module Appsignal
             "../../../resources/appsignal.yml.erb"
           )
           file_contents = File.read(filename)
-          arguments = [file_contents]
-          if ruby_2_6_or_up?
-            arguments << { :trim_mode => "-" }
+          template = if ruby_2_6_or_up?
+            ERB.new(file_contents, trim_mode: "-")
           else
-            arguments << nil
-            arguments << "-"
+            ERB.new(file_contents, nil, "-")
           end
-          template = ERB.new(*arguments)
           config = template.result(OpenStruct.new(data).instance_eval { binding })
 
           FileUtils.mkdir_p(File.join(Dir.pwd, "config"))


### PR DESCRIPTION
By reviewing the failing tests, I identified that all tests fail because the ERB instantiation. The old version prevented the last argument to be seen as keyword argument. By removing the splat arguments, it works as expected.

Related to #671