### PR TITLE
Fix Ruby 1.9 build

### DIFF
--- a/gemfiles/no_dependencies.gemfile
+++ b/gemfiles/no_dependencies.gemfile
@@ -2,4 +2,11 @@ source 'https://rubygems.org'
 
 gem 'rack', '~> 1.6'
 
+ruby_version = Gem::Version.new(RUBY_VERSION)
+if ruby_version < Gem::Version.new("2.0.0")
+  # Newer versions of this gem have rexml as a dependency which doesn't work on
+  # Ruby 1.9
+  gem "crack", "0.4.4"
+end
+
 gemspec :path => '../'


### PR DESCRIPTION
Lock a dependency on an older version so that it does not raise a syntax
error.

```
An error occurred while loading spec_helper.
Failure/Error: require "webmock/rspec"

SyntaxError:
  /home/semaphore/appsignal-ruby/.bundle/gems/rexml-3.2.4/lib/rexml/xpath.rb:34: syntax error, unexpected tPOW, expecting ')'
        parser = XPathParser.new(**options)
                                   ^
  /home/semaphore/appsignal-ruby/.bundle/gems/rexml-3.2.4/lib/rexml/xpath.rb:63: syntax error, unexpected tPOW, expecting ')'
        parser = XPathParser.new(**options)
                                   ^
  /home/semaphore/appsignal-ruby/.bundle/gems/rexml-3.2.4/lib/rexml/xpath.rb:73: syntax error, unexpected tPOW, expecting ')'
        parser = XPathParser.new(**options)
                                   ^
# ./.bundle/gems/rexml-3.2.4/lib/rexml/element.rb:6:in `require_relative'
# ./.bundle/gems/rexml-3.2.4/lib/rexml/element.rb:6:in `<top (required)>'
# ./.bundle/gems/rexml-3.2.4/lib/rexml/document.rb:3:in `require_relative'
# ./.bundle/gems/rexml-3.2.4/lib/rexml/document.rb:3:in `<top (required)>'
# ./.bundle/gems/crack-0.4.5/lib/crack/xml.rb:5:in `require'
# ./.bundle/gems/crack-0.4.5/lib/crack/xml.rb:5:in `<top (required)>'
# ./.bundle/gems/webmock-2.3.2/lib/webmock.rb:5:in `require'
# ./.bundle/gems/webmock-2.3.2/lib/webmock.rb:5:in `<top (required)>'
# ./.bundle/gems/webmock-2.3.2/lib/webmock/rspec.rb:1:in `require'
# ./.bundle/gems/webmock-2.3.2/lib/webmock/rspec.rb:1:in `<top (required)>'
# ./spec/spec_helper.rb:13:in `require'
# ./spec/spec_helper.rb:13:in `<top (required)>'
```

[skip review]