### PR TITLE
Support Ruby 3.0

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -31,6 +31,7 @@ global_job_config:
   prologue:
     commands:
     - checkout
+    - git -C /home/semaphore/.rbenv/plugins/ruby-build pull
     - sem-version ruby $RUBY_VERSION
     - "./support/check_versions"
     - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
@@ -981,6 +982,202 @@ blocks:
       env_vars:
       - name: RUBY_VERSION
         value: 2.7.1
+      - name: GEMSET
+        value: webmachine
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/webmachine.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+- name: Ruby 3.0.0
+  dependencies:
+  - Validation
+  task:
+    prologue:
+      commands:
+      - "./support/bundler_wrapper exec rake extension:install"
+    jobs:
+    - name: Ruby 3.0.0 for no_dependencies
+      env_vars:
+      - name: RUBY_VERSION
+        value: 3.0.0
+      - name: GEMSET
+        value: no_dependencies
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/no_dependencies.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+- name: Ruby 3.0.0 - Gems
+  dependencies:
+  - Ruby 3.0.0
+  task:
+    prologue:
+      commands:
+      - "./support/bundler_wrapper exec rake extension:install"
+    jobs:
+    - name: Ruby 3.0.0 for capistrano2
+      env_vars:
+      - name: RUBY_VERSION
+        value: 3.0.0
+      - name: GEMSET
+        value: capistrano2
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/capistrano2.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.0.0 for capistrano3
+      env_vars:
+      - name: RUBY_VERSION
+        value: 3.0.0
+      - name: GEMSET
+        value: capistrano3
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/capistrano3.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.0.0 for grape
+      env_vars:
+      - name: RUBY_VERSION
+        value: 3.0.0
+      - name: GEMSET
+        value: grape
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/grape.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.0.0 for padrino
+      env_vars:
+      - name: RUBY_VERSION
+        value: 3.0.0
+      - name: GEMSET
+        value: padrino
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/padrino.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.0.0 for que
+      env_vars:
+      - name: RUBY_VERSION
+        value: 3.0.0
+      - name: GEMSET
+        value: que
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/que.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.0.0 for que_beta
+      env_vars:
+      - name: RUBY_VERSION
+        value: 3.0.0
+      - name: GEMSET
+        value: que_beta
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/que_beta.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.0.0 for rails-6.0
+      env_vars:
+      - name: RUBY_VERSION
+        value: 3.0.0
+      - name: GEMSET
+        value: rails-6.0
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/rails-6.0.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.0.0 for resque-2
+      env_vars:
+      - name: RUBY_VERSION
+        value: 3.0.0
+      - name: GEMSET
+        value: resque-2
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/resque-2.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.0.0 for sequel
+      env_vars:
+      - name: RUBY_VERSION
+        value: 3.0.0
+      - name: GEMSET
+        value: sequel
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/sequel.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.0.0 for sinatra
+      env_vars:
+      - name: RUBY_VERSION
+        value: 3.0.0
+      - name: GEMSET
+        value: sinatra
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/sinatra.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.0.0 for webmachine
+      env_vars:
+      - name: RUBY_VERSION
+        value: 3.0.0
       - name: GEMSET
         value: webmachine
       - name: BUNDLE_GEMFILE

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -32,6 +32,7 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
     prologue:
       commands:
         - checkout
+        - git -C /home/semaphore/.rbenv/plugins/ruby-build pull
         - sem-version ruby $RUBY_VERSION
         - ./support/check_versions
         - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
@@ -116,6 +117,7 @@ matrix:
       gems: "minimal"
     - ruby: "2.6.5"
     - ruby: "2.7.1"
+    - ruby: "3.0.0"
     - ruby: "jruby-9.1.17.0"
       gems: "minimal"
   gems:
@@ -138,24 +140,29 @@ matrix:
         ruby:
           - "2.6.5"
           - "2.7.1"
+          - "3.0.0"
     - gem: "rails-4.2"
       bundler: "1.17.3"
       exclude:
         ruby:
           - "2.6.5"
           - "2.7.1"
+          - "3.0.0"
     - gem: "rails-5.0"
       exclude:
         ruby:
           - "2.0.0-p648"
+          - "3.0.0"
     - gem: "rails-5.1"
       exclude:
         ruby:
           - "2.0.0-p648"
+          - "3.0.0"
     - gem: "rails-5.2"
       exclude:
         ruby:
           - "2.0.0-p648"
+          - "3.0.0"
     - gem: "rails-6.0"
       exclude:
         ruby:
@@ -167,11 +174,17 @@ matrix:
           - "jruby-9.1.17.0"
     - gem: "resque-1"
       bundler: "1.17.3"
+      exclude:
+        ruby:
+          - "3.0.0"
     - gem: "resque-2"
       exclude:
         ruby:
           - "2.0.0-p648"
     - gem: "sequel"
     - gem: "sequel-435"
+      exclude:
+        ruby:
+          - "3.0.0"
     - gem: "sinatra"
     - gem: "webmachine"

--- a/ext/base.rb
+++ b/ext/base.rb
@@ -126,11 +126,16 @@ def download_archive(type)
     report["download"]["download_url"] = download_url
 
     begin
-      return open(
+      args = [
         download_url,
         :ssl_ca_cert => CA_CERT_PATH,
         :proxy => http_proxy
-      )
+      ]
+      if URI.respond_to?(:open) # rubocop:disable Style/GuardClause
+        return URI.open(*args)
+      else
+        return open(*args)
+      end
     rescue => error
       download_errors << "- URL: #{download_url}\n  Error: #{error.class}: #{error.message}"
       next

--- a/gemfiles/resque-2.gemfile
+++ b/gemfiles/resque-2.gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'resque', "~> 2.0"
 gem 'sinatra'
-gem 'mime-types', '~> 2.6'
 
 gemspec :path => '../'
 

--- a/gemfiles/webmachine.gemfile
+++ b/gemfiles/webmachine.gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'webmachine'
+gem 'webrick'
 
 gemspec :path => '../'

--- a/lib/appsignal/cli/diagnose/utils.rb
+++ b/lib/appsignal/cli/diagnose/utils.rb
@@ -34,20 +34,17 @@ module Appsignal
         end
 
         def self.parse_yaml(contents)
-          arguments = [contents]
           if YAML.respond_to? :safe_load
-            method = :safe_load
-            arguments << \
-              if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.6.0")
-                # Use keyword params for Ruby 2.6 and up
-                { :permitted_classes => [Time] }
-              else
-                [Time]
-              end
+            if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.6.0")
+              # Use keyword params for Ruby 2.6 and up
+              YAML.safe_load(contents, :permitted_classes => [Time])
+            else
+              YAML.safe_load(contents, [Time])
+            end
           else
-            method = :load
+            # Support for Ruby versions without YAML.safe_load
+            YAML.load(contents) # rubocop:disable Security/YAMLLoad
           end
-          YAML.send(method, *arguments)
         end
       end
     end

--- a/lib/appsignal/cli/install.rb
+++ b/lib/appsignal/cli/install.rb
@@ -278,14 +278,11 @@ module Appsignal
             "../../../resources/appsignal.yml.erb"
           )
           file_contents = File.read(filename)
-          arguments = [file_contents]
-          if ruby_2_6_or_up?
-            arguments << { :trim_mode => "-" }
-          else
-            arguments << nil
-            arguments << "-"
-          end
-          template = ERB.new(*arguments)
+          template = if ruby_2_6_or_up?
+                       ERB.new(file_contents, :trim_mode => "-")
+                     else
+                       ERB.new(file_contents, nil, "-")
+                     end
           config = template.result(OpenStruct.new(data).instance_eval { binding })
 
           FileUtils.mkdir_p(File.join(Dir.pwd, "config"))


### PR DESCRIPTION
Support Ruby 3.0. Backport of https://github.com/appsignal/appsignal-ruby/pull/671 so we can release it as a patch release.

## Add Ruby 3.0 to CI build

- Fix issues with keywords arguments for `YAML.safe_load`.
- Use `URI.open` now that `open` in Ruby 3.0 doesn't open URIs
  anymore.

## Other commits

Other commits not from me, from https://github.com/appsignal/appsignal-ruby/pull/674

### Fix the initialization of ERB instance

The splat version prevented to interpret the last arguments as keyword argument

### Remove mime-types which is incompatible with >= Ruby 2.7 because numbered arguments

_No message_

### Fix webmachine test suite 

_No message_
