### PR TITLE
Bump RuboCop to TargetRubyVersion 2.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 1.9
+  TargetRubyVersion: 2.0
   Include:
     - "**/*.cap"
     - "Gemfile"
@@ -77,6 +77,9 @@ Metrics/BlockLength:
 
 Style/FrozenStringLiteralComment:
   Enabled: true
+
+Style/SymbolArray:
+  EnforcedStyle: brackets
 
 # Metrics/LineLength:
 #   Max: 80

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ ENV["RAILS_ENV"] ||= "test"
 ENV["RACK_ENV"] ||= "test"
 ENV["PADRINO_ENV"] ||= "test"
 
-APPSIGNAL_SPEC_DIR = File.expand_path(File.dirname(__FILE__))
+APPSIGNAL_SPEC_DIR = File.expand_path(__dir__)
 $LOAD_PATH.unshift(File.join(APPSIGNAL_SPEC_DIR, "support/stubs"))
 
 Bundler.require :default


### PR DESCRIPTION
Update the TargetRubyVersion to Ruby 2.0, now that we no longer support
Ruby 1.9.

Configure the Style/SymbolArray to not prefer the `%i[one two three]`
syntax. Keep using brackets.

During the new RuboCop check it found a usage of `__FILE__` where it now
prefers `__dir__`. Updated it.

[skip review]