### PR TITLE
Drop Ruby 1.9, switch to using Module.prepend instead of method aliasing 

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -78,29 +78,6 @@ blocks:
         value: gemfiles/no_dependencies.gemfile
       commands:
       - "./support/bundler_wrapper exec rubocop"
-- name: Ruby 1.9.3-p551
-  dependencies:
-  - Validation
-  task:
-    prologue:
-      commands:
-      - "./support/bundler_wrapper exec rake extension:install"
-    jobs:
-    - name: Ruby 1.9.3-p551 for no_dependencies
-      env_vars:
-      - name: RUBY_VERSION
-        value: 1.9.3-p551
-      - name: GEMSET
-        value: no_dependencies
-      - name: BUNDLE_GEMFILE
-        value: gemfiles/no_dependencies.gemfile
-      - name: _RUBYGEMS_VERSION
-        value: 2.7.8
-      - name: _BUNDLER_VERSION
-        value: 1.17.3
-      commands:
-      - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
 - name: Ruby 2.0.0-p648
   dependencies:
   - Validation

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -93,10 +93,6 @@ matrix:
       - "rails-6.0"
 
   ruby:
-    - ruby: "1.9.3-p551"
-      rubygems: "2.7.8"
-      bundler: "1.17.3"
-      gems: "none"
     - ruby: "2.0.0-p648"
       rubygems: "2.7.8"
       bundler: "1.17.3"

--- a/lib/appsignal/hooks/action_cable.rb
+++ b/lib/appsignal/hooks/action_cable.rb
@@ -14,44 +14,13 @@ module Appsignal
       end
 
       def install
-        patch_perform_action
+        require "appsignal/integrations/action_cable"
+        ActionCable::Channel::Base.send(:prepend, Appsignal::Integrations::ActionCableIntegration)
+
         install_callbacks
       end
 
       private
-
-      def patch_perform_action
-        ActionCable::Channel::Base.class_eval do
-          alias_method :original_perform_action, :perform_action
-
-          def perform_action(*args, &block)
-            # The request is only the original websocket request
-            env = connection.env
-            request = ActionDispatch::Request.new(env)
-            env[Appsignal::Hooks::ActionCableHook::REQUEST_ID] ||=
-              request.request_id || SecureRandom.uuid
-
-            transaction = Appsignal::Transaction.create(
-              env[Appsignal::Hooks::ActionCableHook::REQUEST_ID],
-              Appsignal::Transaction::ACTION_CABLE,
-              request
-            )
-
-            begin
-              original_perform_action(*args, &block)
-            rescue Exception => exception # rubocop:disable Lint/RescueException
-              transaction.set_error(exception)
-              raise exception
-            ensure
-              transaction.params = args.first
-              transaction.set_action_if_nil("#{self.class}##{args.first["action"]}")
-              transaction.set_metadata("path", request.path)
-              transaction.set_metadata("method", "websocket")
-              Appsignal::Transaction.complete_current!
-            end
-          end
-        end
-      end
 
       def install_callbacks
         ActionCable::Channel::Base.set_callback :subscribe, :around, :prepend => true do |channel, inner|

--- a/lib/appsignal/hooks/celluloid.rb
+++ b/lib/appsignal/hooks/celluloid.rb
@@ -16,16 +16,12 @@ module Appsignal
         # down Celluloid so we're sure our thread does not aggravate this situation.
         # This way we also make sure any outstanding transactions get flushed.
 
-        ::Celluloid.class_eval do
-          class << self
-            alias shutdown_without_appsignal shutdown
-
-            def shutdown
-              Appsignal.stop("celluloid")
-              shutdown_without_appsignal
-            end
+        Celluloid.singleton_class.send(:prepend, Module.new do
+          def shutdown
+            Appsignal.stop("celluloid")
+            super
           end
-        end
+        end)
       end
     end
   end

--- a/lib/appsignal/hooks/net_http.rb
+++ b/lib/appsignal/hooks/net_http.rb
@@ -13,18 +13,8 @@ module Appsignal
       end
 
       def install
-        Net::HTTP.class_eval do
-          alias request_without_appsignal request
-
-          def request(request, body = nil, &block)
-            Appsignal.instrument(
-              "request.net_http",
-              "#{request.method} #{use_ssl? ? "https" : "http"}://#{request["host"] || address}"
-            ) do
-              request_without_appsignal(request, body, &block)
-            end
-          end
-        end
+        require "appsignal/integrations/net_http"
+        Net::HTTP.send(:prepend, Appsignal::Integrations::NetHttpIntegration)
 
         Appsignal::Environment.report_enabled("net_http")
       end

--- a/lib/appsignal/hooks/puma.rb
+++ b/lib/appsignal/hooks/puma.rb
@@ -29,14 +29,12 @@ module Appsignal
 
         return unless defined?(::Puma::Cluster)
         # For clustered mode with multiple workers
-        ::Puma::Cluster.class_eval do
-          alias stop_workers_without_appsignal stop_workers
-
+        ::Puma::Cluster.send(:prepend, Module.new do
           def stop_workers
             Appsignal.stop("puma cluster")
-            stop_workers_without_appsignal
+            super
           end
-        end
+        end)
       end
     end
   end

--- a/lib/appsignal/hooks/que.rb
+++ b/lib/appsignal/hooks/que.rb
@@ -12,7 +12,7 @@ module Appsignal
 
       def install
         require "appsignal/integrations/que"
-        ::Que::Job.send(:include, Appsignal::Integrations::QuePlugin)
+        ::Que::Job.send(:prepend, Appsignal::Integrations::QuePlugin)
 
         ::Que.error_notifier = proc do |error, _job|
           Appsignal::Transaction.current.set_error(error)

--- a/lib/appsignal/hooks/rake.rb
+++ b/lib/appsignal/hooks/rake.rb
@@ -11,30 +11,8 @@ module Appsignal
       end
 
       def install
-        ::Rake::Task.class_eval do
-          alias :execute_without_appsignal :execute
-
-          def execute(*args)
-            execute_without_appsignal(*args)
-          rescue Exception => error # rubocop:disable Lint/RescueException
-            # Format given arguments and cast to hash if possible
-            params, _ = args
-            params = params.to_hash if params.respond_to?(:to_hash)
-
-            transaction = Appsignal::Transaction.create(
-              SecureRandom.uuid,
-              Appsignal::Transaction::BACKGROUND_JOB,
-              Appsignal::Transaction::GenericRequest.new(
-                :params => params
-              )
-            )
-            transaction.set_action(name)
-            transaction.set_error(error)
-            transaction.complete
-            Appsignal.stop("rake")
-            raise error
-          end
-        end
+        require "appsignal/integrations/rake"
+        ::Rake::Task.send(:prepend, Appsignal::Integrations::RakeIntegration)
       end
     end
   end

--- a/lib/appsignal/hooks/redis.rb
+++ b/lib/appsignal/hooks/redis.rb
@@ -13,19 +13,8 @@ module Appsignal
       end
 
       def install
-        ::Redis::Client.class_eval do
-          alias process_without_appsignal process
-
-          def process(commands, &block)
-            sanitized_commands = commands.map do |command, *args|
-              "#{command}#{" ?" * args.size}"
-            end.join("\n")
-
-            Appsignal.instrument "query.redis", id, sanitized_commands do
-              process_without_appsignal(commands, &block)
-            end
-          end
-        end
+        require "appsignal/integrations/redis"
+        ::Redis::Client.send(:prepend, Appsignal::Integrations::RedisIntegration)
 
         Appsignal::Environment.report_enabled("redis")
       end

--- a/lib/appsignal/hooks/resque.rb
+++ b/lib/appsignal/hooks/resque.rb
@@ -11,49 +11,8 @@ module Appsignal
       end
 
       def install
-        Resque::Job.class_eval do
-          alias_method :perform_without_appsignal, :perform
-
-          def perform
-            transaction = Appsignal::Transaction.create(
-              SecureRandom.uuid,
-              Appsignal::Transaction::BACKGROUND_JOB,
-              Appsignal::Transaction::GenericRequest.new({})
-            )
-
-            Appsignal.instrument "perform.resque" do
-              perform_without_appsignal
-            end
-          rescue Exception => exception # rubocop:disable Lint/RescueException
-            transaction.set_error(exception)
-            raise exception
-          ensure
-            if transaction
-              transaction.set_action_if_nil("#{payload["class"]}#perform")
-              args =
-                Appsignal::Utils::HashSanitizer.sanitize(
-                  ResqueHelpers.arguments(payload),
-                  Appsignal.config[:filter_parameters]
-                )
-              transaction.params = args if args
-              transaction.set_tags("queue" => queue)
-
-              Appsignal::Transaction.complete_current!
-            end
-            Appsignal.stop("resque")
-          end
-        end
-      end
-
-      class ResqueHelpers
-        def self.arguments(payload)
-          case payload["class"]
-          when "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper"
-            nil # Set in the ActiveJob integration
-          else
-            payload["args"]
-          end
-        end
+        require "appsignal/integrations/resque"
+        Resque::Job.send(:prepend, Appsignal::Integrations::ResqueIntegration)
       end
     end
   end

--- a/lib/appsignal/hooks/unicorn.rb
+++ b/lib/appsignal/hooks/unicorn.rb
@@ -12,30 +12,9 @@ module Appsignal
       end
 
       def install
-        # Make sure that appsignal is started and the last transaction
-        # in a worker gets flushed.
-        #
-        # We'd love to be able to hook this into Unicorn in a less
-        # intrusive way, but this is the best we can do given the
-        # options we have.
-
-        ::Unicorn::HttpServer.class_eval do
-          alias worker_loop_without_appsignal worker_loop
-
-          def worker_loop(worker)
-            Appsignal.forked
-            worker_loop_without_appsignal(worker)
-          end
-        end
-
-        ::Unicorn::Worker.class_eval do
-          alias close_without_appsignal close
-
-          def close
-            Appsignal.stop("unicorn")
-            close_without_appsignal
-          end
-        end
+        require "appsignal/integrations/unicorn"
+        ::Unicorn::HttpServer.send(:prepend, Appsignal::Integrations::UnicornIntegration::Server)
+        ::Unicorn::Worker.send(:prepend, Appsignal::Integrations::UnicornIntegration::Worker)
       end
     end
   end

--- a/lib/appsignal/hooks/webmachine.rb
+++ b/lib/appsignal/hooks/webmachine.rb
@@ -12,13 +12,7 @@ module Appsignal
 
       def install
         require "appsignal/integrations/webmachine"
-        ::Webmachine::Decision::FSM.class_eval do
-          include Appsignal::Integrations::WebmachinePlugin::FSM
-          alias run_without_appsignal run
-          alias run run_with_appsignal
-          alias handle_exceptions_without_appsignal handle_exceptions
-          alias handle_exceptions handle_exceptions_with_appsignal
-        end
+        ::Webmachine::Decision::FSM.send(:prepend, Appsignal::Integrations::WebmachineIntegration)
       end
     end
   end

--- a/lib/appsignal/integrations/action_cable.rb
+++ b/lib/appsignal/integrations/action_cable.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Appsignal
+  module Integrations
+    module ActionCableIntegration
+      def perform_action(*args, &block)
+        # The request is only the original websocket request
+        env = connection.env
+        request = ActionDispatch::Request.new(env)
+        env[Appsignal::Hooks::ActionCableHook::REQUEST_ID] ||=
+          request.request_id || SecureRandom.uuid
+
+        transaction = Appsignal::Transaction.create(
+          env[Appsignal::Hooks::ActionCableHook::REQUEST_ID],
+          Appsignal::Transaction::ACTION_CABLE,
+          request
+        )
+
+        begin
+          super
+        rescue Exception => exception # rubocop:disable Lint/RescueException
+          transaction.set_error(exception)
+          raise exception
+        ensure
+          transaction.params = args.first
+          transaction.set_action_if_nil("#{self.class}##{args.first["action"]}")
+          transaction.set_metadata("path", request.path)
+          transaction.set_metadata("method", "websocket")
+          Appsignal::Transaction.complete_current!
+        end
+      end
+    end
+  end
+end

--- a/lib/appsignal/integrations/active_support_notifications.rb
+++ b/lib/appsignal/integrations/active_support_notifications.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Appsignal
+  module Integrations
+    module ActiveSupportNotificationsIntegration
+      BANG = "!".freeze
+
+      module InstrumentIntegration
+        def instrument(name, payload = {}, &block)
+          # Events that start with a bang are internal to Rails
+          instrument_this = name[0] != ActiveSupportNotificationsIntegration::BANG
+
+          Appsignal::Transaction.current.start_event if instrument_this
+
+          super
+        ensure
+          if instrument_this
+            title, body, body_format = Appsignal::EventFormatter.format(name, payload)
+            Appsignal::Transaction.current.finish_event(
+              name.to_s,
+              title,
+              body,
+              body_format
+            )
+          end
+        end
+      end
+
+      module StartFinishIntegration
+        def start(name, payload = {})
+          # Events that start with a bang are internal to Rails
+          instrument_this = name[0] != ActiveSupportNotificationsIntegration::BANG
+
+          Appsignal::Transaction.current.start_event if instrument_this
+
+          super
+        end
+
+        def finish(name, payload = {})
+          # Events that start with a bang are internal to Rails
+          instrument_this = name[0] != ActiveSupportNotificationsIntegration::BANG
+
+          if instrument_this
+            title, body, body_format = Appsignal::EventFormatter.format(name, payload)
+            Appsignal::Transaction.current.finish_event(
+              name.to_s,
+              title,
+              body,
+              body_format
+            )
+          end
+
+          super
+        end
+      end
+
+      module FinishStateIntegration
+        def finish_with_state(listeners_state, name, payload = {})
+          # Events that start with a bang are internal to Rails
+          instrument_this = name[0] != ActiveSupportNotificationsIntegration::BANG
+
+          if instrument_this
+            title, body, body_format = Appsignal::EventFormatter.format(name, payload)
+            Appsignal::Transaction.current.finish_event(
+              name.to_s,
+              title,
+              body,
+              body_format
+            )
+          end
+
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/appsignal/integrations/net_http.rb
+++ b/lib/appsignal/integrations/net_http.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Appsignal
+  module Integrations
+    module NetHttpIntegration
+      def request(request, body = nil, &block)
+        Appsignal.instrument(
+          "request.net_http",
+          "#{request.method} #{use_ssl? ? "https" : "http"}://#{request["host"] || address}"
+        ) do
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/appsignal/integrations/que.rb
+++ b/lib/appsignal/integrations/que.rb
@@ -3,42 +3,35 @@
 module Appsignal
   module Integrations
     module QuePlugin
-      def self.included(base)
-        base.class_eval do
-          def _run_with_appsignal(*)
-            local_attrs = respond_to?(:que_attrs) ? que_attrs : attrs
-            env = {
-              :metadata    => {
-                :id        => local_attrs[:job_id] || local_attrs[:id],
-                :queue     => local_attrs[:queue],
-                :run_at    => local_attrs[:run_at].to_s,
-                :priority  => local_attrs[:priority],
-                :attempts  => local_attrs[:error_count].to_i
-              },
-              :params => local_attrs[:args]
-            }
+      def _run(*)
+        local_attrs = respond_to?(:que_attrs) ? que_attrs : attrs
+        env = {
+          :metadata    => {
+            :id        => local_attrs[:job_id] || local_attrs[:id],
+            :queue     => local_attrs[:queue],
+            :run_at    => local_attrs[:run_at].to_s,
+            :priority  => local_attrs[:priority],
+            :attempts  => local_attrs[:error_count].to_i
+          },
+          :params => local_attrs[:args]
+        }
 
-            request = Appsignal::Transaction::GenericRequest.new(env)
+        request = Appsignal::Transaction::GenericRequest.new(env)
 
-            transaction = Appsignal::Transaction.create(
-              SecureRandom.uuid,
-              Appsignal::Transaction::BACKGROUND_JOB,
-              request
-            )
+        transaction = Appsignal::Transaction.create(
+          SecureRandom.uuid,
+          Appsignal::Transaction::BACKGROUND_JOB,
+          request
+        )
 
-            begin
-              Appsignal.instrument("perform_job.que") { _run_without_appsignal }
-            rescue Exception => error # rubocop:disable Lint/RescueException
-              transaction.set_error(error)
-              raise error
-            ensure
-              transaction.set_action_if_nil "#{local_attrs[:job_class]}#run"
-              Appsignal::Transaction.complete_current!
-            end
-          end
-
-          alias_method :_run_without_appsignal, :_run
-          alias_method :_run, :_run_with_appsignal
+        begin
+          Appsignal.instrument("perform_job.que") { super }
+        rescue Exception => error # rubocop:disable Lint/RescueException
+          transaction.set_error(error)
+          raise error
+        ensure
+          transaction.set_action_if_nil "#{local_attrs[:job_class]}#run"
+          Appsignal::Transaction.complete_current!
         end
       end
     end

--- a/lib/appsignal/integrations/rake.rb
+++ b/lib/appsignal/integrations/rake.rb
@@ -1,4 +1,28 @@
 # frozen_string_literal: true
 
-# Since version 1.0 requiring this file is not necessary anymore to get
-# Rake integration, it's just here for backward compatibility.
+module Appsignal
+  module Integrations
+    module RakeIntegration
+      def execute(*args)
+        super
+      rescue Exception => error # rubocop:disable Lint/RescueException
+        # Format given arguments and cast to hash if possible
+        params, _ = args
+        params = params.to_hash if params.respond_to?(:to_hash)
+
+        transaction = Appsignal::Transaction.create(
+          SecureRandom.uuid,
+          Appsignal::Transaction::BACKGROUND_JOB,
+          Appsignal::Transaction::GenericRequest.new(
+            :params => params
+          )
+        )
+        transaction.set_action(name)
+        transaction.set_error(error)
+        transaction.complete
+        Appsignal.stop("rake")
+        raise error
+      end
+    end
+  end
+end

--- a/lib/appsignal/integrations/redis.rb
+++ b/lib/appsignal/integrations/redis.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Appsignal
+  module Integrations
+    module RedisIntegration
+      def process(commands, &block)
+        sanitized_commands = commands.map do |command, *args|
+          "#{command}#{" ?" * args.size}"
+        end.join("\n")
+
+        Appsignal.instrument "query.redis", id, sanitized_commands do
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/appsignal/integrations/resque.rb
+++ b/lib/appsignal/integrations/resque.rb
@@ -17,3 +17,50 @@ module Appsignal
     end
   end
 end
+
+module Appsignal
+  module Integrations
+    # @api private
+    module ResqueIntegration
+      def perform
+        transaction = Appsignal::Transaction.create(
+          SecureRandom.uuid,
+          Appsignal::Transaction::BACKGROUND_JOB,
+          Appsignal::Transaction::GenericRequest.new({})
+        )
+
+        Appsignal.instrument "perform.resque" do
+          super
+        end
+      rescue Exception => exception # rubocop:disable Lint/RescueException
+        transaction.set_error(exception)
+        raise exception
+      ensure
+        if transaction
+          transaction.set_action_if_nil("#{payload["class"]}#perform")
+          args =
+            Appsignal::Utils::HashSanitizer.sanitize(
+              ResqueHelpers.arguments(payload),
+              Appsignal.config[:filter_parameters]
+            )
+          transaction.params = args if args
+          transaction.set_tags("queue" => queue)
+
+          Appsignal::Transaction.complete_current!
+        end
+        Appsignal.stop("resque")
+      end
+    end
+
+    class ResqueHelpers
+      def self.arguments(payload)
+        case payload["class"]
+        when "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper"
+          nil # Set in the ActiveJob integration
+        else
+          payload["args"]
+        end
+      end
+    end
+  end
+end

--- a/lib/appsignal/integrations/unicorn.rb
+++ b/lib/appsignal/integrations/unicorn.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Appsignal
+  module Integrations
+    module UnicornIntegration
+      # Make sure that appsignal is started and the last transaction
+      # in a worker gets flushed.
+      #
+      # We'd love to be able to hook this into Unicorn in a less
+      # intrusive way, but this is the best we can do given the
+      # options we have.
+
+      module Server
+        def worker_loop(worker)
+          Appsignal.forked
+          super
+        end
+      end
+
+      module Worker
+        def close
+          Appsignal.stop("unicorn")
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/appsignal/integrations/webmachine.rb
+++ b/lib/appsignal/integrations/webmachine.rb
@@ -3,35 +3,33 @@
 module Appsignal
   module Integrations
     # @api private
-    module WebmachinePlugin
-      module FSM
-        def run_with_appsignal
-          transaction = Appsignal::Transaction.create(
-            SecureRandom.uuid,
-            Appsignal::Transaction::HTTP_REQUEST,
-            request,
-            :params_method => :query
-          )
+    module WebmachineIntegration
+      def run
+        transaction = Appsignal::Transaction.create(
+          SecureRandom.uuid,
+          Appsignal::Transaction::HTTP_REQUEST,
+          request,
+          :params_method => :query
+        )
 
-          transaction.set_action_if_nil("#{resource.class.name}##{request.method}")
+        transaction.set_action_if_nil("#{resource.class.name}##{request.method}")
 
-          Appsignal.instrument("process_action.webmachine") do
-            run_without_appsignal
-          end
-
-          Appsignal::Transaction.complete_current!
+        Appsignal.instrument("process_action.webmachine") do
+          super
         end
 
-        private
+        Appsignal::Transaction.complete_current!
+      end
 
-        def handle_exceptions_with_appsignal
-          handle_exceptions_without_appsignal do
-            begin
-              yield
-            rescue Exception => e # rubocop:disable Lint/RescueException
-              Appsignal.set_error(e)
-              raise e
-            end
+      private
+
+      def handle_exceptions
+        super do
+          begin
+            yield
+          rescue Exception => e # rubocop:disable Lint/RescueException
+            Appsignal.set_error(e)
+            raise e
           end
         end
       end

--- a/spec/lib/appsignal/hooks/celluloid_spec.rb
+++ b/spec/lib/appsignal/hooks/celluloid_spec.rb
@@ -23,7 +23,7 @@ describe Appsignal::Hooks::CelluloidHook do
     end
 
     specify { expect(Appsignal).to receive(:stop) }
-    specify { expect(Celluloid.shut_down?).to be true}
+    specify { expect(Celluloid.shut_down?).to be true }
 
     after do
       Celluloid.shutdown

--- a/spec/lib/appsignal/hooks/celluloid_spec.rb
+++ b/spec/lib/appsignal/hooks/celluloid_spec.rb
@@ -3,6 +3,11 @@ describe Appsignal::Hooks::CelluloidHook do
     before :context do
       module Celluloid
         def self.shutdown
+          @shut_down = true
+        end
+
+        def self.shut_down?
+          @shut_down == true
         end
       end
       Appsignal::Hooks::CelluloidHook.new.install
@@ -18,7 +23,7 @@ describe Appsignal::Hooks::CelluloidHook do
     end
 
     specify { expect(Appsignal).to receive(:stop) }
-    specify { expect(Celluloid).to receive(:shutdown_without_appsignal) }
+    specify { expect(Celluloid.shut_down?).to be true}
 
     after do
       Celluloid.shutdown

--- a/spec/lib/appsignal/hooks/rake_spec.rb
+++ b/spec/lib/appsignal/hooks/rake_spec.rb
@@ -20,8 +20,7 @@ describe Appsignal::Hooks::RakeHook do
       end
 
       it "calls the original task" do
-        expect(task).to receive(:execute_without_appsignal).with(arguments)
-        perform
+        expect(perform).to eq([])
       end
     end
 

--- a/spec/lib/appsignal/hooks/unicorn_spec.rb
+++ b/spec/lib/appsignal/hooks/unicorn_spec.rb
@@ -3,7 +3,7 @@ describe Appsignal::Hooks::UnicornHook do
     before :context do
       module Unicorn
         class HttpServer
-          def worker_loop(worker)
+          def worker_loop(_worker)
             @worker_loop = true
           end
 

--- a/spec/lib/appsignal/hooks/unicorn_spec.rb
+++ b/spec/lib/appsignal/hooks/unicorn_spec.rb
@@ -4,11 +4,21 @@ describe Appsignal::Hooks::UnicornHook do
       module Unicorn
         class HttpServer
           def worker_loop(worker)
+            @worker_loop = true
+          end
+
+          def worker_loop?
+            @worker_loop == true
           end
         end
 
         class Worker
           def close
+            @close = true
+          end
+
+          def close?
+            @close == true
           end
         end
       end
@@ -27,18 +37,19 @@ describe Appsignal::Hooks::UnicornHook do
       worker = double
 
       expect(Appsignal).to receive(:forked)
-      expect(server).to receive(:worker_loop_without_appsignal).with(worker)
 
       server.worker_loop(worker)
+
+      expect(server.worker_loop?).to be true
     end
 
     it "adds behavior to Unicorn::Worker#close" do
       worker = Unicorn::Worker.new
 
       expect(Appsignal).to receive(:stop)
-      expect(worker).to receive(:close_without_appsignal)
 
       worker.close
+      expect(worker.close?).to be true
     end
   end
 

--- a/spec/lib/appsignal/hooks/webmachine_spec.rb
+++ b/spec/lib/appsignal/hooks/webmachine_spec.rb
@@ -10,19 +10,8 @@ describe Appsignal::Hooks::WebmachineHook do
         it { is_expected.to be_truthy }
       end
 
-      it "should include the run alias methods" do
-        expect(fsm).to respond_to(:run_with_appsignal)
-        expect(fsm).to respond_to(:run_without_appsignal)
-      end
-
-      it "should include the handle_exceptions alias methods" do
-        expect(
-          fsm.respond_to?(:handle_exceptions_with_appsignal, true)
-        ).to be_truthy
-
-        expect(
-          fsm.respond_to?(:handle_exceptions_without_appsignal, true)
-        ).to be_truthy
+      it "adds behavior to Webmachine::Decision::FSM" do
+        expect(fsm.class.ancestors.first).to eq(Appsignal::Integrations::WebmachineIntegration)
       end
     end
   else

--- a/spec/lib/appsignal/integrations/padrino_spec.rb
+++ b/spec/lib/appsignal/integrations/padrino_spec.rb
@@ -150,10 +150,9 @@ if DependencyHelper.padrino_present?
             let(:path) { "/static" }
             before do
               env["sinatra.static_file"] = true
-              expect_any_instance_of(app)
-                .to receive(:route_without_appsignal).and_return([200, {}, ["foo"]])
+              app.controllers { get(:static) { "Static!" } }
             end
-            after { expect(response).to match_response(200, "foo") }
+            after { expect(response).to match_response(200, "Static!") }
 
             it "does not instrument the request" do
               expect_no_transaction_to_be_created


### PR DESCRIPTION
Rebased PR of #676, fixed merge conflicts, fixed padrino specs, fixed rubocop errors.

I had to reapply the ActiveSupport::Notiifications refactor to also work for #663. I merged that into the original "Switch to using Module.prepend instead of method aliasing in activesupport notifications hook" commit as that's when the merge conflict happened.