### PR TITLE
Support batched Shoryuken workers 

### DIFF
--- a/lib/appsignal/hooks/shoryuken.rb
+++ b/lib/appsignal/hooks/shoryuken.rb
@@ -5,21 +5,60 @@ module Appsignal
     # @api private
     class ShoryukenMiddleware
       def call(worker_instance, queue, sqs_msg, body)
-        metadata = { :queue => queue }.merge(sqs_msg.attributes)
+        batch = sqs_msg.is_a?(Array)
+        attributes =
+          if batch
+            # We can't instrument batched message separately, the `yield` will
+            # perform all the batched messages.
+            # To provide somewhat useful metadata, Get first message based on
+            # SentTimestamp, and use its attributes as metadata for the
+            # transaction. We can't combine them all because then they would
+            # overwrite each other and the last message (in an sorted order)
+            # would be used as the source of the metadata.  With the
+            # oldest/first message at least some useful information is stored
+            # such as the first received time and the number of retries for the
+            # first message. The newer message should have lower values and
+            # timestamps in their metadata.
+            first_msg = sqs_msg.min do |a, b|
+              a.attributes["SentTimestamp"].to_i <=> b.attributes["SentTimestamp"].to_i
+            end
+            # Add batch => true metadata so people can recognize when a
+            # transaction is about a batch of messages.
+            first_msg.attributes.merge(:batch => true)
+          else
+            sqs_msg.attributes.merge(:message_id => sqs_msg.message_id)
+          end
+        metadata = { :queue => queue }.merge(attributes)
         options = {
           :class => worker_instance.class.name,
           :method => "perform",
           :metadata => metadata
         }
 
-        args = body.is_a?(Hash) ? body : { :params => body }
+        args =
+          if batch
+            bodies = {}
+            sqs_msg.each_with_index do |msg, index|
+              # Store all separate bodies on a hash with the key being the
+              # message_id
+              bodies[msg.message_id] = body[index]
+            end
+            bodies
+          else
+            case body
+            when Hash
+              body
+            else
+              { :params => body }
+            end
+          end
         options[:params] = Appsignal::Utils::HashSanitizer.sanitize(
           args,
           Appsignal.config[:filter_parameters]
         )
 
-        if sqs_msg.attributes.key?("SentTimestamp")
-          options[:queue_start] = Time.at(sqs_msg.attributes["SentTimestamp"].to_i / 1000)
+        if attributes.key?("SentTimestamp")
+          options[:queue_start] = Time.at(attributes["SentTimestamp"].to_i / 1000)
         end
 
         Appsignal.monitor_transaction("perform_job.shoryuken", options) do

--- a/spec/lib/appsignal/hooks/shoryuken_spec.rb
+++ b/spec/lib/appsignal/hooks/shoryuken_spec.rb
@@ -9,9 +9,11 @@ describe Appsignal::Hooks::ShoryukenMiddleware do
   let(:sqs_msg) { double(:attributes => {}) }
   let(:body) { {} }
 
+  before :context do
+    start_agent
+  end
   before do
     allow(Appsignal::Transaction).to receive(:current).and_return(current_transaction)
-    start_agent
   end
 
   context "with a performance call" do

--- a/spec/lib/appsignal/hooks/shoryuken_spec.rb
+++ b/spec/lib/appsignal/hooks/shoryuken_spec.rb
@@ -4,8 +4,8 @@ describe Appsignal::Hooks::ShoryukenMiddleware do
 
   let(:time) { "2010-01-01 10:01:00UTC" }
   let(:worker_instance) { DemoShoryukenWorker.new }
-  let(:queue) { double }
-  let(:sqs_msg) { double(:attributes => {}) }
+  let(:queue) { "some-funky-queue-name" }
+  let(:sqs_msg) { double(:message_id => "msg1", :attributes => {}) }
   let(:body) { {} }
   before(:context) { start_agent }
   around { |example| keep_transactions { example.run } }
@@ -24,10 +24,9 @@ describe Appsignal::Hooks::ShoryukenMiddleware do
   end
 
   context "with a performance call" do
-    let(:queue) { "some-funky-queue-name" }
     let(:sent_timestamp) { Time.parse("1976-11-18 0:00:00UTC").to_i * 1000 }
     let(:sqs_msg) do
-      double(:attributes => { "SentTimestamp" => sent_timestamp })
+      double(:message_id => "msg1", :attributes => { "SentTimestamp" => sent_timestamp })
     end
 
     context "with complex argument" do
@@ -63,6 +62,7 @@ describe Appsignal::Hooks::ShoryukenMiddleware do
         expect(transaction_hash["sample_data"]).to include(
           "params" => { "foo" => "Foo", "bar" => "Bar" },
           "metadata" => {
+            "message_id" => "msg1",
             "queue" => queue,
             "SentTimestamp" => sent_timestamp
           }
@@ -74,6 +74,9 @@ describe Appsignal::Hooks::ShoryukenMiddleware do
         before do
           Appsignal.config = project_fixture_config("production")
           Appsignal.config[:filter_parameters] = ["foo"]
+        end
+        after do
+          Appsignal.config[:filter_parameters] = []
         end
 
         it "filters selected arguments" do
@@ -135,6 +138,72 @@ describe Appsignal::Hooks::ShoryukenMiddleware do
           "backtrace" => kind_of(String)
         }
       )
+    end
+  end
+
+  context "with batched jobs" do
+    let(:sqs_msg) do
+      [
+        double(
+          :message_id => "msg2",
+          :attributes => { "SentTimestamp" => (Time.parse("1976-11-18 01:00:00UTC").to_i * 1000).to_s }
+        ),
+        double(
+          :message_id => "msg1",
+          :attributes => { "SentTimestamp" => sent_timestamp.to_s }
+        )
+      ]
+    end
+    let(:body) do
+      [
+        "foo bar",
+        { :id => "123", :foo => "Foo", :bar => "Bar" }
+      ]
+    end
+    let(:sent_timestamp) { Time.parse("1976-11-18 01:00:00UTC").to_i * 1000 }
+
+    it "creates a transaction for the batch" do
+      allow_any_instance_of(Appsignal::Transaction).to receive(:set_queue_start).and_call_original
+      expect do
+        perform_job {}
+      end.to change { created_transactions.length }.by(1)
+
+      transaction = last_transaction
+      expect(transaction).to be_completed
+      transaction_hash = transaction.to_h
+      expect(transaction_hash).to include(
+        "action" => "DemoShoryukenWorker#perform",
+        "id" => kind_of(String), # AppSignal generated id
+        "namespace" => Appsignal::Transaction::BACKGROUND_JOB,
+        "error" => nil
+      )
+      expect(transaction_hash["events"].first).to include(
+        "allocation_count" => kind_of(Integer),
+        "body" => "",
+        "body_format" => Appsignal::EventFormatter::DEFAULT,
+        "child_allocation_count" => kind_of(Integer),
+        "child_duration" => kind_of(Float),
+        "child_gc_duration" => kind_of(Float),
+        "count" => 1,
+        "gc_duration" => kind_of(Float),
+        "start" => kind_of(Float),
+        "duration" => kind_of(Float),
+        "name" => "perform_job.shoryuken",
+        "title" => ""
+      )
+      expect(transaction_hash["sample_data"]).to include(
+        "params" => {
+          "msg2" => "foo bar",
+          "msg1" => { "id" => "123", "foo" => "Foo", "bar" => "Bar" }
+        },
+        "metadata" => {
+          "batch" => true,
+          "queue" => "some-funky-queue-name",
+          "SentTimestamp" => sent_timestamp.to_s # Earliest/oldest timestamp from messages
+        }
+      )
+      # Queue time based on earliest/oldest timestamp from messages
+      expect(transaction).to have_received(:set_queue_start).with(sent_timestamp)
     end
   end
 end


### PR DESCRIPTION
## Support batched Shoryuken workers

When a worker would receive a batch of messages it would try to
instrument it as a single message. The `sqs_msg` and the `body`
parameters would be Arrays instead of single objects.
This caused the error reported in #661. Closes #661.

To solve this, parse the collection of messages and message bodies as
Arrays when a batch is detected.

Only store the metadata from the first/oldest message, because we can't
store them all as metadata, they would overwrite each other.

The message bodies are stored on the transaction as a Hash with every
key being the message id of the message part of the batch. This way
people can tell apart which parameters belong to which message.

```
{
  "msg1" => "params of message 1", # String or JSON parsed hash
  "msg2" => "params of message 2"
}
```

For non-batched message the `message_id` is added to the transaction
metadata, but not for batched messages because we can't store multiple
values for the `message_id` metadata.

## Rewrite Shoryuken specs to use Transaction#to_h

Update to new spec style to use the testing helpers rather than
asserting if certain methods are called or not.

## Move start_agent in Shoryuken to before :context

If it's called on every spec in the `before` block I can't run the specs
individually. Since we only need to call this `start_agent` method once,
move it to a `before :context` block.
