### PR TITLE
Remove Ruby 1.9 specific spec and helpers

### DIFF
--- a/spec/lib/appsignal/auth_check_spec.rb
+++ b/spec/lib/appsignal/auth_check_spec.rb
@@ -39,7 +39,7 @@ describe Appsignal::AuthCheck do
       end
     end
 
-    context "when encountering an exception", :not_ruby19 do
+    context "when encountering an exception" do
       before { stubbed_request.to_timeout }
 
       it "raises an error" do

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -640,7 +640,7 @@ describe Appsignal::Transaction do
       end
 
       context "when the data cannot be converted to JSON" do
-        it "does not update the sample data on the transaction", :not_ruby19 do
+        it "does not update the sample data on the transaction" do
           klass = Class.new do
             def to_s
               raise "foo" # Cause a deliberate error
@@ -651,19 +651,6 @@ describe Appsignal::Transaction do
           expect(transaction.to_h["sample_data"]).to eq({})
           expect(log_contents(log)).to contains_log :error,
             "Error generating data (RuntimeError: foo) for"
-        end
-
-        it "does not update the sample data on the transaction", :only_ruby19 do
-          klass = Class.new do
-            def to_s
-              raise "foo" # Cause a deliberate error
-            end
-          end
-          transaction.set_sample_data("params", klass.new => 1)
-
-          expect(transaction.to_h["sample_data"]).to eq({})
-          expect(log_contents(log)).to contains_log :error,
-            "Error generating data (RuntimeError: foo). Can't inspect data."
         end
       end
     end

--- a/spec/lib/appsignal/transmitter_spec.rb
+++ b/spec/lib/appsignal/transmitter_spec.rb
@@ -143,7 +143,7 @@ describe Appsignal::Transmitter do
     context "with a proxy" do
       let(:config) { project_fixture_config("production", :http_proxy => "http://localhost:8080") }
 
-      it "is of Net::HTTP class", :not_ruby19 do
+      it "is of Net::HTTP class" do
         expect(subject).to be_instance_of(Net::HTTP)
       end
       it { expect(subject.proxy?).to be_truthy }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -85,20 +85,6 @@ RSpec.configure do |config|
     FileUtils.mkdir_p(spec_system_tmp_dir)
   end
 
-  config.before :each, :only_ruby19 => true do
-    is_ruby19 = Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.0.0")
-    next if is_ruby19
-
-    skip "Skipping spec. Only for Ruby 1.9"
-  end
-
-  config.before :each, :not_ruby19 => true do
-    is_ruby19 = Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.0.0")
-    next unless is_ruby19
-
-    skip "Skipping spec for Ruby 1.9"
-  end
-
   config.before do
     stop_minutely_probes
     ENV["RAILS_ENV"] ||= "test"


### PR DESCRIPTION
Now that we have dropped Ruby 1.9 support, remove specs for Ruby 1.9 and
the helpers to only make it run on Ruby 1.9.

[skip review]