### PR TITLE
Remove ruby-build pull exception

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -31,7 +31,6 @@ global_job_config:
   prologue:
     commands:
     - checkout
-    - git -C /home/semaphore/.rbenv/plugins/ruby-build pull
     - sem-version ruby $RUBY_VERSION
     - "./support/check_versions"
     - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -32,7 +32,6 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
     prologue:
       commands:
         - checkout
-        - git -C /home/semaphore/.rbenv/plugins/ruby-build pull
         - sem-version ruby $RUBY_VERSION
         - ./support/check_versions
         - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)


### PR DESCRIPTION
Now that Semaphore says they support Ruby 3.0 out of the box, remove the
extra ruby-build pull to update ruby-build.

[skip review]