### PR TITLE
Remove rbenv gem-rehash plugin

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -31,7 +31,6 @@ global_job_config:
   prologue:
     commands:
     - checkout
-    - git -C /home/semaphore/.rbenv/plugins/ruby-build pull
     - sem-version ruby $RUBY_VERSION
     - "./support/check_versions"
     - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -31,6 +31,7 @@ global_job_config:
   prologue:
     commands:
     - checkout
+    - rm -f $HOME/.rbenv/plugins/rbenv-gem-rehash/etc/rbenv.d/exec/~gem-rehash.bash
     - sem-version ruby $RUBY_VERSION
     - "./support/check_versions"
     - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -32,6 +32,7 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
     prologue:
       commands:
         - checkout
+        - rm -f $HOME/.rbenv/plugins/rbenv-gem-rehash/etc/rbenv.d/exec/~gem-rehash.bash
         - sem-version ruby $RUBY_VERSION
         - ./support/check_versions
         - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -32,7 +32,6 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
     prologue:
       commands:
         - checkout
-        - git -C /home/semaphore/.rbenv/plugins/ruby-build pull
         - sem-version ruby $RUBY_VERSION
         - ./support/check_versions
         - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)


### PR DESCRIPTION
It's already installed. rbenv doctor gives a warning that it's part of
the main rbenv release now. The duplicate behavior could be causing some
issues with `rbenv rehash` during `bundle install`. It sometimes fails
with this message:

```
rbenv: cannot rehash: /home/semaphore/.rbenv/shims/.rbenv-shim exists
...
post_install hook at
/home/semaphore/.rbenv/plugins/rbenv-gem-rehash/rubygems_plugin.rb:1 failed for
appsignal-2.11.2
```

---

Also includes cherry-picked #689 commit.

[skip review]