### PR TITLE
Forward keyword arguments on Ruby 2.7 and 3.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,8 @@ AllCops:
     - "gemfiles/vendor/**/*"
     - "vendor/**/*"
     - "benchmark.rake"
+    - "lib/appsignal/integrations/object_ruby_modern.rb"
+    - "spec/lib/appsignal/integrations/object_spec.rb"
   DisplayCopNames: true
   UseCache: true
   CacheRootDirectory: ./tmp

--- a/Rakefile
+++ b/Rakefile
@@ -374,19 +374,21 @@ end
 begin
   require "rspec/core/rake_task"
   is_jruby = defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
-  unless is_jruby
-    jruby_opts = "--exclude-pattern=spec/lib/appsignal/extension/jruby_spec.rb"
-  end
+  excludes = []
+  excludes << "spec/lib/appsignal/extension/jruby_spec.rb" unless is_jruby
+  is_ruby19 = RUBY_VERSION < "2.0"
+  excludes << "spec/lib/appsignal/integrations/object_spec.rb" if is_ruby19
+  exclude_pattern = "--exclude-pattern=#{excludes.join(",")}" if excludes.any?
 
   desc "Run the AppSignal gem test suite."
   RSpec::Core::RakeTask.new :test do |t|
-    t.rspec_opts = jruby_opts
+    t.rspec_opts = exclude_pattern
   end
 
   namespace :test do
     desc "Run the Appsignal gem test in an extension failure scenario"
     RSpec::Core::RakeTask.new :failure do |t|
-      t.rspec_opts = "#{jruby_opts} --tag extension_installation_failure"
+      t.rspec_opts = "#{exclude_pattern} --tag extension_installation_failure"
     end
   end
 rescue LoadError # rubocop:disable Lint/HandleExceptions

--- a/lib/appsignal/integrations/object.rb
+++ b/lib/appsignal/integrations/object.rb
@@ -4,38 +4,8 @@ if defined?(Appsignal)
   Appsignal::Environment.report_enabled("object_instrumentation")
 end
 
-class Object
-  def self.appsignal_instrument_class_method(method_name, options = {})
-    singleton_class.send \
-      :alias_method, "appsignal_uninstrumented_#{method_name}", method_name
-    singleton_class.send(:define_method, method_name) do |*args, &block|
-      name = options.fetch(:name) do
-        "#{method_name}.class_method.#{appsignal_reverse_class_name}.other"
-      end
-      Appsignal.instrument name do
-        send "appsignal_uninstrumented_#{method_name}", *args, &block
-      end
-    end
-  end
-
-  def self.appsignal_instrument_method(method_name, options = {})
-    alias_method "appsignal_uninstrumented_#{method_name}", method_name
-    define_method method_name do |*args, &block|
-      name = options.fetch(:name) do
-        "#{method_name}.#{appsignal_reverse_class_name}.other"
-      end
-      Appsignal.instrument name do
-        send "appsignal_uninstrumented_#{method_name}", *args, &block
-      end
-    end
-  end
-
-  def self.appsignal_reverse_class_name
-    return "AnonymousClass" unless name
-    name.split("::").reverse.join(".")
-  end
-
-  def appsignal_reverse_class_name
-    self.class.appsignal_reverse_class_name
-  end
+if RUBY_VERSION < "2.0"
+  require "appsignal/integrations/object_ruby_19"
+else
+  require "appsignal/integrations/object_ruby_modern"
 end

--- a/lib/appsignal/integrations/object_ruby_19.rb
+++ b/lib/appsignal/integrations/object_ruby_19.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class Object
+  def self.appsignal_instrument_class_method(method_name, options = {})
+    singleton_class.send \
+      :alias_method, "appsignal_uninstrumented_#{method_name}", method_name
+    singleton_class.send(:define_method, method_name) do |*args, &block|
+      name = options.fetch(:name) do
+        "#{method_name}.class_method.#{appsignal_reverse_class_name}.other"
+      end
+      Appsignal.instrument name do
+        send "appsignal_uninstrumented_#{method_name}", *args, &block
+      end
+    end
+  end
+
+  def self.appsignal_instrument_method(method_name, options = {})
+    alias_method "appsignal_uninstrumented_#{method_name}", method_name
+    define_method method_name do |*args, &block|
+      name = options.fetch(:name) do
+        "#{method_name}.#{appsignal_reverse_class_name}.other"
+      end
+      Appsignal.instrument name do
+        send "appsignal_uninstrumented_#{method_name}", *args, &block
+      end
+    end
+  end
+
+  def self.appsignal_reverse_class_name
+    return "AnonymousClass" unless name
+    name.split("::").reverse.join(".")
+  end
+
+  def appsignal_reverse_class_name
+    self.class.appsignal_reverse_class_name
+  end
+end

--- a/lib/appsignal/integrations/object_ruby_modern.rb
+++ b/lib/appsignal/integrations/object_ruby_modern.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+class Object
+  if Appsignal::System.ruby_2_7_or_newer?
+    def self.appsignal_instrument_class_method(method_name, options = {})
+      singleton_class.send \
+        :alias_method, "appsignal_uninstrumented_#{method_name}", method_name
+      singleton_class.send(:define_method, method_name) do |*args, **kwargs, &block|
+        name = options.fetch(:name) do
+          "#{method_name}.class_method.#{appsignal_reverse_class_name}.other"
+        end
+        Appsignal.instrument name do
+          send "appsignal_uninstrumented_#{method_name}", *args, **kwargs, &block
+        end
+      end
+    end
+
+    def self.appsignal_instrument_method(method_name, options = {})
+      alias_method "appsignal_uninstrumented_#{method_name}", method_name
+      define_method method_name do |*args, **kwargs, &block|
+        name = options.fetch(:name) do
+          "#{method_name}.#{appsignal_reverse_class_name}.other"
+        end
+        Appsignal.instrument name do
+          send "appsignal_uninstrumented_#{method_name}", *args, **kwargs, &block
+        end
+      end
+    end
+  else
+    def self.appsignal_instrument_class_method(method_name, options = {})
+      singleton_class.send \
+        :alias_method, "appsignal_uninstrumented_#{method_name}", method_name
+      singleton_class.send(:define_method, method_name) do |*args, &block|
+        name = options.fetch(:name) do
+          "#{method_name}.class_method.#{appsignal_reverse_class_name}.other"
+        end
+        Appsignal.instrument name do
+          send "appsignal_uninstrumented_#{method_name}", *args, &block
+        end
+      end
+    end
+
+    def self.appsignal_instrument_method(method_name, options = {})
+      alias_method "appsignal_uninstrumented_#{method_name}", method_name
+      define_method method_name do |*args, &block|
+        name = options.fetch(:name) do
+          "#{method_name}.#{appsignal_reverse_class_name}.other"
+        end
+        Appsignal.instrument name do
+          send "appsignal_uninstrumented_#{method_name}", *args, &block
+        end
+      end
+    end
+  end
+
+  def self.appsignal_reverse_class_name
+    return "AnonymousClass" unless name
+    name.split("::").reverse.join(".")
+  end
+
+  def appsignal_reverse_class_name
+    self.class.appsignal_reverse_class_name
+  end
+end

--- a/lib/appsignal/system.rb
+++ b/lib/appsignal/system.rb
@@ -79,5 +79,9 @@ module Appsignal
     def self.jruby?
       RUBY_PLATFORM == "java"
     end
+
+    def self.ruby_2_7_or_newer?
+      RUBY_VERSION > "2.7"
+    end
   end
 end

--- a/spec/lib/appsignal/integrations/object_19_spec.rb
+++ b/spec/lib/appsignal/integrations/object_19_spec.rb
@@ -9,8 +9,8 @@ describe Object do
     context "with instance method" do
       let(:klass) do
         Class.new do
-          def foo(param1, options = {}, keyword_param: 1)
-            [param1, options, keyword_param]
+          def foo(param1, options = {})
+            [param1, options]
           end
           appsignal_instrument_method :foo
         end
@@ -20,8 +20,7 @@ describe Object do
       def call_with_arguments
         instance.foo(
           "abc",
-          { :foo => "bar" },
-          :keyword_param => 2
+          :foo => "bar"
         )
       end
 
@@ -39,7 +38,7 @@ describe Object do
             expect(transaction).to receive(:start_event)
             expect(transaction).to receive(:finish_event).with \
               "foo.AnonymousClass.other", nil, nil, Appsignal::EventFormatter::DEFAULT
-            expect(call_with_arguments).to eq(["abc", { :foo => "bar" }, 2])
+            expect(call_with_arguments).to eq(["abc", { :foo => "bar" }])
           end
         end
 
@@ -131,7 +130,7 @@ describe Object do
         it "does not instrument, but still calls the method" do
           expect(Appsignal.active?).to be_falsy
           expect(transaction).to_not receive(:start_event)
-          expect(call_with_arguments).to eq(["abc", { :foo => "bar" }, 2])
+          expect(call_with_arguments).to eq(["abc", { :foo => "bar" }])
         end
       end
     end
@@ -139,8 +138,8 @@ describe Object do
     context "with class method" do
       let(:klass) do
         Class.new do
-          def self.bar(param1, options = {}, keyword_param: 1)
-            [param1, options, keyword_param]
+          def self.bar(param1, options = {})
+            [param1, options]
           end
           appsignal_instrument_class_method :bar
         end
@@ -148,8 +147,7 @@ describe Object do
       def call_with_arguments
         klass.bar(
           "abc",
-          { :foo => "bar" },
-          :keyword_param => 2
+          :foo => "bar"
         )
       end
 
@@ -168,7 +166,7 @@ describe Object do
             expect(transaction).to receive(:start_event)
             expect(transaction).to receive(:finish_event).with \
               "bar.class_method.AnonymousClass.other", nil, nil, Appsignal::EventFormatter::DEFAULT
-            expect(call_with_arguments).to eq(["abc", { :foo => "bar" }, 2])
+            expect(call_with_arguments).to eq(["abc", { :foo => "bar" }])
           end
         end
 
@@ -260,7 +258,7 @@ describe Object do
         it "does not instrument, but still call the method" do
           expect(Appsignal.active?).to be_falsy
           expect(transaction).to_not receive(:start_event)
-          expect(call_with_arguments).to eq(["abc", { :foo => "bar" }, 2])
+          expect(call_with_arguments).to eq(["abc", { :foo => "bar" }])
         end
       end
     end


### PR DESCRIPTION
Update Object instrumentation for Ruby 2.7 and 3.0 so that it doesn't
print deprecation warnings on Ruby 2.7 and raises an error on Ruby 3.0.

It didn't look broken because we didn't actually test argument
forwarding so the tests didn't break for Ruby 3.0.

I had to implement it twice, once for Ruby 2.7 and higher, and once for
everything older. This is because the two instrumentation methods are
incompatible and this is the easiest way to instrument all versions.
This means two implementation files and two tests because Ruby 1.9 can't
parse the keyword argument syntax introduced in Ruby 2.0. This is an
ugly fix, but it's also present for a very short time, since our develop
branch already drops support for Ruby 1.9 and we can remove this
workaround when this gets merged into the develop branch.
I justed wanted to get this merged into the main branch so we can fully
support Ruby 3.0 in the Ruby gem 2.x series, rather than only fully
support it in the Ruby gem 3.x series.

This change should make our Ruby 3.0 support complete.

Fixes #656