### PR TITLE
Prepend Sidekiq middleware

### DIFF
--- a/lib/appsignal/hooks/sidekiq.rb
+++ b/lib/appsignal/hooks/sidekiq.rb
@@ -16,7 +16,11 @@ module Appsignal
 
         ::Sidekiq.configure_server do |config|
           config.server_middleware do |chain|
-            chain.add Appsignal::Hooks::SidekiqPlugin
+            if chain.respond_to? :prepend
+              chain.prepend Appsignal::Hooks::SidekiqPlugin
+            else
+              chain.add Appsignal::Hooks::SidekiqPlugin
+            end
           end
         end
       end

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -16,14 +16,31 @@ describe Appsignal::Hooks::SidekiqHook do
   end
 
   describe "#install" do
-    class SidekiqMiddlewareMock < Set
-      def exists?(middleware)
-        include?(middleware)
+    class SidekiqMiddlewareMockWithPrepend < Array
+      alias add <<
+      alias exists? include?
+
+      unless method_defined? :prepend
+        def prepend(middleware) # For Ruby < 2.5
+          insert(0, middleware)
+        end
       end
     end
+
+    class SidekiqMiddlewareMockWithoutPrepend < Array
+      alias add <<
+      alias exists? include?
+
+      undef_method :prepend if method_defined? :prepend # For Ruby >= 2.5
+    end
+
     module SidekiqMock
+      def self.middleware_mock=(mock)
+        @middlewares = mock.new
+      end
+
       def self.middlewares
-        @middlewares ||= SidekiqMiddlewareMock.new
+        @middlewares
       end
 
       def self.configure_server
@@ -36,15 +53,52 @@ describe Appsignal::Hooks::SidekiqHook do
       end
     end
 
+    def add_middleware(middleware)
+      Sidekiq.configure_server do |sidekiq_config|
+        sidekiq_config.middlewares.add(middleware)
+      end
+    end
+
     before do
       Appsignal.config = project_fixture_config
       stub_const "Sidekiq", SidekiqMock
     end
 
-    it "adds the AppSignal SidekiqPlugin to the Sidekiq middleware chain" do
-      described_class.new.install
+    context "when Sidekiq middleware responds to prepend method" do # Sidekiq 3.3.0 and newer
+      before { Sidekiq.middleware_mock = SidekiqMiddlewareMockWithPrepend }
 
-      expect(Sidekiq.server_middleware.exists?(Appsignal::Hooks::SidekiqPlugin)).to be(true)
+      it "adds the AppSignal SidekiqPlugin to the Sidekiq middleware chain in the first position" do
+        user_middleware1 = proc {}
+        add_middleware(user_middleware1)
+        described_class.new.install
+        user_middleware2 = proc {}
+        add_middleware(user_middleware2)
+
+        expect(Sidekiq.server_middleware).to eql([
+          Appsignal::Hooks::SidekiqPlugin, # Prepend makes it the first entry
+          user_middleware1,
+          user_middleware2
+        ])
+      end
+    end
+
+    context "when Sidekiq middleware does not respond to prepend method" do
+      before { Sidekiq.middleware_mock = SidekiqMiddlewareMockWithoutPrepend }
+
+      it "adds the AppSignal SidekiqPlugin to the Sidekiq middleware chain" do
+        user_middleware1 = proc {}
+        add_middleware(user_middleware1)
+        described_class.new.install
+        user_middleware2 = proc {}
+        add_middleware(user_middleware2)
+
+        # Add middlewares in whatever order they were added
+        expect(Sidekiq.server_middleware).to eql([
+          user_middleware1,
+          Appsignal::Hooks::SidekiqPlugin,
+          user_middleware2
+        ])
+      end
     end
   end
 end


### PR DESCRIPTION
Use `prepend` to ensure that the AppSignal middleware is the first
middleware in the chain. This way the AppSignal middleware will also
wrap any other middleware in the chain, and we will catch more errors
this way, but also provide instrumentation that includes the duration
from other middleware for performance samples.

This can still "break", where AppSignal is not the first middleware in
the chain. If another integration or the app itself calls `prepend` as
well, the last caller will be the first in the chain.

I added a small fallback on using `add` when `prepend` is not available
in the Sidekiq middleware chain. It was added in Sidekiq 3.3.0.

Closes #526