### PR TITLE
Require Ruby 2.0 for gem

### DIFF
--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem| # rubocop:disable Metrics/BlockLength
   gem.name                  = "appsignal"
   gem.require_paths         = %w[lib ext]
   gem.version               = Appsignal::VERSION
-  gem.required_ruby_version = ">= 1.9"
+  gem.required_ruby_version = ">= 2.0"
   # Default extension installer. Overridden by JRuby gemspec as defined in
   # `Rakefile`.
   gem.extensions            = %w[ext/extconf.rb]


### PR DESCRIPTION
Now that we have dropped Ruby 1.9 support, bump the required Ruby
version in the gemspec. We cannot guarantee it will work on Ruby 1.9.

Most integrations using the `Module.prepend` patching style wil not work
as `Module.prepend` was introduced in Ruby 2.0. The object
instrumentation also no longer is compatible with Ruby 1.9 as it has
explicit support of keyword arguments now, also introduced in Ruby 2.0.

Safe to say there is no way the gem will work on Ruby 1.9 any more, so
limit the Ruby version it can be installed on by updating the gemspec.