### PR TITLE
Deprecate error helpers tags and namespace arguments

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -4,9 +4,9 @@ require "json"
 require "securerandom"
 
 require "appsignal/logger"
+require "appsignal/utils/deprecation_message"
 require "appsignal/helpers/instrumentation"
 require "appsignal/helpers/metrics"
-require "appsignal/utils/deprecation_message"
 
 # AppSignal for Ruby gem's main module.
 #
@@ -18,7 +18,6 @@ module Appsignal
   class << self
     include Helpers::Instrumentation
     include Helpers::Metrics
-    include Utils::DeprecationMessage
 
     # Accessor for the AppSignal configuration.
     # Return the current AppSignal configuration.

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -285,8 +285,10 @@ module Appsignal
       #   transaction.
       # @param tags [Hash{String, Symbol => String, Symbol, Integer}]
       #   Additional tags to add to the error. See also {.tag_request}.
+      #   This parameter is deprecated. Use the block argument instead.
       # @param namespace [String] The namespace in which the error occurred.
       #   See also {.set_namespace}.
+      #   This parameter is deprecated. Use the block argument instead.
       # @yield [transaction] yields block to allow modification of the
       #   transaction.
       # @yieldparam transaction [Transaction] yields the AppSignal transaction
@@ -298,6 +300,26 @@ module Appsignal
       #   Exception handling guide
       # @since 0.6.6
       def set_error(exception, tags = nil, namespace = nil)
+        if tags
+          call_location = caller(1..1).first
+          deprecation_message \
+            "The tags argument for `Appsignal.set_error` is deprecated. " \
+            "Please use the block method to set tags instead.\n\n" \
+            "  Appsignal.set_error(error) do |transaction|\n" \
+            "    transaction.set_tags(#{tags})\n" \
+            "  end\n\n" \
+            "Appsignal.set_error called on location: #{call_location}"
+        end
+        if namespace
+          call_location = caller(1..1).first
+          deprecation_message \
+            "The namespace argument for `Appsignal.set_error` is deprecated. " \
+            "Please use the block method to set the namespace instead.\n\n" \
+            "  Appsignal.set_error(error) do |transaction|\n" \
+            "    transaction.namespace(#{namespace.inspect})\n" \
+            "  end\n\n" \
+            "Appsignal.set_error called on location: #{call_location}"
+        end
         unless exception.is_a?(Exception)
           logger.error "Appsignal.set_error: Cannot set error. The given " \
             "value is not an exception: #{exception.inspect}"

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -273,12 +273,24 @@ module Appsignal
       #     end
       #   end
       #
+      # @example Add more metadata to transaction
+      #   Appsignal.set_error(e) do |transaction|
+      #     transaction.params(:search_query => params[:search_query])
+      #     transaction.set_action("my_action_name")
+      #     transaction.set_tags(:key => "value")
+      #     transaction.set_namespace("my_namespace")
+      #   end
+      #
       # @param exception [Exception] The error to add to the current
       #   transaction.
       # @param tags [Hash{String, Symbol => String, Symbol, Integer}]
       #   Additional tags to add to the error. See also {.tag_request}.
       # @param namespace [String] The namespace in which the error occurred.
       #   See also {.set_namespace}.
+      # @yield [transaction] yields block to allow modification of the
+      #   transaction.
+      # @yieldparam transaction [Transaction] yields the AppSignal transaction
+      #   used to store the error.
       # @return [void]
       #
       # @see Transaction#set_error
@@ -296,6 +308,7 @@ module Appsignal
         transaction.set_error(exception)
         transaction.set_tags(tags) if tags
         transaction.set_namespace(namespace) if namespace
+        yield transaction if block_given?
       end
       alias :set_exception :set_error
       alias :add_exception :set_error

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -141,7 +141,10 @@ module Appsignal
       )
         yield
       rescue Exception => error # rubocop:disable Lint/RescueException
-        send_error(error, tags, namespace)
+        send_error(error) do |transaction|
+          transaction.set_tags(tags) if tags
+          transaction.set_namespace(namespace) if namespace
+        end
         raise error
       end
       alias :listen_for_exception :listen_for_error


### PR DESCRIPTION
## Deprecate send_error tags and namespace arguments

Favor the block method of setting the tags and namespace for the
transaction created for the to be send error. The advantage is that this
method is more flexible if more data than tags and namespaces need to be
set, as any method on the transaction object can be called.

This method has our preference moving forward. It works similar in the
Elixir integration, giving along a function (instead of a block) to set
these things on spans.

Remove the `DeprecationMessage` module from the `Appsignal` module because
it's not used there anymore. Instead include it in the
`Utils::Instrumentation` module, where it is used.

Part of #678

## Update listen_for_error helper send_error usage

Update the `listen_for_error` helper to use the block method to set
metadata (tags and namespace) on the transaction.

In the previous commit calling the `send_error` helper with tags and
namespace as arguments was deprecated and printed and logged a warning,
so update the method call to not print the deprecation warning.

## Support set_error to yield the transaction

This allows users to add more metadata in the `set_error` helper and
makes it behavior similar to `send_error`. This gives users an easy way
to add more metadata to the transaction in the same block.

```
Appsignal.set_error(StandardError.new("my_error")) do |transaction|
  transaction.set_action("my_action")
  transaction.set_namespace("my_namespace")
end
```

Similar change to #481.

With this change we can deprecate the `tags` and `namespace` arguments
as per #678.

## Deprecate set_error tags and namespace arguments

Favor the block method of setting the tags and namespace for the
transaction created for the to be set error. The advantage is that this
method is more flexible if more data than tags and namespaces need to be
set, as any method on the transaction object can be called.

This method has our preference moving forward. It works similar in the
Elixir integration, giving along a function (instead of a block) to set
these things on spans.

Part of and closes #678

