### PR TITLE
Mark minutely probe thread as fork-safe

### DIFF
--- a/lib/appsignal/minutely.rb
+++ b/lib/appsignal/minutely.rb
@@ -135,6 +135,12 @@ module Appsignal
       def start
         stop
         @thread = Thread.new do
+          # Advise multi-threaded app servers to ignore this thread
+          # for the purposes of fork safety warnings
+          if Thread.current.respond_to?(:thread_variable_set)
+            Thread.current.thread_variable_set(:fork_safe, true)
+          end
+
           sleep initial_wait_time
           initialize_probes
           loop do


### PR DESCRIPTION
The minutely probe thread is designed to live in the main Puma process and not exist in worker processes but triggers Puma's warning message about existing threads because of this design.

In rails/rails#40399 a method for marking such threads as fork-safe for multi-threaded application server (e.g. Puma) was established by setting a thread local variable called `:fork_safe` to true.