### PR TITLE
Update method delegation in method instrumentation

### DIFF
--- a/lib/appsignal/integrations/object_ruby_modern.rb
+++ b/lib/appsignal/integrations/object_ruby_modern.rb
@@ -1,56 +1,33 @@
 # frozen_string_literal: true
 
 class Object
-  if Appsignal::System.ruby_2_7_or_newer?
-    def self.appsignal_instrument_class_method(method_name, options = {})
-      singleton_class.send \
-        :alias_method, "appsignal_uninstrumented_#{method_name}", method_name
-      singleton_class.send(:define_method, method_name) do |*args, **kwargs, &block|
-        name = options.fetch(:name) do
-          "#{method_name}.class_method.#{appsignal_reverse_class_name}.other"
-        end
-        Appsignal.instrument name do
-          send "appsignal_uninstrumented_#{method_name}", *args, **kwargs, &block
-        end
+  def self.appsignal_instrument_class_method(method_name, options = {})
+    singleton_class.send \
+      :alias_method, "appsignal_uninstrumented_#{method_name}", method_name
+    singleton_class.send(:define_method, method_name) do |*args, &block|
+      name = options.fetch(:name) do
+        "#{method_name}.class_method.#{appsignal_reverse_class_name}.other"
+      end
+      Appsignal.instrument name do
+        send "appsignal_uninstrumented_#{method_name}", *args, &block
       end
     end
+    if singleton_class.respond_to?(:ruby2_keywords, true)
+      singleton_class.send(:ruby2_keywords, method_name)
+    end
+  end
 
-    def self.appsignal_instrument_method(method_name, options = {})
-      alias_method "appsignal_uninstrumented_#{method_name}", method_name
-      define_method method_name do |*args, **kwargs, &block|
-        name = options.fetch(:name) do
-          "#{method_name}.#{appsignal_reverse_class_name}.other"
-        end
-        Appsignal.instrument name do
-          send "appsignal_uninstrumented_#{method_name}", *args, **kwargs, &block
-        end
+  def self.appsignal_instrument_method(method_name, options = {})
+    alias_method "appsignal_uninstrumented_#{method_name}", method_name
+    define_method method_name do |*args, &block|
+      name = options.fetch(:name) do
+        "#{method_name}.#{appsignal_reverse_class_name}.other"
+      end
+      Appsignal.instrument name do
+        send "appsignal_uninstrumented_#{method_name}", *args, &block
       end
     end
-  else
-    def self.appsignal_instrument_class_method(method_name, options = {})
-      singleton_class.send \
-        :alias_method, "appsignal_uninstrumented_#{method_name}", method_name
-      singleton_class.send(:define_method, method_name) do |*args, &block|
-        name = options.fetch(:name) do
-          "#{method_name}.class_method.#{appsignal_reverse_class_name}.other"
-        end
-        Appsignal.instrument name do
-          send "appsignal_uninstrumented_#{method_name}", *args, &block
-        end
-      end
-    end
-
-    def self.appsignal_instrument_method(method_name, options = {})
-      alias_method "appsignal_uninstrumented_#{method_name}", method_name
-      define_method method_name do |*args, &block|
-        name = options.fetch(:name) do
-          "#{method_name}.#{appsignal_reverse_class_name}.other"
-        end
-        Appsignal.instrument name do
-          send "appsignal_uninstrumented_#{method_name}", *args, &block
-        end
-      end
-    end
+    ruby2_keywords method_name if respond_to?(:ruby2_keywords, true)
   end
 
   def self.appsignal_reverse_class_name


### PR DESCRIPTION
I came across this article about Ruby method argument delegation and
compared it against our new Ruby 2.7+ implementation since PR #692:
https://eregon.me/blog/2019/11/10/the-delegation-challenge-of-ruby27.html#ruby-3-style-delegation

The `method_name(*args, **kwargs, &block)` delegation we use now can
break on older Ruby versions, making it appear as if an empty hash was
given as an argument when it wasn't. From the article:

```ruby
def delegate(*args, **kwargs, &block)
  target(*args, **kwargs, &block)
end

def target(*args)
  args
end

target()    # => []      in Ruby 2 & 3
target(1)   # => [1]     in Ruby 2 & 3
delegate()  # => [{}]    in Ruby 2.6, []  in Ruby 2.7+
delegate(1) # => [1, {}] in Ruby 2.6, [1] in Ruby 2.7+
```

This doesn't result in an immediate error, like an `ArgumentError`, when
this type of instrumentation is used. It's more subtle than that like
you can see in the example above.

I also realized we have several implementations for this integration
based on the Ruby version. What the article describes is a single way to
delegate methods for all (modern) Ruby versions.

I've updated the method instrumentation based on the article's
recommendation and removed the multiple (modern) Ruby implementations.
The Ruby 1.9 method stays in the 2.x series branch for now.

I've also added more specs to test different types of method arguments
and not just two types (all types of arguments or none).