### PR TITLE
Remove middleware insert for JS middleware

### DIFF
--- a/lib/appsignal/integrations/railtie.rb
+++ b/lib/appsignal/integrations/railtie.rb
@@ -30,10 +30,6 @@ module Appsignal
           Appsignal::Rack::RailsInstrumentation
         )
 
-        if Appsignal.config[:enable_frontend_error_catching]
-          app.middleware.insert_before(Appsignal::Rack::RailsInstrumentation)
-        end
-
         Appsignal.start
       end
     end


### PR DESCRIPTION
This line was change in PR #686, but hastily done by me. I removed the
second argument from this command, but I should have removed the entire
command as this code now causes an `ArgumentError` error on Rails app
boot.

With config:

```
# config/appsignal.yml
production:
  enable_frontend_error_catching: true
```

Causes this error on `rails server`:

```
ArgumentError: wrong number of arguments (given 1, expected 2+)
```

Remove the entire if-statement because the JavaScript error catcher
middleware and options have been removed in favor of the JavaScript
front-end integration.