### PR TITLE
Remove Ruby 1.9 exceptions

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -377,8 +377,6 @@ begin
   is_jruby = defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
   excludes = []
   excludes << "spec/lib/appsignal/extension/jruby_spec.rb" unless is_jruby
-  is_ruby19 = RUBY_VERSION < "2.0"
-  excludes << "spec/lib/appsignal/integrations/object_spec.rb" if is_ruby19
   exclude_pattern = "--exclude-pattern=#{excludes.join(",")}" if excludes.any?
 
   desc "Run the AppSignal gem test suite."

--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -42,11 +42,8 @@ Gem::Specification.new do |gem| # rubocop:disable Metrics/BlockLength
   gem.add_development_dependency "timecop"
   gem.add_development_dependency "webmock"
   gem.add_development_dependency "yard", ">= 0.9.20"
-  is_modern_ruby = Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.0.0")
-  if is_modern_ruby
-    gem.add_development_dependency "pry"
-    gem.add_development_dependency "rubocop", "0.50.0"
-  end
+  gem.add_development_dependency "pry"
+  gem.add_development_dependency "rubocop", "0.50.0"
   if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1.0")
     # Newer versions of rexml use keyword arguments with optional arguments which
     # work in Ruby 2.1 and newer.

--- a/gemfiles/no_dependencies.gemfile
+++ b/gemfiles/no_dependencies.gemfile
@@ -2,11 +2,4 @@ source 'https://rubygems.org'
 
 gem 'rack', '~> 1.6'
 
-ruby_version = Gem::Version.new(RUBY_VERSION)
-if ruby_version < Gem::Version.new("2.0.0")
-  # Newer versions of this gem have rexml as a dependency which doesn't work on
-  # Ruby 1.9
-  gem "crack", "0.4.4"
-end
-
 gemspec :path => '../'

--- a/gemfiles/rails-4.0.gemfile
+++ b/gemfiles/rails-4.0.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'rails', '~> 4.0.0'
-gem 'mime-types', '~> 2.6'
-
-gemspec :path => '../'

--- a/gemfiles/rails-4.1.gemfile
+++ b/gemfiles/rails-4.1.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'rails', '~> 4.1.0'
-gem 'mime-types', '~> 2.6'
-
-gemspec :path => '../'

--- a/spec/lib/puma/appsignal_spec.rb
+++ b/spec/lib/puma/appsignal_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "Puma plugin" do
     wait_for("enough probe calls") { probe.calls >= 2 }
   end
 
-  it "marks the PumaProbe thread as fork-safe", :not_ruby19 do
+  it "marks the PumaProbe thread as fork-safe" do
     out_stream = std_stream
     capture_stdout(out_stream) { Puma.run }
 


### PR DESCRIPTION
Ruby 1.9 support was removed in Ruby gem 3.0, so this code is never
called and can be removed safely.

[skip review]