### PR TITLE
Lock rexml gem on Ruby 2.0 and lower

### DIFF
--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -47,4 +47,9 @@ Gem::Specification.new do |gem| # rubocop:disable Metrics/BlockLength
     gem.add_development_dependency "pry"
     gem.add_development_dependency "rubocop", "0.50.0"
   end
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1.0")
+    # Newer versions of rexml use keyword arguments with optional arguments which
+    # work in Ruby 2.1 and newer.
+    gem.add_development_dependency "rexml", "3.2.4"
+  end
 end


### PR DESCRIPTION
The rexml gem version 3.2.5, dependency of the webmock gem, uses keyword
arguments without any default values. This is only supported in Ruby
2.1, and on Ruby 2.0 this results in a syntax error upon loading the
file from the rexml gem. This has broken the CI build that automatically
used the latest version of the gem.

This fix, by adding the version lock on the gem in the gemspec, is not
the ideal solution. I would have preferred to add it the independent
gemfiles in the `gemfiles/` directory. However, that requires a lot of
copy paste that becomes very brittle over time, and would be required
for every gemfile and any new gemfiles.

## Alternative solution

I wanted to move this all to the `Gemfile` in the root, but this caused
issues with gem load order in the test suite and caused all Rails specs
to fail (Rails was loaded after the AppSignal gem and was not detected).

```
# gemfiles/no_dependencies.gemfile
eval_gemfile("../Gemfile")

gem "rack", "~> 1.6"
```

```
# Gemfile
source "https://rubygems.org"

gemspec
if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1.0")
  # Newer versions of rexml use keyword arguments with optional arguments which
  # work in Ruby 2.1 and newer.
  gem "rexml", "3.2.4"
end
```

## Registered dependency?

The rexml gem doesn't become a registered development dependency (on
RubyGems.org) as long as the gem is published from a Ruby that's newer
than Ruby 2.0, which we usually do. This fix is really only for the Ruby
2.0 gem build on the CI.

[skip review]