### PR TITLE
Fix extension installation failure NoMethodError

### DIFF
--- a/lib/appsignal/extension.rb
+++ b/lib/appsignal/extension.rb
@@ -40,6 +40,16 @@ module Appsignal
       def method_missing(m, *args, &block)
         super if Appsignal.testing?
       end
+
+      unless Appsignal.extension_loaded?
+        def data_map_new
+          Appsignal::Extension::MockData.new
+        end
+
+        def data_array_new
+          Appsignal::Extension::MockData.new
+        end
+      end
     end
 
     if Appsignal::System.jruby?
@@ -60,6 +70,46 @@ module Appsignal
     class Data
       def inspect
         "#<#{self.class.name}:#{object_id} #{self}>"
+      end
+    end
+
+    # Mock of the {Data} class. This mock is used when the extension cannot be
+    # loaded. This mock listens to all method calls and does nothing, and
+    # prevents NoMethodErrors from being raised.
+    #
+    # Disabled in testing so we can make sure that we don't miss an extension
+    # function implementation.
+    #
+    # This class inherits from the {Data} class so that it passes type checks.
+    class MockData < Data
+      def initialize(*_args)
+        # JRuby extension requirement, as it sends a pointer to the Data object
+        # when creating it
+      end
+
+      def method_missing(_method, *_args, &_block)
+        super if Appsignal.testing?
+      end
+
+      def to_s
+        "{}"
+      end
+    end
+
+    # Mock of the {Transaction} class. This mock is used when the extension
+    # cannot be loaded. This mock listens to all method calls and does nothing,
+    # and prevents NoMethodErrors from being raised.
+    #
+    # Disabled in testing so we can make sure that we don't miss an extension
+    # function implementation.
+    class MockTransaction
+      def initialize(*_args)
+        # JRuby extension requirement, as it sends a pointer to the Transaction
+        # object when creating it
+      end
+
+      def method_missing(_method, *_args, &_block)
+        super if Appsignal.testing?
       end
     end
   end

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -90,7 +90,7 @@ module Appsignal
         @transaction_id,
         @namespace,
         self.class.garbage_collection_profiler.total_time
-      )
+      ) || Appsignal::Extension::MockTransaction.new
     end
 
     def nil_transaction?

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -246,6 +246,23 @@ describe Appsignal::Transaction do
         expect(transaction.ext).to_not be_nil
       end
 
+      context "when extension is not loaded", :extension_installation_failure do
+        around do |example|
+          Appsignal::Testing.without_testing { example.run }
+        end
+
+        it "does not error on missing extension method calls" do
+          expect(transaction.ext).to be_kind_of(Appsignal::Extension::MockTransaction)
+          transaction.start_event
+          transaction.finish_event(
+            "name",
+            "title",
+            "body",
+            Appsignal::EventFormatter::DEFAULT
+          )
+        end
+      end
+
       it "sets the transaction id" do
         expect(transaction.transaction_id).to eq "1"
       end

--- a/spec/lib/appsignal/utils/data_spec.rb
+++ b/spec/lib/appsignal/utils/data_spec.rb
@@ -4,24 +4,43 @@ describe Appsignal::Utils::Data do
   describe ".generate" do
     subject { Appsignal::Utils::Data.generate(body) }
 
+    context "when extension is not loaded", :extension_installation_failure do
+      around do |example|
+        Appsignal::Testing.without_testing { example.run }
+      end
+
+      context "with valid hash body" do
+        let(:body) { hash_body }
+
+        it "does not error and returns MockData class" do
+          expect(subject).to be_kind_of(Appsignal::Extension::MockData)
+          expect(subject.to_s).to eql("{}")
+        end
+      end
+
+      context "with valid array body" do
+        let(:body) { array_body }
+
+        it "does not error and returns MockData class" do
+          expect(subject).to be_kind_of(Appsignal::Extension::MockData)
+          expect(subject.to_s).to eql("{}")
+        end
+      end
+
+      context "with an invalid body" do
+        let(:body) { "body" }
+
+        it "raise a type error" do
+          expect do
+            subject
+          end.to raise_error TypeError
+        end
+      end
+    end
+
     context "when extension is loaded" do
       context "with a valid hash body" do
-        let(:body) do
-          {
-            "the" => "payload",
-            "int" => 1, # Fixnum
-            "int61" => 1 << 61, # Fixnum
-            "int62" => 1 << 62, # Bignum, this one still works
-            "int63" => 1 << 63, # Bignum, turnover point for C, too big for long
-            "int64" => 1 << 64, # Bignum
-            "float" => 1.0,
-            1 => true,
-            nil => "test",
-            :foo => [1, 2, "three", { "foo" => "bar" }],
-            "bar" => nil,
-            "baz" => { "foo" => "bʊr", "arr" => [1, 2] }
-          }
-        end
+        let(:body) { hash_body }
 
         it "returns a valid Data object" do
           is_expected.to eq Appsignal::Utils::Data.generate(body)
@@ -47,21 +66,7 @@ describe Appsignal::Utils::Data do
       end
 
       context "with a valid array body" do
-        let(:body) do
-          [
-            nil,
-            true,
-            false,
-            "string",
-            1, # Fixnum
-            1.0, # Float
-            1 << 61, # Fixnum
-            1 << 62, # Bignum, this one still works
-            1 << 63, # Bignum, turnover point for C, too big for long
-            1 << 64, # Bignum
-            { "arr" => [1, 2, "three"], "foo" => "bʊr" }
-          ]
-        end
+        let(:body) { array_body }
 
         it "returns a valid Data object" do
           is_expected.to eq Appsignal::Utils::Data.generate(body)
@@ -117,5 +122,38 @@ describe Appsignal::Utils::Data do
         end
       end
     end
+  end
+
+  def hash_body
+    {
+      "the" => "payload",
+      "int" => 1, # Fixnum
+      "int61" => 1 << 61, # Fixnum
+      "int62" => 1 << 62, # Bignum, this one still works
+      "int63" => 1 << 63, # Bignum, turnover point for C, too big for long
+      "int64" => 1 << 64, # Bignum
+      "float" => 1.0,
+      1 => true,
+      nil => "test",
+      :foo => [1, 2, "three", { "foo" => "bar" }],
+      "bar" => nil,
+      "baz" => { "foo" => "bʊr", "arr" => [1, 2] }
+    }
+  end
+
+  def array_body
+    [
+      nil,
+      true,
+      false,
+      "string",
+      1, # Fixnum
+      1.0, # Float
+      1 << 61, # Fixnum
+      1 << 62, # Bignum, this one still works
+      1 << 63, # Bignum, turnover point for C, too big for long
+      1 << 64, # Bignum
+      { "arr" => [1, 2, "three"], "foo" => "bʊr" }
+    ]
   end
 end

--- a/spec/support/testing.rb
+++ b/spec/support/testing.rb
@@ -1,16 +1,26 @@
 module Appsignal
   class << self
+    attr_writer :testing
     remove_method :testing?
 
     # @api private
     def testing?
-      true
+      @testing = true unless defined?(@testing)
+      @testing
     end
   end
 
   # @api private
   module Testing
     class << self
+      def without_testing
+        original_testing = Appsignal.testing?
+        Appsignal.testing = false
+        yield
+      ensure
+        Appsignal.testing = original_testing
+      end
+
       def transactions
         @transactions ||= []
       end


### PR DESCRIPTION
## Scenario

When the extension installation fails, the AppSignal Ruby gem should
load but not cause any errors that cause the app to stop whenever an
extension method is called.

The extension always fails on Microsoft Windows and Apple M1 machines
currently, but it can also fail for various other reasons, on systems we
expect it to work.

In issue #707, later documented in #719 in more detail, a scenario was
described where a user would call the `Appsignal.increment_counter`
method and it caused the following error.
https://github.com/appsignal/appsignal-ruby/issues/707#issuecomment-818730104

```ruby
# In Ruby it trips on adding tags to a data object
Appsignal.increment_counter "foo", 1, { "foo" => "bar" }
# In JRuby this is enough, just creating the data object for an empty hash
Appsignal.increment_counter "foo", 1
```

Results in:

```
/integration/lib/appsignal/utils/data.rb:24:in `block in map_hash': undefined method `set_string' for nil:NilClass (NoMethodError)
  from /integration/lib/appsignal/utils/data.rb:20:in `each'
  from /integration/lib/appsignal/utils/data.rb:20:in `map_hash'
  from /integration/lib/appsignal/utils/data.rb:10:in `generate'
  from /integration/lib/appsignal/helpers/metrics.rb:35:in `increment_counter'
  from app.rb:29:in `perform'
  from /integration/lib/appsignal/integrations/object.rb:32:in `block (2 levels) in appsignal_instrument_method'
  from /integration/lib/appsignal/helpers/instrumentation.rb:525:in `instrument'
  from /integration/lib/appsignal/integrations/object.rb:31:in `block in appsignal_instrument_method'
  from app.rb:36:in `block (2 levels) in <main>'
  from /integration/lib/appsignal/helpers/instrumentation.rb:77:in `monitor_transaction'
  from app.rb:35:in `block in <main>'
  from app.rb:34:in `times'
  from app.rb:34:in `<main>'
```

This was caused by the `Appsignal::Extension.data_map_new` and
`Appsignal::Extension.data_array_new` methods returning nil, and then
the `Appsignal::Data`'s `map_hash` and `map_array` methods calling
various `set_*` methods on that `nil` object.

```ruby
map = Appsignal::Extension.data_map_new
# map = nil
map.set_string(key, value)
# NoMethodError - undefined method `set_string' for nil:NilClass
```

The same problem occurs for Transactions being created in the following
way, because the `@ext`, transaction extension object, is `nil` in the
`Appsignal::Transaction` object and any method calls on `nil` will raise
a `NoMethodError`.

```ruby
transaction = Appsignal::Transaction.create(
  "demo-id",
  Appsignal::Transaction::HTTP_REQUEST,
  Appsignal::Transaction::GenericRequest.new({})
)
Monitor.new.perform("foo", { :foo => i }, foo: i, bar: i.even?)
Appsignal::Transaction.complete_current!
```

Results in:

```
/integration/lib/appsignal/transaction.rb:349:in `finish_event': undefined method `finish_event' for nil:NilClass (NoMethodError)
  from /integration/lib/appsignal/helpers/instrumentation.rb:529:in `ensure in instrument'
  from /integration/lib/appsignal/helpers/instrumentation.rb:529:in `instrument'
  from /integration/lib/appsignal/integrations/object.rb:31:in `block in appsignal_instrument_method'
  from app.rb:44:in `block in <main>'
  from app.rb:34:in `times'
  from app.rb:34:in `<main>'
/integration/lib/appsignal/transaction.rb:344:in `start_event': undefined method `start_event' for nil:NilClass (NoMethodError)
  from /integration/lib/appsignal/helpers/instrumentation.rb:524:in `instrument'
  from /integration/lib/appsignal/integrations/object.rb:31:in `block in appsignal_instrument_method'
  from app.rb:44:in `block in <main>'
  from app.rb:34:in `times'
  from app.rb:34:in `<main>'
```

## Solution

I added `Appsignal::Extension::MockData` and
`Appsignal::Extension::MockTransaction` classes to act as a fallback for
when the extension is not loaded. Like the `Appsignal::Extension` class
this implements a `method_missing` method that captures any method calls
and will then do nothing. It will prevent any `NoMethodError` from being
raised when any methods are called on the data object

This `MockData` inherits from `Data` so it will pass any type checks in
other methods, like in the JRuby extension.

## Alternative solution

I also considered checking if the extension was loaded in the `map_hash`
and `map_array` methods , and calling `return` early to skip all method
calls to the (not loaded) extension.

This would require any part of the code that interacts with the
extension to have such a guard for that condition. Which adds a lot of
extra checks, which are easy to forget, causing similar issues to be
easily introduced.

It would also cause issues where the return value was interacted with,
such as in the JRuby extension wrapper in `finish_event`. Here it does a
type check and fails when it does not pass it. A `nil` value would fail
that type check and an `ArgumentError` would be raised.

---

Closes #719