### PR TITLE
Bump agent to 6caf6d0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 3.0.4 beta 1
+- Bump agent to 6caf6d0
+    - Add aarch64 (ARM 64-bit Linux) build.
+    - Replace curl HTTP client.
+    - Various other maintenance updates.
+
 # 3.0.3
 - Fix deprecation message for set_error namespace argument. PR #712
 - Fix example code for Transaction#set_namespace method. PR #713

--- a/ext/agent.yml
+++ b/ext/agent.yml
@@ -1,62 +1,69 @@
 ---
-version: 75e76ad
+version: 6caf6d0
 mirrors:
 - https://appsignal-agent-releases.global.ssl.fastly.net
 - https://d135dj0rjqvssy.cloudfront.net
 triples:
   x86_64-darwin:
     static:
-      checksum: 81edea50b934fe5b42c0081a1de5782bc477c321c1c76127d7fa525917f70a04
+      checksum: 94b6fb3ba7c68041c0e31867221acccc7d82702a027e5ffc2376bc09c04728f2
       filename: appsignal-x86_64-darwin-all-static.tar.gz
     dynamic:
-      checksum: 60befd59ac704ee21d5881ca0aef6b38caa50b1d1972425bf8f40b4f9710ec1e
+      checksum: dffb70cd2c2fce05df798591d93cc67ccce66237fbaaee18c368b174656cace8
       filename: appsignal-x86_64-darwin-all-dynamic.tar.gz
   universal-darwin:
     static:
-      checksum: 81edea50b934fe5b42c0081a1de5782bc477c321c1c76127d7fa525917f70a04
+      checksum: 94b6fb3ba7c68041c0e31867221acccc7d82702a027e5ffc2376bc09c04728f2
       filename: appsignal-x86_64-darwin-all-static.tar.gz
     dynamic:
-      checksum: 60befd59ac704ee21d5881ca0aef6b38caa50b1d1972425bf8f40b4f9710ec1e
+      checksum: dffb70cd2c2fce05df798591d93cc67ccce66237fbaaee18c368b174656cace8
       filename: appsignal-x86_64-darwin-all-dynamic.tar.gz
+  aarch64-linux:
+    static:
+      checksum: 4fa48dba3ce6c2d03105ccdb8ff74908ec1eed40c3bb35357fd197bc70d98fb4
+      filename: appsignal-aarch64-linux-all-static.tar.gz
+    dynamic:
+      checksum: 5d04ed04e89ede3946b411d920875346e1dac42665f0f61ddbe7becbd7a7cba3
+      filename: appsignal-aarch64-linux-all-dynamic.tar.gz
   i686-linux:
     static:
-      checksum: 60ad6a1f69c8f89b5642f49fbf794409e8ada7d63a9126b2c59832c2a92d5b22
+      checksum: 849db8eb40ac23bb9c0b0aacadf4a6210f428e5b95e92f93311240bbaf0150d2
       filename: appsignal-i686-linux-all-static.tar.gz
     dynamic:
-      checksum: aedf259de392ea00fd17bc30924cde70d9a1d82a62c6eeefc881cd5ea5dcce63
+      checksum: 251a078aecc6f8e44e4f2a1e09b9bbc481636e324d1dcc3e99d3f13ee3ae8a66
       filename: appsignal-i686-linux-all-dynamic.tar.gz
   x86-linux:
     static:
-      checksum: 60ad6a1f69c8f89b5642f49fbf794409e8ada7d63a9126b2c59832c2a92d5b22
+      checksum: 849db8eb40ac23bb9c0b0aacadf4a6210f428e5b95e92f93311240bbaf0150d2
       filename: appsignal-i686-linux-all-static.tar.gz
     dynamic:
-      checksum: aedf259de392ea00fd17bc30924cde70d9a1d82a62c6eeefc881cd5ea5dcce63
+      checksum: 251a078aecc6f8e44e4f2a1e09b9bbc481636e324d1dcc3e99d3f13ee3ae8a66
       filename: appsignal-i686-linux-all-dynamic.tar.gz
   x86_64-linux:
     static:
-      checksum: 7e3cf760f9bd364a6602f05e5014ce1c8e8ac9a97f7a533769711e0fb21e1f45
+      checksum: 9d09faa4a778040774d02688ce12d1b59af526cc0f25f2a23b3a4fb594972fa0
       filename: appsignal-x86_64-linux-all-static.tar.gz
     dynamic:
-      checksum: 4a9a4ea22abc93c3afa7d5bfd6f442cd69bf4d672e8db2df1aa2157cfb3fcc4b
+      checksum: 13bd67e2a1ae718390c5ba61e03ab7d39f9203de6caa8f3be798e104de49a33a
       filename: appsignal-x86_64-linux-all-dynamic.tar.gz
   x86_64-linux-musl:
     static:
-      checksum: 4d4dd00607cbe0fb4d14a15e74990f207eba90134c2d1a079b58f0d50f1ab76b
+      checksum: 2dcbbf8306f29cc0b32e9665509af43f272dabac632a7d66cfab68f84eb82e63
       filename: appsignal-x86_64-linux-musl-all-static.tar.gz
     dynamic:
-      checksum: 067a6d821e220c9c88ceb8f936390ce458fa94f41c13d32603d773485a8cdfd2
+      checksum: aa71dd709e47114950a1dbfa8eb9ab02c989efd69c8dde50adabfac035f40a7b
       filename: appsignal-x86_64-linux-musl-all-dynamic.tar.gz
   x86_64-freebsd:
     static:
-      checksum: 176bc1ff1ad40a585ea10456a8ae3f6502c614d713dcbb957d550fa1ae44e7ca
+      checksum: e439baee1a4445c0eb8028638bbcc19fe6387457c41f9fad93d9fc142d904518
       filename: appsignal-x86_64-freebsd-all-static.tar.gz
     dynamic:
-      checksum: 88c6f3e03f8f6c25a4705f7d6c4286eaa563069a9fb8fad3c0a19e5b9a09f80b
+      checksum: '08e0f625e22dea0d5121dbacff417ab1c929cae7610e8aac3cf04b862d61d934'
       filename: appsignal-x86_64-freebsd-all-dynamic.tar.gz
   amd64-freebsd:
     static:
-      checksum: 176bc1ff1ad40a585ea10456a8ae3f6502c614d713dcbb957d550fa1ae44e7ca
+      checksum: e439baee1a4445c0eb8028638bbcc19fe6387457c41f9fad93d9fc142d904518
       filename: appsignal-x86_64-freebsd-all-static.tar.gz
     dynamic:
-      checksum: 88c6f3e03f8f6c25a4705f7d6c4286eaa563069a9fb8fad3c0a19e5b9a09f80b
+      checksum: '08e0f625e22dea0d5121dbacff417ab1c929cae7610e8aac3cf04b862d61d934'
       filename: appsignal-x86_64-freebsd-all-dynamic.tar.gz

--- a/lib/appsignal/version.rb
+++ b/lib/appsignal/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Appsignal
-  VERSION = "3.0.3".freeze
+  VERSION = "3.0.4.alpha.1".freeze
 end


### PR DESCRIPTION
- Add aarch64 (ARM 64-bit Linux) build.
- Replace curl HTTP client.
- Various other maintenance updates.

## TODO

- [ ] Remove ARM build if this issue is not resolved beforehand: https://github.com/appsignal/appsignal-agent/pull/690#issuecomment-854639220 (private issue)