### PR TITLE
Add mono config

### DIFF
--- a/.changesets/drop-logger-level-to-debug.md
+++ b/.changesets/drop-logger-level-to-debug.md
@@ -1,0 +1,7 @@
+---
+bump: "patch"
+---
+
+Drop logger level to debug. Reduce the output on the "info" level and only show
+these messages in debug mode. This should reduce the noise for users running
+AppSignal with the STDOUT logger, such as is the default on Heroku.

--- a/.changesets/drop-logger-level-to-debug.md
+++ b/.changesets/drop-logger-level-to-debug.md
@@ -1,7 +1,0 @@
----
-bump: "patch"
----
-
-Drop logger level to debug. Reduce the output on the "info" level and only show
-these messages in debug mode. This should reduce the noise for users running
-AppSignal with the STDOUT logger, such as is the default on Heroku.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.0.4
+
+- [6338e822](https://github.com/appsignal/appsignal-ruby/commit/6338e8227c674ea7bbe6f55cdfde784fa9f5048f) patch - Drop logger level to debug. Reduce the output on the "info" level and only show
+  these messages in debug mode. This should reduce the noise for users running
+  AppSignal with the STDOUT logger, such as is the default on Heroku.
+
 # 3.0.3
 - Fix deprecation message for set_error namespace argument. PR #712
 - Fix example code for Transaction#set_namespace method. PR #713

--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem| # rubocop:disable Metrics/BlockLength
   gem.homepage              = "https://github.com/appsignal/appsignal-ruby"
   gem.license               = "MIT"
 
-  gem.files                 = `git ls-files`.split($\) # rubocop:disable Style/SpecialGlobalVars
+  gem.files                 = `git ls-files`.split($\).reject { |f| f.start_with?(".changesets/") } # rubocop:disable Style/SpecialGlobalVars
   gem.executables           = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files            = gem.files.grep(%r{^(test|spec|features)/})
   gem.name                  = "appsignal"

--- a/lib/appsignal/version.rb
+++ b/lib/appsignal/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Appsignal
-  VERSION = "3.0.3".freeze
+  VERSION = "3.0.4".freeze
 end

--- a/mono.yml
+++ b/mono.yml
@@ -1,0 +1,16 @@
+---
+language: ruby
+repo: "https://github.com/appsignal/appsignal-ruby"
+bootstrap:
+  post:
+    - "rake extension:install"
+clean:
+  post:
+    - "bundle exec rake extension:clean"
+    - "rm -rf pkg"
+build:
+  command: "bundle exec rake build:all"
+publish:
+  gem_files_dir: pkg/
+test:
+  command: "bundle exec rake test"


### PR DESCRIPTION
Add a mono config file for use with the [mono
project](https://github.com/appsignal/mono/).

I didn't add mono to the CI test setup as the Ruby gem's build matrix is
very different. We customize the versions of RubyGems and Bundler in the
current build matrix with a custom "bundler_wrapper" script. We can also
see if we can add it later, but the benefits of adding it to the CI are
more present for mono repos.

[skip review]