### PR TITLE
Update RedisIntegration to override write instead of process and change event body

### DIFF
--- a/.changesets/redis-eval.md
+++ b/.changesets/redis-eval.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Support Redis eval statements better by showing the actual script that was performed. Instead of showing `eval ? ? ?` (for a script with 2 arguments), show `<script> ? ?`, where `<script>` is whatever script was sent to `Redis.new.eval("<script>")`.

--- a/lib/appsignal/integrations/redis.rb
+++ b/lib/appsignal/integrations/redis.rb
@@ -4,7 +4,7 @@ module Appsignal
   module Integrations
     module RedisIntegration
       def write(command)
-        sanitized_command = command[0] == :eval ? command[1] : command[0].to_s
+        sanitized_command = command[0] == :eval ? command[1] : "#{command[0]}#{" ?" * (command.size - 1)}"
 
         Appsignal.instrument "query.redis", id, sanitized_command do
           super

--- a/lib/appsignal/integrations/redis.rb
+++ b/lib/appsignal/integrations/redis.rb
@@ -3,12 +3,10 @@
 module Appsignal
   module Integrations
     module RedisIntegration
-      def process(commands, &block)
-        sanitized_commands = commands.map do |command, *args|
-          "#{command}#{" ?" * args.size}"
-        end.join("\n")
+      def write(command)
+        sanitized_command = command[0] == :eval ? command[1] : command[0].to_s
 
-        Appsignal.instrument "query.redis", id, sanitized_commands do
+        Appsignal.instrument "query.redis", id, sanitized_command do
           super
         end
       end

--- a/lib/appsignal/integrations/redis.rb
+++ b/lib/appsignal/integrations/redis.rb
@@ -4,7 +4,12 @@ module Appsignal
   module Integrations
     module RedisIntegration
       def write(command)
-        sanitized_command = command[0] == :eval ? command[1] : "#{command[0]}#{" ?" * (command.size - 1)}"
+        sanitized_command =
+          if command[0] == :eval
+            "#{command[1]}#{" ?" * (command.size - 3)}"
+          else
+            "#{command[0]}#{" ?" * (command.size - 1)}"
+          end
 
         Appsignal.instrument "query.redis", id, sanitized_command do
           super

--- a/spec/lib/appsignal/hooks/redis_spec.rb
+++ b/spec/lib/appsignal/hooks/redis_spec.rb
@@ -36,21 +36,13 @@ describe Appsignal::Hooks::RedisHook do
               # Stub Redis::Client class so that it doesn't perform an actual
               # Redis query. This class will be included (prepended) with the
               # AppSignal Redis integration.
-              stub_const("Redis::Client", Class.new(Redis::Client) do
+              stub_const("Redis::Client", Class.new do
                 def id
                   :stub_id
                 end
 
-                def write(_command)
-                  nil
-                end
-
-                def read
-                  "value"
-                end
-
-                def call(*args)
-                  super
+                def write(_commands)
+                  :stub_write
                 end
               end)
               # Load the integration again for the stubbed Redis::Client class.
@@ -68,7 +60,7 @@ describe Appsignal::Hooks::RedisHook do
                 .with("query.redis", :stub_id, "get", 0)
 
               client = Redis::Client.new
-              expect(client.call([:get, "key"])).to eql("value")
+              expect(client.write([:get, "key"])).to eql(:stub_write)
             end
 
             it "instrument a redis script call" do
@@ -84,7 +76,7 @@ describe Appsignal::Hooks::RedisHook do
                 .with("query.redis", :stub_id, script, 0)
 
               client = Redis::Client.new
-              expect(client.call([:eval, script, keys.size, keys, argv])).to eql("value")
+              expect(client.write([:eval, script, keys.size, keys, argv])).to eql(:stub_write)
             end
           end
         end

--- a/spec/lib/appsignal/hooks/redis_spec.rb
+++ b/spec/lib/appsignal/hooks/redis_spec.rb
@@ -57,7 +57,7 @@ describe Appsignal::Hooks::RedisHook do
                 .at_least(:once)
               expect(Appsignal::Transaction.current).to receive(:finish_event)
                 .at_least(:once)
-                .with("query.redis", :stub_id, "get", 0)
+                .with("query.redis", :stub_id, "get ?", 0)
 
               client = Redis::Client.new
               expect(client.write([:get, "key"])).to eql(:stub_write)


### PR DESCRIPTION
This PR is an idea for https://github.com/appsignal/appsignal-ruby/issues/726.

Basically it changes the `RedisIntegration` to override the `#write` method, which is the method that actually executes the command. It also handles the case in which you want to execute a Lua script so that the event created in appsignal shows what you run.