### PR TITLE
Skip empty HTTP proxy during extension download

### DIFF
--- a/.changesets/skip-empty-http-proxy-config.md
+++ b/.changesets/skip-empty-http-proxy-config.md
@@ -1,0 +1,7 @@
+---
+bump: "patch"
+---
+
+Skip empty HTTP proxy config. When any of the HTTP proxy config returns an
+empty string, skip this config. This fixes installation issues where an empty
+String is used as a HTTP proxy, causing a RuntimeError upon installation.

--- a/ext/base.rb
+++ b/ext/base.rb
@@ -184,7 +184,18 @@ def store_download_version_on_report
 end
 
 def http_proxy
-  Gem.configuration[:http_proxy] || ENV["http_proxy"] || ENV["HTTP_PROXY"]
+  proxy = try_http_proxy_value(Gem.configuration[:http_proxy])
+  return proxy if proxy
+
+  proxy = try_http_proxy_value(ENV["http_proxy"])
+  return proxy if proxy
+
+  proxy = try_http_proxy_value(ENV["HTTP_PROXY"])
+  return proxy if proxy
+end
+
+def try_http_proxy_value(value)
+  value if value.respond_to?(:empty?) && !value.strip.empty?
 end
 
 # Fail the installation on purpose in a specific test environment.


### PR DESCRIPTION
If the HTTP proxy config was set to an empty String during the AppSignal
extension installation the following error would be logged in the
`install.report` file (available through the diagnose) for the download
step:

```
RuntimeError: Non-HTTP proxy URI:
```
(It is trying to display an empty String in this error message.)

To fix this, when any of the HTTP proxy config returns an empty string,
skip that config value. Only when a config option returns a non-empty
String and non-nil value, use that as the config value. This should fix
download issues where an empty String is used as a HTTP proxy.

This can happen when one of the following config methods are configured
to an empty String, and probably other methods I have not tested as
well.

- `http_proxy=""` env var
- `http_proxy=" "` env var
- `HTTP_PROXY=""` env var
- `HTTP_PROXY=" "` env var
- `~/.gemrc` contains the following config: `http_proxy: ""`
- `~/.gemrc` contains the following config: `http_proxy: " "`