### PR TITLE
Check Rails.backtrace_cleaner method exists

### DIFF
--- a/.changesets/check-rails-backtrace_cleaner-method.md
+++ b/.changesets/check-rails-backtrace_cleaner-method.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Check Rails.backtrace_cleaner method before calling the method. This prevents a NoMethodError from being raised in some edge cases.

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -526,7 +526,7 @@ module Appsignal
     end
 
     def cleaned_backtrace(backtrace)
-      if defined?(::Rails) && backtrace
+      if defined?(::Rails) && Rails.respond_to?(:backtrace_cleaner) && backtrace
         ::Rails.backtrace_cleaner.clean(backtrace, nil)
       else
         backtrace

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -1321,6 +1321,13 @@ describe Appsignal::Transaction do
         expect(subject).to eq ["line 1", "line 2"]
       end
 
+      context "with Rails module but without backtrace_cleaner method" do
+        it "returns the backtrace uncleaned" do
+          stub_const("Rails", Module.new)
+          expect(subject).to eq ["line 1", "line 2"]
+        end
+      end
+
       if rails_present?
         context "with rails" do
           it "cleans the backtrace with the Rails backtrace cleaner" do


### PR DESCRIPTION
Check if the Rails.backtrace_cleaner method exists before calling it.
We've got a report from a user that the method call fails with a
NoMethodError in a Sinatra app using the activesupport and actionmailer
gems version 5.2.0.

```
NoMethodError - undefined method `backtrace_cleaner' for Rails:Module:
/gems/appsignal-3.0.6/lib/appsignal/transaction.rb:530:in `cleaned_backtrace'
```

I was unable to reproduce in the test setups, but I can see a scenario
where this could fail. To make sure we don't cause this kind of error in
such a scenario, check if the Rails module listens to the
`backtrace_cleaner` method before calling it.

https://github.com/appsignal/test-setups/commit/d484b3676c7f5c0ee9bc54e99c662e783028cc12