### PR TITLE
Run diagnose command specification on CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "spec/integration/diagnose"]
+	path = spec/integration/diagnose
+	url = git@github.com:appsignal/diagnose_tests.git

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,8 +4,8 @@ AllCops:
   TargetRubyVersion: 2.0
   Include:
     - "**/*.cap"
-    - "Gemfile"
-    - "Rakefile"
+    - "**/Gemfile"
+    - "**/Rakefile"
     - "appsignal.gemspec"
   Exclude:
     - "pkg/**/*"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -95,6 +95,8 @@ blocks:
         value: 2.6.6
       - name: GEMSET
         value: no_dependencies
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/no_dependencies.gemfile
       - name: LANGUAGE
         value: ruby
       commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -14,20 +14,12 @@ auto_cancel:
     when: branch != 'main' AND branch != 'develop' AND branch != 'diagnose-testing'
 global_job_config:
   env_vars:
+  - name: RUNNING_IN_CI
+    value: 'true'
   - name: _BUNDLER_CACHE
     value: v2
   - name: _GEMS_CACHE
     value: v2
-  - name: BUNDLE_PATH
-    value: "../.bundle/"
-  - name: RUNNING_IN_CI
-    value: 'true'
-  - name: RAILS_ENV
-    value: test
-  - name: JRUBY_OPTS
-    value: ''
-  - name: COV
-    value: '1'
   prologue:
     commands:
     - checkout
@@ -35,26 +27,15 @@ global_job_config:
     - if [ -n "$_C_VERSION" ]; then sem-version c $_C_VERSION; fi
     - sem-version ruby $RUBY_VERSION
     - "./support/check_versions"
-    - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-    - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
-    - "./support/install_deps"
-    - bundle config set clean 'true'
-    - "./support/bundler_wrapper install --jobs=3 --retry=3"
-  epilogue:
-    on_pass:
-      commands:
-      - cache store $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-        .bundle
-      - cache store $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE) $HOME/.gem
-    on_fail:
-      commands:
-      - "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
-        file found'"
-      - "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file found'"
 blocks:
 - name: Validation
   dependencies: []
   task:
+    prologue:
+      commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
     jobs:
     - name: Validate CI setup
       env_vars:
@@ -63,12 +44,24 @@ blocks:
       - name: GEMSET
         value: no_dependencies
       - name: BUNDLE_GEMFILE
-        value: gemfiles/no_dependencies.gemfile
+        value: Gemfile
       commands:
       - "./support/bundler_wrapper exec rake build_matrix:semaphore:validate"
+    epilogue:
+      on_pass:
+        commands:
+        - cache store $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+          .bundle
+        - cache store $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+          $HOME/.gem
 - name: Linters
   dependencies: []
   task:
+    prologue:
+      commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
     jobs:
     - name: RuboCop
       env_vars:
@@ -77,15 +70,25 @@ blocks:
       - name: GEMSET
         value: no_dependencies
       - name: BUNDLE_GEMFILE
-        value: gemfiles/no_dependencies.gemfile
+        value: Gemfile
       commands:
       - "./support/bundler_wrapper exec rubocop"
+    epilogue:
+      on_pass:
+        commands:
+        - cache store $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+          .bundle
+        - cache store $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+          $HOME/.gem
 - name: Integration tests
   dependencies:
   - Validation
   task:
     prologue:
       commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-diagnose-$(checksum Gemfile)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-diagnose-$(checksum Gemfile)
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
       - git submodule init
       - git submodule update
     jobs:
@@ -93,24 +96,56 @@ blocks:
       env_vars:
       - name: RUBY_VERSION
         value: 2.6.6
-      - name: GEMSET
-        value: no_dependencies
-      - name: BUNDLE_GEMFILE
-        value: gemfiles/no_dependencies.gemfile
       - name: LANGUAGE
         value: ruby
       commands:
       - spec/integration/diagnose/bin/test
+    epilogue:
+      on_pass:
+        commands:
+        - cache store $_BUNDLER_CACHE-bundler-$RUBY_VERSION-diagnose-$(checksum Gemfile)
+          .bundle
+        - cache store $_GEMS_CACHE-gems-$RUBY_VERSION-diagnose-$(checksum Gemfile)
+          $HOME/.gem
 - name: Ruby 2.0.0-p648
   dependencies:
   - Validation
   task:
     prologue:
       commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - "./support/install_deps"
+      - bundle config set clean 'true'
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
       - "./support/bundler_wrapper exec rake extension:install"
+    epilogue: &1
+      on_pass:
+        commands:
+        - cache store $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+          .bundle
+        - cache store $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+          $HOME/.gem
+      on_fail:
+        commands:
+        - "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+          file found'"
+        - "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file found'"
     jobs:
     - name: Ruby 2.0.0-p648 for no_dependencies
       env_vars:
+      - &2
+        name: BUNDLE_PATH
+        value: "../.bundle/"
+      - &3
+        name: RAILS_ENV
+        value: test
+      - &4
+        name: JRUBY_OPTS
+        value: ''
+      - &5
+        name: COV
+        value: '1'
       - name: RUBY_VERSION
         value: 2.0.0-p648
       - name: GEMSET
@@ -130,10 +165,20 @@ blocks:
   task:
     prologue:
       commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - "./support/install_deps"
+      - bundle config set clean 'true'
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
       - "./support/bundler_wrapper exec rake extension:install"
+    epilogue: *1
     jobs:
     - name: Ruby 2.0.0-p648 for rails-3.2
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.0.0-p648
       - name: GEMSET
@@ -149,6 +194,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.0.0-p648 for rails-4.2
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.0.0-p648
       - name: GEMSET
@@ -168,10 +217,20 @@ blocks:
   task:
     prologue:
       commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - "./support/install_deps"
+      - bundle config set clean 'true'
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
       - "./support/bundler_wrapper exec rake extension:install"
+    epilogue: *1
     jobs:
     - name: Ruby 2.1.10 for no_dependencies
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.1.10
       - name: GEMSET
@@ -191,10 +250,20 @@ blocks:
   task:
     prologue:
       commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - "./support/install_deps"
+      - bundle config set clean 'true'
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
       - "./support/bundler_wrapper exec rake extension:install"
+    epilogue: *1
     jobs:
     - name: Ruby 2.2.10 for no_dependencies
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.2.10
       - name: GEMSET
@@ -214,10 +283,20 @@ blocks:
   task:
     prologue:
       commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - "./support/install_deps"
+      - bundle config set clean 'true'
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
       - "./support/bundler_wrapper exec rake extension:install"
+    epilogue: *1
     jobs:
     - name: Ruby 2.3.8 for no_dependencies
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.3.8
       - name: GEMSET
@@ -237,10 +316,20 @@ blocks:
   task:
     prologue:
       commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - "./support/install_deps"
+      - bundle config set clean 'true'
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
       - "./support/bundler_wrapper exec rake extension:install"
+    epilogue: *1
     jobs:
     - name: Ruby 2.4.10 for no_dependencies
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.4.10
       - name: GEMSET
@@ -260,10 +349,20 @@ blocks:
   task:
     prologue:
       commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - "./support/install_deps"
+      - bundle config set clean 'true'
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
       - "./support/bundler_wrapper exec rake extension:install"
+    epilogue: *1
     jobs:
     - name: Ruby 2.5.8 for no_dependencies
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.5.8
       - name: GEMSET
@@ -283,10 +382,20 @@ blocks:
   task:
     prologue:
       commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - "./support/install_deps"
+      - bundle config set clean 'true'
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
       - "./support/bundler_wrapper exec rake extension:install"
+    epilogue: *1
     jobs:
     - name: Ruby 2.5.8 for rails-5.2
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.5.8
       - name: GEMSET
@@ -302,6 +411,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.5.8 for rails-6.0
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.5.8
       - name: GEMSET
@@ -321,10 +434,20 @@ blocks:
   task:
     prologue:
       commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - "./support/install_deps"
+      - bundle config set clean 'true'
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
       - "./support/bundler_wrapper exec rake extension:install"
+    epilogue: *1
     jobs:
     - name: Ruby 2.6.6 for no_dependencies
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.6.6
       - name: GEMSET
@@ -344,10 +467,20 @@ blocks:
   task:
     prologue:
       commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - "./support/install_deps"
+      - bundle config set clean 'true'
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
       - "./support/bundler_wrapper exec rake extension:install"
+    epilogue: *1
     jobs:
     - name: Ruby 2.6.6 for capistrano2
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.6.6
       - name: GEMSET
@@ -363,6 +496,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.6 for capistrano3
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.6.6
       - name: GEMSET
@@ -378,6 +515,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.6 for grape
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.6.6
       - name: GEMSET
@@ -393,6 +534,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.6 for padrino
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.6.6
       - name: GEMSET
@@ -408,6 +553,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.6 for que
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.6.6
       - name: GEMSET
@@ -423,6 +572,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.6 for que_beta
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.6.6
       - name: GEMSET
@@ -438,6 +591,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.6 for rails-5.0
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.6.6
       - name: GEMSET
@@ -453,6 +610,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.6 for rails-5.1
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.6.6
       - name: GEMSET
@@ -468,6 +629,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.6 for rails-5.2
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.6.6
       - name: GEMSET
@@ -483,6 +648,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.6 for rails-6.0
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.6.6
       - name: GEMSET
@@ -498,6 +667,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.6 for resque-1
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.6.6
       - name: GEMSET
@@ -513,6 +686,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.6 for resque-2
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.6.6
       - name: GEMSET
@@ -528,6 +705,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.6 for sequel
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.6.6
       - name: GEMSET
@@ -543,6 +724,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.6 for sequel-435
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.6.6
       - name: GEMSET
@@ -558,6 +743,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.6 for sinatra
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.6.6
       - name: GEMSET
@@ -573,6 +762,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.6 for webmachine
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.6.6
       - name: GEMSET
@@ -592,10 +785,20 @@ blocks:
   task:
     prologue:
       commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - "./support/install_deps"
+      - bundle config set clean 'true'
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
       - "./support/bundler_wrapper exec rake extension:install"
+    epilogue: *1
     jobs:
     - name: Ruby 2.7.3 for no_dependencies
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.7.3
       - name: GEMSET
@@ -615,10 +818,20 @@ blocks:
   task:
     prologue:
       commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - "./support/install_deps"
+      - bundle config set clean 'true'
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
       - "./support/bundler_wrapper exec rake extension:install"
+    epilogue: *1
     jobs:
     - name: Ruby 2.7.3 for capistrano2
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.7.3
       - name: GEMSET
@@ -634,6 +847,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.3 for capistrano3
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.7.3
       - name: GEMSET
@@ -649,6 +866,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.3 for grape
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.7.3
       - name: GEMSET
@@ -664,6 +885,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.3 for padrino
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.7.3
       - name: GEMSET
@@ -679,6 +904,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.3 for que
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.7.3
       - name: GEMSET
@@ -694,6 +923,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.3 for que_beta
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.7.3
       - name: GEMSET
@@ -709,6 +942,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.3 for rails-5.0
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.7.3
       - name: GEMSET
@@ -724,6 +961,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.3 for rails-5.1
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.7.3
       - name: GEMSET
@@ -739,6 +980,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.3 for rails-5.2
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.7.3
       - name: GEMSET
@@ -754,6 +999,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.3 for rails-6.0
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.7.3
       - name: GEMSET
@@ -769,6 +1018,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.3 for resque-1
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.7.3
       - name: GEMSET
@@ -784,6 +1037,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.3 for resque-2
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.7.3
       - name: GEMSET
@@ -799,6 +1056,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.3 for sequel
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.7.3
       - name: GEMSET
@@ -814,6 +1075,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.3 for sequel-435
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.7.3
       - name: GEMSET
@@ -829,6 +1094,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.3 for sinatra
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.7.3
       - name: GEMSET
@@ -844,6 +1113,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.3 for webmachine
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 2.7.3
       - name: GEMSET
@@ -863,10 +1136,20 @@ blocks:
   task:
     prologue:
       commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - "./support/install_deps"
+      - bundle config set clean 'true'
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
       - "./support/bundler_wrapper exec rake extension:install"
+    epilogue: *1
     jobs:
     - name: Ruby 3.0.1 for no_dependencies
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 3.0.1
       - name: GEMSET
@@ -886,10 +1169,20 @@ blocks:
   task:
     prologue:
       commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - "./support/install_deps"
+      - bundle config set clean 'true'
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
       - "./support/bundler_wrapper exec rake extension:install"
+    epilogue: *1
     jobs:
     - name: Ruby 3.0.1 for capistrano2
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 3.0.1
       - name: GEMSET
@@ -905,6 +1198,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.0.1 for capistrano3
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 3.0.1
       - name: GEMSET
@@ -920,6 +1217,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.0.1 for grape
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 3.0.1
       - name: GEMSET
@@ -935,6 +1236,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.0.1 for padrino
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 3.0.1
       - name: GEMSET
@@ -950,6 +1255,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.0.1 for que
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 3.0.1
       - name: GEMSET
@@ -965,6 +1274,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.0.1 for que_beta
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 3.0.1
       - name: GEMSET
@@ -980,6 +1293,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.0.1 for rails-6.0
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 3.0.1
       - name: GEMSET
@@ -995,6 +1312,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.0.1 for resque-2
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 3.0.1
       - name: GEMSET
@@ -1010,6 +1331,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.0.1 for sequel
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 3.0.1
       - name: GEMSET
@@ -1025,6 +1350,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.0.1 for sinatra
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 3.0.1
       - name: GEMSET
@@ -1040,6 +1369,10 @@ blocks:
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.0.1 for webmachine
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: 3.0.1
       - name: GEMSET
@@ -1059,10 +1392,20 @@ blocks:
   task:
     prologue:
       commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - "./support/install_deps"
+      - bundle config set clean 'true'
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
       - "./support/bundler_wrapper exec rake extension:install"
+    epilogue: *1
     jobs:
     - name: Ruby jruby-9.2.19.0 for no_dependencies
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: jruby-9.2.19.0
       - name: GEMSET
@@ -1085,10 +1428,20 @@ blocks:
   task:
     prologue:
       commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - "./support/install_deps"
+      - bundle config set clean 'true'
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
       - "./support/bundler_wrapper exec rake extension:install"
+    epilogue: *1
     jobs:
     - name: Ruby jruby-9.2.19.0 for rails-5.2
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: jruby-9.2.19.0
       - name: GEMSET

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -11,7 +11,7 @@ agent:
     os_image: ubuntu1804
 auto_cancel:
   running:
-    when: branch != 'main' AND branch != 'develop'
+    when: branch != 'main' AND branch != 'develop' AND branch != 'diagnose-testing'
 global_job_config:
   env_vars:
   - name: _BUNDLER_CACHE
@@ -80,6 +80,25 @@ blocks:
         value: gemfiles/no_dependencies.gemfile
       commands:
       - "./support/bundler_wrapper exec rubocop"
+- name: Integration tests
+  dependencies:
+  - Validation
+  task:
+    prologue:
+      commands:
+      - git submodule init
+      - git submodule update
+    jobs:
+    - name: Diagnose
+      env_vars:
+      - name: RUBY_VERSION
+        value: 2.6.6
+      - name: GEMSET
+        value: no_dependencies
+      - name: LANGUAGE
+        value: ruby
+      commands:
+      - spec/integration/diagnose/bin/test
 - name: Ruby 2.0.0-p648
   dependencies:
   - Validation

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -89,6 +89,7 @@ blocks:
       - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-diagnose-$(checksum Gemfile)
       - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-diagnose-$(checksum Gemfile)
       - "./support/bundler_wrapper install --jobs=3 --retry=3"
+      - "./support/bundler_wrapper exec rake extension:install"
       - git submodule init
       - git submodule update
     jobs:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1417,7 +1417,7 @@ blocks:
         value: latest
       - name: _BUNDLER_VERSION
         value: latest
-      - &1
+      - &6
         name: _C_VERSION
         value: '8'
       commands:
@@ -1453,12 +1453,16 @@ blocks:
         value: latest
       - name: _BUNDLER_VERSION
         value: latest
-      - *1
+      - *6
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby jruby-9.2.19.0 for rails-6.0
       env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
       - name: RUBY_VERSION
         value: jruby-9.2.19.0
       - name: GEMSET
@@ -1469,7 +1473,7 @@ blocks:
         value: latest
       - name: _BUNDLER_VERSION
         value: latest
-      - *1
+      - *6
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"

--- a/Rakefile
+++ b/Rakefile
@@ -182,7 +182,7 @@ end
 
 namespace :build do
   def base_gemspec
-    eval(File.read("appsignal.gemspec"))
+    eval(File.read("appsignal.gemspec")) # rubocop:disable Security/Eval
   end
 
   def modify_base_gemspec
@@ -401,7 +401,7 @@ begin
     desc "Run the Appsignal gem test in an extension failure scenario"
     task :failure => [:prepare_failure, :rspec_failure]
   end
-rescue LoadError
+rescue LoadError # rubocop:disable Lint/HandleExceptions
   # When running rake install, there is no RSpec yet.
 end
 

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -95,6 +95,8 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
               value: 2.6.6
             - name: GEMSET
               value: no_dependencies
+            - name: BUNDLE_GEMFILE
+              value: gemfiles/no_dependencies.gemfile
             - name: LANGUAGE
               value: ruby
           commands:

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -11,7 +11,7 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
   auto_cancel:
     running:
       # Ignore main AND develop branch as we want it to build all workflows
-      when: "branch != 'main' AND branch != 'develop'"
+      when: "branch != 'main' AND branch != 'develop' AND branch != 'diagnose-testing'"
 
   global_job_config:
     env_vars:
@@ -80,6 +80,25 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
               value: gemfiles/no_dependencies.gemfile
           commands:
             - ./support/bundler_wrapper exec rubocop
+    - name: Integration tests
+      dependencies:
+      - Validation
+      task:
+        prologue:
+          commands:
+          - git submodule init
+          - git submodule update
+        jobs:
+        - name: Diagnose
+          env_vars:
+            - name: RUBY_VERSION
+              value: 2.6.6
+            - name: GEMSET
+              value: no_dependencies
+            - name: LANGUAGE
+              value: ruby
+          commands:
+            - spec/integration/diagnose/bin/test
 
 matrix:
   defaults:

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -87,6 +87,7 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
             - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-diagnose-$(checksum Gemfile)
             - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-diagnose-$(checksum Gemfile)
             - ./support/bundler_wrapper install --jobs=3 --retry=3
+            - ./support/bundler_wrapper exec rake extension:install
             - git submodule init
             - git submodule update
         jobs:

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -15,20 +15,12 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
 
   global_job_config:
     env_vars:
+      - name: RUNNING_IN_CI
+        value: "true"
       - name: _BUNDLER_CACHE
         value: "v2"
       - name: _GEMS_CACHE
         value: "v2"
-      - name: BUNDLE_PATH
-        value: "../.bundle/"
-      - name: RUNNING_IN_CI
-        value: "true"
-      - name: RAILS_ENV
-        value: "test"
-      - name: JRUBY_OPTS
-        value: ""
-      - name: COV
-        value: "1"
     prologue:
       commands:
         - checkout
@@ -36,25 +28,16 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
         - "if [ -n \"$_C_VERSION\" ]; then sem-version c $_C_VERSION; fi"
         - sem-version ruby $RUBY_VERSION
         - ./support/check_versions
-        - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-        - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
-        - ./support/install_deps
-        - bundle config set clean 'true'
-        - ./support/bundler_wrapper install --jobs=3 --retry=3
-    epilogue:
-      on_pass:
-        commands:
-          - cache store $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE) .bundle
-          - cache store $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE) $HOME/.gem
-      on_fail:
-        commands:
-          - "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report file found'"
-          - "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file found'"
 
   blocks:
     - name: Validation
       dependencies: []
       task:
+        prologue:
+          commands:
+            - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+            - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+            - ./support/bundler_wrapper install --jobs=3 --retry=3
         jobs:
         - name: Validate CI setup
           env_vars:
@@ -63,12 +46,22 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
             - name: GEMSET
               value: no_dependencies
             - name: BUNDLE_GEMFILE
-              value: gemfiles/no_dependencies.gemfile
+              value: Gemfile
           commands:
             - ./support/bundler_wrapper exec rake build_matrix:semaphore:validate
+        epilogue:
+          on_pass:
+            commands:
+              - cache store $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE) .bundle
+              - cache store $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE) $HOME/.gem
     - name: Linters
       dependencies: []
       task:
+        prologue:
+          commands:
+            - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+            - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+            - ./support/bundler_wrapper install --jobs=3 --retry=3
         jobs:
         - name: RuboCop
           env_vars:
@@ -77,32 +70,67 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
             - name: GEMSET
               value: no_dependencies
             - name: BUNDLE_GEMFILE
-              value: gemfiles/no_dependencies.gemfile
+              value: Gemfile
           commands:
             - ./support/bundler_wrapper exec rubocop
+        epilogue:
+          on_pass:
+            commands:
+              - cache store $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE) .bundle
+              - cache store $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE) $HOME/.gem
     - name: Integration tests
       dependencies:
       - Validation
       task:
         prologue:
           commands:
-          - git submodule init
-          - git submodule update
+            - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-diagnose-$(checksum Gemfile)
+            - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-diagnose-$(checksum Gemfile)
+            - ./support/bundler_wrapper install --jobs=3 --retry=3
+            - git submodule init
+            - git submodule update
         jobs:
         - name: Diagnose
           env_vars:
             - name: RUBY_VERSION
               value: 2.6.6
-            - name: GEMSET
-              value: no_dependencies
-            - name: BUNDLE_GEMFILE
-              value: gemfiles/no_dependencies.gemfile
             - name: LANGUAGE
               value: ruby
           commands:
             - spec/integration/diagnose/bin/test
+        epilogue:
+          on_pass:
+            commands:
+              - cache store $_BUNDLER_CACHE-bundler-$RUBY_VERSION-diagnose-$(checksum Gemfile) .bundle
+              - cache store $_GEMS_CACHE-gems-$RUBY_VERSION-diagnose-$(checksum Gemfile) $HOME/.gem
 
 matrix:
+  env_vars: # Shared for all jobs in the build matrix
+    - name: BUNDLE_PATH
+      value: "../.bundle/"
+    - name: RAILS_ENV
+      value: "test"
+    - name: JRUBY_OPTS
+      value: ""
+    - name: COV
+      value: "1"
+  prologue: # Shared for all jobs in the build matrix
+    commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - ./support/install_deps
+      - bundle config set clean 'true'
+      - ./support/bundler_wrapper install --jobs=3 --retry=3
+  epilogue: # Shared for all jobs in the build matrix
+    on_pass:
+      commands:
+        - cache store $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE) .bundle
+        - cache store $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE) $HOME/.gem
+    on_fail:
+      commands:
+        - "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report file found'"
+        - "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file found'"
+
   defaults:
     rubygems: "latest"
     bundler: "latest"

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -177,6 +177,11 @@ module Appsignal
           puts "#{"  " * options[:level]}#{label}: #{value}"
         end
 
+        def puts_yes_or_no(label, value, options = {})
+          options[:level] ||= 1
+          puts "#{"  " * options[:level]}#{label}: #{value ? 'yes' : 'no'}"
+        end
+
         def configure_appsignal(options)
           current_path = Dir.pwd
           initial_config = {}
@@ -330,7 +335,8 @@ module Appsignal
             puts_value "Language", "Ruby"
             puts_and_save :package_version, "Gem version", Appsignal::VERSION
             puts_and_save :agent_version, "Agent version", Appsignal::Extension.agent_version
-            puts_and_save :extension_loaded, "Extension loaded", Appsignal.extension_loaded
+            save :extension_loaded, Appsignal.extension_loaded
+            puts_yes_or_no "Extension loaded", Appsignal.extension_loaded
           end
         end
 

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -327,6 +327,7 @@ module Appsignal
           puts "AppSignal library"
           data_section :library do
             save :language, "ruby"
+            puts_value "Language", "Ruby"
             puts_and_save :package_version, "Gem version", Appsignal::VERSION
             puts_and_save :agent_version, "Agent version", Appsignal::Extension.agent_version
             puts_and_save :extension_loaded, "Extension loaded", Appsignal.extension_loaded

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -105,7 +105,6 @@ module Appsignal
           paths_report = Paths.new
           data[:paths] = paths_report.report
           print_paths_section(paths_report)
-          print_empty_line
 
           transmit_report_to_appsignal if send_report_to_appsignal?(options)
         end
@@ -575,9 +574,13 @@ module Appsignal
             "(file: #{ownership[:user]}:#{ownership[:uid]}, " \
             "process: #{process_user[:user]}:#{process_user[:uid]})"
           puts_value "Ownership?", owner, :level => 2
-          return unless path.key?(:content)
-          puts "    Contents (last 10 lines):"
-          puts path[:content].last(10)
+
+          if path.key?(:content)
+            puts "    Contents (last 10 lines):"
+            puts path[:content].last(10)
+          else
+            print_empty_line
+          end
         end
 
         def print_empty_line

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -177,11 +177,6 @@ module Appsignal
           puts "#{"  " * options[:level]}#{label}: #{value}"
         end
 
-        def puts_yes_or_no(label, value, options = {})
-          options[:level] ||= 1
-          puts "#{"  " * options[:level]}#{label}: #{value ? 'yes' : 'no'}"
-        end
-
         def configure_appsignal(options)
           current_path = Dir.pwd
           initial_config = {}
@@ -335,8 +330,7 @@ module Appsignal
             puts_value "Language", "Ruby"
             puts_and_save :package_version, "Gem version", Appsignal::VERSION
             puts_and_save :agent_version, "Agent version", Appsignal::Extension.agent_version
-            save :extension_loaded, Appsignal.extension_loaded
-            puts_yes_or_no "Extension loaded", Appsignal.extension_loaded
+            puts_and_save :extension_loaded, "Extension loaded", Appsignal.extension_loaded
           end
         end
 

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -211,7 +211,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
         before { run }
 
         it "outputs extension is loaded" do
-          expect(output).to include "Extension loaded: true"
+          expect(output).to include "Extension loaded: yes"
         end
 
         it "transmits extension_loaded: true in report" do
@@ -230,7 +230,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
         after { Appsignal.extension_loaded = true }
 
         it "outputs extension is not loaded" do
-          expect(output).to include "Extension loaded: false"
+          expect(output).to include "Extension loaded: no"
           expect(output).to include "Extension is not loaded. No agent report created."
         end
 

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -211,7 +211,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
         before { run }
 
         it "outputs extension is loaded" do
-          expect(output).to include "Extension loaded: yes"
+          expect(output).to include "Extension loaded: true"
         end
 
         it "transmits extension_loaded: true in report" do
@@ -230,7 +230,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
         after { Appsignal.extension_loaded = true }
 
         it "outputs extension is not loaded" do
-          expect(output).to include "Extension loaded: no"
+          expect(output).to include "Extension loaded: false"
           expect(output).to include "Extension is not loaded. No agent report created."
         end
 


### PR DESCRIPTION
https://github.com/appsignal/appsignal-nodejs/pull/401 introduces https://github.com/appsignal/diagnose_tests, a runnable specification for our diagnose commands. Originally built for the Node.js integration, but based on the Ruby integration’s current state (as that’s the leading integration), the eventual goal is to run the diagnose tests for every integration.

This patch adds the diagnose tests to the Ruby integration’s CI.