### PR TITLE
Backport installation failure fix

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -32,6 +32,7 @@ global_job_config:
     commands:
     - checkout
     - rm -f $HOME/.rbenv/plugins/rbenv-gem-rehash/etc/rbenv.d/exec/~gem-rehash.bash
+    - if [ -n "$_C_VERSION" ]; then sem-version c $_C_VERSION; fi
     - sem-version ruby $RUBY_VERSION
     - "./support/check_versions"
     - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
@@ -1054,7 +1055,7 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
-- name: Ruby jruby-9.1.17.0
+- name: Ruby jruby-9.2.19.0
   dependencies:
   - Validation
   task:
@@ -1062,10 +1063,10 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake extension:install"
     jobs:
-    - name: Ruby jruby-9.1.17.0 for no_dependencies
+    - name: Ruby jruby-9.2.19.0 for no_dependencies
       env_vars:
       - name: RUBY_VERSION
-        value: jruby-9.1.17.0
+        value: jruby-9.2.19.0
       - name: GEMSET
         value: no_dependencies
       - name: BUNDLE_GEMFILE
@@ -1074,21 +1075,24 @@ blocks:
         value: latest
       - name: _BUNDLER_VERSION
         value: latest
+      - &1
+        name: _C_VERSION
+        value: '8'
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
-- name: Ruby jruby-9.1.17.0 - Gems
+- name: Ruby jruby-9.2.19.0 - Gems
   dependencies:
-  - Ruby jruby-9.1.17.0
+  - Ruby jruby-9.2.19.0
   task:
     prologue:
       commands:
       - "./support/bundler_wrapper exec rake extension:install"
     jobs:
-    - name: Ruby jruby-9.1.17.0 for rails-5.2
+    - name: Ruby jruby-9.2.19.0 for rails-5.2
       env_vars:
       - name: RUBY_VERSION
-        value: jruby-9.1.17.0
+        value: jruby-9.2.19.0
       - name: GEMSET
         value: rails-5.2
       - name: BUNDLE_GEMFILE
@@ -1097,6 +1101,23 @@ blocks:
         value: latest
       - name: _BUNDLER_VERSION
         value: latest
+      - *1
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby jruby-9.2.19.0 for rails-6.0
+      env_vars:
+      - name: RUBY_VERSION
+        value: jruby-9.2.19.0
+      - name: GEMSET
+        value: rails-6.0
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/rails-6.0.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      - *1
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -133,66 +133,6 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake extension:install"
     jobs:
-    - name: Ruby 2.0.0-p648 for capistrano2
-      env_vars:
-      - name: RUBY_VERSION
-        value: 2.0.0-p648
-      - name: GEMSET
-        value: capistrano2
-      - name: BUNDLE_GEMFILE
-        value: gemfiles/capistrano2.gemfile
-      - name: _RUBYGEMS_VERSION
-        value: 2.7.8
-      - name: _BUNDLER_VERSION
-        value: 1.17.3
-      commands:
-      - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
-    - name: Ruby 2.0.0-p648 for capistrano3
-      env_vars:
-      - name: RUBY_VERSION
-        value: 2.0.0-p648
-      - name: GEMSET
-        value: capistrano3
-      - name: BUNDLE_GEMFILE
-        value: gemfiles/capistrano3.gemfile
-      - name: _RUBYGEMS_VERSION
-        value: 2.7.8
-      - name: _BUNDLER_VERSION
-        value: 1.17.3
-      commands:
-      - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
-    - name: Ruby 2.0.0-p648 for grape
-      env_vars:
-      - name: RUBY_VERSION
-        value: 2.0.0-p648
-      - name: GEMSET
-        value: grape
-      - name: BUNDLE_GEMFILE
-        value: gemfiles/grape.gemfile
-      - name: _RUBYGEMS_VERSION
-        value: 2.7.8
-      - name: _BUNDLER_VERSION
-        value: 1.17.3
-      commands:
-      - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
-    - name: Ruby 2.0.0-p648 for que
-      env_vars:
-      - name: RUBY_VERSION
-        value: 2.0.0-p648
-      - name: GEMSET
-        value: que
-      - name: BUNDLE_GEMFILE
-        value: gemfiles/que.gemfile
-      - name: _RUBYGEMS_VERSION
-        value: 2.7.8
-      - name: _BUNDLER_VERSION
-        value: 1.17.3
-      commands:
-      - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.0.0-p648 for rails-3.2
       env_vars:
       - name: RUBY_VERSION
@@ -216,81 +156,6 @@ blocks:
         value: rails-4.2
       - name: BUNDLE_GEMFILE
         value: gemfiles/rails-4.2.gemfile
-      - name: _RUBYGEMS_VERSION
-        value: 2.7.8
-      - name: _BUNDLER_VERSION
-        value: 1.17.3
-      commands:
-      - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
-    - name: Ruby 2.0.0-p648 for resque-1
-      env_vars:
-      - name: RUBY_VERSION
-        value: 2.0.0-p648
-      - name: GEMSET
-        value: resque-1
-      - name: BUNDLE_GEMFILE
-        value: gemfiles/resque-1.gemfile
-      - name: _RUBYGEMS_VERSION
-        value: 2.7.8
-      - name: _BUNDLER_VERSION
-        value: 1.17.3
-      commands:
-      - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
-    - name: Ruby 2.0.0-p648 for sequel
-      env_vars:
-      - name: RUBY_VERSION
-        value: 2.0.0-p648
-      - name: GEMSET
-        value: sequel
-      - name: BUNDLE_GEMFILE
-        value: gemfiles/sequel.gemfile
-      - name: _RUBYGEMS_VERSION
-        value: 2.7.8
-      - name: _BUNDLER_VERSION
-        value: 1.17.3
-      commands:
-      - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
-    - name: Ruby 2.0.0-p648 for sequel-435
-      env_vars:
-      - name: RUBY_VERSION
-        value: 2.0.0-p648
-      - name: GEMSET
-        value: sequel-435
-      - name: BUNDLE_GEMFILE
-        value: gemfiles/sequel-435.gemfile
-      - name: _RUBYGEMS_VERSION
-        value: 2.7.8
-      - name: _BUNDLER_VERSION
-        value: 1.17.3
-      commands:
-      - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
-    - name: Ruby 2.0.0-p648 for sinatra
-      env_vars:
-      - name: RUBY_VERSION
-        value: 2.0.0-p648
-      - name: GEMSET
-        value: sinatra
-      - name: BUNDLE_GEMFILE
-        value: gemfiles/sinatra.gemfile
-      - name: _RUBYGEMS_VERSION
-        value: 2.7.8
-      - name: _BUNDLER_VERSION
-        value: 1.17.3
-      commands:
-      - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
-    - name: Ruby 2.0.0-p648 for webmachine
-      env_vars:
-      - name: RUBY_VERSION
-        value: 2.0.0-p648
-      - name: GEMSET
-        value: webmachine
-      - name: BUNDLE_GEMFILE
-        value: gemfiles/webmachine.gemfile
       - name: _RUBYGEMS_VERSION
         value: 2.7.8
       - name: _BUNDLER_VERSION
@@ -993,7 +858,7 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
-- name: Ruby 3.0.0
+- name: Ruby 3.0.1
   dependencies:
   - Validation
   task:
@@ -1001,10 +866,10 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake extension:install"
     jobs:
-    - name: Ruby 3.0.0 for no_dependencies
+    - name: Ruby 3.0.1 for no_dependencies
       env_vars:
       - name: RUBY_VERSION
-        value: 3.0.0
+        value: 3.0.1
       - name: GEMSET
         value: no_dependencies
       - name: BUNDLE_GEMFILE
@@ -1016,18 +881,18 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
-- name: Ruby 3.0.0 - Gems
+- name: Ruby 3.0.1 - Gems
   dependencies:
-  - Ruby 3.0.0
+  - Ruby 3.0.1
   task:
     prologue:
       commands:
       - "./support/bundler_wrapper exec rake extension:install"
     jobs:
-    - name: Ruby 3.0.0 for capistrano2
+    - name: Ruby 3.0.1 for capistrano2
       env_vars:
       - name: RUBY_VERSION
-        value: 3.0.0
+        value: 3.0.1
       - name: GEMSET
         value: capistrano2
       - name: BUNDLE_GEMFILE
@@ -1039,10 +904,10 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
-    - name: Ruby 3.0.0 for capistrano3
+    - name: Ruby 3.0.1 for capistrano3
       env_vars:
       - name: RUBY_VERSION
-        value: 3.0.0
+        value: 3.0.1
       - name: GEMSET
         value: capistrano3
       - name: BUNDLE_GEMFILE
@@ -1054,10 +919,10 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
-    - name: Ruby 3.0.0 for grape
+    - name: Ruby 3.0.1 for grape
       env_vars:
       - name: RUBY_VERSION
-        value: 3.0.0
+        value: 3.0.1
       - name: GEMSET
         value: grape
       - name: BUNDLE_GEMFILE
@@ -1069,10 +934,10 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
-    - name: Ruby 3.0.0 for padrino
+    - name: Ruby 3.0.1 for padrino
       env_vars:
       - name: RUBY_VERSION
-        value: 3.0.0
+        value: 3.0.1
       - name: GEMSET
         value: padrino
       - name: BUNDLE_GEMFILE
@@ -1084,10 +949,10 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
-    - name: Ruby 3.0.0 for que
+    - name: Ruby 3.0.1 for que
       env_vars:
       - name: RUBY_VERSION
-        value: 3.0.0
+        value: 3.0.1
       - name: GEMSET
         value: que
       - name: BUNDLE_GEMFILE
@@ -1099,10 +964,10 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
-    - name: Ruby 3.0.0 for que_beta
+    - name: Ruby 3.0.1 for que_beta
       env_vars:
       - name: RUBY_VERSION
-        value: 3.0.0
+        value: 3.0.1
       - name: GEMSET
         value: que_beta
       - name: BUNDLE_GEMFILE
@@ -1114,10 +979,10 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
-    - name: Ruby 3.0.0 for rails-6.0
+    - name: Ruby 3.0.1 for rails-6.0
       env_vars:
       - name: RUBY_VERSION
-        value: 3.0.0
+        value: 3.0.1
       - name: GEMSET
         value: rails-6.0
       - name: BUNDLE_GEMFILE
@@ -1129,10 +994,10 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
-    - name: Ruby 3.0.0 for resque-2
+    - name: Ruby 3.0.1 for resque-2
       env_vars:
       - name: RUBY_VERSION
-        value: 3.0.0
+        value: 3.0.1
       - name: GEMSET
         value: resque-2
       - name: BUNDLE_GEMFILE
@@ -1144,10 +1009,10 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
-    - name: Ruby 3.0.0 for sequel
+    - name: Ruby 3.0.1 for sequel
       env_vars:
       - name: RUBY_VERSION
-        value: 3.0.0
+        value: 3.0.1
       - name: GEMSET
         value: sequel
       - name: BUNDLE_GEMFILE
@@ -1159,10 +1024,10 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
-    - name: Ruby 3.0.0 for sinatra
+    - name: Ruby 3.0.1 for sinatra
       env_vars:
       - name: RUBY_VERSION
-        value: 3.0.0
+        value: 3.0.1
       - name: GEMSET
         value: sinatra
       - name: BUNDLE_GEMFILE
@@ -1174,10 +1039,10 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
-    - name: Ruby 3.0.0 for webmachine
+    - name: Ruby 3.0.1 for webmachine
       env_vars:
       - name: RUBY_VERSION
-        value: 3.0.0
+        value: 3.0.1
       - name: GEMSET
         value: webmachine
       - name: BUNDLE_GEMFILE

--- a/Rakefile
+++ b/Rakefile
@@ -387,10 +387,20 @@ begin
   end
 
   namespace :test do
-    desc "Run the Appsignal gem test in an extension failure scenario"
-    RSpec::Core::RakeTask.new :failure do |t|
+    RSpec::Core::RakeTask.new :rspec_failure do |t|
       t.rspec_opts = "#{exclude_pattern} --tag extension_installation_failure"
     end
+
+    desc "Intentionally fail the extension installation"
+    task :prepare_failure do
+      # ENV var to make sure installation fails on purpurse
+      ENV["_TEST_APPSIGNAL_EXTENSION_FAILURE"] = "true"
+      # Run extension installation with intentional failure
+      `rake extension:install`
+    end
+
+    desc "Run the Appsignal gem test in an extension failure scenario"
+    task :failure => [:prepare_failure, :rspec_failure]
   end
 rescue LoadError # rubocop:disable Lint/HandleExceptions
   # When running rake install, there is no RSpec yet.

--- a/Rakefile
+++ b/Rakefile
@@ -73,7 +73,7 @@ namespace :build_matrix do
 
           job = {
             "name" => "Ruby #{ruby_version} for #{gem["gem"]}",
-            "env_vars" => env,
+            "env_vars" => env + ruby.fetch("env_vars", []),
             "commands" => [
               "./support/bundler_wrapper exec rake test",
               "./support/bundler_wrapper exec rake test:failure"

--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -47,4 +47,9 @@ Gem::Specification.new do |gem| # rubocop:disable Metrics/BlockLength
     gem.add_development_dependency "pry"
     gem.add_development_dependency "rubocop", "0.50.0"
   end
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1.0")
+    # Newer versions of rexml use keyword arguments with optional arguments which
+    # work in Ruby 2.1 and newer.
+    gem.add_development_dependency "rexml", "3.2.4"
+  end
 end

--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -42,14 +42,31 @@ Gem::Specification.new do |gem| # rubocop:disable Metrics/BlockLength
   gem.add_development_dependency "timecop"
   gem.add_development_dependency "webmock"
   gem.add_development_dependency "yard", ">= 0.9.20"
-  is_modern_ruby = Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.0.0")
-  if is_modern_ruby
+
+  ruby_version = Gem::Version.new(RUBY_VERSION)
+  if ruby_version >= Gem::Version.new("2.0.0")
     gem.add_development_dependency "pry"
     gem.add_development_dependency "rubocop", "0.50.0"
   end
-  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1.0")
-    # Newer versions of rexml use keyword arguments with optional arguments which
+
+  # Dependencies that need to be locked to a specific version in developement
+  if ruby_version < Gem::Version.new("2.0.0")
+    # The rexml gem use keyword arguments with optional arguments which
+    # work in Ruby 2.1 and newer. Lock crack to a version without rexml.
+    gem.add_development_dependency "crack", "0.4.4"
+  elsif ruby_version < Gem::Version.new("2.1.0")
+    # The rexml gem use keyword arguments with optional arguments which
     # work in Ruby 2.1 and newer.
     gem.add_development_dependency "rexml", "3.2.4"
+  end
+  if ruby_version < Gem::Version.new("2.0.0")
+    # public_suffix 2.0 and newer don't support Ruby < 2.0
+    gem.add_development_dependency "public_suffix", "~> 1.4.6"
+  elsif ruby_version < Gem::Version.new("2.1.0")
+    # public_suffix 3.0 and newer don't support Ruby < 2.1
+    gem.add_development_dependency "public_suffix", "~> 2.0.5"
+  elsif ruby_version < Gem::Version.new("2.3.0")
+    # public_suffix 4.0 and newer don't support Ruby < 2.3
+    gem.add_development_dependency "public_suffix", "~> 3.1.1"
   end
 end

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -88,6 +88,10 @@ matrix:
   gemsets: # By default all gems are tested
     none:
       - "no_dependencies"
+    old_rails:
+      - "no_dependencies"
+      - "rails-3.2"
+      - "rails-4.2"
     minimal:
       - "no_dependencies"
       - "rails-5.2"
@@ -101,6 +105,7 @@ matrix:
     - ruby: "2.0.0-p648"
       rubygems: "2.7.8"
       bundler: "1.17.3"
+      gems: "old_rails"
     - ruby: "2.1.10"
       rubygems: "2.7.8"
       bundler: "1.17.3"
@@ -117,7 +122,7 @@ matrix:
       gems: "minimal"
     - ruby: "2.6.5"
     - ruby: "2.7.1"
-    - ruby: "3.0.0"
+    - ruby: "3.0.1"
     - ruby: "jruby-9.1.17.0"
       gems: "minimal"
   gems:
@@ -126,47 +131,37 @@ matrix:
     - gem: "capistrano3"
     - gem: "grape"
     - gem: "padrino"
-      exclude:
-        ruby:
-          - "2.0.0-p648"
     - gem: "que"
     - gem: "que_beta"
-      exclude:
-        ruby:
-          - "2.0.0-p648"
     - gem: "rails-3.2"
       bundler: "1.17.3"
       exclude:
         ruby:
           - "2.6.5"
           - "2.7.1"
-          - "3.0.0"
+          - "3.0.1"
     - gem: "rails-4.2"
       bundler: "1.17.3"
       exclude:
         ruby:
           - "2.6.5"
           - "2.7.1"
-          - "3.0.0"
+          - "3.0.1"
     - gem: "rails-5.0"
       exclude:
         ruby:
-          - "2.0.0-p648"
-          - "3.0.0"
+          - "3.0.1"
     - gem: "rails-5.1"
       exclude:
         ruby:
-          - "2.0.0-p648"
-          - "3.0.0"
+          - "3.0.1"
     - gem: "rails-5.2"
       exclude:
         ruby:
-          - "2.0.0-p648"
-          - "3.0.0"
+          - "3.0.1"
     - gem: "rails-6.0"
       exclude:
         ruby:
-          - "2.0.0-p648"
           - "2.1.10"
           - "2.2.10"
           - "2.3.8"
@@ -176,15 +171,12 @@ matrix:
       bundler: "1.17.3"
       exclude:
         ruby:
-          - "3.0.0"
+          - "3.0.1"
     - gem: "resque-2"
-      exclude:
-        ruby:
-          - "2.0.0-p648"
     - gem: "sequel"
     - gem: "sequel-435"
       exclude:
         ruby:
-          - "3.0.0"
+          - "3.0.1"
     - gem: "sinatra"
     - gem: "webmachine"

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -33,6 +33,7 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
       commands:
         - checkout
         - rm -f $HOME/.rbenv/plugins/rbenv-gem-rehash/etc/rbenv.d/exec/~gem-rehash.bash
+        - "if [ -n \"$_C_VERSION\" ]; then sem-version c $_C_VERSION; fi"
         - sem-version ruby $RUBY_VERSION
         - ./support/check_versions
         - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
@@ -123,8 +124,11 @@ matrix:
     - ruby: "2.6.5"
     - ruby: "2.7.1"
     - ruby: "3.0.1"
-    - ruby: "jruby-9.1.17.0"
+    - ruby: "jruby-9.2.19.0"
       gems: "minimal"
+      env_vars:
+        - name: "_C_VERSION"
+          value: "8"
   gems:
     - gem: "no_dependencies"
     - gem: "capistrano2"
@@ -150,14 +154,17 @@ matrix:
     - gem: "rails-5.0"
       exclude:
         ruby:
+          - "2.0.0-p648"
           - "3.0.1"
     - gem: "rails-5.1"
       exclude:
         ruby:
+          - "2.0.0-p648"
           - "3.0.1"
     - gem: "rails-5.2"
       exclude:
         ruby:
+          - "2.0.0-p648"
           - "3.0.1"
     - gem: "rails-6.0"
       exclude:
@@ -166,7 +173,6 @@ matrix:
           - "2.2.10"
           - "2.3.8"
           - "2.4.9"
-          - "jruby-9.1.17.0"
     - gem: "resque-1"
       bundler: "1.17.3"
       exclude:

--- a/gemfiles/capistrano2.gemfile
+++ b/gemfiles/capistrano2.gemfile
@@ -2,6 +2,5 @@ source 'https://rubygems.org'
 
 gem 'capistrano', '< 3.0'
 gem 'net-ssh', '2.9.2'
-gem 'rack', '~> 1.6'
 
 gemspec :path => '../'

--- a/gemfiles/capistrano3.gemfile
+++ b/gemfiles/capistrano3.gemfile
@@ -3,6 +3,5 @@ source 'https://rubygems.org'
 gem 'capistrano', '~> 3.0'
 gem 'i18n', '~> 1.2.0'
 gem 'net-ssh', '2.9.2'
-gem 'rack', '~> 1.6'
 
 gemspec :path => '../'

--- a/gemfiles/grape.gemfile
+++ b/gemfiles/grape.gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'grape', '0.14.0'
-gem 'rack', '~> 1.6'
 gem 'activesupport', '~> 4.2'
 
 gemspec :path => '../'

--- a/gemfiles/no_dependencies.gemfile
+++ b/gemfiles/no_dependencies.gemfile
@@ -1,6 +1,9 @@
 source 'https://rubygems.org'
 
-gem 'rack', '~> 1.6'
+ruby_version = Gem::Version.new(RUBY_VERSION)
+if ruby_version < Gem::Version.new("2.3.0")
+  gem 'rack', '~> 1.6'
+end
 
 ruby_version = Gem::Version.new(RUBY_VERSION)
 if ruby_version < Gem::Version.new("2.0.0")

--- a/gemfiles/rails-3.2.gemfile
+++ b/gemfiles/rails-3.2.gemfile
@@ -3,4 +3,6 @@ source 'https://rubygems.org'
 gem 'rails', '~> 3.2.14'
 gem 'test-unit'
 
+gem "rack-cache", "~> 1.9.0"
+
 gemspec :path => '../'

--- a/gemfiles/rails-4.2.gemfile
+++ b/gemfiles/rails-4.2.gemfile
@@ -13,5 +13,11 @@ end
 if ruby_version < Gem::Version.new("2.1.0")
   gem 'nokogiri', '~> 1.6.0'
 end
+if ruby_version < Gem::Version.new("2.5.0")
+  gem 'sprockets', '~> 3.7.2'
+end
+
+gem "minitest", "5.12.0"
+gem "connection_pool", "2.2.3"
 
 gemspec :path => '../'

--- a/gemfiles/resque-2.gemfile
+++ b/gemfiles/resque-2.gemfile
@@ -4,7 +4,3 @@ gem 'resque', "~> 2.0"
 gem 'sinatra'
 
 gemspec :path => '../'
-
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1.0")
-  gem 'nokogiri', '~> 1.6.0'
-end

--- a/gemfiles/sequel-435.gemfile
+++ b/gemfiles/sequel-435.gemfile
@@ -6,6 +6,5 @@ if RUBY_PLATFORM == "java"
 else
   gem 'sqlite3'
 end
-gem 'rack', '~> 1.6'
 
 gemspec :path => '../'

--- a/gemfiles/sequel.gemfile
+++ b/gemfiles/sequel.gemfile
@@ -6,6 +6,5 @@ if RUBY_PLATFORM == "java"
 else
   gem 'sqlite3'
 end
-gem 'rack', '~> 1.6'
 
 gemspec :path => '../'

--- a/gemfiles/sinatra.gemfile
+++ b/gemfiles/sinatra.gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'sinatra'
-gem 'rack', '~> 1.6'
 
 gemspec :path => '../'

--- a/lib/appsignal/extension.rb
+++ b/lib/appsignal/extension.rb
@@ -40,6 +40,16 @@ module Appsignal
       def method_missing(m, *args, &block)
         super if Appsignal.testing?
       end
+
+      unless Appsignal.extension_loaded?
+        def data_map_new
+          Appsignal::Extension::MockData.new
+        end
+
+        def data_array_new
+          Appsignal::Extension::MockData.new
+        end
+      end
     end
 
     if Appsignal::System.jruby?
@@ -60,6 +70,46 @@ module Appsignal
     class Data
       def inspect
         "#<#{self.class.name}:#{object_id} #{self}>"
+      end
+    end
+
+    # Mock of the {Data} class. This mock is used when the extension cannot be
+    # loaded. This mock listens to all method calls and does nothing, and
+    # prevents NoMethodErrors from being raised.
+    #
+    # Disabled in testing so we can make sure that we don't miss an extension
+    # function implementation.
+    #
+    # This class inherits from the {Data} class so that it passes type checks.
+    class MockData < Data
+      def initialize(*_args)
+        # JRuby extension requirement, as it sends a pointer to the Data object
+        # when creating it
+      end
+
+      def method_missing(_method, *_args, &_block)
+        super if Appsignal.testing?
+      end
+
+      def to_s
+        "{}"
+      end
+    end
+
+    # Mock of the {Transaction} class. This mock is used when the extension
+    # cannot be loaded. This mock listens to all method calls and does nothing,
+    # and prevents NoMethodErrors from being raised.
+    #
+    # Disabled in testing so we can make sure that we don't miss an extension
+    # function implementation.
+    class MockTransaction
+      def initialize(*_args)
+        # JRuby extension requirement, as it sends a pointer to the Transaction
+        # object when creating it
+      end
+
+      def method_missing(_method, *_args, &_block)
+        super if Appsignal.testing?
       end
     end
   end

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -90,7 +90,7 @@ module Appsignal
         @transaction_id,
         @namespace,
         self.class.garbage_collection_profiler.total_time
-      )
+      ) || Appsignal::Extension::MockTransaction.new
     end
 
     def nil_transaction?

--- a/spec/lib/appsignal/extension_install_failure_spec.rb
+++ b/spec/lib/appsignal/extension_install_failure_spec.rb
@@ -1,13 +1,6 @@
 describe Appsignal::Extension, :extension_installation_failure do
   context "when the extension library cannot be loaded" do
-    # This test breaks the installation on purpose and is not run by default.
-    # See `rake test:failure`. If this test was run, run `rake
-    # extension:install` again to fix the extension installation.
     it "prints and logs an error" do
-      # ENV var to make sure installation fails on purpurse
-      ENV["_TEST_APPSIGNAL_EXTENSION_FAILURE"] = "true"
-      `rake extension:install` # Run installation
-
       require "open3"
       _stdout, stderr, _status = Open3.capture3("bin/appsignal --version")
       expect(stderr).to include("ERROR: AppSignal failed to load extension")

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -246,6 +246,23 @@ describe Appsignal::Transaction do
         expect(transaction.ext).to_not be_nil
       end
 
+      context "when extension is not loaded", :extension_installation_failure do
+        around do |example|
+          Appsignal::Testing.without_testing { example.run }
+        end
+
+        it "does not error on missing extension method calls" do
+          expect(transaction.ext).to be_kind_of(Appsignal::Extension::MockTransaction)
+          transaction.start_event
+          transaction.finish_event(
+            "name",
+            "title",
+            "body",
+            Appsignal::EventFormatter::DEFAULT
+          )
+        end
+      end
+
       it "sets the transaction id" do
         expect(transaction.transaction_id).to eq "1"
       end

--- a/spec/lib/appsignal/utils/data_spec.rb
+++ b/spec/lib/appsignal/utils/data_spec.rb
@@ -4,110 +4,156 @@ describe Appsignal::Utils::Data do
   describe ".generate" do
     subject { Appsignal::Utils::Data.generate(body) }
 
-    context "with a valid hash body" do
-      let(:body) do
-        {
-          "the" => "payload",
-          "int" => 1, # Fixnum
-          "int61" => 1 << 61, # Fixnum
-          "int62" => 1 << 62, # Bignum, this one still works
-          "int63" => 1 << 63, # Bignum, turnover point for C, too big for long
-          "int64" => 1 << 64, # Bignum
-          "float" => 1.0,
-          1 => true,
-          nil => "test",
-          :foo => [1, 2, "three", { "foo" => "bar" }],
-          "bar" => nil,
-          "baz" => { "foo" => "bʊr", "arr" => [1, 2] }
-        }
+    context "when extension is not loaded", :extension_installation_failure do
+      around do |example|
+        Appsignal::Testing.without_testing { example.run }
       end
 
-      it { is_expected.to eq Appsignal::Utils::Data.generate(body) }
-      it { is_expected.to_not eq Appsignal::Utils::Data.generate({}) }
+      context "with valid hash body" do
+        let(:body) { hash_body }
 
-      describe "#to_s" do
-        it "returns a serialized hash" do
-          expect(subject.to_s).to eq %({"":"test",) +
-            %("1":true,) +
-            %("bar":null,) +
-            %("baz":{"arr":[1,2],"foo":"bʊr"},) +
-            %("float":1.0,) +
-            %("foo":[1,2,"three",{"foo":"bar"}],) +
-            %("int":1,) +
-            %("int61":#{1 << 61},) +
-            %("int62":#{1 << 62},) +
-            %("int63":"bigint:#{1 << 63}",) +
-            %("int64":"bigint:#{1 << 64}",) +
-            %("the":"payload"})
+        it "does not error and returns MockData class" do
+          expect(subject).to be_kind_of(Appsignal::Extension::MockData)
+          expect(subject.to_s).to eql("{}")
+        end
+      end
+
+      context "with valid array body" do
+        let(:body) { array_body }
+
+        it "does not error and returns MockData class" do
+          expect(subject).to be_kind_of(Appsignal::Extension::MockData)
+          expect(subject.to_s).to eql("{}")
+        end
+      end
+
+      context "with an invalid body" do
+        let(:body) { "body" }
+
+        it "raise a type error" do
+          expect do
+            subject
+          end.to raise_error TypeError
         end
       end
     end
 
-    context "with a valid array body" do
-      let(:body) do
-        [
-          nil,
-          true,
-          false,
-          "string",
-          1, # Fixnum
-          1.0, # Float
-          1 << 61, # Fixnum
-          1 << 62, # Bignum, this one still works
-          1 << 63, # Bignum, turnover point for C, too big for long
-          1 << 64, # Bignum
-          { "arr" => [1, 2, "three"], "foo" => "bʊr" }
-        ]
-      end
+    context "when extension is loaded" do
+      context "with a valid hash body" do
+        let(:body) { hash_body }
 
-      it { is_expected.to eq Appsignal::Utils::Data.generate(body) }
-      it { is_expected.to_not eq Appsignal::Utils::Data.generate({}) }
+        it "returns a valid Data object" do
+          is_expected.to eq Appsignal::Utils::Data.generate(body)
+          is_expected.to_not eq Appsignal::Utils::Data.generate({})
+        end
 
-      describe "#to_s" do
-        it "returns a serialized array" do
-          expect(subject.to_s).to eq %([null,) +
-            %(true,) +
-            %(false,) +
-            %(\"string\",) +
-            %(1,) +
-            %(1.0,) +
-            %(#{1 << 61},) +
-            %(#{1 << 62},) +
-            %("bigint:#{1 << 63}",) +
-            %("bigint:#{1 << 64}",) +
-            %({\"arr\":[1,2,\"three\"],\"foo\":\"bʊr\"}])
+        describe "#to_s" do
+          it "returns a serialized hash" do
+            expect(subject.to_s).to eq %({"":"test",) +
+              %("1":true,) +
+              %("bar":null,) +
+              %("baz":{"arr":[1,2],"foo":"bʊr"},) +
+              %("float":1.0,) +
+              %("foo":[1,2,"three",{"foo":"bar"}],) +
+              %("int":1,) +
+              %("int61":#{1 << 61},) +
+              %("int62":#{1 << 62},) +
+              %("int63":"bigint:#{1 << 63}",) +
+              %("int64":"bigint:#{1 << 64}",) +
+              %("the":"payload"})
+          end
         end
       end
-    end
 
-    context "with a body that contains strings with invalid utf-8 content" do
-      let(:string_with_invalid_utf8) { [0x61, 0x61, 0x85].pack("c*") }
-      let(:body) do
-        {
-          "field_one" => [0x61, 0x61].pack("c*"),
-          :field_two => string_with_invalid_utf8,
-          "field_three" => [
-            "one", string_with_invalid_utf8
-          ],
-          "field_four" => {
-            "one" => string_with_invalid_utf8
+      context "with a valid array body" do
+        let(:body) { array_body }
+
+        it "returns a valid Data object" do
+          is_expected.to eq Appsignal::Utils::Data.generate(body)
+          is_expected.to_not eq Appsignal::Utils::Data.generate({})
+        end
+
+        describe "#to_s" do
+          it "returns a serialized array" do
+            expect(subject.to_s).to eq %([null,) +
+              %(true,) +
+              %(false,) +
+              %(\"string\",) +
+              %(1,) +
+              %(1.0,) +
+              %(#{1 << 61},) +
+              %(#{1 << 62},) +
+              %("bigint:#{1 << 63}",) +
+              %("bigint:#{1 << 64}",) +
+              %({\"arr\":[1,2,\"three\"],\"foo\":\"bʊr\"}])
+          end
+        end
+      end
+
+      context "with a body that contains strings with invalid utf-8 content" do
+        let(:string_with_invalid_utf8) { [0x61, 0x61, 0x85].pack("c*") }
+        let(:body) do
+          {
+            "field_one" => [0x61, 0x61].pack("c*"),
+            :field_two => string_with_invalid_utf8,
+            "field_three" => [
+              "one", string_with_invalid_utf8
+            ],
+            "field_four" => {
+              "one" => string_with_invalid_utf8
+            }
           }
-        }
+        end
+
+        describe "#to_s" do
+          it "returns a JSON representation in a String" do
+            expect(subject.to_s).to eq %({"field_four":{"one":"aa�"},"field_one":"aa","field_three":["one","aa�"],"field_two":"aa�"})
+          end
+        end
       end
 
-      describe "#to_s" do
-        it { expect(subject.to_s).to eq %({"field_four":{"one":"aa�"},"field_one":"aa","field_three":["one","aa�"],"field_two":"aa�"}) }
+      context "with an invalid body" do
+        let(:body) { "body" }
+
+        it "raises a type error" do
+          expect do
+            subject
+          end.to raise_error TypeError
+        end
       end
     end
+  end
 
-    context "with an invalid body" do
-      let(:body) { "body" }
+  def hash_body
+    {
+      "the" => "payload",
+      "int" => 1, # Fixnum
+      "int61" => 1 << 61, # Fixnum
+      "int62" => 1 << 62, # Bignum, this one still works
+      "int63" => 1 << 63, # Bignum, turnover point for C, too big for long
+      "int64" => 1 << 64, # Bignum
+      "float" => 1.0,
+      1 => true,
+      nil => "test",
+      :foo => [1, 2, "three", { "foo" => "bar" }],
+      "bar" => nil,
+      "baz" => { "foo" => "bʊr", "arr" => [1, 2] }
+    }
+  end
 
-      it "should raise a type error" do
-        expect do
-          subject
-        end.to raise_error TypeError
-      end
-    end
+  def array_body
+    [
+      nil,
+      true,
+      false,
+      "string",
+      1, # Fixnum
+      1.0, # Float
+      1 << 61, # Fixnum
+      1 << 62, # Bignum, this one still works
+      1 << 63, # Bignum, turnover point for C, too big for long
+      1 << 64, # Bignum
+      { "arr" => [1, 2, "three"], "foo" => "bʊr" }
+    ]
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -131,6 +131,28 @@ RSpec.configure do |config|
     allow(Appsignal::Config).to receive(:system_tmp_dir).and_return(spec_system_tmp_dir)
   end
 
+  # These tests are not run by default. They require a failed extension
+  # installation. See the `rake test:failure` task. If a test with this tag was
+  # run, run `rake extension:install` again to fix the extension installation
+  # before running other tests.
+  config.before :extension_installation_failure => true do
+    next unless Appsignal.extension_loaded?
+
+    raise "Extension is loaded, please run the following task and rerun the test." \
+      "\n\n    rake test:prepare_failure"
+  end
+
+  # Check to see if the extension is loaded before running the specs. If the
+  # extension is not loaded it can result in unexpected behavior.
+  config.before do |example|
+    next if Appsignal.extension_loaded?
+    next if example.metadata[:extension_installation_failure]
+
+    puts "\nWARNING: The AppSignal extension is not loaded, please run the "\
+      "following task and rerun the test." \
+      "\n\n    rake extension:install\n"
+  end
+
   config.after do
     Appsignal::Testing.clear!
     clear_current_transaction!

--- a/spec/support/testing.rb
+++ b/spec/support/testing.rb
@@ -1,16 +1,26 @@
 module Appsignal
   class << self
+    attr_writer :testing
     remove_method :testing?
 
     # @api private
     def testing?
-      true
+      @testing = true unless defined?(@testing)
+      @testing
     end
   end
 
   # @api private
   module Testing
     class << self
+      def without_testing
+        original_testing = Appsignal.testing?
+        Appsignal.testing = false
+        yield
+      ensure
+        Appsignal.testing = original_testing
+      end
+
       def transactions
         @transactions ||= []
       end

--- a/support/install_deps
+++ b/support/install_deps
@@ -9,18 +9,22 @@ fi
 
 case "${_RUBYGEMS_VERSION-"latest"}" in
   "latest")
+    echo "Updating rubygems"
     gem update $gem_args --system
   ;;
   *)
+    echo "Updating rubygems to $_RUBYGEMS_VERSION}"
     gem update $gem_args --system $_RUBYGEMS_VERSION
   ;;
 esac
 
 case "${_BUNDLER_VERSION-"latest"}" in
   "latest")
+    echo "Updating bundler"
     gem update bundler $gem_args
   ;;
   *)
+    echo "Updating bundler to $_BUNDLER_VERSION"
     gem install bundler $gem_args --version $_BUNDLER_VERSION
   ;;
 esac


### PR DESCRIPTION
Backport of #720 for the 2.x series of the Ruby gem. The other commits in this PR are also backports of commits fixing the build for newer Ruby packages.

[skip review] because they are already previously approved on the main branch.

## Scenario

When the extension installation fails, the AppSignal Ruby gem should
load but not cause any errors that cause the app to stop whenever an
extension method is called.

The extension always fails on Microsoft Windows and Apple M1 machines
currently, but it can also fail for various other reasons, on systems we
expect it to work.

In issue #707, later documented in #719 in more detail, a scenario was
described where a user would call the `Appsignal.increment_counter`
method and it caused the following error.
#707 (comment)

```ruby
# In Ruby it trips on adding tags to a data object
Appsignal.increment_counter "foo", 1, { "foo" => "bar" }
# In JRuby this is enough, just creating the data object for an empty hash
Appsignal.increment_counter "foo", 1
```

Results in:

```
/integration/lib/appsignal/utils/data.rb:24:in `block in map_hash': undefined method `set_string' for nil:NilClass (NoMethodError)
  from /integration/lib/appsignal/utils/data.rb:20:in `each'
  from /integration/lib/appsignal/utils/data.rb:20:in `map_hash'
  from /integration/lib/appsignal/utils/data.rb:10:in `generate'
  from /integration/lib/appsignal/helpers/metrics.rb:35:in `increment_counter'
  from app.rb:29:in `perform'
  from /integration/lib/appsignal/integrations/object.rb:32:in `block (2 levels) in appsignal_instrument_method'
  from /integration/lib/appsignal/helpers/instrumentation.rb:525:in `instrument'
  from /integration/lib/appsignal/integrations/object.rb:31:in `block in appsignal_instrument_method'
  from app.rb:36:in `block (2 levels) in <main>'
  from /integration/lib/appsignal/helpers/instrumentation.rb:77:in `monitor_transaction'
  from app.rb:35:in `block in <main>'
  from app.rb:34:in `times'
  from app.rb:34:in `<main>'
```

This was caused by the `Appsignal::Extension.data_map_new` and
`Appsignal::Extension.data_array_new` methods returning nil, and then
the `Appsignal::Data`'s `map_hash` and `map_array` methods calling
various `set_*` methods on that `nil` object.

```
map = Appsignal::Extension.data_map_new
# map = nil
map.set_string(key, value)
# NoMethodError - undefined method `set_string' for nil:NilClass
```

The same problem occurs for Transactions being created in the following
way, because the `@ext`, transaction extension object, is `nil` in the
`Appsignal::Transaction` object and any method calls on `nil` will raise
a `NoMethodError`.

```
transaction = Appsignal::Transaction.create(
  "demo-id",
  Appsignal::Transaction::HTTP_REQUEST,
  Appsignal::Transaction::GenericRequest.new({})
)
Monitor.new.perform("foo", { :foo => i }, foo: i, bar: i.even?)
Appsignal::Transaction.complete_current!
```

Results in:

```
/integration/lib/appsignal/transaction.rb:349:in `finish_event': undefined method `finish_event' for nil:NilClass (NoMethodError)
  from /integration/lib/appsignal/helpers/instrumentation.rb:529:in `ensure in instrument'
  from /integration/lib/appsignal/helpers/instrumentation.rb:529:in `instrument'
  from /integration/lib/appsignal/integrations/object.rb:31:in `block in appsignal_instrument_method'
  from app.rb:44:in `block in <main>'
  from app.rb:34:in `times'
  from app.rb:34:in `<main>'
/integration/lib/appsignal/transaction.rb:344:in `start_event': undefined method `start_event' for nil:NilClass (NoMethodError)
  from /integration/lib/appsignal/helpers/instrumentation.rb:524:in `instrument'
  from /integration/lib/appsignal/integrations/object.rb:31:in `block in appsignal_instrument_method'
  from app.rb:44:in `block in <main>'
  from app.rb:34:in `times'
  from app.rb:34:in `<main>'
```

## Solution

I added `Appsignal::Extension::MockData` and
`Appsignal::Extension::MockTransaction` classes to act as a fallback for
when the extension is not loaded. Like the `Appsignal::Extension` class
this implements a `method_missing` method that captures any method calls
and will then do nothing. It will prevent any `NoMethodError` from being
raised when any methods are called on the data object

This `MockData` inherits from `Data` so it will pass any type checks in
other methods, like in the JRuby extension.

## Alternative solution

I also considered checking if the extension was loaded in the `map_hash`
and `map_array` methods , and calling `return` early to skip all method
calls to the (not loaded) extension.

This would require any part of the code that interacts with the
extension to have such a guard for that condition. Which adds a lot of
extra checks, which are easy to forget, causing similar issues to be
easily introduced.

It would also cause issues where the return value was interacted with,
such as in the JRuby extension wrapper in `finish_event`. Here it does a
type check and fails when it does not pass it. A `nil` value would fail
that type check and an `ArgumentError` would be raised.