### PR TITLE
Fix JRuby build by specifying GCC version

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -32,6 +32,7 @@ global_job_config:
     commands:
     - checkout
     - rm -f $HOME/.rbenv/plugins/rbenv-gem-rehash/etc/rbenv.d/exec/~gem-rehash.bash
+    - if [ -n "$_C_VERSION" ]; then sem-version c $_C_VERSION; fi
     - sem-version ruby $RUBY_VERSION
     - "./support/check_versions"
     - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
@@ -1054,7 +1055,7 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
-- name: Ruby jruby-9.1.17.0
+- name: Ruby jruby-9.2.19.0
   dependencies:
   - Validation
   task:
@@ -1062,10 +1063,10 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake extension:install"
     jobs:
-    - name: Ruby jruby-9.1.17.0 for no_dependencies
+    - name: Ruby jruby-9.2.19.0 for no_dependencies
       env_vars:
       - name: RUBY_VERSION
-        value: jruby-9.1.17.0
+        value: jruby-9.2.19.0
       - name: GEMSET
         value: no_dependencies
       - name: BUNDLE_GEMFILE
@@ -1074,21 +1075,24 @@ blocks:
         value: latest
       - name: _BUNDLER_VERSION
         value: latest
+      - &1
+        name: _C_VERSION
+        value: '8'
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
-- name: Ruby jruby-9.1.17.0 - Gems
+- name: Ruby jruby-9.2.19.0 - Gems
   dependencies:
-  - Ruby jruby-9.1.17.0
+  - Ruby jruby-9.2.19.0
   task:
     prologue:
       commands:
       - "./support/bundler_wrapper exec rake extension:install"
     jobs:
-    - name: Ruby jruby-9.1.17.0 for rails-5.2
+    - name: Ruby jruby-9.2.19.0 for rails-5.2
       env_vars:
       - name: RUBY_VERSION
-        value: jruby-9.1.17.0
+        value: jruby-9.2.19.0
       - name: GEMSET
         value: rails-5.2
       - name: BUNDLE_GEMFILE
@@ -1097,6 +1101,23 @@ blocks:
         value: latest
       - name: _BUNDLER_VERSION
         value: latest
+      - *1
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby jruby-9.2.19.0 for rails-6.0
+      env_vars:
+      - name: RUBY_VERSION
+        value: jruby-9.2.19.0
+      - name: GEMSET
+        value: rails-6.0
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/rails-6.0.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      - *1
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"

--- a/Rakefile
+++ b/Rakefile
@@ -73,7 +73,7 @@ namespace :build_matrix do
 
           job = {
             "name" => "Ruby #{ruby_version} for #{gem["gem"]}",
-            "env_vars" => env,
+            "env_vars" => env + ruby.fetch("env_vars", []),
             "commands" => [
               "./support/bundler_wrapper exec rake test",
               "./support/bundler_wrapper exec rake test:failure"

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -33,6 +33,7 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
       commands:
         - checkout
         - rm -f $HOME/.rbenv/plugins/rbenv-gem-rehash/etc/rbenv.d/exec/~gem-rehash.bash
+        - "if [ -n \"$_C_VERSION\" ]; then sem-version c $_C_VERSION; fi"
         - sem-version ruby $RUBY_VERSION
         - ./support/check_versions
         - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
@@ -123,8 +124,11 @@ matrix:
     - ruby: "2.6.5"
     - ruby: "2.7.1"
     - ruby: "3.0.1"
-    - ruby: "jruby-9.1.17.0"
+    - ruby: "jruby-9.2.19.0"
       gems: "minimal"
+      env_vars:
+        - name: "_C_VERSION"
+          value: "8"
   gems:
     - gem: "no_dependencies"
     - gem: "capistrano2"
@@ -150,14 +154,17 @@ matrix:
     - gem: "rails-5.0"
       exclude:
         ruby:
+          - "2.0.0-p648"
           - "3.0.1"
     - gem: "rails-5.1"
       exclude:
         ruby:
+          - "2.0.0-p648"
           - "3.0.1"
     - gem: "rails-5.2"
       exclude:
         ruby:
+          - "2.0.0-p648"
           - "3.0.1"
     - gem: "rails-6.0"
       exclude:
@@ -166,7 +173,6 @@ matrix:
           - "2.2.10"
           - "2.3.8"
           - "2.4.9"
-          - "jruby-9.1.17.0"
     - gem: "resque-1"
       bundler: "1.17.3"
       exclude:


### PR DESCRIPTION
Backport of https://github.com/appsignal/appsignal-ruby/pull/737

The JRuby builds were failing because the JRuby installation failed when
switching using `sem-version ruby jruby-<version>`. The installation
failed because we're using a different version than the one installed by
default on the Semaphore VM. The default version was probably updated
and then this broke the build for our setup.

The JRuby builds we use need a newer GCC version than the one selected
by default (GCC 6).  Switch the C language to version 8 to also switch
to GCC 8 and allow JRuby to be installed properly.

Bump the JRuby version as well, we don't really need to test against the
older one anymore, it's EOL.

[skip review]