### PR TITLE
Add Git linter to build

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,9 +24,19 @@ global_job_config:
     commands:
     - checkout
     - rm -f $HOME/.rbenv/plugins/rbenv-gem-rehash/etc/rbenv.d/exec/~gem-rehash.bash
-    - if [ -n "$_C_VERSION" ]; then sem-version c $_C_VERSION; fi
-    - sem-version ruby $RUBY_VERSION
-    - "./support/check_versions"
+    - |
+      if [ -n "$_C_VERSION" ]; then
+        sem-version c $_C_VERSION
+      else
+        echo Skipping C-lang install
+      fi
+    - |
+      if [ -n "$RUBY_VERSION" ]; then
+        sem-version ruby $RUBY_VERSION
+        ./support/check_versions
+      else
+        echo Skipping Ruby install
+      fi
 blocks:
 - name: Validation
   dependencies: []

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -64,7 +64,7 @@ blocks:
           .bundle
         - cache store $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
           $HOME/.gem
-- name: Linters
+- name: Ruby linters
   dependencies: []
   task:
     prologue:
@@ -90,6 +90,17 @@ blocks:
           .bundle
         - cache store $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
           $HOME/.gem
+- name: Other linters
+  dependencies: []
+  task:
+    jobs:
+    - name: Git Lint (Lintje)
+      env_vars:
+      - name: LINTJE_VERSION
+        value: 0.2.0
+      commands:
+      - script/install_lintje
+      - "$HOME/bin/lintje $SEMAPHORE_GIT_COMMIT_RANGE"
 - name: Integration tests
   dependencies:
   - Validation

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -25,9 +25,19 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
       commands:
         - checkout
         - rm -f $HOME/.rbenv/plugins/rbenv-gem-rehash/etc/rbenv.d/exec/~gem-rehash.bash
-        - "if [ -n \"$_C_VERSION\" ]; then sem-version c $_C_VERSION; fi"
-        - sem-version ruby $RUBY_VERSION
-        - ./support/check_versions
+        - |
+          if [ -n "$_C_VERSION" ]; then
+            sem-version c $_C_VERSION
+          else
+            echo Skipping C-lang install
+          fi
+        - |
+          if [ -n "$RUBY_VERSION" ]; then
+            sem-version ruby $RUBY_VERSION
+            ./support/check_versions
+          else
+            echo Skipping Ruby install
+          fi
 
   blocks:
     - name: Validation

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -64,7 +64,7 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
             commands:
               - cache store $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE) .bundle
               - cache store $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE) $HOME/.gem
-    - name: Linters
+    - name: Ruby linters
       dependencies: []
       task:
         prologue:
@@ -88,6 +88,17 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
             commands:
               - cache store $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE) .bundle
               - cache store $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE) $HOME/.gem
+    - name: Other linters
+      dependencies: []
+      task:
+        jobs:
+        - name: Git Lint (Lintje)
+          env_vars:
+            - name: LINTJE_VERSION
+              value: 0.2.0
+          commands:
+            - script/install_lintje
+            - $HOME/bin/lintje $SEMAPHORE_GIT_COMMIT_RANGE
     - name: Integration tests
       dependencies:
       - Validation

--- a/script/install_lintje
+++ b/script/install_lintje
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -eu
+
+mkdir -p $HOME/bin
+cache_key=v1-lintje-$LINTJE_VERSION
+cache restore $cache_key
+
+# File exists and is executable
+if [ -x "$HOME/bin/lintje" ]; then
+  echo "Restored Lintje $LINTJE_VERSION from cache"
+else
+  echo "Downloading Lintje $LINTJE_VERSION"
+  curl -L \
+    https://github.com/tombruijn/lintje/releases/download/v$LINTJE_VERSION/x86_64-unknown-linux-gnu.tar.gz | \
+    tar -xz --directory $HOME/bin
+  cache store $cache_key $HOME/bin/lintje
+fi


### PR DESCRIPTION
## Add Git linter to build

Enforce a Git standard by adding a linter to the build.
Lintje can be found at: https://github.com/tombruijn/lintje/

Whenever a commit is found that doesn't match the Git standards enforced
by Lintje it will fail this job and in turn the build. Fix the issues
highlighted by Lintje and (force) push your changes (on feature/PR
branches. Don't force push base branches).
Lintje will check all pushed commits in a PR or pushed branch using the
`SEMAPHORE_GIT_COMMIT_RANGE` env variable.

Disclaimer: I am the author of Lintje. Lintje is a personal project.
This addition was discussed with Jeff before making this change.

## Skip installs in CI global config when not needed

Some builds do not need C-lang or Ruby to be installed, so skip those
steps to save time on downloading and installing those versions. Should
speed up the build by a few seconds.


