### PR TITLE
Fix Apple ARM detection

### DIFF
--- a/ext/agent.yml
+++ b/ext/agent.yml
@@ -32,6 +32,13 @@ triples:
     dynamic:
       checksum: 13c646d2a98719f0ef9bb15f4e06b5b58bd8b938f1efb6e6cdfd999fe2872a38
       filename: appsignal-aarch64-darwin-all-dynamic.tar.gz
+  arm-darwin:
+    static:
+      checksum: 70db73144a1ee9475636512e6f55b0c7189ee6d2d390341d33fcaaece10b5a13
+      filename: appsignal-aarch64-darwin-all-static.tar.gz
+    dynamic:
+      checksum: 13c646d2a98719f0ef9bb15f4e06b5b58bd8b938f1efb6e6cdfd999fe2872a38
+      filename: appsignal-aarch64-darwin-all-dynamic.tar.gz
   aarch64-linux:
     static:
       checksum: 0ff967bd1d2d117cdc5a988adfd6083352f0ff3e3a18d8e85360b998ed08997e


### PR DESCRIPTION
On new Macbook Pro (version MacBookPro17) with `System Version: macOS 11.5.1 (20G80)` an  `Kernel Version: Darwin 20.6.0` the following target triple has been detected:
```ruby
AGENT_PLATFORM = Appsignal::System.agent_platform # => "darwin"
AGENT_ARCHITECTURE = Appsignal::System.agent_architecture # => "arm"
TARGET_TRIPLE = "#{AGENT_ARCHITECTURE}-#{AGENT_PLATFORM}".freeze # => "arm-darwin"
```
The triplet `arm-darwin` was missing in `ext/agent.yml` configuration. I've reused the same config as for `arm64-darwin` and the installation went smoothly.

The fix was inspired by https://github.com/appsignal/appsignal-elixir/pull/662