### PR TITLE
ability to not send error message to appsignal

### DIFF
--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -331,9 +331,16 @@ module Appsignal
       return unless Appsignal.active?
 
       backtrace = cleaned_backtrace(error.backtrace)
+
+      if Appsignal.config[:send_error_message]
+        error_message = error.message.to_s
+      else
+        error_message = ''
+      end
+
       @ext.set_error(
         error.class.name,
-        error.message.to_s,
+        error_message,
         backtrace ? Appsignal::Utils::Data.generate(backtrace) : Appsignal::Extension.data_array_new
       )
     end


### PR DESCRIPTION
here's the start of a feature which allows config to turn off sending error messages to appsignal

an exception might have PII in it, so along with skip_session_data and send_params, this is useful for environments where someone wants to ensure that no PII is sent up.

i didn't look into writing tests or making my style consistent with the rest of the code or adding documentation (and i didn't even test if this works) but hopefully this is a helpful start, if you are interested in adding this feature.

thanks!