### PR TITLE
Allow configuration of diagnose endpoint

### DIFF
--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -143,7 +143,7 @@ module Appsignal
         def transmit_report_to_appsignal
           puts "  Transmitting diagnostics report"
           transmitter = Transmitter.new(
-            DIAGNOSE_ENDPOINT,
+            ENV.fetch("APPSIGNAL_DIAGNOSE_ENDPOINT", DIAGNOSE_ENDPOINT),
             Appsignal.config
           )
           response = transmitter.transmit(:diagnose => data)


### PR DESCRIPTION
For the diagnose tests we need to send the diagnose JSON report to a
custom endpoint. This change introduces the APPSIGNAL_DIAGNOSE_ENDPOINT
environment variable for this purpose.

The APPSIGNAL_DIAGNOSE_ENDPOINT environment variable is not a variable
we'll document publicly, because it's only meant for testing purposes.

[skip changeset]
Relies on https://github.com/appsignal/diagnose_tests/pull/25