### PR TITLE
Use Ruby 3 for diagnose tests

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -113,7 +113,7 @@ blocks:
     - name: Diagnose
       env_vars:
       - name: RUBY_VERSION
-        value: 2.6.6
+        value: 3.0.2
       - name: LANGUAGE
         value: ruby
       commands:

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -111,7 +111,7 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
         - name: Diagnose
           env_vars:
             - name: RUBY_VERSION
-              value: 2.6.6
+              value: 3.0.2
             - name: LANGUAGE
               value: ruby
           commands:


### PR DESCRIPTION
Diagnose tests are now run with Ruby 3. Update the build matrix and the
submodule.

Version switch worked as expected:

https://appsignal.semaphoreci.com/jobs/0ef9b323-8024-4dbe-ba28-76d7d5af6fd1#L118-L120

[skip changeset]