### PR TITLE
Standardize key validation error message 

### DIFF
--- a/.changesets/standardize-diagnose-validation-error-message.md
+++ b/.changesets/standardize-diagnose-validation-error-message.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Standardize diagnose validation failure message. Explain the diagnose request failed and why.

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -566,7 +566,7 @@ module Appsignal
             when "401"
               ["invalid", :red]
             else
-              ["Failed with status #{status}\n#{error.inspect}", :red]
+              ["Failed to validate: status #{status}\n#{error.inspect}", :red]
             end
           data[:validation][:push_api_key] = result
           puts_value "Validating Push API key", colorize(result, color)

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -1007,7 +1007,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
 
         it "outputs failure with status code" do
           expect(output).to include "Validation",
-            "Validating Push API key: Failed with status 500\n" +
+            "Validating Push API key: Failed to validate: status 500\n" +
             %("Could not confirm authorization: 500")
         end
 
@@ -1015,14 +1015,19 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
           it "outputs error in color" do
             expect(output).to include "Validation",
               "Validating Push API key: " +
-              colorize(%(Failed with status 500\n"Could not confirm authorization: 500"), :red)
+              colorize(
+                "Failed to validate: status 500\n" +
+                %("Could not confirm authorization: 500"),
+                :red
+              )
           end
         end
 
         it "transmits validation in report" do
           expect(received_report).to include(
             "validation" => {
-              "push_api_key" => %(Failed with status 500\n\"Could not confirm authorization: 500")
+              "push_api_key" => "Failed to validate: status 500\n" +
+              %("Could not confirm authorization: 500")
             }
           )
         end


### PR DESCRIPTION
Update the error message to be standard for all integrations. Not all
integrations necessarily have the response status code on error, so
make sure all integrations start with "Failed to validate".

Add test for diagnose Push API key output and report.
Update the diagnose tests with tests for the Push API key validation in
the diagnose CLI.

Depends on https://github.com/appsignal/diagnose_tests/pull/37