### PR TITLE
Update diagnose tests filter data keys

### DIFF
--- a/.changesets/format-printed-values.md
+++ b/.changesets/format-printed-values.md
@@ -1,5 +1,0 @@
----
-bump: "patch"
----
-
-Print String values in the diagnose report surrounded by quotes. Makes it more clear that it's a String value and not a label we print.

--- a/.changesets/standardize-diagnose-validation-error-message.md
+++ b/.changesets/standardize-diagnose-validation-error-message.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Standardize diagnose validation failure message. Explain the diagnose request failed and why.

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -113,7 +113,7 @@ blocks:
     - name: Diagnose
       env_vars:
       - name: RUBY_VERSION
-        value: 2.6.6
+        value: 3.0.2
       - name: LANGUAGE
         value: ruby
       commands:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # AppSignal for Ruby gem Changelog
 
+## 3.0.15
+
+- [b40b3b4f](https://github.com/appsignal/appsignal-ruby/commit/b40b3b4f5264c6b69f9515b53806435258c73086) patch - Print String values in the diagnose report surrounded by quotes. Makes it more clear that it's a String value and not a label we print.
+- [fd6faf16](https://github.com/appsignal/appsignal-ruby/commit/fd6faf16d9feb73c3076c2e1283f6101dc4abf97) patch - Bump agent to 09308fb
+  
+  - Update sql_lexer dependency with support for reversed operators in queries.
+  - Add debug level logging to custom metrics in transaction_debug_mode.
+  - Add hostname config option to standalone agent.
+
 ## 3.0.14
 
 - [c40f6d75](https://github.com/appsignal/appsignal-ruby/commit/c40f6d759e8d516cc47bd55cc83bfcb680fbd1ea) patch - Add minutely probe that collects metrics for :class_serial and :global_constant_state from RubyVM.

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -111,7 +111,7 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
         - name: Diagnose
           env_vars:
             - name: RUBY_VERSION
-              value: 2.6.6
+              value: 3.0.2
             - name: LANGUAGE
               value: ruby
           commands:

--- a/ext/agent.yml
+++ b/ext/agent.yml
@@ -3,92 +3,92 @@
 # appsignal-agent repository.
 # Modifications to this file will be overwritten with the next agent release.
 ---
-version: '7376537'
+version: '09308fb'
 mirrors:
 - https://appsignal-agent-releases.global.ssl.fastly.net
 - https://d135dj0rjqvssy.cloudfront.net
 triples:
   x86_64-darwin:
     static:
-      checksum: 108f022d9def20cea03aae52f9c07e8f35ef64a2c046edaad01a38966e1e45a7
+      checksum: 72e3e84ce59f4b84287f0d72ec567447a28e42fb758eb27dd7676cd7613eb2e9
       filename: appsignal-x86_64-darwin-all-static.tar.gz
     dynamic:
-      checksum: da1ed61e3a2b3b0aac3557dfa1d394d3cfaa06dd1c523800b3aa4036f603d6dd
+      checksum: 6ad516e25fe140cc8f13ca2e14494d7d8a696ce1344faf71952f6c6f8b972fa5
       filename: appsignal-x86_64-darwin-all-dynamic.tar.gz
   universal-darwin:
     static:
-      checksum: 108f022d9def20cea03aae52f9c07e8f35ef64a2c046edaad01a38966e1e45a7
+      checksum: 72e3e84ce59f4b84287f0d72ec567447a28e42fb758eb27dd7676cd7613eb2e9
       filename: appsignal-x86_64-darwin-all-static.tar.gz
     dynamic:
-      checksum: da1ed61e3a2b3b0aac3557dfa1d394d3cfaa06dd1c523800b3aa4036f603d6dd
+      checksum: 6ad516e25fe140cc8f13ca2e14494d7d8a696ce1344faf71952f6c6f8b972fa5
       filename: appsignal-x86_64-darwin-all-dynamic.tar.gz
   aarch64-darwin:
     static:
-      checksum: 0eacd24a3a053f2f80c8c7aeb7fafa9e851588ddbe798de8f40277b77e2819d5
+      checksum: 446da8ea04b9a23de970332fb30fa7aa44b5aa3da371a8bacc240b3c8dfef3df
       filename: appsignal-aarch64-darwin-all-static.tar.gz
     dynamic:
-      checksum: ef50dbb8f69ce25bc9d6145df2df71e105c7c48a66b42005f5529d5671b9618e
+      checksum: 86d3bffeaa1329628c3dc540c6dcde735e58e2593c769a29f373e38c20657c70
       filename: appsignal-aarch64-darwin-all-dynamic.tar.gz
   arm64-darwin:
     static:
-      checksum: 0eacd24a3a053f2f80c8c7aeb7fafa9e851588ddbe798de8f40277b77e2819d5
+      checksum: 446da8ea04b9a23de970332fb30fa7aa44b5aa3da371a8bacc240b3c8dfef3df
       filename: appsignal-aarch64-darwin-all-static.tar.gz
     dynamic:
-      checksum: ef50dbb8f69ce25bc9d6145df2df71e105c7c48a66b42005f5529d5671b9618e
+      checksum: 86d3bffeaa1329628c3dc540c6dcde735e58e2593c769a29f373e38c20657c70
       filename: appsignal-aarch64-darwin-all-dynamic.tar.gz
   arm-darwin:
     static:
-      checksum: 0eacd24a3a053f2f80c8c7aeb7fafa9e851588ddbe798de8f40277b77e2819d5
+      checksum: 446da8ea04b9a23de970332fb30fa7aa44b5aa3da371a8bacc240b3c8dfef3df
       filename: appsignal-aarch64-darwin-all-static.tar.gz
     dynamic:
-      checksum: ef50dbb8f69ce25bc9d6145df2df71e105c7c48a66b42005f5529d5671b9618e
+      checksum: 86d3bffeaa1329628c3dc540c6dcde735e58e2593c769a29f373e38c20657c70
       filename: appsignal-aarch64-darwin-all-dynamic.tar.gz
   aarch64-linux:
     static:
-      checksum: e45c227bf87d855e0a94d3fcb42a96a4140458f796c67865c650ef3ff1275c57
+      checksum: d14ed2b2ba05b7a0a229eaba8ee710c35ff0c8681084ec5d0650fb53dae7b3d3
       filename: appsignal-aarch64-linux-all-static.tar.gz
     dynamic:
-      checksum: 36468b88d52d5a9bf139bf6bc58ecf1726691b3e5897d531f3ed444a839366e0
+      checksum: 359e45e9d00d1795e6f1d1d2452350effd24a9baefc72cd3bca3631b09d4abc6
       filename: appsignal-aarch64-linux-all-dynamic.tar.gz
   i686-linux:
     static:
-      checksum: 52a6e693650710f1a8b2b389d4a3dc7194069a4eb507b02b068e05f60b92e790
+      checksum: 18cd5ef04e547dcc522faa0a462a00bac27e9bd221bd4dd8e6e2e934d4afd5b7
       filename: appsignal-i686-linux-all-static.tar.gz
     dynamic:
-      checksum: 5365cff91857b87522a524a8e7ba3c19ea2306d4b0b5ea994afd18bdece4e414
+      checksum: e5edeee4c66cb7e1ff372c3d9eddf5832741bc41b237bbddb2dd2e14c07e076d
       filename: appsignal-i686-linux-all-dynamic.tar.gz
   x86-linux:
     static:
-      checksum: 52a6e693650710f1a8b2b389d4a3dc7194069a4eb507b02b068e05f60b92e790
+      checksum: 18cd5ef04e547dcc522faa0a462a00bac27e9bd221bd4dd8e6e2e934d4afd5b7
       filename: appsignal-i686-linux-all-static.tar.gz
     dynamic:
-      checksum: 5365cff91857b87522a524a8e7ba3c19ea2306d4b0b5ea994afd18bdece4e414
+      checksum: e5edeee4c66cb7e1ff372c3d9eddf5832741bc41b237bbddb2dd2e14c07e076d
       filename: appsignal-i686-linux-all-dynamic.tar.gz
   x86_64-linux:
     static:
-      checksum: 8ee5443ca68a3cbac7b63a079bfd734fffd84dbdeab1b9fae7379d7da544d096
+      checksum: 98aaa72590d45b8a6aec3d8222468d1875f8fc798f1d891b6424749102d0b0f0
       filename: appsignal-x86_64-linux-all-static.tar.gz
     dynamic:
-      checksum: 46c4597cc9cefea80e0a8105998125308dbdfba52939c5bdd8685cbe7493df99
+      checksum: 0ac7ffcb92c56fbc392d82e8242c32d071b62790414ab7b2b4d1ba967acf4520
       filename: appsignal-x86_64-linux-all-dynamic.tar.gz
   x86_64-linux-musl:
     static:
-      checksum: 4e01355da3a638bf1fefda47786323eb76345a49e77afab42d79df8510f52e07
+      checksum: 1e2685775d45299e6f6b7439f44586c87fcb6ae14e3eb4f2ed0034b5ffed4d42
       filename: appsignal-x86_64-linux-musl-all-static.tar.gz
     dynamic:
-      checksum: 33d98d3c11670d92ed51df76f30c6024204a2d8d258df5745b50b6319751b377
+      checksum: be0619c4b49dd201f4e4d3e4445c4d627c1d1f1453a0e1de03cc9933a4f5a26b
       filename: appsignal-x86_64-linux-musl-all-dynamic.tar.gz
   x86_64-freebsd:
     static:
-      checksum: 6ba022dc3c66b3ff53316ef55b4841e329dc84c0c585dcd87314bcd9ffae9aab
+      checksum: 7ffd025a7dccca6f6730df2146faeb541fb0a4659fb802e88587471cd625ca94
       filename: appsignal-x86_64-freebsd-all-static.tar.gz
     dynamic:
-      checksum: cdce0bf8a9eb0b8496904594a282c58f6c295b1e7c521ed3e4146ea73fb09b0d
+      checksum: bfa4ca6c793efd081ac6991fae30c470c7edf9a0808726907b607120ba0eb505
       filename: appsignal-x86_64-freebsd-all-dynamic.tar.gz
   amd64-freebsd:
     static:
-      checksum: 6ba022dc3c66b3ff53316ef55b4841e329dc84c0c585dcd87314bcd9ffae9aab
+      checksum: 7ffd025a7dccca6f6730df2146faeb541fb0a4659fb802e88587471cd625ca94
       filename: appsignal-x86_64-freebsd-all-static.tar.gz
     dynamic:
-      checksum: cdce0bf8a9eb0b8496904594a282c58f6c295b1e7c521ed3e4146ea73fb09b0d
+      checksum: bfa4ca6c793efd081ac6991fae30c470c7edf9a0808726907b607120ba0eb505
       filename: appsignal-x86_64-freebsd-all-dynamic.tar.gz

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -143,7 +143,7 @@ module Appsignal
         def transmit_report_to_appsignal
           puts "  Transmitting diagnostics report"
           transmitter = Transmitter.new(
-            DIAGNOSE_ENDPOINT,
+            ENV.fetch("APPSIGNAL_DIAGNOSE_ENDPOINT", DIAGNOSE_ENDPOINT),
             Appsignal.config
           )
           response = transmitter.transmit(:diagnose => data)
@@ -566,7 +566,7 @@ module Appsignal
             when "401"
               ["invalid", :red]
             else
-              ["Failed with status #{status}\n#{error.inspect}", :red]
+              ["Failed to validate: status #{status}\n#{error.inspect}", :red]
             end
           data[:validation][:push_api_key] = result
           puts_value "Validating Push API key", colorize(result, color)

--- a/lib/appsignal/version.rb
+++ b/lib/appsignal/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Appsignal
-  VERSION = "3.0.14".freeze
+  VERSION = "3.0.15".freeze
 end

--- a/script/lint_git
+++ b/script/lint_git
@@ -2,7 +2,7 @@
 
 set -eu
 
-LINTJE_VERSION="0.4.1"
+LINTJE_VERSION="0.5.0"
 
 mkdir -p $HOME/bin
 cache_key=v1-lintje-$LINTJE_VERSION

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -1007,7 +1007,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
 
         it "outputs failure with status code" do
           expect(output).to include "Validation",
-            "Validating Push API key: Failed with status 500\n" +
+            "Validating Push API key: Failed to validate: status 500\n" +
             %("Could not confirm authorization: 500")
         end
 
@@ -1015,14 +1015,19 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
           it "outputs error in color" do
             expect(output).to include "Validation",
               "Validating Push API key: " +
-              colorize(%(Failed with status 500\n"Could not confirm authorization: 500"), :red)
+              colorize(
+                "Failed to validate: status 500\n" +
+                %("Could not confirm authorization: 500"),
+                :red
+              )
           end
         end
 
         it "transmits validation in report" do
           expect(received_report).to include(
             "validation" => {
-              "push_api_key" => %(Failed with status 500\n\"Could not confirm authorization: 500")
+              "push_api_key" => "Failed to validate: status 500\n" +
+              %("Could not confirm authorization: 500")
             }
           )
         end


### PR DESCRIPTION
## Merge main branch in develop branch

See commits

## Update diagnose tests submodule

After the changes in the develop branch for the Span API added in #708,
update the diagnose tests to also test for the Ruby gem's
`filter_data_keys` config option.

Depends on https://github.com/appsignal/diagnose_tests/pull/41

[skip changeset]
[skip review]