### PR TITLE
Split up filter_data_keys option from Span API

### DIFF
--- a/.changesets/bump-agent-to-v-5b63505.md
+++ b/.changesets/bump-agent-to-v-5b63505.md
@@ -1,0 +1,8 @@
+---
+bump: "patch"
+---
+
+Bump agent to v-5b63505
+
+- Only filter parameters with the `filter_parameters` config option.
+- Only filter session data with the `filter_session_data` config option.

--- a/.changesets/span-api-data-filtering.md
+++ b/.changesets/span-api-data-filtering.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Use the `filter_parameters` and `filter_session_data` options to filter out specific parameter keys or session data keys for the experimental Span API. Previously only the (undocumented) `filter_data_keys` config option was available to filter out all kinds of app data.

--- a/ext/agent.yml
+++ b/ext/agent.yml
@@ -3,92 +3,92 @@
 # appsignal-agent repository.
 # Modifications to this file will be overwritten with the next agent release.
 ---
-version: '09308fb'
+version: 5b63505
 mirrors:
 - https://appsignal-agent-releases.global.ssl.fastly.net
 - https://d135dj0rjqvssy.cloudfront.net
 triples:
   x86_64-darwin:
     static:
-      checksum: 72e3e84ce59f4b84287f0d72ec567447a28e42fb758eb27dd7676cd7613eb2e9
+      checksum: 122bbf4a5931f850644853a80b3fc929db93e18d32c2c75d487f5dc6a17358f7
       filename: appsignal-x86_64-darwin-all-static.tar.gz
     dynamic:
-      checksum: 6ad516e25fe140cc8f13ca2e14494d7d8a696ce1344faf71952f6c6f8b972fa5
+      checksum: 85218afeba617f8a19e90c3f658245997dcf1d4613311906cb2b488b808bf7f4
       filename: appsignal-x86_64-darwin-all-dynamic.tar.gz
   universal-darwin:
     static:
-      checksum: 72e3e84ce59f4b84287f0d72ec567447a28e42fb758eb27dd7676cd7613eb2e9
+      checksum: 122bbf4a5931f850644853a80b3fc929db93e18d32c2c75d487f5dc6a17358f7
       filename: appsignal-x86_64-darwin-all-static.tar.gz
     dynamic:
-      checksum: 6ad516e25fe140cc8f13ca2e14494d7d8a696ce1344faf71952f6c6f8b972fa5
+      checksum: 85218afeba617f8a19e90c3f658245997dcf1d4613311906cb2b488b808bf7f4
       filename: appsignal-x86_64-darwin-all-dynamic.tar.gz
   aarch64-darwin:
     static:
-      checksum: 446da8ea04b9a23de970332fb30fa7aa44b5aa3da371a8bacc240b3c8dfef3df
+      checksum: b881d9cb9517c4717c7d9180109068d0283d674b161f4827ced05a0a7f884c7c
       filename: appsignal-aarch64-darwin-all-static.tar.gz
     dynamic:
-      checksum: 86d3bffeaa1329628c3dc540c6dcde735e58e2593c769a29f373e38c20657c70
+      checksum: 9a4ef87c3969463f09db806a9db9ec4e46a9dcb6cda1efadba70b351555ff11b
       filename: appsignal-aarch64-darwin-all-dynamic.tar.gz
   arm64-darwin:
     static:
-      checksum: 446da8ea04b9a23de970332fb30fa7aa44b5aa3da371a8bacc240b3c8dfef3df
+      checksum: b881d9cb9517c4717c7d9180109068d0283d674b161f4827ced05a0a7f884c7c
       filename: appsignal-aarch64-darwin-all-static.tar.gz
     dynamic:
-      checksum: 86d3bffeaa1329628c3dc540c6dcde735e58e2593c769a29f373e38c20657c70
+      checksum: 9a4ef87c3969463f09db806a9db9ec4e46a9dcb6cda1efadba70b351555ff11b
       filename: appsignal-aarch64-darwin-all-dynamic.tar.gz
   arm-darwin:
     static:
-      checksum: 446da8ea04b9a23de970332fb30fa7aa44b5aa3da371a8bacc240b3c8dfef3df
+      checksum: b881d9cb9517c4717c7d9180109068d0283d674b161f4827ced05a0a7f884c7c
       filename: appsignal-aarch64-darwin-all-static.tar.gz
     dynamic:
-      checksum: 86d3bffeaa1329628c3dc540c6dcde735e58e2593c769a29f373e38c20657c70
+      checksum: 9a4ef87c3969463f09db806a9db9ec4e46a9dcb6cda1efadba70b351555ff11b
       filename: appsignal-aarch64-darwin-all-dynamic.tar.gz
   aarch64-linux:
     static:
-      checksum: d14ed2b2ba05b7a0a229eaba8ee710c35ff0c8681084ec5d0650fb53dae7b3d3
+      checksum: d2eeac3b67e6629b43965f5056131b79dc9dd5ac3767951c79c9e2d8f7aca8c3
       filename: appsignal-aarch64-linux-all-static.tar.gz
     dynamic:
-      checksum: 359e45e9d00d1795e6f1d1d2452350effd24a9baefc72cd3bca3631b09d4abc6
+      checksum: a4b3caf1c7bc64f8316e95943bcc0905d31787b4c47c5f1f36dfc05089553dc6
       filename: appsignal-aarch64-linux-all-dynamic.tar.gz
   i686-linux:
     static:
-      checksum: 18cd5ef04e547dcc522faa0a462a00bac27e9bd221bd4dd8e6e2e934d4afd5b7
+      checksum: 5a292e5a14e737a0a3756573b264ab749f211ff370717b80f9812e837e09392d
       filename: appsignal-i686-linux-all-static.tar.gz
     dynamic:
-      checksum: e5edeee4c66cb7e1ff372c3d9eddf5832741bc41b237bbddb2dd2e14c07e076d
+      checksum: 4bca45872fb19d2181ce8a18f8208b8ad1299186e59e339b3584433db7954e75
       filename: appsignal-i686-linux-all-dynamic.tar.gz
   x86-linux:
     static:
-      checksum: 18cd5ef04e547dcc522faa0a462a00bac27e9bd221bd4dd8e6e2e934d4afd5b7
+      checksum: 5a292e5a14e737a0a3756573b264ab749f211ff370717b80f9812e837e09392d
       filename: appsignal-i686-linux-all-static.tar.gz
     dynamic:
-      checksum: e5edeee4c66cb7e1ff372c3d9eddf5832741bc41b237bbddb2dd2e14c07e076d
+      checksum: 4bca45872fb19d2181ce8a18f8208b8ad1299186e59e339b3584433db7954e75
       filename: appsignal-i686-linux-all-dynamic.tar.gz
   x86_64-linux:
     static:
-      checksum: 98aaa72590d45b8a6aec3d8222468d1875f8fc798f1d891b6424749102d0b0f0
+      checksum: 3a2688cf0e645d1d881f535ffbcf9602f626d7cc426591c605d89eeabd66d5f7
       filename: appsignal-x86_64-linux-all-static.tar.gz
     dynamic:
-      checksum: 0ac7ffcb92c56fbc392d82e8242c32d071b62790414ab7b2b4d1ba967acf4520
+      checksum: 856c8fa9b6bfe4b6a0454d122cfcc0bed35c15d1da39834ee583cff90109dd21
       filename: appsignal-x86_64-linux-all-dynamic.tar.gz
   x86_64-linux-musl:
     static:
-      checksum: 1e2685775d45299e6f6b7439f44586c87fcb6ae14e3eb4f2ed0034b5ffed4d42
+      checksum: 0cab0c9dadd9a9d48df0e35a8e8e1896edad1678d04bb7b5742d571c5fbff4f9
       filename: appsignal-x86_64-linux-musl-all-static.tar.gz
     dynamic:
-      checksum: be0619c4b49dd201f4e4d3e4445c4d627c1d1f1453a0e1de03cc9933a4f5a26b
+      checksum: f22e23971cea7c82c5a3f050275f024a7b746f16c463ac4b57d866578778ee70
       filename: appsignal-x86_64-linux-musl-all-dynamic.tar.gz
   x86_64-freebsd:
     static:
-      checksum: 7ffd025a7dccca6f6730df2146faeb541fb0a4659fb802e88587471cd625ca94
+      checksum: 3f470aaeb68fca7a7e2a7d36f557f23c72056807efc429f2ceef8922e73e8ca2
       filename: appsignal-x86_64-freebsd-all-static.tar.gz
     dynamic:
-      checksum: bfa4ca6c793efd081ac6991fae30c470c7edf9a0808726907b607120ba0eb505
+      checksum: 5237af35387c9cf932bf77e6f0176dddb59a96e48be403e701516742b3ed469c
       filename: appsignal-x86_64-freebsd-all-dynamic.tar.gz
   amd64-freebsd:
     static:
-      checksum: 7ffd025a7dccca6f6730df2146faeb541fb0a4659fb802e88587471cd625ca94
+      checksum: 3f470aaeb68fca7a7e2a7d36f557f23c72056807efc429f2ceef8922e73e8ca2
       filename: appsignal-x86_64-freebsd-all-static.tar.gz
     dynamic:
-      checksum: bfa4ca6c793efd081ac6991fae30c470c7edf9a0808726907b607120ba0eb505
+      checksum: 5237af35387c9cf932bf77e6f0176dddb59a96e48be403e701516742b3ed469c
       filename: appsignal-x86_64-freebsd-all-dynamic.tar.gz

--- a/ext/appsignal_extension.c
+++ b/ext/appsignal_extension.c
@@ -309,18 +309,6 @@ static VALUE data_map_new(VALUE self) {
   }
 }
 
-static VALUE data_filtered_map_new(VALUE self) {
-  appsignal_data_t* data;
-
-  data = appsignal_data_filtered_map_new();
-
-  if (data) {
-    return Data_Wrap_Struct(Data, NULL, appsignal_free_data, data);
-  } else {
-    return Qnil;
-  }
-}
-
 static VALUE data_array_new(VALUE self) {
   appsignal_data_t* data;
 
@@ -869,7 +857,6 @@ void Init_appsignal_extension(void) {
 
   // Create a data map or array
   rb_define_singleton_method(Extension, "data_map_new", data_map_new, 0);
-  rb_define_singleton_method(Extension, "data_filtered_map_new", data_filtered_map_new, 0);
   rb_define_singleton_method(Extension, "data_array_new", data_array_new, 0);
 
   // Add content to a data map

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -39,7 +39,6 @@ module Appsignal
       :enable_statsd                  => true,
       :ca_file_path                   => File.expand_path(File.join("../../../resources/cacert.pem"), __FILE__),
       :dns_servers                    => [],
-      :filter_data_keys               => [],
       :files_world_accessible         => true,
       :transaction_debug_mode         => false
     }.freeze
@@ -78,7 +77,6 @@ module Appsignal
       "APPSIGNAL_FILES_WORLD_ACCESSIBLE"         => :files_world_accessible,
       "APPSIGNAL_REQUEST_HEADERS"                => :request_headers,
       "APPSIGNAL_TRANSACTION_DEBUG_MODE"         => :transaction_debug_mode,
-      "APPSIGNAL_FILTER_DATA_KEYS"               => :filter_data_keys,
       "APP_REVISION"                             => :revision
     }.freeze
     # @api private
@@ -123,7 +121,6 @@ module Appsignal
       APPSIGNAL_IGNORE_ERRORS
       APPSIGNAL_IGNORE_NAMESPACES
       APPSIGNAL_REQUEST_HEADERS
-      APPSIGNAL_FILTER_DATA_KEYS
     ].freeze
 
     # @attribute [r] system_config
@@ -297,7 +294,8 @@ module Appsignal
       ENV["_APPSIGNAL_TRANSACTION_DEBUG_MODE"]       = config_hash[:transaction_debug_mode].to_s
       ENV["_APPSIGNAL_SEND_ENVIRONMENT_METADATA"]    = config_hash[:send_environment_metadata].to_s
       ENV["_APPSIGNAL_ENABLE_STATSD"]                = config_hash[:enable_statsd].to_s
-      ENV["_APPSIGNAL_FILTER_DATA_KEYS"]             = config_hash[:filter_data_keys].join(",")
+      ENV["_APPSIGNAL_FILTER_PARAMETERS"]            = config_hash[:filter_parameters].join(",")
+      ENV["_APPSIGNAL_FILTER_SESSION_DATA"]          = config_hash[:filter_session_data].join(",")
       ENV["_APP_REVISION"]                           = config_hash[:revision].to_s
     end
 

--- a/lib/appsignal/extension/jruby.rb
+++ b/lib/appsignal/extension/jruby.rb
@@ -193,7 +193,6 @@ module Appsignal
         # Data struct methods
         attach_function :appsignal_free_data, [], :void
         attach_function :appsignal_data_map_new, [], :pointer
-        attach_function :appsignal_data_filtered_map_new, [], :pointer
         attach_function :appsignal_data_array_new, [], :pointer
         attach_function :appsignal_data_map_set_string,
           [:pointer, :appsignal_string, :appsignal_string],
@@ -277,10 +276,6 @@ module Appsignal
       end
 
       def data_map_new
-        Data.new(appsignal_data_map_new)
-      end
-
-      def data_filtered_map_new
         Data.new(appsignal_data_map_new)
       end
 

--- a/lib/appsignal/span.rb
+++ b/lib/appsignal/span.rb
@@ -36,7 +36,7 @@ module Appsignal
       return unless key && data && (data.is_a?(Array) || data.is_a?(Hash))
       @ext.set_sample_data(
         key.to_s,
-        Appsignal::Utils::Data.generate(data, true)
+        Appsignal::Utils::Data.generate(data)
       )
     end
 

--- a/lib/appsignal/utils/data.rb
+++ b/lib/appsignal/utils/data.rb
@@ -5,22 +5,18 @@ module Appsignal
     # @api private
     class Data
       class << self
-        def generate(body, filtered = false)
+        def generate(body)
           if body.is_a?(Hash)
-            map_hash(body, filtered)
+            map_hash(body)
           elsif body.is_a?(Array)
-            map_array(body, filtered)
+            map_array(body)
           else
             raise TypeError, "Body of type #{body.class} should be a Hash or Array"
           end
         end
 
-        def map_hash(hash_value, filtered)
-          map = if filtered
-                  Appsignal::Extension.data_filtered_map_new
-                else
-                  Appsignal::Extension.data_map_new
-                end
+        def map_hash(hash_value)
+          map = Appsignal::Extension.data_map_new
           hash_value.each do |key, value|
             key = key.to_s
             case value
@@ -41,9 +37,9 @@ module Appsignal
             when NilClass
               map.set_nil(key)
             when Hash
-              map.set_data(key, map_hash(value, filtered))
+              map.set_data(key, map_hash(value))
             when Array
-              map.set_data(key, map_array(value, filtered))
+              map.set_data(key, map_array(value))
             else
               map.set_string(key, value.to_s)
             end
@@ -51,7 +47,7 @@ module Appsignal
           map
         end
 
-        def map_array(array_value, filtered)
+        def map_array(array_value)
           array = Appsignal::Extension.data_array_new
           array_value.each do |value|
             case value
@@ -72,9 +68,9 @@ module Appsignal
             when NilClass
               array.append_nil
             when Hash
-              array.append_data(map_hash(value, filtered))
+              array.append_data(map_hash(value))
             when Array
-              array.append_data(map_array(value, filtered))
+              array.append_data(map_array(value))
             else
               array.append_string(value.to_s)
             end

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -158,7 +158,6 @@ describe Appsignal::Config do
         :ignore_namespaces              => [],
         :filter_parameters              => [],
         :filter_session_data            => [],
-        :filter_data_keys               => [],
         :instrument_net_http            => true,
         :instrument_redis               => true,
         :instrument_sequel              => true,
@@ -503,6 +502,7 @@ describe Appsignal::Config do
       config[:log] = "stdout"
       config[:log_path] = "/tmp"
       config[:filter_parameters] = %w[password confirm_password]
+      config[:filter_session_data] = %w[key1 key2]
       config[:running_in_container] = false
       config[:dns_servers] = ["8.8.8.8", "8.8.4.4"]
       config[:transaction_debug_mode] = true
@@ -536,6 +536,8 @@ describe Appsignal::Config do
       expect(ENV["_APPSIGNAL_FILES_WORLD_ACCESSIBLE"]).to       eq "true"
       expect(ENV["_APPSIGNAL_TRANSACTION_DEBUG_MODE"]).to       eq "true"
       expect(ENV["_APPSIGNAL_SEND_ENVIRONMENT_METADATA"]).to    eq "false"
+      expect(ENV["_APPSIGNAL_FILTER_PARAMETERS"]).to            eq "password,confirm_password"
+      expect(ENV["_APPSIGNAL_FILTER_SESSION_DATA"]).to          eq "key1,key2"
       expect(ENV["_APP_REVISION"]).to                           eq "v2.5.1"
       expect(ENV).to_not                                        have_key("_APPSIGNAL_WORKING_DIR_PATH")
       expect(ENV).to_not                                        have_key("_APPSIGNAL_WORKING_DIRECTORY_PATH")


### PR DESCRIPTION
The filter_data_keys config option was previously used in the Span API
to filter out any kind of data object (parameters and session data), but
the merged config values could cause some unexpected behavior, filtering
out more than the user intended.

The config options have been split up in the `filter_parameters` and
`filter_session_data` options. The filtering is still done in the
extension for the Span API, so those two config options also need to be
set in the environment for the extension.

Since the filtering is now done with a data object is given to the
`appsignal_set_span_sample_data` function, the
`appsignal_data_filtered_map_new` function implementation can be
removed.

This change does not affect the default Transaction API.

Part of https://github.com/appsignal/integration-guide/issues/31