### PR TITLE
Add changeset types to existing changesets

### DIFF
--- a/.changesets/add-experimental-span-api.md
+++ b/.changesets/add-experimental-span-api.md
@@ -1,5 +1,6 @@
 ---
 bump: "patch"
+type: "add"
 ---
 
 Add experimental Span API. This is not loaded by default and we do not recommend using it yet.

--- a/.changesets/bump-agent-to-v-5b63505.md
+++ b/.changesets/bump-agent-to-v-5b63505.md
@@ -1,5 +1,6 @@
 ---
 bump: "patch"
+type: "change"
 ---
 
 Bump agent to v-5b63505

--- a/.changesets/span-api-data-filtering.md
+++ b/.changesets/span-api-data-filtering.md
@@ -1,5 +1,6 @@
 ---
 bump: "patch"
+type: "change"
 ---
 
 Use the `filter_parameters` and `filter_session_data` options to filter out specific parameter keys or session data keys for the experimental Span API. Previously only the (undocumented) `filter_data_keys` config option was available to filter out all kinds of app data.

--- a/.changesets/standardize-diagnose-validation-error-message.md
+++ b/.changesets/standardize-diagnose-validation-error-message.md
@@ -1,5 +1,6 @@
 ---
 bump: "patch"
+type: "change"
 ---
 
 Standardize diagnose validation failure message. Explain the diagnose request failed and why.


### PR DESCRIPTION
In the latest mono version support for changeset types were added. Newer
mono versions won't publish package changesets without types. Add these
types for existing changesets so they can be published with the latest
mono version.

[skip changeset]
[skip ci]