### PR TITLE
Method of cleaning up error messages

### DIFF
--- a/.changesets/clean-up-error-messages-in-pg-index-violation-errors.md
+++ b/.changesets/clean-up-error-messages-in-pg-index-violation-errors.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Clean up error messages in PG index violation errors

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -333,7 +333,7 @@ module Appsignal
       backtrace = cleaned_backtrace(error.backtrace)
       @ext.set_error(
         error.class.name,
-        error.message.to_s,
+        cleaned_error_message(error),
         backtrace ? Appsignal::Utils::Data.generate(backtrace) : Appsignal::Extension.data_array_new
       )
     end
@@ -530,6 +530,17 @@ module Appsignal
         ::Rails.backtrace_cleaner.clean(backtrace, nil)
       else
         backtrace
+      end
+    end
+
+    # Clean error messages that are known to potentially contain user data.
+    # Returns an unchanged message otherwise.
+    def cleaned_error_message(error)
+      case error.class.to_s
+      when "PG::UniqueViolation"
+        error.message.to_s.gsub(/\)=\(.*\)/, ")=(?)")
+      else
+        error.message.to_s
       end
     end
 

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -1341,6 +1341,31 @@ describe Appsignal::Transaction do
     end
   end
 
+  describe "#cleaned_error_message" do
+    let(:error) { StandardError.new("Error message") }
+    subject { transaction.send(:cleaned_error_message, error) }
+
+    it "returns the error message" do
+      expect(subject).to eq "Error message"
+    end
+
+    context "with a PG::UniqueViolation" do
+      module PG
+        class UniqueViolation < StandardError; end
+      end
+
+      let(:error) do
+        PG::UniqueViolation.new(
+          "ERROR: duplicate key value violates unique constraint \"index_users_on_email\" DETAIL: Key (email)=(test@test.com) already exists."
+        )
+      end
+
+      it "returns a sanizited error message" do
+        expect(subject).to eq "ERROR: duplicate key value violates unique constraint \"index_users_on_email\" DETAIL: Key (email)=(?) already exists."
+      end
+    end
+  end
+
   describe ".to_hash / .to_h" do
     subject { transaction.to_hash }
 


### PR DESCRIPTION
Add a protected method that we can use to clean up user data in error messages if we encounter common errors that leak data.