### PR TITLE
Update YAML.load call to support ruby 3.1

### DIFF
--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -370,7 +370,8 @@ module Appsignal
     def load_from_disk
       return if !config_file || !File.exist?(config_file)
 
-      configurations = YAML.load(ERB.new(IO.read(config_file)).result)
+      read_options = RUBY_VERSION >= "3.1.0" ? { :aliases => true } : {}
+      configurations = YAML.load(ERB.new(IO.read(config_file)).result, **read_options)
       config_for_this_env = configurations[env]
       if config_for_this_env
         config_for_this_env =

--- a/lib/appsignal/integrations/sidekiq.rb
+++ b/lib/appsignal/integrations/sidekiq.rb
@@ -158,7 +158,11 @@ module Appsignal
 
       # Based on: https://github.com/mperham/sidekiq/blob/63ee43353bd3b753beb0233f64865e658abeb1c3/lib/sidekiq/api.rb#L403-L412
       def safe_load(content, default)
-        yield(*YAML.load(content))
+        if RUBY_VERSION >= "3.1.0"
+          yield(*YAML.unsafe_load(content))
+        else
+          yield(*YAML.load(content))
+        end
       rescue => error
         # Sidekiq issue #1761: in dev mode, it's possible to have jobs enqueued
         # which haven't been loaded into memory yet so the YAML can't be

--- a/spec/lib/appsignal/event_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter_spec.rb
@@ -28,7 +28,7 @@ end
 
 class MockDependentFormatter < Appsignal::EventFormatter
   def initialize
-    NonsenseDependency.something
+    raise "There is an error"
   end
 
   def format(_payload)
@@ -72,7 +72,7 @@ describe Appsignal::EventFormatter do
         end
         expect(klass.registered?("mock.dependent")).to be_falsy
         expect(logs).to contains_log :error, \
-          "'uninitialized constant MockDependentFormatter::NonsenseDependency' " \
+          "'There is an error' " \
           "when initializing mock.dependent event formatter"
       end
     end


### PR DESCRIPTION
[Ruby 3.1 is released](https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/), and `YAML.safe_load` becomes the default behavior of `YAML.load`, which doesn't support aliases by default. This breaks when AppSignal tries to read configuration file that contains aliases.