### PR TITLE
Support Ruby 3.1.0

### DIFF
--- a/.changesets/add-ruby-3-1-0-support.md
+++ b/.changesets/add-ruby-3-1-0-support.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add Ruby 3.1.0 support. There was an issue with `YAML.load` arguments when parsing the `appsignal.yml` config file.

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1442,6 +1442,243 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
+- name: Ruby 3.1.0
+  dependencies:
+  - Validation
+  task:
+    prologue:
+      commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - "./support/install_deps"
+      - bundle config set clean 'true'
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
+      - "./support/bundler_wrapper exec rake extension:install"
+    epilogue: *1
+    jobs:
+    - name: Ruby 3.1.0 for no_dependencies
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.1.0
+      - name: GEMSET
+        value: no_dependencies
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/no_dependencies.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+- name: Ruby 3.1.0 - Gems
+  dependencies:
+  - Ruby 3.1.0
+  task:
+    prologue:
+      commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - "./support/install_deps"
+      - bundle config set clean 'true'
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
+      - "./support/bundler_wrapper exec rake extension:install"
+    epilogue: *1
+    jobs:
+    - name: Ruby 3.1.0 for capistrano2
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.1.0
+      - name: GEMSET
+        value: capistrano2
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/capistrano2.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.1.0 for capistrano3
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.1.0
+      - name: GEMSET
+        value: capistrano3
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/capistrano3.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.1.0 for grape
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.1.0
+      - name: GEMSET
+        value: grape
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/grape.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.1.0 for padrino
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.1.0
+      - name: GEMSET
+        value: padrino
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/padrino.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.1.0 for que
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.1.0
+      - name: GEMSET
+        value: que
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/que.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.1.0 for que_beta
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.1.0
+      - name: GEMSET
+        value: que_beta
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/que_beta.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.1.0 for resque-2
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.1.0
+      - name: GEMSET
+        value: resque-2
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/resque-2.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.1.0 for sequel
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.1.0
+      - name: GEMSET
+        value: sequel
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/sequel.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.1.0 for sinatra
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.1.0
+      - name: GEMSET
+        value: sinatra
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/sinatra.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.1.0 for webmachine
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.1.0
+      - name: GEMSET
+        value: webmachine
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/webmachine.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
 - name: Ruby jruby-9.2.19.0
   dependencies:
   - Validation

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -188,6 +188,7 @@ matrix:
     - ruby: "2.6.9"
     - ruby: "2.7.5"
     - ruby: "3.0.3"
+    - ruby: "3.1.0"
     - ruby: "jruby-9.2.19.0"
       gems: "minimal"
       env_vars:
@@ -208,6 +209,7 @@ matrix:
           - "2.6.9"
           - "2.7.5"
           - "3.0.3"
+          - "3.1.0"
     - gem: "rails-4.2"
       bundler: "1.17.3"
       exclude:
@@ -215,18 +217,22 @@ matrix:
           - "2.6.9"
           - "2.7.5"
           - "3.0.3"
+          - "3.1.0"
     - gem: "rails-5.0"
       exclude:
         ruby:
           - "3.0.3"
+          - "3.1.0"
     - gem: "rails-5.1"
       exclude:
         ruby:
           - "3.0.3"
+          - "3.1.0"
     - gem: "rails-5.2"
       exclude:
         ruby:
           - "3.0.3"
+          - "3.1.0"
     - gem: "rails-6.0"
       exclude:
         ruby:
@@ -234,6 +240,7 @@ matrix:
           - "2.2.10"
           - "2.3.8"
           - "2.4.10"
+          - "3.1.0"
     - gem: "rails-7.0"
       exclude:
         ruby:
@@ -243,17 +250,20 @@ matrix:
           - "2.4.10"
           - "2.5.8"
           - "2.6.9"
+          - "3.1.0"
           - "jruby-9.2.19.0"
     - gem: "resque-1"
       bundler: "1.17.3"
       exclude:
         ruby:
           - "3.0.3"
+          - "3.1.0"
     - gem: "resque-2"
     - gem: "sequel"
     - gem: "sequel-435"
       exclude:
         ruby:
           - "3.0.3"
+          - "3.1.0"
     - gem: "sinatra"
     - gem: "webmachine"

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -370,7 +370,8 @@ module Appsignal
     def load_from_disk
       return if !config_file || !File.exist?(config_file)
 
-      configurations = YAML.load(ERB.new(IO.read(config_file)).result)
+      read_options = RUBY_VERSION >= "3.1.0" ? { :aliases => true } : {}
+      configurations = YAML.load(ERB.new(IO.read(config_file)).result, **read_options)
       config_for_this_env = configurations[env]
       if config_for_this_env
         config_for_this_env =

--- a/lib/appsignal/integrations/sidekiq.rb
+++ b/lib/appsignal/integrations/sidekiq.rb
@@ -158,7 +158,11 @@ module Appsignal
 
       # Based on: https://github.com/mperham/sidekiq/blob/63ee43353bd3b753beb0233f64865e658abeb1c3/lib/sidekiq/api.rb#L403-L412
       def safe_load(content, default)
-        yield(*YAML.load(content))
+        if RUBY_VERSION >= "3.1.0"
+          yield(*YAML.unsafe_load(content))
+        else
+          yield(*YAML.load(content))
+        end
       rescue => error
         # Sidekiq issue #1761: in dev mode, it's possible to have jobs enqueued
         # which haven't been loaded into memory yet so the YAML can't be

--- a/spec/lib/appsignal/event_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter_spec.rb
@@ -28,7 +28,7 @@ end
 
 class MockDependentFormatter < Appsignal::EventFormatter
   def initialize
-    NonsenseDependency.something
+    raise "There is an error"
   end
 
   def format(_payload)
@@ -72,7 +72,7 @@ describe Appsignal::EventFormatter do
         end
         expect(klass.registered?("mock.dependent")).to be_falsy
         expect(logs).to contains_log :error, \
-          "'uninitialized constant MockDependentFormatter::NonsenseDependency' " \
+          "'There is an error' " \
           "when initializing mock.dependent event formatter"
       end
     end

--- a/spec/lib/appsignal/integrations/padrino_spec.rb
+++ b/spec/lib/appsignal/integrations/padrino_spec.rb
@@ -98,7 +98,13 @@ if DependencyHelper.padrino_present?
         RSpec::Matchers.define :match_response do |expected_status, expected_content|
           match do |response|
             status, _headers, content = response
-            status == expected_status && content == [expected_content].compact
+            matches_content =
+              if expected_content.is_a?(Regexp)
+                content.join =~ expected_content
+              else
+                content == [expected_content].compact
+              end
+            status == expected_status && matches_content
           end
         end
 
@@ -142,7 +148,7 @@ if DependencyHelper.padrino_present?
               expect_a_transaction_to_be_created
               # Uses path for action name
               expect(transaction).to receive(:set_action_if_nil).with("PadrinoTestApp#unknown")
-              expect(response).to match_response(404, "GET /404")
+              expect(response).to match_response(404, %r{^GET /404})
             end
           end
 


### PR DESCRIPTION
## Add Ruby 3.1.0 to build matrix

Test against Ruby 3.1.0 on the CI build.

I've excluded Ruby 3.1.0 from a bunch of older Rails versions that are
not compatible with it. They are also either no longer maintained or
only receive security fixes.

Rails 7.0.0 doesn't work with Ruby 3.1.0 yet. I'm running into an issue
on spec start on the CI. I also can't install it locally in this
combination yet because of Nokogiri Ruby version restrictions.

```
An error occurred while loading spec_helper.
Failure/Error: Bundler.require :default

Bundler::GemRequireError:
  There was an error while trying to load the gem 'rails'.
  Gem Load Error is: Rails::Engine is abstract, you cannot instantiate it directly.
```

Part of #789

## Update YAML.load call to support ruby 3.1

Because YAML.safe_load is now the default behavior

## Fix Padrino specs on Ruby 3.1.0

On Ruby 3.1.0 the error response body format includes more content, that
we don't need to match on.

The error on Ruby 3.1.0 looks like this:

```
GET /404
  raise NotFound, \"\#{request.request_method} \#{request.path_info}\"
  ^^^^^
```

Part of #789
