### PR TITLE
Remove Ruby encoding comments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,9 +59,6 @@ Style/MethodMissing:
 Style/TrailingUnderscoreVariable:
   Enabled: false
 
-Style/Encoding: # For Ruby 1.9 as it doesn't default to UTF-8
-  Enabled: false
-
 Style/Lambda:
   EnforcedStyle: lambda
 

--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require File.expand_path("../lib/appsignal/version", __FILE__)
 
 Gem::Specification.new do |gem| # rubocop:disable Metrics/BlockLength

--- a/spec/lib/appsignal/utils/data_spec.rb
+++ b/spec/lib/appsignal/utils/data_spec.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 describe Appsignal::Utils::Data do
   describe ".generate" do
     subject { Appsignal::Utils::Data.generate(body) }

--- a/spec/lib/appsignal/utils/json_spec.rb
+++ b/spec/lib/appsignal/utils/json_spec.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 describe Appsignal::Utils::JSON do
   describe ".generate" do
     subject { Appsignal::Utils::JSON.generate(body) }


### PR DESCRIPTION
These were only necessary for Ruby 1.9, which we have dropped support
for in #683 and related PRs.

[skip changeset]