### PR TITLE
Add Rails 6.1.0 and Rails 7.0.0 to build matrix

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -446,6 +446,25 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 2.5.8 for rails-6.1
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 2.5.8
+      - name: GEMSET
+        value: rails-6.1
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/rails-6.1.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
 - name: Ruby 2.6.9
   dependencies:
   - Validation
@@ -676,6 +695,25 @@ blocks:
         value: rails-6.0
       - name: BUNDLE_GEMFILE
         value: gemfiles/rails-6.0.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 2.6.9 for rails-6.1
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 2.6.9
+      - name: GEMSET
+        value: rails-6.1
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/rails-6.1.gemfile
       - name: _RUBYGEMS_VERSION
         value: latest
       - name: _BUNDLER_VERSION
@@ -1034,6 +1072,25 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 2.7.5 for rails-6.1
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 2.7.5
+      - name: GEMSET
+        value: rails-6.1
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/rails-6.1.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.5 for rails-7.0
       env_vars:
       - *2
@@ -1347,6 +1404,25 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.0.3 for rails-6.1
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.0.3
+      - name: GEMSET
+        value: rails-6.1
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/rails-6.1.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.0.3 for rails-7.0
       env_vars:
       - *2
@@ -1603,6 +1679,25 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.1.0 for rails-6.1
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.1.0
+      - name: GEMSET
+        value: rails-6.1
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/rails-6.1.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.1.0 for resque-2
       env_vars:
       - *2
@@ -1761,6 +1856,26 @@ blocks:
         value: rails-6.0
       - name: BUNDLE_GEMFILE
         value: gemfiles/rails-6.0.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      - *6
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby jruby-9.2.19.0 for rails-6.1
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: jruby-9.2.19.0
+      - name: GEMSET
+        value: rails-6.1
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/rails-6.1.gemfile
       - name: _RUBYGEMS_VERSION
         value: latest
       - name: _BUNDLER_VERSION

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -164,6 +164,7 @@ matrix:
       - "no_dependencies"
       - "rails-5.2"
       - "rails-6.0"
+      - "rails-6.1"
       - "rails-7.0"
 
   ruby:
@@ -241,6 +242,13 @@ matrix:
           - "2.3.8"
           - "2.4.10"
           - "3.1.0"
+    - gem: "rails-6.1"
+      exclude:
+        ruby:
+          - "2.1.10"
+          - "2.2.10"
+          - "2.3.8"
+          - "2.4.10"
     - gem: "rails-7.0"
       exclude:
         ruby:
@@ -250,7 +258,7 @@ matrix:
           - "2.4.10"
           - "2.5.8"
           - "2.6.9"
-          - "3.1.0"
+          - "3.1.0" # Requires unreleased Rails 7.0.1
           - "jruby-9.2.19.0"
     - gem: "resque-1"
       bundler: "1.17.3"

--- a/gemfiles/rails-6.1.gemfile
+++ b/gemfiles/rails-6.1.gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 6.1.0"
+gem "net-smtp", require: false
+gem "sidekiq"
+
+gemspec :path => "../"

--- a/spec/lib/appsignal/hooks/activejob_spec.rb
+++ b/spec/lib/appsignal/hooks/activejob_spec.rb
@@ -30,6 +30,7 @@ if DependencyHelper.active_job_present?
   end
 
   describe Appsignal::Hooks::ActiveJobHook::ActiveJobClassInstrumentation do
+    include ActiveJobHelpers
     let(:time) { Time.parse("2001-01-01 10:00:00UTC") }
     let(:namespace) { Appsignal::Transaction::BACKGROUND_JOB }
     let(:queue) { "default" }
@@ -65,7 +66,7 @@ if DependencyHelper.active_job_present?
       ]
     end
     let(:expected_perform_events) do
-      if DependencyHelper.rails_version >= Gem::Version.new("7.0.0")
+      if DependencyHelper.rails7_present?
         ["perform.active_job", "perform_start.active_job"]
       else
         ["perform_start.active_job", "perform.active_job"]
@@ -595,24 +596,6 @@ if DependencyHelper.active_job_present?
         "_aj_ruby2_keywords"
       else
         "_aj_symbol_keys"
-      end
-    end
-
-    def active_job_args_wrapper(args: [], params: nil)
-      if DependencyHelper.rails_version >= Gem::Version.new("7.0.0")
-        wrapped_args = {
-          "_aj_ruby2_keywords" => ["args"],
-          "args" => args
-        }
-
-        unless params.nil?
-          wrapped_args["params"] = params
-          wrapped_args["_aj_ruby2_keywords"] = ["params", "args"]
-        end
-
-        [wrapped_args]
-      else
-        params.nil? ? args : args + [params]
       end
     end
   end

--- a/spec/lib/appsignal/integrations/sidekiq_spec.rb
+++ b/spec/lib/appsignal/integrations/sidekiq_spec.rb
@@ -339,6 +339,7 @@ if DependencyHelper.active_job_present?
   require "sidekiq/testing"
 
   describe "Sidekiq ActiveJob integration" do
+    include ActiveJobHelpers
     let(:namespace) { Appsignal::Transaction::BACKGROUND_JOB }
     let(:time) { Time.parse("2001-01-01 10:00:00UTC") }
     let(:log) { StringIO.new }
@@ -367,7 +368,7 @@ if DependencyHelper.active_job_present?
       ]
     end
     let(:expected_wrapped_args) do
-      if DependencyHelper.rails_version >= Gem::Version.new("7.0.0")
+      if (DependencyHelper.rails6_1_present? && DependencyHelper.ruby_3_1_or_newer?) || DependencyHelper.rails7_present?
         [{
           "_aj_ruby2_keywords" => ["args"],
           "args" => expected_args
@@ -385,7 +386,7 @@ if DependencyHelper.active_job_present?
       end
     end
     let(:expected_perform_events) do
-      if DependencyHelper.rails_version >= Gem::Version.new("7.0.0")
+      if DependencyHelper.rails7_present?
         ["perform_job.sidekiq", "perform.active_job", "perform_start.active_job"]
       else
         ["perform_job.sidekiq", "perform_start.active_job", "perform.active_job"]

--- a/spec/support/helpers/activejob_helpers.rb
+++ b/spec/support/helpers/activejob_helpers.rb
@@ -1,0 +1,27 @@
+module ActiveJobHelpers
+  def active_job_args_wrapper(args: [], params: nil)
+    if (DependencyHelper.rails6_1_present? && DependencyHelper.ruby_3_1_or_newer?) || DependencyHelper.rails7_present?
+      wrapped_args = {}
+
+      if params
+        if DependencyHelper.rails7_present?
+          wrapped_args["_aj_ruby2_keywords"] = ["params", "args"]
+          wrapped_args["args"] = []
+          wrapped_args["params"] = {
+            "_aj_symbol_keys" => ["foo"]
+          }.merge(params)
+        else
+          wrapped_args["_aj_symbol_keys"] = ["foo"]
+          wrapped_args.merge!(params)
+        end
+      else
+        wrapped_args["_aj_ruby2_keywords"] = ["args"]
+        wrapped_args["args"] = args
+      end
+
+      [wrapped_args]
+    else
+      params.nil? ? args : args + [params]
+    end
+  end
+end

--- a/spec/support/helpers/dependency_helper.rb
+++ b/spec/support/helpers/dependency_helper.rb
@@ -9,6 +9,10 @@ module DependencyHelper
     ruby_version.segments.take(2) == [2, 0]
   end
 
+  def ruby_3_1_or_newer?
+    ruby_version >= Gem::Version.new("3.1.0")
+  end
+
   def running_jruby?
     defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
   end
@@ -19,6 +23,14 @@ module DependencyHelper
 
   def rails6_present?
     rails_present? && rails_version >= Gem::Version.new("6.0.0")
+  end
+
+  def rails6_1_present?
+    rails_present? && rails_version >= Gem::Version.new("6.1.0")
+  end
+
+  def rails7_present?
+    rails_present? && rails_version >= Gem::Version.new("7.0.0")
   end
 
   def rails_version


### PR DESCRIPTION
## Add Rails 6.1.0 and Rails 7.0.0 to build matrix

Rails 6.1.0 is the latest 6.x minor release. Rails 7 is also out, but
Rails 6.1 is still supported so we should test against it as well.

Rails 7 doesn't work on Ruby 3.1.0 yet. I've created issue #793 for
this.

Closes #792

[skip changeset]

## Fix ActiveJob tests for Rails 6.1 and 7.0

Apply the same ActiveJob fixes to the Sidekiq specs. Move it to its own
helper module to reduce duplicate code.

There are some changes between Rails 6.1 and 7.0 in the format of the
arguments. Most of the fixes for Rails 7 can also be applied to Rails
6.1, but only if it's running on Ruby 3.1.0 or newer. It's weird
behavior, hence the weird if statement, but Rails must be doing some
kind of Ruby version check for Ruby 3.1, but only in Rails 6.1.

[skip changeset] as it's only test related changes.
