### PR TITLE
Test helpers refactor

### DIFF
--- a/lib/appsignal/system.rb
+++ b/lib/appsignal/system.rb
@@ -106,9 +106,5 @@ module Appsignal
     def self.jruby?
       RUBY_PLATFORM == "java"
     end
-
-    def self.ruby_2_7_or_newer?
-      RUBY_VERSION > "2.7"
-    end
   end
 end

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -251,7 +251,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
 
       it "adds the installation report to the diagnostics report" do
         run
-        jruby = DependencyHelper.running_jruby?
+        jruby = Appsignal::System.jruby?
         expect(received_report["installation"]).to match(
           "result" => {
             "status" => "success"

--- a/spec/lib/appsignal/hooks/sequel_spec.rb
+++ b/spec/lib/appsignal/hooks/sequel_spec.rb
@@ -1,7 +1,7 @@
 describe Appsignal::Hooks::SequelHook do
   if DependencyHelper.sequel_present?
     let(:db) do
-      if Appsignal::System.jruby?
+      if DependencyHelper.running_jruby?
         Sequel.connect("jdbc:sqlite::memory:")
       else
         Sequel.sqlite

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -86,8 +86,7 @@ describe Appsignal do
           expect_environment_metadata("ruby_gc_instrumentation_enabled", "true")
         end
 
-        unless Appsignal::System.jruby?
-
+        unless DependencyHelper.running_jruby?
           it "installs the allocation event hook" do
             expect(Appsignal::Extension).to receive(:install_allocation_event_hook)
               .and_call_original

--- a/spec/support/helpers/dependency_helper.rb
+++ b/spec/support/helpers/dependency_helper.rb
@@ -10,7 +10,7 @@ module DependencyHelper
   end
 
   def running_jruby?
-    defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
+    Appsignal::System.jruby?
   end
 
   def rails_present?


### PR DESCRIPTION
## Remove unused ruby_2_7_or_newer? method

This method is not used by anything, so remove it.

[skip changeset]

## Fix usage of JRuby detection methods

The `Appsignal::System.jruby?` method is used by the library itself, and
to test values from the library.

The `DependencyHelper.running_jruby?` method is used to determine if
certain blocks of specs need to be run or not.

These two methods have different implementations. I'm not sure why. I
think the DependencyHelper's implementation is better.

[skip changeset] because it's a small internal test suite refactor.

## Update test suite JRuby detection implementation

Use the same implementation as the `Appsignal::System.jruby?` method.
That way we can be sure they behave the same way. I do want to keep the
separate `DependencyHelper` method, because I want to keep the checks we
do in the test suite in one module.

[skip changeset]

[skip review] because it's a small test refactor of some test helpers.