### PR TITLE
Test against Rails 7.0.1 on Ruby 3.1.0

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1698,6 +1698,25 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.1.0 for rails-7.0
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.1.0
+      - name: GEMSET
+        value: rails-7.0
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/rails-7.0.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.1.0 for resque-2
       env_vars:
       - *2

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -258,7 +258,6 @@ matrix:
           - "2.4.10"
           - "2.5.8"
           - "2.6.9"
-          - "3.1.0" # Requires unreleased Rails 7.0.1
           - "jruby-9.2.19.0"
     - gem: "resque-1"
       bundler: "1.17.3"

--- a/gemfiles/rails-7.0.gemfile
+++ b/gemfiles/rails-7.0.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rails', '~> 7.0.0'
+gem 'rails', "~> 7.0.1"
 gem "sidekiq"
 gem "rake", "> 12.2"
 


### PR DESCRIPTION
Add a job for Rails 7.0.1 on Ruby 3.1.0 that was omitted from PR #795,
because Rails 7.0.1 wasn't released yet. This version is required for
Ruby 3.1.0 compatibility.

WIP note: Currently testing against the unreleased `7-0-stable` Git
branch.

Closes #793 
[skip changeset]
[skip review]

## To do

- [x] Change Git branch to actual released version of Rails 7.0.1 when it's been released.