### PR TITLE
Update class in ActiveRecord SQL event formatter

### DIFF
--- a/spec/lib/appsignal/event_formatter/active_record/sql_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/active_record/sql_formatter_spec.rb
@@ -1,5 +1,5 @@
-describe Appsignal::EventFormatter::ActiveRecord::InstantiationFormatter do
-  let(:klass)     { Appsignal::EventFormatter::ActiveRecord::SqlFormatter }
+describe Appsignal::EventFormatter::ActiveRecord::SqlFormatter do
+  let(:klass)     { described_class }
   let(:formatter) { klass.new }
 
   it "should register sql.active_record" do


### PR DESCRIPTION
The file was probably copy-pasted from another spec and the class name
was not updated.

[skip review]
[skip changeset]