### PR TITLE
Add sequel-rails event formatter for SQL queries

### DIFF
--- a/.changesets/track-sequel-rails-sql-query-in-event.md
+++ b/.changesets/track-sequel-rails-sql-query-in-event.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Improve compatibility with the sequel-rails gem by tracking the performed SQL query in instrumentation events.

--- a/lib/appsignal/event_formatter/sequel/sql_formatter.rb
+++ b/lib/appsignal/event_formatter/sequel/sql_formatter.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Appsignal
+  class EventFormatter
+    # @api private
+    module Sequel
+      # Compatability with the sequel-rails gem.
+      # The sequel-rails gem adds its own ActiveSupport::Notifications events
+      # that conflict with our own sequel instrumentor. Without this event
+      # formatter the sequel-rails events are recorded without the SQL query
+      # that's being executed.
+      class SqlFormatter
+        def format(payload)
+          [payload[:name].to_s, payload[:sql], SQL_BODY_FORMAT]
+        end
+      end
+    end
+  end
+end
+
+Appsignal::EventFormatter.register(
+  "sql.sequel",
+  Appsignal::EventFormatter::Sequel::SqlFormatter
+)

--- a/spec/lib/appsignal/event_formatter/sequel/sql_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/sequel/sql_formatter_spec.rb
@@ -1,0 +1,30 @@
+describe Appsignal::EventFormatter::Sequel::SqlFormatter do
+  let(:klass)     { described_class }
+  let(:formatter) { klass.new }
+
+  it "registers the sql.sequel event formatter" do
+    expect(Appsignal::EventFormatter.registered?("sql.sequel", klass)).to be_truthy
+  end
+
+  describe "#format" do
+    before do
+      stub_const(
+        "SequelDatabaseTypeClass",
+        Class.new do
+          def self.to_s
+            "SequelDatabaseTypeClassToString"
+          end
+        end
+      )
+    end
+    let(:payload) do
+      {
+        :name => SequelDatabaseTypeClass,
+        :sql => "SELECT * FROM users"
+      }
+    end
+    subject { formatter.format(payload) }
+
+    it { is_expected.to eq ["SequelDatabaseTypeClassToString", "SELECT * FROM users", 1] }
+  end
+end


### PR DESCRIPTION
The sequel-rails gem has its own ActiveSupport::Notifications
instrumentor, tracking events about Sequel queries that are being made.

This conflicts with our own sequel instrumentation, recording a
duplicate event. This duplicate event can be worked around by setting
`instrument_sequel` to `false`, disabling the AppSignal integration.
This issue is not addressed in this commit. It requires the manual
config change.

The problem then is that the sequel-rails ActiveSupport::Notifications
event was not handled in any special way, so the event was stored
without an event body, not showing the query that was executed.

To track the SQL query that was made, add an AppSignal event formatter
(used by the ActiveSupport::Notifications integration) to extract the
SQL query from the event and store it on the AppSignal event.

Fixes #799