### PR TITLE
Fix reported Ruby version in diagnose report

### DIFF
--- a/.changesets/fix-reported-ruby-version.md
+++ b/.changesets/fix-reported-ruby-version.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix reported Ruby version in diagnose report. It would report only the first major release of the series, e.g. 2.6.0 for 2.6.1.

--- a/ext/base.rb
+++ b/ext/base.rb
@@ -31,7 +31,7 @@ def report
         },
         "language" => {
           "name" => "ruby",
-          "version" => "#{rbconfig["ruby_version"]}-p#{rbconfig["PATCHLEVEL"]}"
+          "version" => "#{rbconfig["RUBY_PROGRAM_VERSION"]}-p#{rbconfig["PATCHLEVEL"]}"
         },
         "download" => {
           "checksum" => "unverified",

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -443,7 +443,7 @@ module Appsignal
             save :os, os
             puts_value "Operating System", os_label
 
-            language_version = "#{rbconfig["ruby_version"]}-p#{rbconfig["PATCHLEVEL"]}"
+            language_version = "#{rbconfig["RUBY_PROGRAM_VERSION"]}-p#{rbconfig["PATCHLEVEL"]}"
             save :language_version, language_version
             puts_format "Ruby version", language_version
 

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -258,7 +258,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
           },
           "language" => {
             "name" => "ruby",
-            "version" => "#{rbconfig["ruby_version"]}-p#{rbconfig["PATCHLEVEL"]}",
+            "version" => "#{rbconfig["RUBY_PROGRAM_VERSION"]}-p#{rbconfig["PATCHLEVEL"]}",
             "implementation" => jruby ? "jruby" : "ruby"
           },
           "download" => {
@@ -295,7 +295,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
           "  Status: success",
           "Language details",
           "  Implementation: \"#{jruby ? "jruby" : "ruby"}\"",
-          "  Ruby version: \"#{"#{rbconfig["ruby_version"]}-p#{rbconfig["PATCHLEVEL"]}"}\"",
+          "  Ruby version: \"#{"#{rbconfig["RUBY_PROGRAM_VERSION"]}-p#{rbconfig["PATCHLEVEL"]}"}\"",
           "Download details",
           "  Download URL: \"https://",
           "  Checksum: \"verified\"",
@@ -604,7 +604,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
 
     describe "host information" do
       let(:rbconfig) { RbConfig::CONFIG }
-      let(:language_version) { "#{rbconfig["ruby_version"]}-p#{rbconfig["PATCHLEVEL"]}" }
+      let(:language_version) { "#{rbconfig["RUBY_PROGRAM_VERSION"]}-p#{rbconfig["PATCHLEVEL"]}" }
 
       it "outputs host information" do
         run


### PR DESCRIPTION
Use the RbConfig `RUBY_PROGRAM_VERSION` that reports the full patch
version. The `ruby_version` field only reported the first major release.

Fixes https://github.com/appsignal/support/issues/183