### PR TITLE
Require MFA on gem push

### DIFF
--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |gem| # rubocop:disable Metrics/BlockLength
   gem.extensions            = %w[ext/extconf.rb]
 
   gem.metadata = {
+    "rubygems_mfa_required" => "true",
     "bug_tracker_uri"   => "https://github.com/appsignal/appsignal-ruby/issues",
     "changelog_uri"     =>
       "https://github.com/appsignal/appsignal-ruby/blob/main/CHANGELOG.md",


### PR DESCRIPTION
Whenever we publish a new gem version, require that the user
pushing/publishing the new gem version uses MFA/2FA on their user
account.

I can't find any docs for this option on the Rubygems gemspec reference:
https://guides.rubygems.org/specification-reference/
But it is documented on a separate page:
https://guides.rubygems.org/mfa-requirement-opt-in/

I was made aware of this when creating a new gem, by a newer RuboCop
version rule:
https://docs.rubocop.org/rubocop/cops_gemspec.html#gemspecrequiremfa
We can't upgrade from this older version of RuboCop until we drop older
Ruby versions support, because it's not available in newer RuboCop
versions.

Example of similar use:
https://github.com/tombruijn/commit-format/blob/910d4bc67e901fe4c5975d4d348d1a30df361316/commit_format.gemspec#L24

Notice the "Requires MFA accounts:" metadata in the sidebar on after
publishing a gem with this metadata on Rubygems:
https://rubygems.org/gems/commit_format

[skip changeset] as it is a setting for pushing new versions, not a
change that affects the released version itself.