### PR TITLE
Fix RSpec mock expectations for Ruby 3

### DIFF
--- a/spec/lib/appsignal/event_formatter/mongo_ruby_driver/query_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/mongo_ruby_driver/query_formatter_spec.rb
@@ -11,8 +11,12 @@ describe Appsignal::EventFormatter::MongoRubyDriver::QueryFormatter do
     end
 
     it "should apply a strategy for each key" do
+      # TODO: additional curly brackets required for issue
+      # https://github.com/rspec/rspec-mocks/issues/1460
+      # rubocop:disable Style/BracesAroundHashParameters
       expect(formatter).to receive(:apply_strategy)
-        .with(:sanitize_document, "_id" => 1)
+        .with(:sanitize_document, { "_id" => 1 })
+      # rubocop:enable Style/BracesAroundHashParameters
 
       expect(formatter).to receive(:apply_strategy)
         .with(:allow, "users")

--- a/spec/lib/appsignal/integrations/mongo_ruby_driver_spec.rb
+++ b/spec/lib/appsignal/integrations/mongo_ruby_driver_spec.rb
@@ -17,8 +17,12 @@ describe Appsignal::Hooks::MongoMonitorSubscriber do
       end
 
       it "should sanitize command" do
+        # TODO: additional curly brackets required for issue
+        # https://github.com/rspec/rspec-mocks/issues/1460
+        # rubocop:disable Style/BracesAroundHashParameters
         expect(Appsignal::EventFormatter::MongoRubyDriver::QueryFormatter)
-          .to receive(:format).with("find", "foo" => "bar")
+          .to receive(:format).with("find", { "foo" => "bar" })
+        # rubocop:enable Style/BracesAroundHashParameters
 
         subscriber.started(event)
       end

--- a/spec/lib/appsignal/integrations/sidekiq_spec.rb
+++ b/spec/lib/appsignal/integrations/sidekiq_spec.rb
@@ -228,10 +228,14 @@ describe Appsignal::Integrations::SidekiqMiddleware, :with_yaml_parse_error => f
     let(:error) { ExampleException }
 
     it "creates a transaction and adds the error" do
+      # TODO: additional curly brackets required for issue
+      # https://github.com/rspec/rspec-mocks/issues/1460
+      # rubocop:disable Style/BracesAroundHashParameters
       expect(Appsignal).to receive(:increment_counter)
-        .with("sidekiq_queue_job_count", 1, :queue => "default", :status => :failed)
+        .with("sidekiq_queue_job_count", 1, { :queue => "default", :status => :failed })
       expect(Appsignal).to receive(:increment_counter)
-        .with("sidekiq_queue_job_count", 1, :queue => "default", :status => :processed)
+        .with("sidekiq_queue_job_count", 1, { :queue => "default", :status => :processed })
+      # rubocop:enable Style/BracesAroundHashParameters
 
       expect do
         perform_job { raise error, "uh oh" }
@@ -267,8 +271,12 @@ describe Appsignal::Integrations::SidekiqMiddleware, :with_yaml_parse_error => f
 
   context "without an error" do
     it "creates a transaction with events" do
+      # TODO: additional curly brackets required for issue
+      # https://github.com/rspec/rspec-mocks/issues/1460
+      # rubocop:disable Style/BracesAroundHashParameters
       expect(Appsignal).to receive(:increment_counter)
-        .with("sidekiq_queue_job_count", 1, :queue => "default", :status => :processed)
+        .with("sidekiq_queue_job_count", 1, { :queue => "default", :status => :processed })
+      # rubocop:enable Style/BracesAroundHashParameters
 
       perform_job
 

--- a/spec/support/helpers/transaction_helpers.rb
+++ b/spec/support/helpers/transaction_helpers.rb
@@ -56,6 +56,16 @@ module TransactionHelpers
     Thread.current[:appsignal_transaction] = nil
   end
 
+  # Set the current for the duration of the given block.
+  #
+  # Helper for {set_current_transaction} and {clear_current_transaction!}
+  def with_current_transaction(transaction)
+    set_current_transaction transaction
+    yield
+  ensure
+    clear_current_transaction!
+  end
+
   # Track the AppSignal transaction JSON when a transaction gets completed
   # ({Appsignal::Transaction.complete}).
   #


### PR DESCRIPTION
Something changed in the rspec-mocks gem between versions 3.10.2
and 3.10.3, because that's what causes tests to fail like this
on Ruby 3.1.0 and 3.0.3 locally and on the CI:

```
Failure/Error: monitor_transaction(name, env, &block)

  Appsignal received :monitor_transaction with unexpected arguments
    expected: ("perform_job.something", {:key=>:value})
         got: ("perform_job.something", {:key=>:value})
  Diff:
```

In this example the arguments are exactly the same, except they're not
the identical objects. This particular issue seems to be caused by a
recent change that for Ruby 3 keyword argument matching:
https://github.com/rspec/rspec-mocks/issues/1460

### Rewriting specs

What helps is rewriting the tests to not mock method calls and check the
arguments given. Instead, assert what's being stored on the
transactions, like how we want all tests to be written as described in
issue https://github.com/appsignal/appsignal-ruby/issues/252.

### Adding curly brackets

For other specs that are a little more difficult to rewrite this way
right now, I've chosen to add additional curly brackets around the
argument expectations so that it's clear to Ruby/RSpec it's a hash
argument and not keywords arguments.

To solve this more permanently, we should rewrite the specs at some
point. We can remove these curly brackets if the issue is fixed in a
future rspec-mocks version as well.

[skip changeset]
