### PR TITLE
Remove the private and internal extension system

### DIFF
--- a/.changesets/remove-internal-extensions-system.md
+++ b/.changesets/remove-internal-extensions-system.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "remove"
+---
+
+Remove internal `Appsigna.extensions` system. It was unused.

--- a/.changesets/remove-internal-extensions-system.md
+++ b/.changesets/remove-internal-extensions-system.md
@@ -3,4 +3,4 @@ bump: "patch"
 type: "remove"
 ---
 
-Remove internal `Appsigna.extensions` system. It was unused.
+Remove internal `Appsignal.extensions` system. It was unused.

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -59,20 +59,6 @@ module Appsignal
     attr_writer :logger
 
     # @api private
-    def extensions
-      @extensions ||= []
-    end
-
-    # @api private
-    def initialize_extensions
-      Appsignal.logger.debug("Initializing extensions")
-      extensions.each do |extension|
-        Appsignal.logger.debug("Initializing #{extension}")
-        extension.initializer
-      end
-    end
-
-    # @api private
     def testing?
       false
     end
@@ -123,7 +109,6 @@ module Appsignal
           config.write_to_environment
           Appsignal::Extension.start
           Appsignal::Hooks.load_hooks
-          initialize_extensions
 
           if config[:enable_allocation_tracking] && !Appsignal::System.jruby?
             Appsignal::Extension.install_allocation_event_hook

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -5,7 +5,6 @@ describe Appsignal do
     # Make sure we have a clean state because we want to test
     # initialization here.
     Appsignal.config = nil
-    Appsignal.extensions.clear
   end
 
   let(:transaction) { http_request_transaction }
@@ -17,14 +16,6 @@ describe Appsignal do
 
       Appsignal.config = config
       expect(Appsignal.config).to eq config
-    end
-  end
-
-  describe ".extensions" do
-    it "should keep a list of extensions" do
-      expect(Appsignal.extensions).to be_empty
-      Appsignal.extensions << Appsignal::MockExtension
-      expect(Appsignal.extensions.size).to eq(1)
     end
   end
 
@@ -61,15 +52,6 @@ describe Appsignal do
       it "should start native" do
         expect(Appsignal::Extension).to receive(:start)
         Appsignal.start
-      end
-
-      context "with an extension" do
-        before { Appsignal.extensions << Appsignal::MockExtension }
-
-        it "should call the extension's initializer" do
-          expect(Appsignal::MockExtension).to receive(:initializer)
-          Appsignal.start
-        end
       end
 
       context "when allocation tracking and gc instrumentation have been enabled" do

--- a/spec/support/mocks/mock_extension.rb
+++ b/spec/support/mocks/mock_extension.rb
@@ -1,6 +1,0 @@
-module Appsignal
-  module MockExtension
-    def self.initializer
-    end
-  end
-end


### PR DESCRIPTION
This system was introduced eight years ago in this commit:
dda717d1b9a853cae7045afab35d001ae6078119

It is currently unused. Let's remove it so we remove some unused code
and can't confuse future readers.

Fixes #817