### PR TITLE
Add config override source

### DIFF
--- a/.changesets/add-config-override-source.md
+++ b/.changesets/add-config-override-source.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Add config override source. Track final decisions made by the Ruby gem in the configuration in the `override` config source. This will help us track new config options which are being set by their deprecated predecessors in the diagnose report.

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -471,7 +471,8 @@ module Appsignal
               :system => config.system_config,
               :initial => config.initial_config,
               :file => config.file_config,
-              :env => config.env_config
+              :env => config.env_config,
+              :override => config.override_config
             }
           }
           print_config_options(config)

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -772,10 +772,11 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
             "options" => default_config.merge("env" => "", "send_session_data" => true),
             "sources" => {
               "default" => default_config,
-              "system" => { "send_session_data" => true },
+              "system" => {},
               "initial" => { "env" => "" },
               "file" => {},
-              "env" => {}
+              "env" => {},
+              "override" => { "send_session_data" => true }
             }
           )
         end
@@ -890,10 +891,11 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
             "options" => hash_with_string_keys(final_config),
             "sources" => {
               "default" => hash_with_string_keys(Appsignal::Config::DEFAULT_CONFIG),
-              "system" => { "send_session_data" => true },
+              "system" => {},
               "initial" => hash_with_string_keys(config.initial_config.merge(additional_initial_config)),
               "file" => hash_with_string_keys(config.file_config),
-              "env" => {}
+              "env" => {},
+              "override" => { "send_session_data" => true }
             }
           )
         end
@@ -917,10 +919,11 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
             "options" => hash_with_string_keys(config.config_hash).merge("env" => "foobar"),
             "sources" => {
               "default" => hash_with_string_keys(Appsignal::Config::DEFAULT_CONFIG),
-              "system" => { "send_session_data" => true },
+              "system" => {},
               "initial" => hash_with_string_keys(config.initial_config),
               "file" => hash_with_string_keys(config.file_config),
-              "env" => {}
+              "env" => {},
+              "override" => { "send_session_data" => true }
             }
           )
         end

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -434,6 +434,87 @@ describe Appsignal::Config do
     end
   end
 
+  describe "with config based on overrides" do
+    let(:log_stream) { StringIO.new }
+    let(:logger) { test_logger(log_stream) }
+    let(:logs) { log_contents(log_stream) }
+    let(:config) do
+      described_class.new(Dir.pwd, "production", config_options, logger)
+    end
+
+    describe "skip_session_data" do
+      let(:err_stream) { std_stream }
+      let(:stderr) { err_stream.read }
+      let(:deprecation_message) do
+        "The `skip_session_data` config option is deprecated. Please use " \
+          "`send_session_data` instead."
+      end
+      before do
+        capture_std_streams(std_stream, err_stream) { config }
+      end
+
+      context "when not set" do
+        let(:config_options) { {} }
+
+        it "sets the default send_session_data value" do
+          expect(config[:skip_session_data]).to be_nil
+          expect(config[:send_session_data]).to eq(true)
+          expect(config.override_config[:send_session_data]).to eq(true)
+        end
+
+        it "does not print a deprecation warning" do
+          expect(stderr).to_not include("appsignal WARNING: #{deprecation_message}")
+          expect(logs).to_not include(deprecation_message)
+        end
+      end
+
+      context "when set to true" do
+        let(:config_options) { { :skip_session_data => true } }
+
+        it "sets send_session_data if send_session_data is not set by the user" do
+          expect(config[:skip_session_data]).to eq(true)
+          expect(config[:send_session_data]).to eq(false)
+          expect(config.override_config[:send_session_data]).to eq(false)
+        end
+
+        it "prints a deprecation warning" do
+          expect(stderr).to include("appsignal WARNING: #{deprecation_message}")
+          expect(logs).to include(deprecation_message)
+        end
+      end
+
+      context "when set to false" do
+        let(:config_options) { { :skip_session_data => false } }
+
+        it "sets send_session_data if send_session_data is not set by the user" do
+          expect(config[:skip_session_data]).to eq(false)
+          expect(config[:send_session_data]).to eq(true)
+          expect(config.override_config[:send_session_data]).to eq(true)
+        end
+
+        it "prints a deprecation warning" do
+          expect(stderr).to include("appsignal WARNING: #{deprecation_message}")
+          expect(logs).to include(deprecation_message)
+        end
+      end
+
+      context "when skip_session_data and send_session_data are both set" do
+        let(:config_options) { { :skip_session_data => true, :send_session_data => true } }
+
+        it "does not overwrite the send_session_data value" do
+          expect(config[:skip_session_data]).to eq(true)
+          expect(config[:send_session_data]).to eq(true)
+          expect(config.override_config[:send_session_data]).to be_nil
+        end
+
+        it "prints a deprecation warning" do
+          expect(stderr).to include("appsignal WARNING: #{deprecation_message}")
+          expect(logs).to include(deprecation_message)
+        end
+      end
+    end
+  end
+
   describe "config keys" do
     describe ":endpoint" do
       subject { config[:endpoint] }
@@ -784,78 +865,6 @@ describe Appsignal::Config do
         end
 
         it "does not print a deprecation warning" do
-          expect(stderr).to include("appsignal WARNING: #{deprecation_message}")
-          expect(logs).to include(deprecation_message)
-        end
-      end
-    end
-
-    describe "skip_session_data" do
-      let(:err_stream) { std_stream }
-      let(:stderr) { err_stream.read }
-      let(:deprecation_message) do
-        "The `skip_session_data` config option is deprecated. Please use " \
-          "`send_session_data` instead."
-      end
-      before do
-        capture_std_streams(std_stream, err_stream) { config }
-      end
-
-      context "when not set" do
-        let(:config_options) { {} }
-
-        it "sets the default send_session_data value" do
-          expect(config[:skip_session_data]).to be_nil
-          expect(config[:send_session_data]).to eq(true)
-          expect(config.system_config[:send_session_data]).to eq(true)
-        end
-
-        it "does not print a deprecation warning" do
-          expect(stderr).to_not include("appsignal WARNING: #{deprecation_message}")
-          expect(logs).to_not include(deprecation_message)
-        end
-      end
-
-      context "when set to true" do
-        let(:config_options) { { :skip_session_data => true } }
-
-        it "sets send_session_data if send_session_data is not set by the user" do
-          expect(config[:skip_session_data]).to eq(true)
-          expect(config[:send_session_data]).to eq(false)
-          expect(config.system_config[:send_session_data]).to eq(false)
-        end
-
-        it "prints a deprecation warning" do
-          expect(stderr).to include("appsignal WARNING: #{deprecation_message}")
-          expect(logs).to include(deprecation_message)
-        end
-      end
-
-      context "when set to false" do
-        let(:config_options) { { :skip_session_data => false } }
-
-        it "sets send_session_data if send_session_data is not set by the user" do
-          expect(config[:skip_session_data]).to eq(false)
-          expect(config[:send_session_data]).to eq(true)
-          expect(config.system_config[:send_session_data]).to eq(true)
-        end
-
-        it "prints a deprecation warning" do
-          expect(stderr).to include("appsignal WARNING: #{deprecation_message}")
-          expect(logs).to include(deprecation_message)
-        end
-      end
-
-      context "when skip_session_data and send_session_data are both set" do
-        let(:config_options) { { :skip_session_data => true, :send_session_data => true } }
-
-        it "does not overwrite the send_session_data value" do
-          expect(config[:skip_session_data]).to eq(true)
-          expect(config[:send_session_data]).to eq(true)
-          expect(config.system_config[:send_session_data]).to be_nil
-        end
-
-        it "prints a deprecation warning" do
           expect(stderr).to include("appsignal WARNING: #{deprecation_message}")
           expect(logs).to include(deprecation_message)
         end


### PR DESCRIPTION
Add the `override` config source to track the final decisions made by
the Ruby gem concerning some config options.

Currently only the `send_session_data` option is tracked this way. When
the deprecated `skip_session_data` option is set, but
`send_session_data` is not, it defaults to the `skip_session_data`
value. This decision was previously stored on the `system` source.

Now it's more clear that the Ruby gem made this particular decision and
we don't have to figure it out in the report viewer.

Fixes #811