### PR TITLE
Fix Padrino tests for new Sinatra version

### DIFF
--- a/spec/lib/appsignal/integrations/padrino_spec.rb
+++ b/spec/lib/appsignal/integrations/padrino_spec.rb
@@ -148,7 +148,7 @@ if DependencyHelper.padrino_present?
               expect_a_transaction_to_be_created
               # Uses path for action name
               expect(transaction).to receive(:set_action_if_nil).with("PadrinoTestApp#unknown")
-              expect(response).to match_response(404, %r{^GET /404})
+              expect(response).to match_response(404, /^GET &#x2F;404/)
             end
           end
 


### PR DESCRIPTION
Looks like something changed in Sinatra 2.2.0, released February 15,
2022. The build on main started failing.

Looks like the response body is escaping characters. Update the test to
match.

---

[skip changeset]
Just one person sanity checking this would be fine for this PR.