### PR TITLE
Fix Array type wrapper in QueryParamsSanitizer

### DIFF
--- a/.changesets/fix-wrapper-array-around-sanitized-values.md
+++ b/.changesets/fix-wrapper-array-around-sanitized-values.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix sanitized values wrapped in Arrays. When a value like `[{ "foo" => "bar" }]` was sanitized it would be stored as `{ "foo" => "?" }`, omitting the parent value's Array square brackets. Now values will appear with the same structure as they were originally sanitized. This only applies to certain integrations like MongoDB, moped and ElasticSearch.

--- a/lib/appsignal/utils/query_params_sanitizer.rb
+++ b/lib/appsignal/utils/query_params_sanitizer.rb
@@ -35,7 +35,7 @@ module Appsignal
 
         def sanitize_array(array, only_top_level, key_sanitizer)
           if only_top_level
-            sanitize(array[0], only_top_level, key_sanitizer)
+            [sanitize(array[0], only_top_level, key_sanitizer)]
           else
             array.map do |value|
               sanitize(value, only_top_level, key_sanitizer)

--- a/spec/lib/appsignal/event_formatter/moped/query_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/moped/query_formatter_spec.rb
@@ -76,7 +76,7 @@ describe Appsignal::EventFormatter::Moped::QueryFormatter do
         )
       end
 
-      it { is_expected.to eq ["Insert", '{:database=>"database.collection", :documents=>{"_id"=>"?", "events"=>"?"}, :count=>2, :flags=>[]}'] }
+      it { is_expected.to eq ["Insert", '{:database=>"database.collection", :documents=>[{"_id"=>"?", "events"=>"?"}], :count=>2, :flags=>[]}'] }
     end
 
     context "Moped::Protocol::Update" do

--- a/spec/lib/appsignal/utils/query_params_sanitizer_spec.rb
+++ b/spec/lib/appsignal/utils/query_params_sanitizer_spec.rb
@@ -33,7 +33,7 @@ describe Appsignal::Utils::QueryParamsSanitizer do
         let(:value) { ["foo" => "bar"] }
 
         it "should sanitize all hash values with a questionmark" do
-          expect(subject).to eq("foo" => "?")
+          expect(subject).to eq(["foo" => "?"])
         end
 
         it "should not modify source value" do
@@ -45,8 +45,8 @@ describe Appsignal::Utils::QueryParamsSanitizer do
       context "when value is an array" do
         let(:value) { %w[foo bar] }
 
-        it "should only return the first level of the object" do
-          expect(subject).to eq("?")
+        it "sanitizes all array values" do
+          expect(subject).to eq(["?"])
         end
 
         it "should not modify source value" do
@@ -58,8 +58,8 @@ describe Appsignal::Utils::QueryParamsSanitizer do
       context "when value is a mixed array" do
         let(:value) { [nil, "foo", "bar"] }
 
-        it "should sanitize all hash values with a single questionmark" do
-          expect(subject).to eq("?")
+        it "should sanitize all array values with a single questionmark" do
+          expect(subject).to eq(["?"])
         end
       end
 


### PR DESCRIPTION
When an value sanitized by the QueryParamsSanitizer was an Array at the
root level, and `only_top_level = true` was set, it would not return a
sanitized Array object, only the child values.

The Array wrapper value would be removed, returning an inaccurate
picture of the structure of the sanitized value.

```ruby
# Before change
> Appsignal::Utils::QueryParamsSanitizer.sanitize(["foo" => "bar"], false)
# [{"foo"=>"?"}]
> Appsignal::Utils::QueryParamsSanitizer.sanitize(["foo" => "bar"], true)
# {"foo"=>"?"}

# After change
> Appsignal::Utils::QueryParamsSanitizer.sanitize(["foo" => "bar"], false)
# [{"foo"=>"?"}]
> Appsignal::Utils::QueryParamsSanitizer.sanitize(["foo" => "bar"], true)
# [{"foo"=>"?"}]
```

Closes #820
Based on #824 