### PR TITLE
Fix load order issue with ActiveJob default queue

### DIFF
--- a/.changesets/fix-activejob-default_queue_name-issue-being-reset-to--default-.md
+++ b/.changesets/fix-activejob-default_queue_name-issue-being-reset-to--default-.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix the ActiveJob `default_queue_name` config option issue being reset to "default". When ActiveJob `default_queue_name` was set in a Rails initializer it would reset on load to `default`. Now the `default_queue_name` can be set in an initializer as well.

--- a/lib/appsignal/hooks/active_job.rb
+++ b/lib/appsignal/hooks/active_job.rb
@@ -11,8 +11,10 @@ module Appsignal
       end
 
       def install
-        ::ActiveJob::Base
-          .extend ::Appsignal::Hooks::ActiveJobHook::ActiveJobClassInstrumentation
+        ActiveSupport.on_load(:active_job) do
+          ::ActiveJob::Base
+            .extend ::Appsignal::Hooks::ActiveJobHook::ActiveJobClassInstrumentation
+        end
       end
 
       module ActiveJobClassInstrumentation


### PR DESCRIPTION
## Fix load order issue with ActiveJob default queue

Fixes #827 for now.

### The problem

In issue #827 it was reported the ActiveJob `default_queue_name` would
be reset to `default` even if an app configures it to another value like
`medium`.

```ruby
# config/initializers/active_job.rb
Rails.application.config.active_job.default_queue_name = :medium
```

```ruby
# In a Rails view
Rails.application.config.active_job.default_queue_name # => :medium
ActiveJob::Base.default_queue_name # => :default
```

The last value should also be `:default`, but it's either never set or
overwritten later.

For some reason, calling `ActiveJob::Base` in the ActiveJob hook class
modifies the class in such a way it doesn't properly configure the
ActiveJob::Base class in Rails later. It may even break the loading, by
loading the ActiveJob class too early.

This only happens when the app sets this config in an initializer. If
set in `config/application.rb` it is configured correctly.

I'm not quite sure what happens exactly, we've decided to not spend too
much time on it and create this small fix. We can come back to it later,
but this may indicate issues with other integrations we have as well.

### Solution

By wrapping the instal code in `ActiveSupport.on_load(:active_job)` we
make sure to install AppSignal after ActiveJob has been loaded in the
normal process.

This block could also be moved to the Railtie, but then the ActiveJob
hook class isn't really a hook anymore. It could also be implemented
like so in the Railtie:

```ruby
# lib/appsignal/integrations/railtie.rb
initializer "appsignal.configure_rails_initialization" do |app|
  app.config.after_initialize do
    ::ActiveJob::Base
      .extend ::Appsignal::Hooks::ActiveJobHook::ActiveJobClassInstrumentation
  end

  # OR

  ActiveSupport.on_load(:active_job) do
    ::ActiveJob::Base
      .extend ::Appsignal::Hooks::ActiveJobHook::ActiveJobClassInstrumentation
  end
end
```

I've chosen for the smaller change that keeps the hook behavior, it's
only installed when Rails itself loads ActiveJob.
