### PR TITLE
Bump minimal Rake version to version 12

### DIFF
--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |gem| # rubocop:disable Metrics/BlockLength
 
   gem.add_dependency "rack"
 
-  gem.add_development_dependency "rake", "~> 11"
+  gem.add_development_dependency "rake", ">= 12"
   gem.add_development_dependency "rspec", "~> 3.8"
   gem.add_development_dependency "timecop"
   gem.add_development_dependency "webmock"


### PR DESCRIPTION
Update Rake dependency version to minimal version 12.

We were locked to version 11 for older Ruby versions that we no longer
support.

By installing Rake 12 and newer, we should resolve CVE-2020-8130.

[skip changeset] because it's only a development dependency.