### PR TITLE
Clean ActiveRecord::RecordNotUnique error message

### DIFF
--- a/.changesets/sanitize-activerecord::recordnotunique-error-messages.md
+++ b/.changesets/sanitize-activerecord::recordnotunique-error-messages.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Sanitize `ActiveRecord::RecordNotUnique` error messages to not include any database values that is not unique in the database. This ensures no personal information is sent to AppSignal through error messages from this error.

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -537,7 +537,7 @@ module Appsignal
     # Returns an unchanged message otherwise.
     def cleaned_error_message(error)
       case error.class.to_s
-      when "PG::UniqueViolation"
+      when "PG::UniqueViolation", "ActiveRecord::RecordNotUnique"
         error.message.to_s.gsub(/\)=\(.*\)/, ")=(?)")
       else
         error.message.to_s

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -1350,8 +1350,8 @@ describe Appsignal::Transaction do
     end
 
     context "with a PG::UniqueViolation" do
-      module PG
-        class UniqueViolation < StandardError; end
+      before do
+        stub_const("PG::UniqueViolation", Class.new(StandardError))
       end
 
       let(:error) do

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -1364,6 +1364,25 @@ describe Appsignal::Transaction do
         expect(subject).to eq "ERROR: duplicate key value violates unique constraint \"index_users_on_email\" DETAIL: Key (email)=(?) already exists."
       end
     end
+
+    context "with a ActiveRecord::RecordNotUnique" do
+      before do
+        stub_const("ActiveRecord::RecordNotUnique", Class.new(StandardError))
+      end
+
+      let(:error) do
+        ActiveRecord::RecordNotUnique.new(
+          "PG::UniqueViolation: ERROR: duplicate key value violates unique constraint \"example_constraint\"\n" \
+          "DETAIL: Key (email)=(foo@example.com) already exists."
+        )
+      end
+
+      it "returns a sanizited error message" do
+        expect(subject).to eq \
+          "PG::UniqueViolation: ERROR: duplicate key value violates unique constraint \"example_constraint\"\n" \
+          "DETAIL: Key (email)=(?) already exists."
+      end
+    end
   end
 
   describe ".to_hash / .to_h" do


### PR DESCRIPTION
## Stub constant in spec rather than defining it

By defining it we may inadvertently overwrite an existing constant for
the whole test suite. Use RSpec's `stub_const` to only overwrite it for
this one test.

## Clean ActiveRecord::RecordNotUnique error message

Like we've done before for `PG::UniqueViolation`, sanitize the
`ActiveRecord::RecordNotUnique` message.

The `RecordNotUnique` error class is a type of error that wraps around
errors from database adapter gems like the "pg" gem's
`PG::UniqueViolation`. The message for this `RecordNotUnique` error is
the same for `PG::UniqueViolation` in this case, prefixed with error
class name.

Fixes  #833
