### PR TITLE
Fix Rails 6.1.5 ActiveJob build errors

### DIFF
--- a/spec/lib/appsignal/integrations/sidekiq_spec.rb
+++ b/spec/lib/appsignal/integrations/sidekiq_spec.rb
@@ -376,7 +376,7 @@ if DependencyHelper.active_job_present?
       ]
     end
     let(:expected_wrapped_args) do
-      if (DependencyHelper.rails6_1_present? && DependencyHelper.ruby_3_1_or_newer?) || DependencyHelper.rails7_present?
+      if DependencyHelper.active_job_wraps_args?
         [{
           "_aj_ruby2_keywords" => ["args"],
           "args" => expected_args

--- a/spec/support/helpers/activejob_helpers.rb
+++ b/spec/support/helpers/activejob_helpers.rb
@@ -1,6 +1,6 @@
 module ActiveJobHelpers
   def active_job_args_wrapper(args: [], params: nil)
-    if (DependencyHelper.rails6_1_present? && DependencyHelper.ruby_3_1_or_newer?) || DependencyHelper.rails7_present?
+    if DependencyHelper.active_job_wraps_args?
       wrapped_args = {}
 
       if params

--- a/spec/support/helpers/dependency_helper.rb
+++ b/spec/support/helpers/dependency_helper.rb
@@ -29,8 +29,16 @@ module DependencyHelper
     rails_present? && rails_version >= Gem::Version.new("6.1.0")
   end
 
+  def rails6_1_5_present?
+    rails_present? && rails_version >= Gem::Version.new("6.1.5")
+  end
+
   def rails7_present?
     rails_present? && rails_version >= Gem::Version.new("7.0.0")
+  end
+
+  def active_job_wraps_args?
+    rails7_present? || (ruby_3_1_or_newer? && rails6_1_present? && !rails6_1_5_present?)
   end
 
   def rails_version


### PR DESCRIPTION
For whatever reason, Rails 6.1.5 reverts to the behaviour from versions previous to Rails 6.1, when sending Ruby hashes through ActiveJob in Ruby 3.1.

This means that, in the JSON sent internally by ActiveJob, the hash is no longer wrapped in an additional JSON object to indicate that the hash has the `ruby2_keywords_hash?` flag activated.

Fixes #835.

[skip changeset]