### PR TITLE
Add Ruby 3.2 preview to the build matrix

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -32,7 +32,16 @@ global_job_config:
       fi
     - |
       if [ -n "$RUBY_VERSION" ]; then
-        sem-version ruby $RUBY_VERSION
+        if ! (sem-version ruby "$RUBY_VERSION"); then
+          ruby_key="rbenv-ruby-$RUBY_VERSION"
+          echo "Attempting to build Ruby $RUBY_VERSION from source"
+          git -C "$HOME/.rbenv/plugins/ruby-build" pull
+          cache restore "$ruby_key"
+          sem-version ruby "$RUBY_VERSION"
+          if ! cache has_key "$ruby_key"; then
+            cache store "$ruby_key" "$HOME/.rbenv/versions/$RUBY_VERSION"
+          fi
+        fi
         ./support/check_versions
       else
         echo Skipping Ruby install
@@ -1858,6 +1867,319 @@ blocks:
       - *5
       - name: RUBY_VERSION
         value: 3.1.1
+      - name: GEMSET
+        value: webmachine
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/webmachine.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+- name: Ruby 3.2.0-preview1
+  dependencies:
+  - Validation
+  task:
+    prologue:
+      commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - "./support/install_deps"
+      - bundle config set clean 'true'
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
+      - "./support/bundler_wrapper exec rake extension:install"
+    epilogue: *1
+    jobs:
+    - name: Ruby 3.2.0-preview1 for no_dependencies
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: no_dependencies
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/no_dependencies.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+- name: Ruby 3.2.0-preview1 - Gems
+  dependencies:
+  - Ruby 3.2.0-preview1
+  task:
+    prologue:
+      commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - "./support/install_deps"
+      - bundle config set clean 'true'
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
+      - "./support/bundler_wrapper exec rake extension:install"
+    epilogue: *1
+    jobs:
+    - name: Ruby 3.2.0-preview1 for capistrano2
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: capistrano2
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/capistrano2.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.2.0-preview1 for capistrano3
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: capistrano3
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/capistrano3.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.2.0-preview1 for grape
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: grape
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/grape.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.2.0-preview1 for padrino
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: padrino
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/padrino.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.2.0-preview1 for psych-3
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: psych-3
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/psych-3.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.2.0-preview1 for psych-4
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: psych-4
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/psych-4.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.2.0-preview1 for que
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: que
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/que.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.2.0-preview1 for que_beta
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: que_beta
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/que_beta.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.2.0-preview1 for rails-6.1
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: rails-6.1
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/rails-6.1.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.2.0-preview1 for rails-7.0
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: rails-7.0
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/rails-7.0.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.2.0-preview1 for resque-2
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: resque-2
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/resque-2.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.2.0-preview1 for sequel
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: sequel
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/sequel.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.2.0-preview1 for sinatra
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: sinatra
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/sinatra.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.2.0-preview1 for webmachine
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
       - name: GEMSET
         value: webmachine
       - name: BUNDLE_GEMFILE

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -33,7 +33,16 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
           fi
         - |
           if [ -n "$RUBY_VERSION" ]; then
-            sem-version ruby $RUBY_VERSION
+            if ! (sem-version ruby "$RUBY_VERSION"); then
+              ruby_key="rbenv-ruby-$RUBY_VERSION"
+              echo "Attempting to build Ruby $RUBY_VERSION from source"
+              git -C "$HOME/.rbenv/plugins/ruby-build" pull
+              cache restore "$ruby_key"
+              sem-version ruby "$RUBY_VERSION"
+              if ! cache has_key "$ruby_key"; then
+                cache store "$ruby_key" "$HOME/.rbenv/versions/$RUBY_VERSION"
+              fi
+            fi
             ./support/check_versions
           else
             echo Skipping Ruby install
@@ -190,6 +199,7 @@ matrix:
     - ruby: "2.7.5"
     - ruby: "3.0.3"
     - ruby: "3.1.1"
+    - ruby: "3.2.0-preview1"
     - ruby: "jruby-9.2.19.0"
       gems: "minimal"
       env_vars:
@@ -206,11 +216,13 @@ matrix:
         ruby:
           - "3.0.3"
           - "3.1.1"
+          - "3.2.0-preview1"
     - gem: "psych-4"
       only:
         ruby:
           - "3.0.3"
           - "3.1.1"
+          - "3.2.0-preview1"
     - gem: "que"
     - gem: "que_beta"
     - gem: "rails-3.2"
@@ -283,6 +295,7 @@ matrix:
           - "2.7.5"
           - "3.0.3"
           - "3.1.1"
+          - "3.2.0-preview1"
           - "jruby-9.2.19.0"
     - gem: "rails-7.0"
       only:
@@ -290,6 +303,7 @@ matrix:
           - "2.7.5"
           - "3.0.3"
           - "3.1.1"
+          - "3.2.0-preview1"
     - gem: "resque-1"
       bundler: "1.17.3"
       only:

--- a/gemfiles/grape.gemfile
+++ b/gemfiles/grape.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'grape', '0.14.0'
+gem 'grape'
 gem 'activesupport', '~> 4.2'
 
 gemspec :path => '../'


### PR DESCRIPTION
### [Add Ruby 3.2 preview to build matrix](https://github.com/appsignal/appsignal-ruby/commit/b3bb28bc2491d2ad6a9e53d0534b264804f83418)

Add the preview version of Ruby 3.2 to the build matrix. Exclude
testing against gemsets that were already excluded from Ruby 3.1.

If the requested Ruby version cannot be found, fetch the latest
build definitions for `ruby-build` from its Git repository and
attempt to build from source. Source builds are slow, so they're
cached in Semaphore.

### ~[Temporarily disable failing test for Ruby 3.2](https://github.com/appsignal/appsignal-ruby/commit/7c1fcf0a38f8e799ce8d2735f2b2fb2f8f898e47)~

<details>
<summary>Commit rebased out</summary>
Disable this test to be able to see potential failing tests in CI
in the test suites for the integrations.

This commit should be rebased out, and the failure in the disabled
test should be addressed before merging, along with the failures
in the integration tests.
</details>

### [Test against the latest grape gem versions](https://github.com/appsignal/appsignal-ruby/pull/840/commits/f51d0548124261e8893ed73ab1195db3f1a06954)

The version was restricted to 0.14.0, which was released more than
five years ago. Test against the latest versions of the library.

## TO-DO

- [x] **Address the test failures in the `no_dependencies` build**
It seems that [`RubyVM.stat`](https://docs.ruby-lang.org/en/3.1/RubyVM.html), an undocumented view into the MRI's currently allocated globals and constants, has changed its output format. Our MRI probe reports these values to AppSignal. I'm not sure if there is an equivalence between the new values it outputs and the old ones. We may want to report these different values when the user is running 3.2, or to somehow convert them to the old ones.
~**When this is addressed, rebase out the commit above.**~
**EDIT:** commit rebased out; to be addressed by #852.

- [x] **Address the test failures in the `grape` build**
The version of grape we're testing against checks in the guts of its DSL whether a value is `Fixnum`. The `Fixnum` and `Bignum` constants have been deprecated and aliased to `Integer` for a long time, and [Ruby 3.2.0 is dropping them entirely](https://github.com/ruby/ruby/commit/40e7aefebad412bde50fa9bdadcc8405f7605355). It seems that [newer grape versions have also deprecated the use of `Fixnum`](https://github.com/ruby-grape/grape/commit/96fd175d3e8b4648015a3ae0b4fe0be4f6d1df7a), at least since 0.19.1 (current version is 1.6.2). A potential fix might be to upgrade the version of grape we test against.
**EDIT:** addressed (see commit above)

- [x] **Address the test failures in the `sequel` build**
The version of sequel we're testing against calls `.untaint` on a string. [The `.untaint` method was deprecated and turned into a no-op in version 2.7](https://bugs.ruby-lang.org/issues/16131), and it no longer exists in Ruby 3.2.0. Newer versions of sequel (checked against 5.8.0) don't seem to call `.untaint` anywhere. A potential fix might be to upgrade the version of sequel we test against. 
**EDIT:** already addressed by #845.