### PR TITLE
Fix YAML.load options on Ruby 3 and newer

### DIFF
--- a/.changesets/fix-older-psych-version-on-new-ruby-version.md
+++ b/.changesets/fix-older-psych-version-on-new-ruby-version.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix runtime errors on YAML load with older psych versions (`< 4`) used in combination with newer Ruby version (`3.x`).

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1347,6 +1347,44 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.0.3 for psych-3
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.0.3
+      - name: GEMSET
+        value: psych-3
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/psych-3.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.0.3 for psych-4
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.0.3
+      - name: GEMSET
+        value: psych-4
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/psych-4.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.0.3 for que
       env_vars:
       - *2
@@ -1634,6 +1672,44 @@ blocks:
         value: padrino
       - name: BUNDLE_GEMFILE
         value: gemfiles/padrino.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.1.1 for psych-3
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.1.1
+      - name: GEMSET
+        value: psych-3
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/psych-3.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.1.1 for psych-4
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.1.1
+      - name: GEMSET
+        value: psych-4
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/psych-4.gemfile
       - name: _RUBYGEMS_VERSION
         value: latest
       - name: _BUNDLER_VERSION

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -201,6 +201,16 @@ matrix:
     - gem: "capistrano3"
     - gem: "grape"
     - gem: "padrino"
+    - gem: "psych-3"
+      only:
+        ruby:
+          - "3.0.3"
+          - "3.1.1"
+    - gem: "psych-4"
+      only:
+        ruby:
+          - "3.0.3"
+          - "3.1.1"
     - gem: "que"
     - gem: "que_beta"
     - gem: "rails-3.2"

--- a/gemfiles/psych-3.gemfile
+++ b/gemfiles/psych-3.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "psych", "~> 3.3"
+
+gemspec :path => "../"

--- a/gemfiles/psych-4.gemfile
+++ b/gemfiles/psych-4.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "psych", "~> 4.0"
+
+gemspec :path => "../"

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -376,7 +376,7 @@ module Appsignal
     def load_from_disk
       return if !config_file || !File.exist?(config_file)
 
-      read_options = RUBY_VERSION >= "3.1.0" ? { :aliases => true } : {}
+      read_options = YAML::VERSION >= "4.0.0" ? { :aliases => true } : {}
       configurations = YAML.load(ERB.new(IO.read(config_file)).result, **read_options)
       config_for_this_env = configurations[env]
       if config_for_this_env

--- a/lib/appsignal/integrations/sidekiq.rb
+++ b/lib/appsignal/integrations/sidekiq.rb
@@ -158,7 +158,7 @@ module Appsignal
 
       # Based on: https://github.com/mperham/sidekiq/blob/63ee43353bd3b753beb0233f64865e658abeb1c3/lib/sidekiq/api.rb#L403-L412
       def safe_load(content, default)
-        if RUBY_VERSION >= "3.1.0"
+        if YAML::VERSION >= "4.0.0"
           yield(*YAML.unsafe_load(content))
         else
           yield(*YAML.load(content))


### PR DESCRIPTION
Fix the YAML load errors on using an older pysch gem version on newer
Ruby versions.

Check the psych/YAML version rather than Ruby, because you can use a
different psych version than what ships with the Ruby version.

I've added separate jobs to test these different scenarios on the CI.

Fixes #838
