### PR TITLE
Test against the latest sequel gem versions

### DIFF
--- a/gemfiles/sequel.gemfile
+++ b/gemfiles/sequel.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'sequel', '< 4.35'
+gem 'sequel'
 if RUBY_PLATFORM == "java"
   gem 'jdbc-sqlite3'
 else


### PR DESCRIPTION
We restricted the versions to the previous major version release.
Version 5.55.0 is out already, so let's test against the latest version
instead.

[skip changeset]