### PR TITLE
Use Dir.pwd instead of ENV['PWD'] in Capistrano integration

### DIFF
--- a/.changesets/use-dir-pwd-for-capistrano-3-current-directory.md
+++ b/.changesets/use-dir-pwd-for-capistrano-3-current-directory.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Use `Dir.pwd` to determine the current directory in the Capistrano 3 integration. It previously relied on `ENV["pwd"]` which returned `nil` in some scenarios.

--- a/lib/appsignal/integrations/capistrano/appsignal.cap
+++ b/lib/appsignal/integrations/capistrano/appsignal.cap
@@ -5,7 +5,7 @@ namespace :appsignal do
     revision = fetch(:appsignal_revision, fetch(:current_revision))
 
     appsignal_config = Appsignal::Config.new(
-      ENV["PWD"],
+      Dir.pwd,
       appsignal_env,
       {},
       Logger.new(StringIO.new)

--- a/spec/lib/appsignal/capistrano3_spec.rb
+++ b/spec/lib/appsignal/capistrano3_spec.rb
@@ -42,7 +42,11 @@ if DependencyHelper.capistrano3_present?
     describe "appsignal:deploy task" do
       before do
         ENV["USER"] = "batman"
-        allow(Dir).to receive(:pwd).and_return(project_fixture_path)
+      end
+      around do |example|
+        Dir.chdir project_fixture_path do
+          example.run
+        end
       end
 
       context "config" do

--- a/spec/lib/appsignal/capistrano3_spec.rb
+++ b/spec/lib/appsignal/capistrano3_spec.rb
@@ -42,7 +42,7 @@ if DependencyHelper.capistrano3_present?
     describe "appsignal:deploy task" do
       before do
         ENV["USER"] = "batman"
-        ENV["PWD"] = project_fixture_path
+        allow(Dir).to receive(:pwd).and_return(project_fixture_path)
       end
 
       context "config" do


### PR DESCRIPTION
I'm using a pretty different setup for my Deploy with Capistrano, which includes deploying from a dev container in rootless podman, using the [Ruby on Whales](https://evilmartians.com/chronicles/ruby-on-whales-docker-for-ruby-rails-development) guide, with some changes.

I don't know exactly why it happens, but when deploying `ENV["PWD"]` returns `nil`. I tinkered a little and it seems that `Dir.pwd` is more reliable.