### PR TITLE
MRI VM Stats

### DIFF
--- a/.changesets/add-a-mri-vm-probe-to-add-a-magic-dashboard.md
+++ b/.changesets/add-a-mri-vm-probe-to-add-a-magic-dashboard.md
@@ -3,4 +3,4 @@ bump: "minor"
 type: "add"
 ---
 
-Add a MRI VM probe to add a Magic Dashboard
+Add tracking of thread counts, garbage collection runs, heap slots and other garbage collection stats to the default MRI probe. These metrics will be shown in AppSignal.com in a new Ruby VM Magic Dashboard.

--- a/.changesets/add-a-mri-vm-probe-to-add-a-magic-dashboard.md
+++ b/.changesets/add-a-mri-vm-probe-to-add-a-magic-dashboard.md
@@ -1,0 +1,6 @@
+---
+bump: "minor"
+type: "add"
+---
+
+Add a MRI VM probe to add a Magic Dashboard

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -32,7 +32,16 @@ global_job_config:
       fi
     - |
       if [ -n "$RUBY_VERSION" ]; then
-        sem-version ruby $RUBY_VERSION
+        if ! (sem-version ruby "$RUBY_VERSION"); then
+          ruby_key="rbenv-ruby-$RUBY_VERSION"
+          echo "Attempting to build Ruby $RUBY_VERSION from source"
+          git -C "$HOME/.rbenv/plugins/ruby-build" pull
+          cache restore "$ruby_key"
+          sem-version ruby "$RUBY_VERSION"
+          if ! cache has_key "$ruby_key"; then
+            cache store "$ruby_key" "$HOME/.rbenv/versions/$RUBY_VERSION"
+          fi
+        fi
         ./support/check_versions
       else
         echo Skipping Ruby install
@@ -1858,6 +1867,319 @@ blocks:
       - *5
       - name: RUBY_VERSION
         value: 3.1.1
+      - name: GEMSET
+        value: webmachine
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/webmachine.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+- name: Ruby 3.2.0-preview1
+  dependencies:
+  - Validation
+  task:
+    prologue:
+      commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - "./support/install_deps"
+      - bundle config set clean 'true'
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
+      - "./support/bundler_wrapper exec rake extension:install"
+    epilogue: *1
+    jobs:
+    - name: Ruby 3.2.0-preview1 for no_dependencies
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: no_dependencies
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/no_dependencies.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+- name: Ruby 3.2.0-preview1 - Gems
+  dependencies:
+  - Ruby 3.2.0-preview1
+  task:
+    prologue:
+      commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - "./support/install_deps"
+      - bundle config set clean 'true'
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
+      - "./support/bundler_wrapper exec rake extension:install"
+    epilogue: *1
+    jobs:
+    - name: Ruby 3.2.0-preview1 for capistrano2
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: capistrano2
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/capistrano2.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.2.0-preview1 for capistrano3
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: capistrano3
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/capistrano3.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.2.0-preview1 for grape
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: grape
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/grape.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.2.0-preview1 for padrino
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: padrino
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/padrino.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.2.0-preview1 for psych-3
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: psych-3
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/psych-3.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.2.0-preview1 for psych-4
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: psych-4
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/psych-4.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.2.0-preview1 for que
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: que
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/que.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.2.0-preview1 for que_beta
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: que_beta
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/que_beta.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.2.0-preview1 for rails-6.1
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: rails-6.1
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/rails-6.1.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.2.0-preview1 for rails-7.0
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: rails-7.0
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/rails-7.0.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.2.0-preview1 for resque-2
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: resque-2
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/resque-2.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.2.0-preview1 for sequel
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: sequel
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/sequel.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.2.0-preview1 for sinatra
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
+      - name: GEMSET
+        value: sinatra
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/sinatra.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+    - name: Ruby 3.2.0-preview1 for webmachine
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-preview1
       - name: GEMSET
         value: webmachine
       - name: BUNDLE_GEMFILE

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -33,7 +33,16 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
           fi
         - |
           if [ -n "$RUBY_VERSION" ]; then
-            sem-version ruby $RUBY_VERSION
+            if ! (sem-version ruby "$RUBY_VERSION"); then
+              ruby_key="rbenv-ruby-$RUBY_VERSION"
+              echo "Attempting to build Ruby $RUBY_VERSION from source"
+              git -C "$HOME/.rbenv/plugins/ruby-build" pull
+              cache restore "$ruby_key"
+              sem-version ruby "$RUBY_VERSION"
+              if ! cache has_key "$ruby_key"; then
+                cache store "$ruby_key" "$HOME/.rbenv/versions/$RUBY_VERSION"
+              fi
+            fi
             ./support/check_versions
           else
             echo Skipping Ruby install
@@ -190,6 +199,7 @@ matrix:
     - ruby: "2.7.5"
     - ruby: "3.0.3"
     - ruby: "3.1.1"
+    - ruby: "3.2.0-preview1"
     - ruby: "jruby-9.2.19.0"
       gems: "minimal"
       env_vars:
@@ -206,11 +216,13 @@ matrix:
         ruby:
           - "3.0.3"
           - "3.1.1"
+          - "3.2.0-preview1"
     - gem: "psych-4"
       only:
         ruby:
           - "3.0.3"
           - "3.1.1"
+          - "3.2.0-preview1"
     - gem: "que"
     - gem: "que_beta"
     - gem: "rails-3.2"
@@ -283,6 +295,7 @@ matrix:
           - "2.7.5"
           - "3.0.3"
           - "3.1.1"
+          - "3.2.0-preview1"
           - "jruby-9.2.19.0"
     - gem: "rails-7.0"
       only:
@@ -290,6 +303,7 @@ matrix:
           - "2.7.5"
           - "3.0.3"
           - "3.1.1"
+          - "3.2.0-preview1"
     - gem: "resque-1"
       bundler: "1.17.3"
       only:

--- a/gemfiles/grape.gemfile
+++ b/gemfiles/grape.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'grape', '0.14.0'
+gem 'grape'
 gem 'activesupport', '~> 4.2'
 
 gemspec :path => '../'

--- a/lib/appsignal/probes/mri.rb
+++ b/lib/appsignal/probes/mri.rb
@@ -20,6 +20,8 @@ module Appsignal
             :metric => metric
           )
         end
+
+        Appsignal.set_gauge("thread_count", Thread.list.size)
       end
     end
   end

--- a/lib/appsignal/probes/mri.rb
+++ b/lib/appsignal/probes/mri.rb
@@ -30,7 +30,7 @@ module Appsignal
         @appsignal.set_gauge("gc_total_time", MriProbe.garbage_collection_profiler.total_time)
 
         gc_stats = GC.stat
-        @appsignal.set_gauge("total_allocated_objects", gc_stats[:total_allocated_objects])
+        @appsignal.set_gauge("total_allocated_objects", gc_stats[:total_allocated_objects] || gc_stats[:total_allocated_object])
 
         @appsignal.add_distribution_value("gc_count", GC.count, :metric => :gc_count)
         @appsignal.add_distribution_value("gc_count", gc_stats[:minor_gc_count], :metric => :minor_gc_count)

--- a/lib/appsignal/probes/mri.rb
+++ b/lib/appsignal/probes/mri.rb
@@ -26,16 +26,13 @@ module Appsignal
         @appsignal.set_gauge("gc_runs", GC.count)
 
         gc_stats = GC.stat
+        @appsignal.set_gauge("total_allocated_objects", gc_stats[:total_allocated_objects])
 
-        {
-          :total_allocated_objects => gc_stats[:total_allocated_objects],
-          :major_gc_count => gc_stats[:major_gc_count],
-          :minor_gc_count => gc_stats[:minor_gc_count],
-          :heap_live => gc_stats[:heap_live_slots],
-          :heap_free => gc_stats[:heap_free_slots]
-        }.each do |metric, value|
-          @appsignal.add_distribution_value("gc_stats", value, :metric => metric)
-        end
+        @appsignal.add_distribution_value("gc_count", gc_stats[:minor_gc_count], :metric => :minor_gc_count)
+        @appsignal.add_distribution_value("gc_count", gc_stats[:major_gc_count], :metric => :major_gc_count)
+
+        @appsignal.add_distribution_value("heap_slots", gc_stats[:heap_live_slots], :metric => :heap_live)
+        @appsignal.add_distribution_value("heap_slots", gc_stats[:heap_free_slots], :metric => :heap_free)
       end
     end
   end

--- a/lib/appsignal/probes/mri.rb
+++ b/lib/appsignal/probes/mri.rb
@@ -24,6 +24,18 @@ module Appsignal
 
         @appsignal.set_gauge("thread_count", Thread.list.size)
         @appsignal.set_gauge("gc_runs", GC.count)
+
+        gc_stats = GC.stat
+
+        {
+          :total_allocated_objects => gc_stats[:total_allocated_objects],
+          :major_gc_count => gc_stats[:major_gc_count],
+          :minor_gc_count => gc_stats[:minor_gc_count],
+          :heap_live => gc_stats[:heap_live_slots],
+          :heap_free => gc_stats[:heap_free_slots]
+        }.each do |metric, value|
+          @appsignal.add_distribution_value("gc_stats", value, :metric => metric)
+        end
       end
     end
   end

--- a/lib/appsignal/probes/mri.rb
+++ b/lib/appsignal/probes/mri.rb
@@ -18,13 +18,18 @@ module Appsignal
       # @api private
       def call
         stat = RubyVM.stat
-        [:class_serial, :global_constant_state].each do |metric|
-          @appsignal.add_distribution_value(
-            "ruby_vm",
-            stat[metric],
-            :metric => metric
-          )
-        end
+
+        @appsignal.add_distribution_value(
+          "ruby_vm",
+          stat[:class_serial],
+          :metric => :class_serial
+        )
+
+        @appsignal.add_distribution_value(
+          "ruby_vm",
+          stat[:constant_cache] ? stat[:constant_cache].values.sum : stat[:global_constant_state],
+          :metric => :global_constant_state
+        )
 
         @appsignal.set_gauge("thread_count", Thread.list.size)
         @appsignal.set_gauge("gc_total_time", MriProbe.garbage_collection_profiler.total_time)

--- a/lib/appsignal/probes/mri.rb
+++ b/lib/appsignal/probes/mri.rb
@@ -6,6 +6,10 @@ module Appsignal
         defined?(::RubyVM) && ::RubyVM.respond_to?(:stat)
       end
 
+      def self.garbage_collection_profiler
+        @garbage_collection_profiler ||= Appsignal::GarbageCollectionProfiler.new
+      end
+
       def initialize(appsignal = Appsignal)
         Appsignal.logger.debug("Initializing VM probe")
         @appsignal = appsignal
@@ -23,11 +27,12 @@ module Appsignal
         end
 
         @appsignal.set_gauge("thread_count", Thread.list.size)
-        @appsignal.set_gauge("gc_runs", GC.count)
+        @appsignal.set_gauge("gc_total_time", MriProbe.garbage_collection_profiler.total_time)
 
         gc_stats = GC.stat
         @appsignal.set_gauge("total_allocated_objects", gc_stats[:total_allocated_objects])
 
+        @appsignal.add_distribution_value("gc_count", GC.count, :metric => :gc_count)
         @appsignal.add_distribution_value("gc_count", gc_stats[:minor_gc_count], :metric => :minor_gc_count)
         @appsignal.add_distribution_value("gc_count", gc_stats[:major_gc_count], :metric => :major_gc_count)
 

--- a/lib/appsignal/probes/mri.rb
+++ b/lib/appsignal/probes/mri.rb
@@ -23,6 +23,7 @@ module Appsignal
         end
 
         @appsignal.set_gauge("thread_count", Thread.list.size)
+        @appsignal.set_gauge("gc_runs", GC.count)
       end
     end
   end

--- a/lib/appsignal/probes/mri.rb
+++ b/lib/appsignal/probes/mri.rb
@@ -6,22 +6,23 @@ module Appsignal
         defined?(::RubyVM) && ::RubyVM.respond_to?(:stat)
       end
 
-      def initialize
+      def initialize(appsignal = Appsignal)
         Appsignal.logger.debug("Initializing VM probe")
+        @appsignal = appsignal
       end
 
       # @api private
       def call
         stat = RubyVM.stat
         [:class_serial, :global_constant_state].each do |metric|
-          Appsignal.add_distribution_value(
+          @appsignal.add_distribution_value(
             "ruby_vm",
             stat[metric],
             :metric => metric
           )
         end
 
-        Appsignal.set_gauge("thread_count", Thread.list.size)
+        @appsignal.set_gauge("thread_count", Thread.list.size)
       end
     end
   end

--- a/lib/appsignal/probes/mri.rb
+++ b/lib/appsignal/probes/mri.rb
@@ -36,8 +36,8 @@ module Appsignal
         @appsignal.add_distribution_value("gc_count", gc_stats[:minor_gc_count], :metric => :minor_gc_count)
         @appsignal.add_distribution_value("gc_count", gc_stats[:major_gc_count], :metric => :major_gc_count)
 
-        @appsignal.add_distribution_value("heap_slots", gc_stats[:heap_live_slots], :metric => :heap_live)
-        @appsignal.add_distribution_value("heap_slots", gc_stats[:heap_free_slots], :metric => :heap_free)
+        @appsignal.add_distribution_value("heap_slots", gc_stats[:heap_live_slots] || gc_stats[:heap_live_slot], :metric => :heap_live)
+        @appsignal.add_distribution_value("heap_slots", gc_stats[:heap_free_slots] || gc_stats[:heap_free_slot], :metric => :heap_free)
       end
     end
   end

--- a/spec/lib/appsignal/probes/mri_spec.rb
+++ b/spec/lib/appsignal/probes/mri_spec.rb
@@ -10,7 +10,7 @@ class AppsignalMock
     @distribution_values << args
   end
 
-  def set_gauge(*args)
+  def set_gauge(*args) # rubocop:disable Naming/AccessorMethodName
     @gauges << args
   end
 end
@@ -68,7 +68,7 @@ describe Appsignal::Probes::MriProbe do
     expect(appsignal_mock.distribution_values).to satisfy do |distribution_values|
       distribution_values.any? do |distribution_value|
         key, value, metadata = distribution_value
-        key == expected_key && !value.nil? && metadata == {:metric => metric}
+        key == expected_key && !value.nil? && metadata == { :metric => metric }
       end
     end
   end

--- a/spec/lib/appsignal/probes/mri_spec.rb
+++ b/spec/lib/appsignal/probes/mri_spec.rb
@@ -46,14 +46,18 @@ describe Appsignal::Probes::MriProbe do
         expect_gauge_value("thread_count")
       end
 
+      it "tracks GC total time" do
+        expect_gauge_value("gc_total_time")
+      end
+
       it "tracks GC runs" do
-        expect_gauge_value("gc_runs")
+        expect_distribution_value("gc_count", :gc_count)
+        expect_distribution_value("gc_count", :major_gc_count)
+        expect_distribution_value("gc_count", :minor_gc_count)
       end
 
       it "tracks GC stats" do
         expect_gauge_value("total_allocated_objects")
-        expect_distribution_value("gc_count", :major_gc_count)
-        expect_distribution_value("gc_count", :minor_gc_count)
         expect_distribution_value("heap_slots", :heap_live)
         expect_distribution_value("heap_slots", :heap_free)
       end

--- a/spec/lib/appsignal/probes/mri_spec.rb
+++ b/spec/lib/appsignal/probes/mri_spec.rb
@@ -36,36 +36,37 @@ describe Appsignal::Probes::MriProbe do
       it "should track vm metrics" do
         probe.call
 
-        expect_distribution_value(:class_serial)
-        expect_distribution_value(:global_constant_state)
+        expect_distribution_value("ruby_vm", :class_serial)
+        expect_distribution_value("ruby_vm", :global_constant_state)
       end
 
       it "tracks thread counts" do
         probe.call
 
-        expect_gauge_value(:thread_count)
+        expect_gauge_value("thread_count")
       end
 
       it "tracks GC runs" do
         probe.call
 
-        expect_gauge_value(:gc_runs)
+        expect_gauge_value("gc_runs")
       end
     end
   end
 
-  def expect_distribution_value(metric)
+  def expect_distribution_value(expected_key, metric)
     expect(appsignal_mock.distribution_values).to satisfy do |distribution_values|
       distribution_values.any? do |distribution_value|
-        distribution_value.last == {:metric => metric}
+        key, value, metadata = distribution_value
+        key == expected_key && !value.nil? && metadata == {:metric => metric}
       end
     end
   end
 
   def expect_gauge_value(key)
-    expect(appsignal_mock.gauges).to satisfy do |distribution_values|
-      distribution_values.any? do |distribution_value|
-        distribution_value.first == key.to_s
+    expect(appsignal_mock.gauges).to satisfy do |gauges|
+      gauges.any? do |gauge|
+        gauge.first == key && !gauge.last.nil?
       end
     end
   end

--- a/spec/lib/appsignal/probes/mri_spec.rb
+++ b/spec/lib/appsignal/probes/mri_spec.rb
@@ -51,11 +51,11 @@ describe Appsignal::Probes::MriProbe do
       end
 
       it "tracks GC stats" do
-        expect_distribution_value("gc_stats", :total_allocated_objects)
-        expect_distribution_value("gc_stats", :major_gc_count)
-        expect_distribution_value("gc_stats", :minor_gc_count)
-        expect_distribution_value("gc_stats", :heap_live)
-        expect_distribution_value("gc_stats", :heap_free)
+        expect_gauge_value("total_allocated_objects")
+        expect_distribution_value("gc_count", :major_gc_count)
+        expect_distribution_value("gc_count", :minor_gc_count)
+        expect_distribution_value("heap_slots", :heap_live)
+        expect_distribution_value("heap_slots", :heap_free)
       end
     end
   end

--- a/spec/lib/appsignal/probes/mri_spec.rb
+++ b/spec/lib/appsignal/probes/mri_spec.rb
@@ -45,6 +45,12 @@ describe Appsignal::Probes::MriProbe do
 
         expect_gauge_value(:thread_count)
       end
+
+      it "tracks GC runs" do
+        probe.call
+
+        expect_gauge_value(:gc_runs)
+      end
     end
   end
 

--- a/spec/lib/appsignal/probes/mri_spec.rb
+++ b/spec/lib/appsignal/probes/mri_spec.rb
@@ -33,22 +33,20 @@ describe Appsignal::Probes::MriProbe do
 
   unless DependencyHelper.running_jruby? || DependencyHelper.running_ruby_2_0?
     describe "#call" do
-      it "should track vm metrics" do
+      before do
         probe.call
+      end
 
+      it "should track vm metrics" do
         expect_distribution_value("ruby_vm", :class_serial)
         expect_distribution_value("ruby_vm", :global_constant_state)
       end
 
       it "tracks thread counts" do
-        probe.call
-
         expect_gauge_value("thread_count")
       end
 
       it "tracks GC runs" do
-        probe.call
-
         expect_gauge_value("gc_runs")
       end
     end

--- a/spec/lib/appsignal/probes/mri_spec.rb
+++ b/spec/lib/appsignal/probes/mri_spec.rb
@@ -49,6 +49,14 @@ describe Appsignal::Probes::MriProbe do
       it "tracks GC runs" do
         expect_gauge_value("gc_runs")
       end
+
+      it "tracks GC stats" do
+        expect_distribution_value("gc_stats", :total_allocated_objects)
+        expect_distribution_value("gc_stats", :major_gc_count)
+        expect_distribution_value("gc_stats", :minor_gc_count)
+        expect_distribution_value("gc_stats", :heap_live)
+        expect_distribution_value("gc_stats", :heap_free)
+      end
     end
   end
 

--- a/spec/lib/appsignal/probes/mri_spec.rb
+++ b/spec/lib/appsignal/probes/mri_spec.rb
@@ -21,11 +21,24 @@ describe Appsignal::Probes::MriProbe do
 
         probe.call
       end
+
+      it "tracks thread counts" do
+        expect_gauge_value(:thread_count)
+
+        probe.call
+      end
     end
 
     def expect_distribution_value(metric)
       expect(Appsignal).to receive(:add_distribution_value)
         .with("ruby_vm", kind_of(Numeric), :metric => metric)
+        .and_call_original
+        .once
+    end
+
+    def expect_gauge_value(metric)
+      expect(Appsignal).to receive(:set_gauge)
+        .with("thread_count", kind_of(Numeric))
         .and_call_original
         .once
     end


### PR DESCRIPTION
This patch adds Ruby VM stats to be used with a Magic Dashboard. It reports allocated objects, garbage collection run stats, heap slots, stats from RubyVM.stats, thread counts, and total GC time, because those seem to be the most reported. Let me know if there’s something you’re missing for these!

Please help me test this by running a Ruby app (any one from the test setups will do) locally on this version of the Ruby integration on as many different Ruby versions you can. Also, check out the [dashboard](https://github.com/appsignal/public_config/pull/37) to see if everything there makes sense and properly works. It hasn’t been merged yet, but you can import the serialized version in that pull request.

Feel free to reach out if you need help! :)