### PR TITLE
Fix appsignal_free_* FFI missing pointer arguments

### DIFF
--- a/.changesets/fix-ffi-arguments-for-free-functions.md
+++ b/.changesets/fix-ffi-arguments-for-free-functions.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix FFI function calls missing arguments for `appsignal_free_transaction` and `appsignal_free_data` extension functions. This fixes a high CPU issue when these function calls would be retried indefinitely.

--- a/lib/appsignal/extension/jruby.rb
+++ b/lib/appsignal/extension/jruby.rb
@@ -83,7 +83,7 @@ module Appsignal
 
         # Transaction methods
         attach_function :appsignal_free_transaction,
-          [],
+          [:pointer],
           :void
         attach_function :appsignal_start_transaction,
           [:appsignal_string, :appsignal_string, :long],
@@ -191,7 +191,7 @@ module Appsignal
           :void
 
         # Data struct methods
-        attach_function :appsignal_free_data, [], :void
+        attach_function :appsignal_free_data, [:pointer], :void
         attach_function :appsignal_data_map_new, [], :pointer
         attach_function :appsignal_data_array_new, [], :pointer
         attach_function :appsignal_data_map_set_string,


### PR DESCRIPTION
The `appsignal_free_transaction` and `appsignal_free_data` Rust
extension function calls were missing their argument definitions in the
FFI declaration.

These are the function definitions from the `appsignal.h` file,
downloaded upon installation.

```c
void appsignal_free_transaction(appsignal_transaction_t*);
void appsignal_free_data(appsignal_data_t*);
```

Fixes #854 where users saw very high CPU usage because the function call
was being retried indefinitely.

Co-authored-by: Raimonds Simanovskis <raimonds.simanovskis@gmail.com>