### PR TITLE
Test failure tests only once per Ruby version

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -218,7 +218,6 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.0.0-p648 for rails-4.2
       env_vars:
       - *2
@@ -237,7 +236,6 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
 - name: Ruby 2.1.10
   dependencies:
   - Validation
@@ -435,7 +433,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.5.8 for rails-6.0
       env_vars:
       - *2
@@ -454,7 +451,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.5.8 for rails-6.1
       env_vars:
       - *2
@@ -473,7 +469,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
 - name: Ruby 2.6.9
   dependencies:
   - Validation
@@ -539,7 +534,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.9 for capistrano3
       env_vars:
       - *2
@@ -558,7 +552,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.9 for grape
       env_vars:
       - *2
@@ -577,7 +570,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.9 for padrino
       env_vars:
       - *2
@@ -596,7 +588,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.9 for que
       env_vars:
       - *2
@@ -615,7 +606,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.9 for que_beta
       env_vars:
       - *2
@@ -634,7 +624,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.9 for rails-5.0
       env_vars:
       - *2
@@ -653,7 +642,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.9 for rails-5.1
       env_vars:
       - *2
@@ -672,7 +660,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.9 for rails-5.2
       env_vars:
       - *2
@@ -691,7 +678,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.9 for rails-6.0
       env_vars:
       - *2
@@ -710,7 +696,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.9 for rails-6.1
       env_vars:
       - *2
@@ -729,7 +714,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.9 for resque-1
       env_vars:
       - *2
@@ -748,7 +732,6 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.9 for resque-2
       env_vars:
       - *2
@@ -767,7 +750,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.9 for sequel
       env_vars:
       - *2
@@ -786,7 +768,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.9 for sequel-435
       env_vars:
       - *2
@@ -805,7 +786,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.9 for sinatra
       env_vars:
       - *2
@@ -824,7 +804,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.6.9 for webmachine
       env_vars:
       - *2
@@ -843,7 +822,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
 - name: Ruby 2.7.5
   dependencies:
   - Validation
@@ -909,7 +887,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.5 for capistrano3
       env_vars:
       - *2
@@ -928,7 +905,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.5 for grape
       env_vars:
       - *2
@@ -947,7 +923,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.5 for padrino
       env_vars:
       - *2
@@ -966,7 +941,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.5 for que
       env_vars:
       - *2
@@ -985,7 +959,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.5 for que_beta
       env_vars:
       - *2
@@ -1004,7 +977,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.5 for rails-5.0
       env_vars:
       - *2
@@ -1023,7 +995,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.5 for rails-5.1
       env_vars:
       - *2
@@ -1042,7 +1013,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.5 for rails-5.2
       env_vars:
       - *2
@@ -1061,7 +1031,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.5 for rails-6.0
       env_vars:
       - *2
@@ -1080,7 +1049,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.5 for rails-6.1
       env_vars:
       - *2
@@ -1099,7 +1067,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.5 for rails-7.0
       env_vars:
       - *2
@@ -1118,7 +1085,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.5 for resque-1
       env_vars:
       - *2
@@ -1137,7 +1103,6 @@ blocks:
         value: 1.17.3
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.5 for resque-2
       env_vars:
       - *2
@@ -1156,7 +1121,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.5 for sequel
       env_vars:
       - *2
@@ -1175,7 +1139,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.5 for sequel-435
       env_vars:
       - *2
@@ -1194,7 +1157,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.5 for sinatra
       env_vars:
       - *2
@@ -1213,7 +1175,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 2.7.5 for webmachine
       env_vars:
       - *2
@@ -1232,7 +1193,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
 - name: Ruby 3.0.3
   dependencies:
   - Validation
@@ -1298,7 +1258,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.0.3 for capistrano3
       env_vars:
       - *2
@@ -1317,7 +1276,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.0.3 for grape
       env_vars:
       - *2
@@ -1336,7 +1294,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.0.3 for padrino
       env_vars:
       - *2
@@ -1355,7 +1312,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.0.3 for psych-3
       env_vars:
       - *2
@@ -1374,7 +1330,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.0.3 for psych-4
       env_vars:
       - *2
@@ -1393,7 +1348,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.0.3 for que
       env_vars:
       - *2
@@ -1412,7 +1366,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.0.3 for que_beta
       env_vars:
       - *2
@@ -1431,7 +1384,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.0.3 for rails-6.0
       env_vars:
       - *2
@@ -1450,7 +1402,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.0.3 for rails-6.1
       env_vars:
       - *2
@@ -1469,7 +1420,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.0.3 for rails-7.0
       env_vars:
       - *2
@@ -1488,7 +1438,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.0.3 for resque-2
       env_vars:
       - *2
@@ -1507,7 +1456,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.0.3 for sequel
       env_vars:
       - *2
@@ -1526,7 +1474,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.0.3 for sinatra
       env_vars:
       - *2
@@ -1545,7 +1492,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.0.3 for webmachine
       env_vars:
       - *2
@@ -1564,7 +1510,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
 - name: Ruby 3.1.1
   dependencies:
   - Validation
@@ -1630,7 +1575,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.1.1 for capistrano3
       env_vars:
       - *2
@@ -1649,7 +1593,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.1.1 for grape
       env_vars:
       - *2
@@ -1668,7 +1611,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.1.1 for padrino
       env_vars:
       - *2
@@ -1687,7 +1629,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.1.1 for psych-3
       env_vars:
       - *2
@@ -1706,7 +1647,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.1.1 for psych-4
       env_vars:
       - *2
@@ -1725,7 +1665,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.1.1 for que
       env_vars:
       - *2
@@ -1744,7 +1683,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.1.1 for que_beta
       env_vars:
       - *2
@@ -1763,7 +1701,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.1.1 for rails-6.1
       env_vars:
       - *2
@@ -1782,7 +1719,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.1.1 for rails-7.0
       env_vars:
       - *2
@@ -1801,7 +1737,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.1.1 for resque-2
       env_vars:
       - *2
@@ -1820,7 +1755,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.1.1 for sequel
       env_vars:
       - *2
@@ -1839,7 +1773,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.1.1 for sinatra
       env_vars:
       - *2
@@ -1858,7 +1791,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.1.1 for webmachine
       env_vars:
       - *2
@@ -1877,7 +1809,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
 - name: Ruby 3.2.0-preview1
   dependencies:
   - Validation
@@ -1943,7 +1874,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.2.0-preview1 for capistrano3
       env_vars:
       - *2
@@ -1962,7 +1892,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.2.0-preview1 for grape
       env_vars:
       - *2
@@ -1981,7 +1910,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.2.0-preview1 for padrino
       env_vars:
       - *2
@@ -2000,7 +1928,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.2.0-preview1 for psych-3
       env_vars:
       - *2
@@ -2019,7 +1946,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.2.0-preview1 for psych-4
       env_vars:
       - *2
@@ -2038,7 +1964,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.2.0-preview1 for que
       env_vars:
       - *2
@@ -2057,7 +1982,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.2.0-preview1 for que_beta
       env_vars:
       - *2
@@ -2076,7 +2000,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.2.0-preview1 for rails-6.1
       env_vars:
       - *2
@@ -2095,7 +2018,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.2.0-preview1 for rails-7.0
       env_vars:
       - *2
@@ -2114,7 +2036,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.2.0-preview1 for resque-2
       env_vars:
       - *2
@@ -2133,7 +2054,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.2.0-preview1 for sequel
       env_vars:
       - *2
@@ -2152,7 +2072,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.2.0-preview1 for sinatra
       env_vars:
       - *2
@@ -2171,7 +2090,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby 3.2.0-preview1 for webmachine
       env_vars:
       - *2
@@ -2190,7 +2108,6 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
 - name: Ruby jruby-9.2.19.0
   dependencies:
   - Validation
@@ -2260,7 +2177,6 @@ blocks:
       - *6
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby jruby-9.2.19.0 for rails-6.0
       env_vars:
       - *2
@@ -2280,7 +2196,6 @@ blocks:
       - *6
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"
     - name: Ruby jruby-9.2.19.0 for rails-6.1
       env_vars:
       - *2
@@ -2300,4 +2215,3 @@ blocks:
       - *6
       commands:
       - "./support/bundler_wrapper exec rake test"
-      - "./support/bundler_wrapper exec rake test:failure"

--- a/Rakefile
+++ b/Rakefile
@@ -77,11 +77,12 @@ namespace :build_matrix do
             "name" => "Ruby #{ruby_version} for #{gem["gem"]}",
             "env_vars" => env + ruby.fetch("env_vars", []),
             "commands" => [
-              "./support/bundler_wrapper exec rake test",
-              "./support/bundler_wrapper exec rake test:failure"
+              "./support/bundler_wrapper exec rake test"
             ]
           }
           if gem["gem"] == "no_dependencies"
+            # Only test the failure scenarios once per Ruby version
+            job["commands"] << "./support/bundler_wrapper exec rake test:failure"
             ruby_primary_block["task"]["jobs"] << job
           else
             ruby_secondary_block["task"]["jobs"] << job


### PR DESCRIPTION
On the CI the tests tagged with failure were tested for every Ruby
version and gem combination.

This is redundant as it doesn't test anything new for those gem
combinations, as it's only for the extension installation failure
scenario.

[skip changeset]
[skip review]