### PR TITLE
Add MimeNegotiation::InvalidType to suggested ignore_errors

### DIFF
--- a/resources/appsignal.yml.erb
+++ b/resources/appsignal.yml.erb
@@ -25,6 +25,7 @@ default: &defaults
   #   - Interrupt
   #   - SystemExit
   #   - SystemStackError
+  #   - ActionDispatch::Http::MimeNegotiation::InvalidType
 
   # See http://docs.appsignal.com/ruby/configuration/options.html for
   # all configuration options.


### PR DESCRIPTION
This error is often caused by bots and malicious actors, and was introduced by Rails to help APM tools ignore it:
https://github.com/getsentry/sentry-ruby/commit/8cb0fedd74c8393f1e94e85b487c76ebcb3b8ab5

Since AppSignal doesn’t ignore any errors by default I thought it might be handy to suggest it. 