### PR TITLE
Bump Lintje 0.7.1

### DIFF
--- a/script/lint_git
+++ b/script/lint_git
@@ -2,7 +2,7 @@
 
 set -eu
 
-LINTJE_VERSION="0.6.1"
+LINTJE_VERSION="0.7.1"
 
 mkdir -p $HOME/bin
 cache_key=v1-lintje-$LINTJE_VERSION

--- a/script/lint_git
+++ b/script/lint_git
@@ -4,7 +4,7 @@ set -eu
 
 LINTJE_VERSION="0.7.1"
 
-mkdir -p $HOME/bin
+mkdir -p "$HOME/bin"
 cache_key=v1-lintje-$LINTJE_VERSION
 cache restore $cache_key
 
@@ -15,8 +15,8 @@ else
   echo "Downloading Lintje $LINTJE_VERSION"
   curl -L \
     https://github.com/tombruijn/lintje/releases/download/v$LINTJE_VERSION/x86_64-unknown-linux-gnu.tar.gz | \
-    tar -xz --directory $HOME/bin
-  cache store $cache_key $HOME/bin/lintje
+    tar -xz --directory "$HOME/bin"
+  cache store $cache_key "$HOME/bin/lintje"
 fi
 
-$HOME/bin/lintje $SEMAPHORE_GIT_COMMIT_RANGE
+"$HOME/bin/lintje" "$SEMAPHORE_GIT_COMMIT_RANGE"


### PR DESCRIPTION
## Bump Lintje 0.7.1

This fixes the issue with version numbers being detected as ticket
numbers in branch names.

## Fix Shellcheck issues on script/lint_git

Fix issues by following the Shellcheck suggestions. Wrap variables in
double quotes so it can't accidentally break things.

> SC2086 (info): Double quote to prevent globbing and word splitting

[skip review]
[skip changeset]
