### PR TITLE
Add JRuby 9.3 build to CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2215,3 +2215,68 @@ blocks:
       - *6
       commands:
       - "./support/bundler_wrapper exec rake test"
+- name: Ruby jruby-9.3.6.0
+  dependencies:
+  - Validation
+  task:
+    prologue:
+      commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - "./support/install_deps"
+      - bundle config set clean 'true'
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
+      - "./support/bundler_wrapper exec rake extension:install"
+    epilogue: *1
+    jobs:
+    - name: Ruby jruby-9.3.6.0 for no_dependencies
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: jruby-9.3.6.0
+      - name: GEMSET
+        value: no_dependencies
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/no_dependencies.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+      - "./support/bundler_wrapper exec rake test:failure"
+- name: Ruby jruby-9.3.6.0 - Gems
+  dependencies:
+  - Ruby jruby-9.3.6.0
+  task:
+    prologue:
+      commands:
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - "./support/install_deps"
+      - bundle config set clean 'true'
+      - "./support/bundler_wrapper install --jobs=3 --retry=3"
+      - "./support/bundler_wrapper exec rake extension:install"
+    epilogue: *1
+    jobs:
+    - name: Ruby jruby-9.3.6.0 for rails-6.1
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: jruby-9.3.6.0
+      - name: GEMSET
+        value: rails-6.1
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/rails-6.1.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -205,6 +205,8 @@ matrix:
       env_vars:
         - name: "_C_VERSION"
           value: "8"
+    - ruby: "jruby-9.3.6.0"
+      gems: "minimal"
   gems:
     - gem: "no_dependencies"
     - gem: "capistrano2"
@@ -297,6 +299,7 @@ matrix:
           - "3.1.1"
           - "3.2.0-preview1"
           - "jruby-9.2.19.0"
+          - "jruby-9.3.6.0"
     - gem: "rails-7.0"
       only:
         ruby:


### PR DESCRIPTION
Only test against Rails 6 versions. Rails 7 is not supported, because
Rails 7 requires Ruby > 2.7 and JRuby 9.3 is recognized as Ruby < 2.7.

Closes #858

[skip changeset]
[skip review]