### PR TITLE
Store delta gauge of allocated objects in Ruby

### DIFF
--- a/.changesets/report-gauge-delta-value-for-allocated-objects.md
+++ b/.changesets/report-gauge-delta-value-for-allocated-objects.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Report gauge delta value for allocated objects. This reports a more user friendly metric we can graph with a more stable continuous value in apps with stable memory allocation.

--- a/lib/appsignal/probes.rb
+++ b/lib/appsignal/probes.rb
@@ -3,5 +3,6 @@ module Appsignal
   end
 end
 
+require "appsignal/probes/helpers"
 require "appsignal/probes/mri"
 require "appsignal/probes/sidekiq"

--- a/lib/appsignal/probes/helpers.rb
+++ b/lib/appsignal/probes/helpers.rb
@@ -1,0 +1,29 @@
+module Appsignal
+  module Probes
+    module Helpers
+      private
+
+      def gauge_delta_cache
+        @gauge_delta_cache ||= {}
+      end
+
+      # Calculate the delta of two values for a gauge metric
+      #
+      # First call will store the data for the metric in the cache and the
+      # second call will return the delta of the gauge metric. This is used for
+      # absolute counter values which we want to track as gauges.
+      #
+      # @example
+      #   gauge_delta :my_cache_key, 10
+      #   gauge_delta :my_cache_key, 15
+      #   # Returns a value of `5`
+      def gauge_delta(cache_key, value)
+        previous_value = gauge_delta_cache[cache_key]
+        gauge_delta_cache[cache_key] = value
+        return unless previous_value
+
+        value - previous_value
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Store delta gauge of allocated objects in Ruby

The total_allocated_objects metric will continuously report an growing
value, which resets on every restart or new deploy. Creating a lot of
highs and lows.

This makes it difficult to track if the app is allocating more or less
objects between deploys, other than tracking how steep the increase is.

The delta of this metric reports the difference between probe runs,
which should result in a more stable graph in apps with stable memory
allocation.

This is what users see now, increases until it's time for a deploy or restart and then it drops to zero, only to start going up again:
![image](https://user-images.githubusercontent.com/282402/180961977-b06c043a-611f-4235-98e3-7aae836781a1.png)

This new metric instead shows if you have sudden increases or not:

![image](https://user-images.githubusercontent.com/282402/180998820-4d784df5-7937-4527-8c88-12f3fc7e5922.png)


## Move probe gauge_delta method to helper

This helper can then be more easily used by other probes.

I removed the call to the `gauge` method because I'm not moving that to
the helper right now. It's a tiny wrapper around `Appsignal.set_gauge`.

[skip changeset]

## To do

If accepted:

- [ ] Update PR https://github.com/appsignal/public_config/pull/37 to use the new metric name
- [ ] Update the `gc_count` metric to also report as the delta