### PR TITLE
Bump agent to 06391fb

### DIFF
--- a/.changesets/bump-agent-06391fb.md
+++ b/.changesets/bump-agent-06391fb.md
@@ -1,0 +1,11 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Bump agent to 06391fb
+
+- Accept "warning" value for the `log_level` config option.
+- Add aarch64 Linux musl build.
+- Improve debug logging from the extension.
+- Fix high CPU issue for appsignal-agent when nothing could be read from the socket.

--- a/ext/agent.yml
+++ b/ext/agent.yml
@@ -3,92 +3,99 @@
 # appsignal-agent repository.
 # Modifications to this file will be overwritten with the next agent release.
 ---
-version: d573c9b
+version: '06391fb'
 mirrors:
 - https://appsignal-agent-releases.global.ssl.fastly.net
 - https://d135dj0rjqvssy.cloudfront.net
 triples:
   x86_64-darwin:
     static:
-      checksum: a9a86594e50f22e7f7fd93a050e334048248a6dc971015e66c26150c4a689345
+      checksum: 9bf41c183d94c80e980f57ea2e29d08bae97e8097b5284a2b91a5484bf866f8c
       filename: appsignal-x86_64-darwin-all-static.tar.gz
     dynamic:
-      checksum: 04a69d0b608aa0e834c96c75a3bb226e7ca252fd2c74e439fdd43bf297d6bde2
+      checksum: 4d3789e65cf00e446600e883d95d097323ebb3835703c67c8d09f434f09ab496
       filename: appsignal-x86_64-darwin-all-dynamic.tar.gz
   universal-darwin:
     static:
-      checksum: a9a86594e50f22e7f7fd93a050e334048248a6dc971015e66c26150c4a689345
+      checksum: 9bf41c183d94c80e980f57ea2e29d08bae97e8097b5284a2b91a5484bf866f8c
       filename: appsignal-x86_64-darwin-all-static.tar.gz
     dynamic:
-      checksum: 04a69d0b608aa0e834c96c75a3bb226e7ca252fd2c74e439fdd43bf297d6bde2
+      checksum: 4d3789e65cf00e446600e883d95d097323ebb3835703c67c8d09f434f09ab496
       filename: appsignal-x86_64-darwin-all-dynamic.tar.gz
   aarch64-darwin:
     static:
-      checksum: 92f7f71b685985b310a9f3693a96a5db6b9133b0af807d000b90248e097063c7
+      checksum: 74edd7b97995f3314c10e3d84fc832c1b842c236c331ed4f2f77146ad004d179
       filename: appsignal-aarch64-darwin-all-static.tar.gz
     dynamic:
-      checksum: ffb54af4c35dd281a4735b57d8e537b8b08e87e08841e5d344caff325948a9e8
+      checksum: 7165bb164a9cd7a2a5f97897d954390412f7034c667e5826b3307ffbd848bff9
       filename: appsignal-aarch64-darwin-all-dynamic.tar.gz
   arm64-darwin:
     static:
-      checksum: 92f7f71b685985b310a9f3693a96a5db6b9133b0af807d000b90248e097063c7
+      checksum: 74edd7b97995f3314c10e3d84fc832c1b842c236c331ed4f2f77146ad004d179
       filename: appsignal-aarch64-darwin-all-static.tar.gz
     dynamic:
-      checksum: ffb54af4c35dd281a4735b57d8e537b8b08e87e08841e5d344caff325948a9e8
+      checksum: 7165bb164a9cd7a2a5f97897d954390412f7034c667e5826b3307ffbd848bff9
       filename: appsignal-aarch64-darwin-all-dynamic.tar.gz
   arm-darwin:
     static:
-      checksum: 92f7f71b685985b310a9f3693a96a5db6b9133b0af807d000b90248e097063c7
+      checksum: 74edd7b97995f3314c10e3d84fc832c1b842c236c331ed4f2f77146ad004d179
       filename: appsignal-aarch64-darwin-all-static.tar.gz
     dynamic:
-      checksum: ffb54af4c35dd281a4735b57d8e537b8b08e87e08841e5d344caff325948a9e8
+      checksum: 7165bb164a9cd7a2a5f97897d954390412f7034c667e5826b3307ffbd848bff9
       filename: appsignal-aarch64-darwin-all-dynamic.tar.gz
   aarch64-linux:
     static:
-      checksum: 79f1e7f9c34ab36c06d5c3d676173ee7c1219af2f51dc77865897598dc01349a
+      checksum: 0f2430e637eb77ce2093f021777087e87cb1e7be7c86a53771172696791c4879
       filename: appsignal-aarch64-linux-all-static.tar.gz
     dynamic:
-      checksum: cfd8e98238e2c7cdb10c0e136c47ab8e2dacab0a14d8ccf0e4c6c14946e325f1
+      checksum: 0e4f9305aeaaa2d7847e83be04227b865723a0591574108d78040b5921a677a7
       filename: appsignal-aarch64-linux-all-dynamic.tar.gz
   i686-linux:
     static:
-      checksum: 835c6f823a2c6e9f8fa12704bf0953e3610dc9836355b57d2d6981e6ae412fb4
+      checksum: 449ba623aaa1853c2d211bf1e2d3a14e5ae09225a62457cbdbcc0983a5713a52
       filename: appsignal-i686-linux-all-static.tar.gz
     dynamic:
-      checksum: febc5d80a7b0fd9644e2d68d068d28c66359bbef9473f01e9f71fb07fd73bcb8
+      checksum: dae994292d602eaf0910bd2ce53f0163e19767a4cbb8e5d0db99c0010d6df486
       filename: appsignal-i686-linux-all-dynamic.tar.gz
   x86-linux:
     static:
-      checksum: 835c6f823a2c6e9f8fa12704bf0953e3610dc9836355b57d2d6981e6ae412fb4
+      checksum: 449ba623aaa1853c2d211bf1e2d3a14e5ae09225a62457cbdbcc0983a5713a52
       filename: appsignal-i686-linux-all-static.tar.gz
     dynamic:
-      checksum: febc5d80a7b0fd9644e2d68d068d28c66359bbef9473f01e9f71fb07fd73bcb8
+      checksum: dae994292d602eaf0910bd2ce53f0163e19767a4cbb8e5d0db99c0010d6df486
       filename: appsignal-i686-linux-all-dynamic.tar.gz
   x86_64-linux:
     static:
-      checksum: 6eb6f0df2f8c62a29769bf7f21cefaec92a24ee0ab363acc5bd4f9c2d1241c53
+      checksum: 394796c0ddeb4881c9f2e6ce82f840e66bcb69e027324f6c04f6671067445fbb
       filename: appsignal-x86_64-linux-all-static.tar.gz
     dynamic:
-      checksum: ce710ff2edea2fc7b3b6bafd10af849e95f513abf5d775b9a8361ffed45b70c3
+      checksum: 9ca4762c464482b0a5a89898a839388597dd57a17a21527a67f3e3db0e540a03
       filename: appsignal-x86_64-linux-all-dynamic.tar.gz
   x86_64-linux-musl:
     static:
-      checksum: b16d46074527da5700e10e5a8b176aeb46b7bbb19431653029eda04437bef918
+      checksum: 673271c8c5fd55053d8a719bcd307f787db4ca4633baf8cf961c442bf1805614
       filename: appsignal-x86_64-linux-musl-all-static.tar.gz
     dynamic:
-      checksum: 261b79ab790e6a12a748d4649a4389e96d5cf7d1f981c3b56ed331f164d1627b
+      checksum: 609d59376d6633652015e838eb649229fe2523d443a5471232b869f48eb99640
       filename: appsignal-x86_64-linux-musl-all-dynamic.tar.gz
+  aarch64-linux-musl:
+    static:
+      checksum: e90ca19bf61596be022ba04897e8902b3401add58f351a40a3d3a7af241d0bbb
+      filename: appsignal-aarch64-linux-musl-all-static.tar.gz
+    dynamic:
+      checksum: afb66c65fb82b672887bc6b6e82d82f09d9855a5497a7abb06b438dadea97aca
+      filename: appsignal-aarch64-linux-musl-all-dynamic.tar.gz
   x86_64-freebsd:
     static:
-      checksum: e7bfc1dc355ce1237aaee6fdf967c78ecca533db41b09c2b10716e7f8593dbe0
+      checksum: cb45da91c51123859e5ef5cea850460c28d6e77dfa08b90375178d9017162ba8
       filename: appsignal-x86_64-freebsd-all-static.tar.gz
     dynamic:
-      checksum: 97af9419cf00e22ea544a2365785a6b5df2a990f17e7735b3bbec1a690b68f0b
+      checksum: 6a03e02c2526e05edaa7fa932b2e764318c63ec93d517c6c00f6b7541bfe71f3
       filename: appsignal-x86_64-freebsd-all-dynamic.tar.gz
   amd64-freebsd:
     static:
-      checksum: e7bfc1dc355ce1237aaee6fdf967c78ecca533db41b09c2b10716e7f8593dbe0
+      checksum: cb45da91c51123859e5ef5cea850460c28d6e77dfa08b90375178d9017162ba8
       filename: appsignal-x86_64-freebsd-all-static.tar.gz
     dynamic:
-      checksum: 97af9419cf00e22ea544a2365785a6b5df2a990f17e7735b3bbec1a690b68f0b
+      checksum: 6a03e02c2526e05edaa7fa932b2e764318c63ec93d517c6c00f6b7541bfe71f3
       filename: appsignal-x86_64-freebsd-all-dynamic.tar.gz


### PR DESCRIPTION
- Accept "warning" value for the `log_level` config option.
- Add aarch64 Linux musl build.
- Improve debug logging from the extension.
- Fix high CPU issue for appsignal-agent when nothing could be read from
  the socket.

[skip review]