### PR TITLE
Store delta gauge of Garbage Collection counts

### DIFF
--- a/.changesets/report-gauge-delta-value-for-gc_count.md
+++ b/.changesets/report-gauge-delta-value-for-gc_count.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Report gauge delta value for Garbage Collection counts. This reports a more user friendly metric that doesn't always goes up until the app restarts or gets a new deploy.

--- a/lib/appsignal/probes/mri.rb
+++ b/lib/appsignal/probes/mri.rb
@@ -46,9 +46,18 @@ module Appsignal
           @appsignal.set_gauge("allocated_objects", allocated_objects)
         end
 
-        @appsignal.add_distribution_value("gc_count", GC.count, :metric => :gc_count)
-        @appsignal.add_distribution_value("gc_count", gc_stats[:minor_gc_count], :metric => :minor_gc_count)
-        @appsignal.add_distribution_value("gc_count", gc_stats[:major_gc_count], :metric => :major_gc_count)
+        gc_count = gauge_delta(:gc_count, GC.count)
+        if gc_count
+          @appsignal.add_distribution_value("gc_count", gc_count, :metric => :gc_count)
+        end
+        minor_gc_count = gauge_delta(:minor_gc_count, gc_stats[:minor_gc_count])
+        if minor_gc_count
+          @appsignal.add_distribution_value("gc_count", minor_gc_count, :metric => :minor_gc_count)
+        end
+        major_gc_count = gauge_delta(:major_gc_count, gc_stats[:major_gc_count])
+        if major_gc_count
+          @appsignal.add_distribution_value("gc_count", major_gc_count, :metric => :major_gc_count)
+        end
 
         @appsignal.add_distribution_value("heap_slots", gc_stats[:heap_live_slots] || gc_stats[:heap_live_slot], :metric => :heap_live)
         @appsignal.add_distribution_value("heap_slots", gc_stats[:heap_free_slots] || gc_stats[:heap_free_slot], :metric => :heap_free)


### PR DESCRIPTION
The `gc_count` metric will continuously report an growing
value, which resets on every restart or new deploy. Creating a lot of
highs and lows.

This makes it difficult to track if the app is doing more or less
garbage collection between deploys, other than tracking how steep the
increase is visually.

The delta of this metric reports the difference between probe runs,
which should result in a more stable graph that shows more heavy garbage
collection as a spike.