### PR TITLE
Report Ruby VM probe metrics as gauges with a hostname tag

### DIFF
--- a/.changesets/report-all-ruby-vm-metrics-as-gauges.md
+++ b/.changesets/report-all-ruby-vm-metrics-as-gauges.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Report all Ruby VM metrics as gauges. We previously reported some metrics as distributions, but all fields for those distributions would report the same values.

--- a/.changesets/track-hostname-tag-for-ruby-vm-metrics.md
+++ b/.changesets/track-hostname-tag-for-ruby-vm-metrics.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Add hostname tag for Ruby VM metrics. This allows us to graph every host separately and multiple hosts won't overwrite each other metrics.

--- a/lib/appsignal/probes/mri.rb
+++ b/lib/appsignal/probes/mri.rb
@@ -21,20 +21,20 @@ module Appsignal
       def call
         stat = RubyVM.stat
 
-        @appsignal.set_gauge(
+        set_gauge(
           "ruby_vm",
           stat[:class_serial],
           :metric => :class_serial
         )
 
-        @appsignal.set_gauge(
+        set_gauge(
           "ruby_vm",
           stat[:constant_cache] ? stat[:constant_cache].values.sum : stat[:global_constant_state],
           :metric => :global_constant_state
         )
 
-        @appsignal.set_gauge("thread_count", Thread.list.size)
-        @appsignal.set_gauge("gc_total_time", MriProbe.garbage_collection_profiler.total_time)
+        set_gauge("thread_count", Thread.list.size)
+        set_gauge("gc_total_time", MriProbe.garbage_collection_profiler.total_time)
 
         gc_stats = GC.stat
         allocated_objects =
@@ -42,25 +42,27 @@ module Appsignal
             :allocated_objects,
             gc_stats[:total_allocated_objects] || gc_stats[:total_allocated_object]
           )
-        if allocated_objects
-          @appsignal.set_gauge("allocated_objects", allocated_objects)
-        end
+        set_gauge("allocated_objects", allocated_objects) if allocated_objects
 
         gc_count = gauge_delta(:gc_count, GC.count)
-        if gc_count
-          @appsignal.set_gauge("gc_count", gc_count, :metric => :gc_count)
-        end
+        set_gauge("gc_count", gc_count, :metric => :gc_count) if gc_count
         minor_gc_count = gauge_delta(:minor_gc_count, gc_stats[:minor_gc_count])
         if minor_gc_count
-          @appsignal.set_gauge("gc_count", minor_gc_count, :metric => :minor_gc_count)
+          set_gauge("gc_count", minor_gc_count, :metric => :minor_gc_count)
         end
         major_gc_count = gauge_delta(:major_gc_count, gc_stats[:major_gc_count])
         if major_gc_count
-          @appsignal.set_gauge("gc_count", major_gc_count, :metric => :major_gc_count)
+          set_gauge("gc_count", major_gc_count, :metric => :major_gc_count)
         end
 
-        @appsignal.set_gauge("heap_slots", gc_stats[:heap_live_slots] || gc_stats[:heap_live_slot], :metric => :heap_live)
-        @appsignal.set_gauge("heap_slots", gc_stats[:heap_free_slots] || gc_stats[:heap_free_slot], :metric => :heap_free)
+        set_gauge("heap_slots", gc_stats[:heap_live_slots] || gc_stats[:heap_live_slot], :metric => :heap_live)
+        set_gauge("heap_slots", gc_stats[:heap_free_slots] || gc_stats[:heap_free_slot], :metric => :heap_free)
+      end
+
+      private
+
+      def set_gauge(metric, value, tags = {})
+        @appsignal.set_gauge(metric, value, tags)
       end
     end
   end

--- a/lib/appsignal/probes/mri.rb
+++ b/lib/appsignal/probes/mri.rb
@@ -62,7 +62,24 @@ module Appsignal
       private
 
       def set_gauge(metric, value, tags = {})
-        @appsignal.set_gauge(metric, value, tags)
+        @appsignal.set_gauge(metric, value, { :hostname => hostname }.merge(tags))
+      end
+
+      def hostname
+        return @hostname if defined?(@hostname)
+
+        config = @appsignal.config
+        @hostname =
+          if config[:hostname]
+            config[:hostname]
+          else
+            # Auto detect hostname as fallback. May be inaccurate.
+            Socket.gethostname
+          end
+        Appsignal.logger.debug "MRI probe: Using hostname config " \
+          "option '#{@hostname.inspect}' as hostname"
+
+        @hostname
       end
     end
   end

--- a/lib/appsignal/probes/mri.rb
+++ b/lib/appsignal/probes/mri.rb
@@ -21,13 +21,13 @@ module Appsignal
       def call
         stat = RubyVM.stat
 
-        @appsignal.add_distribution_value(
+        @appsignal.set_gauge(
           "ruby_vm",
           stat[:class_serial],
           :metric => :class_serial
         )
 
-        @appsignal.add_distribution_value(
+        @appsignal.set_gauge(
           "ruby_vm",
           stat[:constant_cache] ? stat[:constant_cache].values.sum : stat[:global_constant_state],
           :metric => :global_constant_state
@@ -48,19 +48,19 @@ module Appsignal
 
         gc_count = gauge_delta(:gc_count, GC.count)
         if gc_count
-          @appsignal.add_distribution_value("gc_count", gc_count, :metric => :gc_count)
+          @appsignal.set_gauge("gc_count", gc_count, :metric => :gc_count)
         end
         minor_gc_count = gauge_delta(:minor_gc_count, gc_stats[:minor_gc_count])
         if minor_gc_count
-          @appsignal.add_distribution_value("gc_count", minor_gc_count, :metric => :minor_gc_count)
+          @appsignal.set_gauge("gc_count", minor_gc_count, :metric => :minor_gc_count)
         end
         major_gc_count = gauge_delta(:major_gc_count, gc_stats[:major_gc_count])
         if major_gc_count
-          @appsignal.add_distribution_value("gc_count", major_gc_count, :metric => :major_gc_count)
+          @appsignal.set_gauge("gc_count", major_gc_count, :metric => :major_gc_count)
         end
 
-        @appsignal.add_distribution_value("heap_slots", gc_stats[:heap_live_slots] || gc_stats[:heap_live_slot], :metric => :heap_live)
-        @appsignal.add_distribution_value("heap_slots", gc_stats[:heap_free_slots] || gc_stats[:heap_free_slot], :metric => :heap_free)
+        @appsignal.set_gauge("heap_slots", gc_stats[:heap_live_slots] || gc_stats[:heap_live_slot], :metric => :heap_live)
+        @appsignal.set_gauge("heap_slots", gc_stats[:heap_free_slots] || gc_stats[:heap_free_slot], :metric => :heap_free)
       end
     end
   end

--- a/spec/lib/appsignal/probes/mri_spec.rb
+++ b/spec/lib/appsignal/probes/mri_spec.rb
@@ -1,13 +1,8 @@
 class AppsignalMock
-  attr_reader :distribution_values, :gauges
+  attr_reader :gauges
 
   def initialize
-    @distribution_values = []
     @gauges = []
-  end
-
-  def add_distribution_value(*args)
-    @distribution_values << args
   end
 
   def set_gauge(*args) # rubocop:disable Naming/AccessorMethodName
@@ -35,8 +30,8 @@ describe Appsignal::Probes::MriProbe do
     describe "#call" do
       it "should track vm metrics" do
         probe.call
-        expect_distribution_value("ruby_vm", :class_serial)
-        expect_distribution_value("ruby_vm", :global_constant_state)
+        expect_gauge_value("ruby_vm", :tags => { :metric => :class_serial })
+        expect_gauge_value("ruby_vm", :tags => { :metric => :global_constant_state })
       end
 
       it "tracks thread counts" do
@@ -57,9 +52,9 @@ describe Appsignal::Probes::MriProbe do
         )
         probe.call
         probe.call
-        expect_distribution_value("gc_count", :gc_count, 5)
-        expect_distribution_value("gc_count", :minor_gc_count, 6)
-        expect_distribution_value("gc_count", :major_gc_count, 7)
+        expect_gauge_value("gc_count", 5, :tags => { :metric => :gc_count })
+        expect_gauge_value("gc_count", 6, :tags => { :metric => :minor_gc_count })
+        expect_gauge_value("gc_count", 7, :tags => { :metric => :major_gc_count })
       end
 
       it "tracks object allocation" do
@@ -75,29 +70,22 @@ describe Appsignal::Probes::MriProbe do
 
       it "tracks heap slots" do
         probe.call
-        expect_distribution_value("heap_slots", :heap_live)
-        expect_distribution_value("heap_slots", :heap_free)
+        expect_gauge_value("heap_slots", :tags => { :metric => :heap_live })
+        expect_gauge_value("heap_slots", :tags => { :metric => :heap_free })
       end
     end
   end
 
-  def expect_distribution_value(expected_key, metric, expected_value = nil)
-    expect(appsignal_mock.distribution_values).to satisfy do |distribution_values|
-      distribution_values.any? do |distribution_value|
-        key, value, metadata = distribution_value
+  def expect_gauge_value(expected_key, expected_value = nil, tags: nil)
+    expected_tags = tags
+    expect(appsignal_mock.gauges).to satisfy do |gauges|
+      gauges.any? do |distribution_value|
+        key, value, tags = distribution_value
         next unless key == expected_key
         next unless expected_value ? expected_value == value : !value.nil?
-        next unless metadata == { :metric => metric }
+        next if tags && tags != expected_tags
 
         true
-      end
-    end
-  end
-
-  def expect_gauge_value(expected_key, expected_value = nil)
-    expect(appsignal_mock.gauges).to satisfy do |gauges|
-      gauges.any? do |(key, value)|
-        expected_key == key && expected_value ? expected_value == value : !value.nil?
       end
     end
   end

--- a/spec/support/helpers/config_helpers.rb
+++ b/spec/support/helpers/config_helpers.rb
@@ -14,6 +14,7 @@ module ConfigHelpers
       config_file
     )
   end
+  module_function :project_fixture_config, :project_fixture_path
 
   def start_agent(env = "production")
     Appsignal.config = project_fixture_config(env)


### PR DESCRIPTION
## Change all Ruby VM distributions to gauges

The problem the distribution values is that they will always be the same
because we report the metrics at very regular intervals, so the values
between mean, 90th percentile and 95 percentile won't be any different
as we've seen in the graphs these metrics create.

## Refactor gauge calls to helper method in MRI probe

Call a private method that calls `Appsignal.set_guage` so that if we
want to change some defaults in metrics reported by this probe we only
have to do it in one place. Like adding a hostname tag.

## Report hostname tag for Ruby VM probe metrics

The added hostname tag allows us to tell multiple hosts from each other
and graph them separately. If we do not, an app with multiple hosts
would have hosts overwrite one another's metrics. Only the last reported
value would be stored and shown.

I've copied some of the Sidekiq probe's and Puma plugin to determine the
hostname automatically and listen to the AppSignal config in case a
hostname was configured.
