### PR TITLE
Store delta gauge of Garbage Collection total time

### DIFF
--- a/.changesets/report-delta-gc-total-time-metric.md
+++ b/.changesets/report-delta-gc-total-time-metric.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Report Garbage Collection total time metric as the delta between measurements. This reports a more user friendly metric that doesn't always goes up until the app restarts or gets a new deploy. This metric is reported 0 by default without `GC::Profiler.enable` having been called.

--- a/lib/appsignal/probes/mri.rb
+++ b/lib/appsignal/probes/mri.rb
@@ -32,7 +32,7 @@ module Appsignal
 
         set_gauge("thread_count", Thread.list.size)
         total_time = gauge_delta(:gc_total_time, @gc_profiler.total_time)
-        set_gauge("gc_total_time", total_time) if total_time
+        set_gauge("gc_total_time", total_time) if total_time && total_time > 0
 
         gc_stats = GC.stat
         allocated_objects =


### PR DESCRIPTION
The `gc_total_time` metric will continuously report an growing value,
which resets on every restart, new deploy, or every 23 days (see the
`Appsignal::GarbageCollectionProfiler#total_time` method). Creating a
lot of highs and lows in a graph.

This makes it difficult to track if the app is taking longer for garbage
collection between deploys, other than tracking how steep the increase
is visually.

The delta of this metric reports the difference between probe runs,
which should result in a more stable graph that shows longer garbage
collection as a spike.