### PR TITLE
Change `gauge_delta` so it expects a block

### DIFF
--- a/lib/appsignal/probes/helpers.rb
+++ b/lib/appsignal/probes/helpers.rb
@@ -7,22 +7,35 @@ module Appsignal
         @gauge_delta_cache ||= {}
       end
 
-      # Calculate the delta of two values for a gauge metric
+      # Calculate the delta of two values for a gauge metric.
       #
-      # First call will store the data for the metric in the cache and the
-      # second call will return the delta of the gauge metric. This is used for
-      # absolute counter values which we want to track as gauges.
+      # When this method is called, the given value is stored in a cache
+      # under the given cache key.
+      #
+      # A block must be passed to this method. The first time the method
+      # is called for a given cache key, the block will not be yielded to.
+      # In subsequent calls, the delta between the previously stored value
+      # in the cache for that key and the value given in this invocation
+      # will be yielded to the block.
+      #
+      # This is used for absolute counter values which we want to track as
+      # gauges.
       #
       # @example
-      #   gauge_delta :my_cache_key, 10
-      #   gauge_delta :my_cache_key, 15
-      #   # Returns a value of `5`
+      #   gauge_delta :with_block, 10 do |delta|
+      #     puts "this block will not be yielded to"
+      #   end
+      #   gauge_delta :with_block, 15 do |delta|
+      #     # `delta` has a value of `5`
+      #     puts "this block will be yielded to with delta = #{delta}"
+      #   end
+      #
       def gauge_delta(cache_key, value)
         previous_value = gauge_delta_cache[cache_key]
         gauge_delta_cache[cache_key] = value
         return unless previous_value
 
-        value - previous_value
+        yield value - previous_value
       end
     end
   end

--- a/lib/appsignal/probes/mri.rb
+++ b/lib/appsignal/probes/mri.rb
@@ -31,25 +31,25 @@ module Appsignal
         )
 
         set_gauge("thread_count", Thread.list.size)
-        total_time = gauge_delta(:gc_total_time, @gc_profiler.total_time)
-        set_gauge("gc_total_time", total_time) if total_time && total_time > 0
+        gauge_delta(:gc_total_time, @gc_profiler.total_time) do |total_time|
+          set_gauge("gc_total_time", total_time) if total_time > 0
+        end
 
         gc_stats = GC.stat
-        allocated_objects =
-          gauge_delta(
-            :allocated_objects,
-            gc_stats[:total_allocated_objects] || gc_stats[:total_allocated_object]
-          )
-        set_gauge("allocated_objects", allocated_objects) if allocated_objects
+        gauge_delta(
+          :allocated_objects,
+          gc_stats[:total_allocated_objects] || gc_stats[:total_allocated_object]
+        ) do |allocated_objects|
+          set_gauge("allocated_objects", allocated_objects)
+        end
 
-        gc_count = gauge_delta(:gc_count, GC.count)
-        set_gauge("gc_count", gc_count, :metric => :gc_count) if gc_count
-        minor_gc_count = gauge_delta(:minor_gc_count, gc_stats[:minor_gc_count])
-        if minor_gc_count
+        gauge_delta(:gc_count, GC.count) do |gc_count|
+          set_gauge("gc_count", gc_count, :metric => :gc_count)
+        end
+        gauge_delta(:minor_gc_count, gc_stats[:minor_gc_count]) do |minor_gc_count|
           set_gauge("gc_count", minor_gc_count, :metric => :minor_gc_count)
         end
-        major_gc_count = gauge_delta(:major_gc_count, gc_stats[:major_gc_count])
-        if major_gc_count
+        gauge_delta(:major_gc_count, gc_stats[:major_gc_count]) do |major_gc_count|
           set_gauge("gc_count", major_gc_count, :metric => :major_gc_count)
         end
 

--- a/lib/appsignal/probes/sidekiq.rb
+++ b/lib/appsignal/probes/sidekiq.rb
@@ -44,15 +44,16 @@ module Appsignal
 
         gauge "worker_count", stats.workers_size
         gauge "process_count", stats.processes_size
-        jobs_processed = gauge_delta :jobs_processed, stats.processed
-        if jobs_processed
+        gauge_delta :jobs_processed, stats.processed do |jobs_processed|
           gauge "job_count", jobs_processed, :status => :processed
         end
-        jobs_failed = gauge_delta :jobs_failed, stats.failed
-        gauge "job_count", jobs_failed, :status => :failed if jobs_failed
+        gauge_delta :jobs_failed, stats.failed do |jobs_failed|
+          gauge "job_count", jobs_failed, :status => :failed
+        end
         gauge "job_count", stats.retry_size, :status => :retry_queue
-        jobs_dead = gauge_delta :jobs_dead, stats.dead_size
-        gauge "job_count", jobs_dead, :status => :died if jobs_dead
+        gauge_delta :jobs_dead, stats.dead_size do |jobs_dead|
+          gauge "job_count", jobs_dead, :status => :died
+        end
         gauge "job_count", stats.scheduled_size, :status => :scheduled
         gauge "job_count", stats.enqueued, :status => :enqueued
       end


### PR DESCRIPTION
The `gauge_delta` helper would return the delta between the value passed in the current call and the value stored in its cache from a previous call, or `nil` if no previous call had taken place yet.

Because of this, at every point where `gauge_delta` is used, there is an `if` that follows, that checks for the value not being `nil`.

This commit changes the `gauge_delta` method so that it expects a block that will take the delta value as argument. This block will not be called on the first invocation of `gauge_delta` for a given cache key, avoiding the need to manually handle the case where the delta is `nil`.

Mentioned in [this comment in #865](https://github.com/appsignal/appsignal-ruby/pull/865#issuecomment-1198051389).

[skip changeset]