### PR TITLE
Lock webmock version for older Rubies

### DIFF
--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -39,12 +39,16 @@ Gem::Specification.new do |gem| # rubocop:disable Metrics/BlockLength
   gem.add_development_dependency "rake", ">= 12"
   gem.add_development_dependency "rspec", "~> 3.8"
   gem.add_development_dependency "timecop"
-  gem.add_development_dependency "webmock"
   gem.add_development_dependency "yard", ">= 0.9.20"
   gem.add_development_dependency "pry"
 
   # Dependencies that need to be locked to a specific version in developement
   ruby_version = Gem::Version.new(RUBY_VERSION)
+  if ruby_version < Gem::Version.new("2.3.0")
+    gem.add_development_dependency "webmock", "3.14.0"
+  else
+    gem.add_development_dependency "webmock"
+  end
   if ruby_version > Gem::Version.new("2.5.0")
     # RuboCop dependency parallel depends on Ruby > 2.4
     gem.add_development_dependency "rubocop", "0.50.0"


### PR DESCRIPTION
Webmock 3.15.0 uses the Ruby 2.3 safe navigator symbol (`&`), which
doesn't work on older Rubies, so use an older Webmock version.

[skip changeset]
[skip review]