### PR TITLE
Add Transaction.current? helper

### DIFF
--- a/.changesets/add-transaction-current?-helper.md
+++ b/.changesets/add-transaction-current?-helper.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add the `Transaction.current?` helper to determine if any Transaction is currently active or not. AppSignal `NilTransaction`s are not considered active transactions.

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -325,7 +325,8 @@ module Appsignal
             "value is not an exception: #{exception.inspect}"
           return
         end
-        return if !active? || Appsignal::Transaction.current.nil?
+        return if !active? || !Appsignal::Transaction.current?
+
         transaction = Appsignal::Transaction.current
         transaction.set_error(exception)
         transaction.set_tags(tags) if tags
@@ -359,7 +360,7 @@ module Appsignal
       # @since 2.2.0
       def set_action(action)
         return if !active? ||
-            Appsignal::Transaction.current.nil? ||
+            !Appsignal::Transaction.current? ||
             action.nil?
         Appsignal::Transaction.current.set_action(action)
       end
@@ -398,7 +399,7 @@ module Appsignal
       # @since 2.2.0
       def set_namespace(namespace)
         return if !active? ||
-            Appsignal::Transaction.current.nil? ||
+            !Appsignal::Transaction.current? ||
             namespace.nil?
         Appsignal::Transaction.current.set_namespace(namespace)
       end
@@ -438,9 +439,9 @@ module Appsignal
       #   Tagging guide
       def tag_request(tags = {})
         return unless active?
-        transaction = Appsignal::Transaction.current
-        return unless transaction
+        return unless Appsignal::Transaction.current?
 
+        transaction = Appsignal::Transaction.current
         transaction.set_tags(tags)
       end
       alias :tag_job :tag_request
@@ -472,9 +473,9 @@ module Appsignal
       # @since 2.12.0
       def add_breadcrumb(category, action, message = "", metadata = {}, time = Time.now.utc)
         return unless active?
-        transaction = Appsignal::Transaction.current
-        return unless transaction
+        return unless Appsignal::Transaction.current?
 
+        transaction = Appsignal::Transaction.current
         transaction.add_breadcrumb(category, action, message, metadata, time)
       end
 

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -439,7 +439,8 @@ module Appsignal
       def tag_request(tags = {})
         return unless active?
         transaction = Appsignal::Transaction.current
-        return false unless transaction
+        return unless transaction
+
         transaction.set_tags(tags)
       end
       alias :tag_job :tag_request
@@ -472,7 +473,8 @@ module Appsignal
       def add_breadcrumb(category, action, message = "", metadata = {}, time = Time.now.utc)
         return unless active?
         transaction = Appsignal::Transaction.current
-        return false unless transaction
+        return unless transaction
+
         transaction.add_breadcrumb(category, action, message, metadata, time)
       end
 

--- a/lib/appsignal/hooks/active_job.rb
+++ b/lib/appsignal/hooks/active_job.rb
@@ -20,9 +20,11 @@ module Appsignal
       module ActiveJobClassInstrumentation
         def execute(job)
           job_status = nil
-          current_transaction = Appsignal::Transaction.current
+          has_wrapper_transaction = Appsignal::Transaction.current?
           transaction =
-            if current_transaction.nil_transaction?
+            if has_wrapper_transaction
+              Appsignal::Transaction.current
+            else
               # No standalone integration started before ActiveJob integration.
               # We don't have a separate integration for this QueueAdapter like
               # we do for Sidekiq.
@@ -33,8 +35,6 @@ module Appsignal
                 Appsignal::Transaction::BACKGROUND_JOB,
                 Appsignal::Transaction::GenericRequest.new({})
               )
-            else
-              current_transaction
             end
 
           super
@@ -64,7 +64,7 @@ module Appsignal
               transaction.set_queue_start((Time.parse(enqueued_at).to_f * 1_000).to_i)
             end
 
-            if current_transaction.nil_transaction?
+            unless has_wrapper_transaction
               # Only complete transaction if ActiveJob is not wrapped in
               # another supported integration, such as Sidekiq.
               Appsignal::Transaction.complete_current!

--- a/lib/appsignal/integrations/mongo_ruby_driver.rb
+++ b/lib/appsignal/integrations/mongo_ruby_driver.rb
@@ -6,8 +6,9 @@ module Appsignal
     class MongoMonitorSubscriber
       # Called by Mongo::Monitor when query starts
       def started(event)
+        return unless Appsignal::Transaction.current?
+
         transaction = Appsignal::Transaction.current
-        return if transaction.nil_transaction?
         return if transaction.paused?
 
         # Format the command
@@ -36,8 +37,9 @@ module Appsignal
 
       # Finishes the event in the AppSignal extension
       def finish(result, event)
+        return unless Appsignal::Transaction.current?
+
         transaction = Appsignal::Transaction.current
-        return if transaction.nil_transaction?
         return if transaction.paused?
 
         # Get the query from the transaction store

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -35,8 +35,22 @@ module Appsignal
         end
       end
 
+      # Returns currently active transaction or a {NilTransaction} if none is
+      # active.
+      #
+      # @see .current?
+      # @return [Boolean]
       def current
         Thread.current[:appsignal_transaction] || NilTransaction.new
+      end
+
+      # Returns if any transaction is currently active or not. A
+      # {NilTransaction} is not considered an active transaction.
+      #
+      # @see .current
+      # @return [Boolean]
+      def current?
+        current && !current.nil_transaction?
       end
 
       def complete_current!

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -85,7 +85,9 @@ describe Appsignal::Transaction do
     end
 
     describe ".current" do
-      subject { Appsignal::Transaction.current }
+      def current_transaction
+        Appsignal::Transaction.current
+      end
 
       context "when there is a current transaction" do
         let!(:transaction) do
@@ -93,13 +95,17 @@ describe Appsignal::Transaction do
         end
 
         it "reads :appsignal_transaction from the current Thread" do
-          expect(subject).to eq Thread.current[:appsignal_transaction]
-          expect(subject).to eq transaction
+          expect(current_transaction).to eq Thread.current[:appsignal_transaction]
+          expect(current_transaction).to eq transaction
         end
 
         it "is not a NilTransaction" do
-          expect(subject.nil_transaction?).to eq false
-          expect(subject).to be_a Appsignal::Transaction
+          expect(current_transaction.nil_transaction?).to eq false
+          expect(current_transaction).to be_a Appsignal::Transaction
+        end
+
+        it "returns true for current?" do
+          expect(Appsignal::Transaction.current?).to be(true)
         end
       end
 
@@ -109,8 +115,12 @@ describe Appsignal::Transaction do
         end
 
         it "returns a NilTransaction stub" do
-          expect(subject.nil_transaction?).to eq true
-          expect(subject).to be_a Appsignal::Transaction::NilTransaction
+          expect(current_transaction.nil_transaction?).to eq true
+          expect(current_transaction).to be_a Appsignal::Transaction::NilTransaction
+        end
+
+        it "returns false for current?" do
+          expect(Appsignal::Transaction.current?).to be(false)
         end
       end
     end

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -511,7 +511,14 @@ describe Appsignal do
       before { allow(Appsignal::Transaction).to receive(:current).and_return(transaction) }
 
       context "with transaction" do
-        let(:transaction) { double }
+        let(:transaction) { http_request_transaction }
+        around do |example|
+          Appsignal.config = project_fixture_config
+          set_current_transaction transaction do
+            example.run
+          end
+        end
+
         it "should call add_breadcrumb on transaction" do
           expect(transaction).to receive(:add_breadcrumb)
             .with("Network", "http", "User made network request", { :response => 200 }, fixed_time)

--- a/spec/support/helpers/transaction_helpers.rb
+++ b/spec/support/helpers/transaction_helpers.rb
@@ -46,8 +46,14 @@ module TransactionHelpers
 
   # Set current transaction manually.
   # Cleared by {clear_current_transaction!}
+  #
+  # When a block is given, the current transaction is automatically unset after
+  # the block.
   def set_current_transaction(transaction) # rubocop:disable Naming/AccessorMethodName
     Thread.current[:appsignal_transaction] = transaction
+    yield if block_given?
+  ensure
+    clear_current_transaction! if block_given?
   end
 
   # Use when {Appsignal::Transaction.clear_current_transaction!} is stubbed to


### PR DESCRIPTION
## Remove return false from void methods

The `Appsignal.add_breadcrumb` and `Appsignal.tag_request` methods are
defined to return a void, nothing. No one should think this returns any
value or base their app behavior on it. If something is returned by
being the last value of the method that should also not be relied upon
as it may change without notice.

Remove the return value of `false` for these two methods.

## Add Transaction.current? helper

This helper returns true if a transaction is active and false if there
is none. This makes the following cumbersome code easier:

```ruby
# Before
current = Appsignal::Transaction.current
if !current.nil? && !current.nil_transaction?
  current.set_error(error)
end

# After
if Appsignal::Transaction.current?
  Appsignal::Transaction.current.set_error(error)
end
```

This is usually not necessary when no transaction is active, because the
`NilTransaction` object returned by `Transaction.current` will trigger
any errors regardless of what you call on it, but sometimes you need to
know if there really is a transaction active or not.

We do this internally in some helpers to avoid overhead fetching data
when no transaction is active. This can also be useful for users
implementing their own instrumentation, so I've documented the
`Transaction.current` and `Transaction.current?` methods.

I've also updated calls to `Transaction.current.nil?` because they do
not check if the returned transaction is a `NilTransaction`. You need to
use `NilTransaction.nil_transaction?` for that.
