### PR TITLE
Rewrite Rails middleware specs to use to_json

### DIFF
--- a/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
@@ -7,16 +7,29 @@ if DependencyHelper.rails_present?
       start_agent
     end
 
+    let(:params) do
+      {
+        "controller" => "blog_posts",
+        "action" => "show",
+        "id" => "1",
+        "my_custom_param" => "my custom secret",
+        "password" => "super secret"
+      }
+    end
     let(:app) { double(:call => true) }
     let(:env) do
-      http_request_env_with_data("action_dispatch.request_id" => "1").tap do |request|
-        request["action_controller.instance"] = double(
+      http_request_env_with_data(
+        :params => params,
+        "action_dispatch.request_id" => "1",
+        "action_dispatch.parameter_filter" => [:my_custom_param, :password],
+        "action_controller.instance" => double(
           :class => MockController,
           :action_name => "index"
         )
-      end
+      )
     end
     let(:middleware) { Appsignal::Rack::RailsInstrumentation.new(app, {}) }
+    around { |example| keep_transactions { example.run } }
 
     describe "#call" do
       before do
@@ -46,30 +59,47 @@ if DependencyHelper.rails_present?
       after { middleware.call(env) }
     end
 
-    describe "#call_with_appsignal_monitoring", :error => false do
-      it "should create a transaction" do
-        expect(Appsignal::Transaction).to receive(:create).with(
-          "1",
-          Appsignal::Transaction::HTTP_REQUEST,
-          kind_of(ActionDispatch::Request),
-          :params_method => :filtered_parameters
-        ).and_return(
-          instance_double(
-            "Appsignal::Transaction",
-            :set_action => nil,
-            :set_action_if_nil => nil,
-            :set_http_or_background_queue_start => nil,
-            :set_metadata => nil
+    describe "#call_with_appsignal_monitoring" do
+      def run
+        middleware.call(env)
+      end
+
+      it "calls the wrapped app" do
+        run
+        expect(app).to have_received(:call).with(env)
+      end
+
+      it "creates one transaction with metadata" do
+        run
+
+        expect(created_transactions.length).to eq(1)
+        transaction_hash = last_transaction.to_h
+        expect(transaction_hash).to include(
+          "namespace" => Appsignal::Transaction::HTTP_REQUEST,
+          "action" => "MockController#index",
+          "metadata" => hash_including(
+            "method" => "GET",
+            "path" => "/blog"
           )
         )
       end
 
-      it "should call the app" do
-        expect(app).to receive(:call).with(env)
+      it "filter parameters in Rails" do
+        run
+
+        transaction_hash = last_transaction.to_h
+        expect(transaction_hash).to include(
+          "sample_data" => hash_including(
+            "params" => params.merge(
+              "my_custom_param" => "[FILTERED]",
+              "password" => "[FILTERED]"
+            )
+          )
+        )
       end
 
-      context "with an exception", :error => true do
-        let(:error) { ExampleException }
+      context "with an exception" do
+        let(:error) { ExampleException.new("ExampleException message") }
         let(:app) do
           double.tap do |d|
             allow(d).to receive(:call).and_raise(error)
@@ -77,21 +107,16 @@ if DependencyHelper.rails_present?
         end
 
         it "records the exception" do
-          expect_any_instance_of(Appsignal::Transaction).to receive(:set_error).with(error)
+          expect { run }.to raise_error(error)
+
+          transaction_hash = last_transaction.to_h
+          expect(transaction_hash["error"]).to include(
+            "name" => "ExampleException",
+            "message" => "ExampleException message",
+            "backtrace" => kind_of(String)
+          )
         end
       end
-
-      it "should set metadata" do
-        expect_any_instance_of(Appsignal::Transaction).to receive(:set_metadata).twice
-      end
-
-      it "should set the action and queue start" do
-        expect_any_instance_of(Appsignal::Transaction).to receive(:set_action_if_nil).with("MockController#index")
-        expect_any_instance_of(Appsignal::Transaction).to receive(:set_http_or_background_queue_start)
-      end
-
-      after(:error => false) { middleware.call(env) }
-      after(:error => true) { expect { middleware.call(env) }.to raise_error(error) }
     end
 
     describe "#request_id" do

--- a/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
@@ -20,6 +20,7 @@ if DependencyHelper.rails_present?
     let(:env) do
       http_request_env_with_data(
         :params => params,
+        :with_queue_start => true,
         "action_dispatch.request_id" => "1",
         "action_dispatch.parameter_filter" => [:my_custom_param, :password],
         "action_controller.instance" => double(
@@ -81,6 +82,9 @@ if DependencyHelper.rails_present?
             "method" => "GET",
             "path" => "/blog"
           )
+        )
+        expect(last_transaction.ext.queue_start).to eq(
+          fixed_time * 1_000.0
         )
       end
 

--- a/spec/support/helpers/env_helpers.rb
+++ b/spec/support/helpers/env_helpers.rb
@@ -1,7 +1,8 @@
 module EnvHelpers
   def http_request_env_with_data(args = {})
+    with_queue_start = args.delete(:with_queue_start)
     path = args.delete(:path) || "/blog"
-    Rack::MockRequest.env_for(
+    request = Rack::MockRequest.env_for(
       path,
       :params => args[:params] || {
         "controller" => "blog_posts",
@@ -18,6 +19,13 @@ module EnvHelpers
       :db_runtime => 500,
       :metadata => { :key => "value" }
     ).merge(args)
+
+    # Set default queue value
+    if with_queue_start
+      request["HTTP_X_QUEUE_START"] = "t=#{(fixed_time * 1_000).to_i}" # in milliseconds
+    end
+
+    request
   end
 
   def background_env_with_data(args = {})

--- a/spec/support/testing.rb
+++ b/spec/support/testing.rb
@@ -50,6 +50,17 @@ module Appsignal
 
   class Extension
     class Transaction
+      if Appsignal.extension_loaded?
+        attr_reader :queue_start
+        alias original_set_queue_start set_queue_start
+        # Temporary helper until the extension returns this information
+        # https://github.com/appsignal/appsignal-agent/issues/293
+        def set_queue_start(start) # rubocop:disable Naming/AccessorMethodName
+          @queue_start = start
+          original_set_queue_start(start)
+        end
+      end
+
       alias original_finish finish if method_defined? :finish
 
       # Override default {Extension::Transaction#finish} behavior to always


### PR DESCRIPTION
## Rewrite Rails middleware specs to use to_json

Instead of asserting method calls, test what is actually set on the
extension.

This also test it in more detail by asserting the actual values that are
set, rather than if a certain method is called with what we hope is the
expected value.

Part of #252.

## Add queue_start test helper to fetch queue start

Previously we asserted a method call and didn't check the value it was
called with. I've adapted some implementation of the queue start
assertion I found in the Transaction specs to create a test for the
Rails instrumentation.

This should really be fixed in
https://github.com/appsignal/appsignal-agent/issues/293 (no hurry), but
at least we now has a somewhat smaller helper we can reuse in the test
suite.

We can also start using this new method of asserting queue time in other
tests, but I wanted to finish this quickly and not get hung up on
updating everything. We can do this at a later time.

[skip changeset]