### PR TITLE
Fix Rails error on unknown request method

### DIFF
--- a/.changesets/fix-error-on-unknown-http-request-method.md
+++ b/.changesets/fix-error-on-unknown-http-request-method.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix error on unknown HTTP request method. When a request is made with an unknown request method, triggering and `ActionController::UnknownHttpMethod`, it will no longer break the AppSignal instrumentation but omit the request method in the sample data.

--- a/lib/appsignal/rack/rails_instrumentation.rb
+++ b/lib/appsignal/rack/rails_instrumentation.rb
@@ -40,7 +40,11 @@ module Appsignal
           end
           transaction.set_http_or_background_queue_start
           transaction.set_metadata("path", request.path)
-          transaction.set_metadata("method", request.request_method)
+          begin
+            transaction.set_metadata("method", request.request_method)
+          rescue => error
+            Appsignal.logger.error("Unable to report HTTP request method: '#{error}'")
+          end
           Appsignal::Transaction.complete_current!
         end
       end


### PR DESCRIPTION
If `ActionDispatch::Request#request_method` is called when the request
method is not an known request method by Rails it will raise an
`ActionController::UnknownHttpMethod`.

We do not expect this method to raise an error, so it broke our Rails
instrumentation, didn't close the transaction which would cause it be
reused by the next request handled by Rails.

Add exception handling to the method calls so it doesn't break our
instrumentation anymore.

Fixes #851
Fixes https://github.com/appsignal/support/issues/201
~Depends on #872~