### PR TITLE
Rename gc_total_time to gc_time

### DIFF
--- a/.changesets/rename-gc_total_time-metric-to-gc_time.md
+++ b/.changesets/rename-gc_total_time-metric-to-gc_time.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Rename the (so far privately reported) `gc_total_time` metric to `gc_time`. It no longer reports the total time of Garbage Collection measured, but only the time between two (minutely) measurements.

--- a/lib/appsignal/probes/mri.rb
+++ b/lib/appsignal/probes/mri.rb
@@ -31,8 +31,8 @@ module Appsignal
         )
 
         set_gauge("thread_count", Thread.list.size)
-        gauge_delta(:gc_total_time, @gc_profiler.total_time) do |total_time|
-          set_gauge("gc_total_time", total_time) if total_time > 0
+        gauge_delta(:gc_time, @gc_profiler.total_time) do |gc_time|
+          set_gauge("gc_time", gc_time) if gc_time > 0
         end
 
         gc_stats = GC.stat

--- a/spec/lib/appsignal/probes/mri_spec.rb
+++ b/spec/lib/appsignal/probes/mri_spec.rb
@@ -52,11 +52,11 @@ describe Appsignal::Probes::MriProbe do
         expect_gauge_value("thread_count")
       end
 
-      it "tracks GC total time" do
+      it "tracks GC time between measurements" do
         expect(gc_profiler_mock).to receive(:total_time).and_return(10, 15)
         probe.call
         probe.call
-        expect_gauge_value("gc_total_time", 5)
+        expect_gauge_value("gc_time", 5)
       end
 
       context "when GC total time overflows" do
@@ -66,7 +66,7 @@ describe Appsignal::Probes::MriProbe do
           probe.call # Report delta value based on cached value
           probe.call # The value overflows and reports no value. Then stores 0 in the cache
           probe.call # Report new value based on cache of 0
-          expect_gauges([["gc_total_time", 5], ["gc_total_time", 10]])
+          expect_gauges([["gc_time", 5], ["gc_time", 10]])
         end
       end
 


### PR DESCRIPTION
Update naming to only be about the time measured.

It no longer reports the total time, but reports the delta of two
measurements.

Part of #868 