### PR TITLE
Remove GC::Profiler.enable

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -116,7 +116,6 @@ module Appsignal
           end
 
           if config[:enable_gc_instrumentation]
-            GC::Profiler.enable
             Appsignal::Environment.report_enabled("gc_instrumentation")
           end
 

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -62,8 +62,7 @@ describe Appsignal do
           capture_environment_metadata_report_calls
         end
 
-        it "should enable Ruby's GC::Profiler" do
-          expect(GC::Profiler).to receive(:enable)
+        it "reports GC instrumentation was enabled" do
           Appsignal.start
           expect_environment_metadata("ruby_gc_instrumentation_enabled", "true")
         end


### PR DESCRIPTION
I don't think we should provide this in our gem, but have users add this
to their own app manually in a Rails's `application.rb` file, or
`development.rb`.

This way they also have more control over when to disable it again, by
using `GC::Profiler.disable` if they only want to enable it for certain
parts of their app. It leaves control with the app developer.

The `enable_gc_instrumentation` config option should remain so that we
fetch the Garbage Collection profiler wrapper or the nil wrapper
`NilProfiler`.

Part of #868
[skip changeset] because this is undocumented behavior