### PR TITLE
Only report gc_time metric if profiler is enabled

### DIFF
--- a/.changesets/support-temporarily-disabling-gc-profiling.md
+++ b/.changesets/support-temporarily-disabling-gc-profiling.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Support temporarily disabling GC profiling without reporting inaccurate `gc_time` metric durations. The MRI probe's `gc_time` will not report any value when the `GC::Profiler.enabled?` returns `false`.

--- a/lib/appsignal/probes/mri.rb
+++ b/lib/appsignal/probes/mri.rb
@@ -31,8 +31,10 @@ module Appsignal
         )
 
         set_gauge("thread_count", Thread.list.size)
-        gauge_delta(:gc_time, @gc_profiler.total_time) do |gc_time|
-          set_gauge("gc_time", gc_time) if gc_time > 0
+        if GC::Profiler.enabled?
+          gauge_delta(:gc_time, @gc_profiler.total_time) do |gc_time|
+            set_gauge("gc_time", gc_time) if gc_time > 0
+          end
         end
 
         gc_stats = GC.stat


### PR DESCRIPTION
Let's only report the `gc_time` metric when there's an actual value to
report to avoid confusion of very small GC times.

If the Profiler is disabled, it reports 0.0 as the value for this
metric. We know when the profiler is enabled by asking it
`GC::Profiler.enabled?`.

By directly asking the Ruby GC profiler, instead of our wrapper based on
the `enable_gc_instrumentation` config option, we allow users to enable
and disable the profiler temporarily with `GC::Profiler.enable` and
`GC::Profiler.disable` calls in their app.

If the profiler is enabled, disabled, and then enabled again, it
remembers the total time from the last time it was enabled. By not
reporting 0 when it is disabled we don't reset the cache and don't
trigger a very high duration being reported the next time it's enabled.

```ruby
> GC::Profiler.total_time
# => 0.0

> GC::Profiler.enable
> GC::Profiler.total_time
=> 0.001
> 10000.times { SecureRandom.uuid }
# => Does stuff for a long time
> GC::Profiler.total_time
# => 58.93548299997067

> GC::Profiler.disable
> GC::Profiler.total_time
# => 0.0
> 10000.times { SecureRandom.uuid }
# => Does stuff for a long time
> GC::Profiler.total_time
# => 0.0
> GC::Profiler.enable
> GC::Profiler.total_time
# => 58.93548299997067
# Same as before it was disabled without the GC time of the code that
# was run when it was disabled
```

Part of #868