### PR TITLE
Remove transaction GC tracking

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -115,10 +115,6 @@ module Appsignal
             Appsignal::Environment.report_enabled("allocation_tracking")
           end
 
-          if config[:enable_gc_instrumentation]
-            Appsignal::Environment.report_enabled("gc_instrumentation")
-          end
-
           Appsignal::Minutely.start if config[:enable_minutely_probes]
 
           collect_environment_metadata

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -15,7 +15,6 @@ module Appsignal
       :debug                          => false,
       :dns_servers                    => [],
       :enable_allocation_tracking     => true,
-      :enable_gc_instrumentation      => false,
       :enable_host_metrics            => true,
       :enable_minutely_probes         => true,
       :enable_statsd                  => true,
@@ -63,7 +62,6 @@ module Appsignal
       "APPSIGNAL_DEBUG"                          => :debug,
       "APPSIGNAL_DNS_SERVERS"                    => :dns_servers,
       "APPSIGNAL_ENABLE_ALLOCATION_TRACKING"     => :enable_allocation_tracking,
-      "APPSIGNAL_ENABLE_GC_INSTRUMENTATION"      => :enable_gc_instrumentation,
       "APPSIGNAL_ENABLE_HOST_METRICS"            => :enable_host_metrics,
       "APPSIGNAL_ENABLE_MINUTELY_PROBES"         => :enable_minutely_probes,
       "APPSIGNAL_ENABLE_STATSD"                  => :enable_statsd,
@@ -114,7 +112,6 @@ module Appsignal
       APPSIGNAL_ACTIVE
       APPSIGNAL_DEBUG
       APPSIGNAL_ENABLE_ALLOCATION_TRACKING
-      APPSIGNAL_ENABLE_GC_INSTRUMENTATION
       APPSIGNAL_ENABLE_HOST_METRICS
       APPSIGNAL_ENABLE_MINUTELY_PROBES
       APPSIGNAL_ENABLE_STATSD

--- a/lib/appsignal/garbage_collection.rb
+++ b/lib/appsignal/garbage_collection.rb
@@ -5,18 +5,12 @@ module Appsignal
   module GarbageCollection
     # Return the GC profiler wrapper.
     #
-    # Returns {Profiler} if `enable_gc_instrumentation` is enabled and
-    # {NilProfiler} if it is disabled.
+    # Temporarily always returns the {NilProfiler}.
     #
     # GC profiling is disabled by default due to the overhead it causes. Do not
     # enable this in production for long periods of time.
-    def self.profiler(appsignal = Appsignal)
-      @profiler ||=
-        if appsignal.config[:enable_gc_instrumentation]
-          Profiler.new
-        else
-          NilProfiler.new
-        end
+    def self.profiler
+      @profiler ||= NilProfiler.new
     end
 
     # Unset the currently cached profiler

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -66,10 +66,6 @@ module Appsignal
       def clear_current_transaction!
         Thread.current[:appsignal_transaction] = nil
       end
-
-      def garbage_collection_profiler
-        Appsignal::GarbageCollection.profiler
-      end
     end
 
     attr_reader :ext, :transaction_id, :action, :namespace, :request, :paused, :tags, :options, :discarded, :breadcrumbs
@@ -102,7 +98,7 @@ module Appsignal
       @ext = Appsignal::Extension.start_transaction(
         @transaction_id,
         @namespace,
-        self.class.garbage_collection_profiler.total_time
+        0
       ) || Appsignal::Extension::MockTransaction.new
     end
 
@@ -116,9 +112,7 @@ module Appsignal
           "because it was manually discarded."
         return
       end
-      if @ext.finish(self.class.garbage_collection_profiler.total_time)
-        sample_data
-      end
+      sample_data if @ext.finish(0)
       @ext.complete
     end
 
@@ -354,7 +348,7 @@ module Appsignal
 
     def start_event
       return if paused?
-      @ext.start_event(self.class.garbage_collection_profiler.total_time)
+      @ext.start_event(0)
     end
 
     def finish_event(name, title, body, body_format = Appsignal::EventFormatter::DEFAULT)
@@ -364,7 +358,7 @@ module Appsignal
         title || BLANK,
         body || BLANK,
         body_format || Appsignal::EventFormatter::DEFAULT,
-        self.class.garbage_collection_profiler.total_time
+        0
       )
     end
 
@@ -376,7 +370,7 @@ module Appsignal
         body || BLANK,
         body_format || Appsignal::EventFormatter::DEFAULT,
         duration,
-        self.class.garbage_collection_profiler.total_time
+        0
       )
     end
 

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -156,7 +156,6 @@ describe Appsignal::Config do
         :debug                          => false,
         :dns_servers                    => [],
         :enable_allocation_tracking     => true,
-        :enable_gc_instrumentation      => false,
         :enable_host_metrics            => true,
         :enable_minutely_probes         => true,
         :enable_statsd                  => true,

--- a/spec/lib/appsignal/garbage_collection_spec.rb
+++ b/spec/lib/appsignal/garbage_collection_spec.rb
@@ -1,28 +1,19 @@
 describe Appsignal::GarbageCollection do
   describe ".profiler" do
-    let(:appsignal) { class_double("Appsignal") }
     before do
       # Unset the internal memoized variable to avoid state leaking
       described_class.clear_profiler!
     end
 
     context "when GC instrumentation is disabled" do
-      let(:config) { Appsignal::Config.new("production", Dir.pwd, :enable_gc_instrumentation => false) }
-
       it "returns the NilProfiler" do
-        allow(appsignal).to receive(:config).and_return(config)
-
-        expect(described_class.profiler(appsignal)).to be_a(Appsignal::GarbageCollection::NilProfiler)
+        expect(described_class.profiler).to be_a(Appsignal::GarbageCollection::NilProfiler)
       end
     end
 
     context "when GC profiling is enabled" do
-      let(:config) { Appsignal::Config.new("production", Dir.pwd, :enable_gc_instrumentation => true) }
-
       it "returns the Profiler" do
-        allow(appsignal).to receive(:config).and_return(config)
-
-        expect(described_class.profiler(appsignal)).to be_a(Appsignal::GarbageCollection::Profiler)
+        expect(described_class.profiler).to be_a(Appsignal::GarbageCollection::NilProfiler)
       end
     end
   end

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -810,11 +810,7 @@ describe Appsignal::Transaction do
     end
 
     describe "#finish_event" do
-      let(:fake_gc_time) { 123 }
-      before do
-        expect(described_class.garbage_collection_profiler)
-          .to receive(:total_time).at_least(:once).and_return(fake_gc_time)
-      end
+      let(:fake_gc_time) { 0 }
 
       it "should finish the event in the extension" do
         expect(transaction.ext).to receive(:finish_event).with(
@@ -861,11 +857,7 @@ describe Appsignal::Transaction do
     end
 
     describe "#record_event" do
-      let(:fake_gc_time) { 123 }
-      before do
-        expect(described_class.garbage_collection_profiler)
-          .to receive(:total_time).at_least(:once).and_return(fake_gc_time)
-      end
+      let(:fake_gc_time) { 0 }
 
       it "should record the event in the extension" do
         expect(transaction.ext).to receive(:record_event).with(

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -54,17 +54,10 @@ describe Appsignal do
         Appsignal.start
       end
 
-      context "when allocation tracking and gc instrumentation have been enabled" do
+      context "when allocation tracking has been enabled" do
         before do
-          allow(GC::Profiler).to receive(:enable)
           Appsignal.config.config_hash[:enable_allocation_tracking] = true
-          Appsignal.config.config_hash[:enable_gc_instrumentation] = true
           capture_environment_metadata_report_calls
-        end
-
-        it "reports GC instrumentation was enabled" do
-          Appsignal.start
-          expect_environment_metadata("ruby_gc_instrumentation_enabled", "true")
         end
 
         unless DependencyHelper.running_jruby?
@@ -77,28 +70,16 @@ describe Appsignal do
         end
       end
 
-      context "when allocation tracking and gc instrumentation have been disabled" do
+      context "when allocation tracking has been disabled" do
         before do
           Appsignal.config.config_hash[:enable_allocation_tracking] = false
-          Appsignal.config.config_hash[:enable_gc_instrumentation] = false
           capture_environment_metadata_report_calls
-        end
-
-        it "should not enable Ruby's GC::Profiler" do
-          expect(GC::Profiler).not_to receive(:enable)
-          Appsignal.start
         end
 
         it "should not install the allocation event hook" do
           expect(Appsignal::Minutely).not_to receive(:install_allocation_event_hook)
           Appsignal.start
           expect_not_environment_metadata("ruby_allocation_tracking_enabled")
-        end
-
-        it "should not add the gc probe to minutely" do
-          expect(Appsignal::Minutely).not_to receive(:register_garbage_collection_probe)
-          Appsignal.start
-          expect_not_environment_metadata("ruby_gc_instrumentation_enabled")
         end
       end
 


### PR DESCRIPTION
## Remove transaction and event level GC tracking

Remove the undocumented transaction and event level Garbage Collection
time tracking. This tracked how much time the GC spent time cleaning up
garbage during the transaction or one of its child events.

This was never shipped, we did not document it or use this data in the
AppSignal.com app. We're unsure about its future in the new Span API and
how to implement this on top of OpenTelemetry spans.

I don't want to have to update the old Transaction API in the extension,
so instead I've changed it to hardcoded `0` values, the same as it
reported with the `GarbageCollection::NilProfiler` by default.

[skip changeset] because it's an undocumented feature I'm removing.

## Remove enable_gc_instrumentation config option

This undocumented config option originally enabled Garbage Collection
time tracking on Transaction and event level. This has been removed in
the previous commit.

I've broken the MRI probe's `gc_time` metric by always returning the
`NilProfiler` now. It was previously determining which profiler to
return based on the removed `enable_gc_instrumentation` config option.

I'll reimplement this using the new logic in the next commit/PR.

[skip changeset] because this removes an undocumented config option.

---

Test that never fail suddenly fail! Awesome!!! But all tests that fail seem unrelated.

Part of https://github.com/appsignal/appsignal-ruby/issues/868