### PR TITLE
Fix CI by locking gem versions in specs

### DIFF
--- a/gemfiles/padrino.gemfile
+++ b/gemfiles/padrino.gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'padrino', "~> 0.15"
-gem 'rack'
+gem 'rack', "~> 2"
+gem 'sinatra', "~> 2"
 
 gemspec :path => '../'

--- a/gemfiles/que.gemfile
+++ b/gemfiles/que.gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'que'
+gem 'que', "~> 1.0"
 
 gemspec :path => '../'


### PR DESCRIPTION
## Fix spec relying on Rack environment

In Rack 3.0 the Rack default environment changed to include another key. We don't really care which values are given by Rack in this test, so use an `include` matcher to test if some expected keys are at least there.

I've rewritten the test to use the `transaction.to_h` helper so that testing doesn't rely on stubbing all method calls to the extension.

This won't fix all broken specs, but at least the main AppSignal spec are running again. That the build is not green yet with this commit is unfortunately correct.

[skip changeset]

## Downgrade Sinatra for Padrino tests

Sinatra 3 has just been released but doesn't work nice with Padrino yet I think.

It raises a FrozenError about a frozen array that cannot be modified. We're not creating Padrino apps in a weird way, other than them being anonymous classes. If I used a standard class, e.g. `class MyApp < Padrino::Application`, like the docs say, it doesn't fix it.

```
FrozenError: can't modify frozen Array: [
  /\/sinatra(\/(base|main|show_exceptions))?\.rb$/,
  /lib\/tilt.*\.rb$/,
  /^\(.*\)$/,
  /rubygems\/(custom|core_ext\/kernel)_require\.rb$/,
  /active_support/,
  /bundler(\/(?:runtime|inline))?\.rb/,
  /<internal:/
]
```

Downgrade Sinatra in the Padrino tests until it's resolved in Padrino. I don't think this is an issue on our end.

[skip changeset]

## Lock que gem to version 1

Que 2 is out, and we're not compatible. Downgrade to version 1 in our test suite until we are compatible.

I've created an issue for que version 2 support: https://github.com/appsignal/appsignal-ruby/issues/883

[skip changeset]
