### PR TITLE
Call new Puma 6 log writer to log messages

### DIFF
--- a/.changesets/support-puma-6-logging.md
+++ b/.changesets/support-puma-6-logging.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix NoMethodError for AppSignal Puma plugin for Puma 6. Puma 5 is also still supported.


### PR DESCRIPTION
The class responsible for logging was split of from the Puma Events class into a new LogWriter class in PR
https://github.com/puma/puma/pull/2798.

Rely on this location first for Puma 6 and fallback on the events class for Puma 5.

Fixes #886