### PR TITLE
Support Sidekiq 7 in the Sidekiq minutely probe

### DIFF
--- a/.changesets/support-sidekiq-7-in-the-sidekiq-minutely-probe.md
+++ b/.changesets/support-sidekiq-7-in-the-sidekiq-minutely-probe.md
@@ -3,4 +3,4 @@ bump: "patch"
 type: "fix"
 ---
 
-Support Sidekiq 7 in the Sidekiq minutely probe. Fixes the "unknown command `connection`" error logged to `appsignal.log`.
+Support Sidekiq 7 in the Sidekiq minutely probe. It will now report metrics to Sidekiq magic dashboard for Sidekiq version 7 and newer.

--- a/.changesets/support-sidekiq-7-in-the-sidekiq-minutely-probe.md
+++ b/.changesets/support-sidekiq-7-in-the-sidekiq-minutely-probe.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Support Sidekiq 7 in the Sidekiq minutely probe. Fixes the "unknown command `connection`" error logged to `appsignal.log`.

--- a/spec/lib/appsignal/probes/sidekiq_spec.rb
+++ b/spec/lib/appsignal/probes/sidekiq_spec.rb
@@ -136,6 +136,8 @@ describe Appsignal::Probes::SidekiqProbe do
     def with_sidekiq7!
       stub_const("Sidekiq", Sidekiq7Mock)
     end
+    # Version not relevant, but requires any version for tests
+    alias_method :with_sidekiq!, :with_sidekiq7!
 
     def with_sidekiq6!
       stub_const("Sidekiq", Sidekiq6Mock)
@@ -175,7 +177,7 @@ describe Appsignal::Probes::SidekiqProbe do
     end
 
     it "loads Sidekiq::API" do
-      with_sidekiq7! # Version irrelevant, but requires any version
+      with_sidekiq!
       # Hide the Sidekiq constant if it was already loaded. It will be
       # redefined by loading "sidekiq/api" in the probe.
       hide_const "Sidekiq::Stats"
@@ -186,7 +188,7 @@ describe Appsignal::Probes::SidekiqProbe do
     end
 
     it "logs config on initialize" do
-      with_sidekiq7! # Version irrelevant, but requires any version
+      with_sidekiq!
       log = capture_logs { probe }
       expect(log).to contains_log(:debug, "Initializing Sidekiq probe\n")
     end
@@ -281,7 +283,7 @@ describe Appsignal::Probes::SidekiqProbe do
       let(:probe) { described_class.new(:hostname => redis_hostname) }
 
       it "uses the redis hostname for the hostname tag" do
-        with_sidekiq7! # Version irrelevant, but requires any version
+        with_sidekiq!
 
         allow(Appsignal).to receive(:set_gauge).and_call_original
         log = capture_logs { probe }

--- a/spec/lib/appsignal/probes/sidekiq_spec.rb
+++ b/spec/lib/appsignal/probes/sidekiq_spec.rb
@@ -7,7 +7,103 @@ describe Appsignal::Probes::SidekiqProbe do
     let(:expected_default_tags) { { :hostname => "localhost" } }
     before do
       Appsignal.config = project_fixture_config
-      module SidekiqMock
+
+      class SidekiqStats
+        class << self
+          attr_reader :calls
+
+          def count_call
+            @calls ||= -1
+            @calls += 1
+          end
+        end
+
+        def workers_size
+          # First method called, so count it towards a call
+          self.class.count_call
+          24
+        end
+
+        def processes_size
+          25
+        end
+
+        # Return two different values for two separate calls.
+        # This allows us to test the delta of the value send as a gauge.
+        def processed
+          [10, 15][self.class.calls]
+        end
+
+        # Return two different values for two separate calls.
+        # This allows us to test the delta of the value send as a gauge.
+        def failed
+          [10, 13][self.class.calls]
+        end
+
+        def retry_size
+          12
+        end
+
+        # Return two different values for two separate calls.
+        # This allows us to test the delta of the value send as a gauge.
+        def dead_size
+          [10, 12][self.class.calls]
+        end
+
+        def scheduled_size
+          14
+        end
+
+        def enqueued
+          15
+        end
+      end
+
+      class SidekiqQueue
+        Queue = Struct.new(:name, :size, :latency)
+
+        def self.all
+          [
+            Queue.new("default", 10, 12),
+            Queue.new("critical", 1, 2)
+          ]
+        end
+      end
+
+      module Sidekiq7Mock
+        VERSION = "7.0.0".freeze
+
+        def self.redis
+          yield Client.new
+        end
+
+        class Client
+          def config
+            Config.new
+          end
+
+          def info
+            {
+              "connected_clients" => 2,
+              "used_memory" => 1024,
+              "used_memory_rss" => 512
+            }
+          end
+        end
+
+        class Config
+          def host
+            "localhost"
+          end
+        end
+
+        Stats = ::SidekiqStats
+        Queue = ::SidekiqQueue
+      end
+
+      module Sidekiq6Mock
+        VERSION = "6.9.9".freeze
+
         def self.redis_info
           {
             "connected_clients" => 2,
@@ -26,95 +122,60 @@ describe Appsignal::Probes::SidekiqProbe do
           end
         end
 
-        class Stats
-          class << self
-            attr_reader :calls
-
-            def count_call
-              @calls ||= -1
-              @calls += 1
-            end
-          end
-
-          def workers_size
-            # First method called, so count it towards a call
-            self.class.count_call
-            24
-          end
-
-          def processes_size
-            25
-          end
-
-          # Return two different values for two separate calls.
-          # This allows us to test the delta of the value send as a gauge.
-          def processed
-            [10, 15][self.class.calls]
-          end
-
-          # Return two different values for two separate calls.
-          # This allows us to test the delta of the value send as a gauge.
-          def failed
-            [10, 13][self.class.calls]
-          end
-
-          def retry_size
-            12
-          end
-
-          # Return two different values for two separate calls.
-          # This allows us to test the delta of the value send as a gauge.
-          def dead_size
-            [10, 12][self.class.calls]
-          end
-
-          def scheduled_size
-            14
-          end
-
-          def enqueued
-            15
-          end
-        end
-
-        class Queue
-          Queue = Struct.new(:name, :size, :latency)
-
-          def self.all
-            [
-              Queue.new("default", 10, 12),
-              Queue.new("critical", 1, 2)
-            ]
-          end
-        end
+        Stats = ::SidekiqStats
+        Queue = ::SidekiqQueue
       end
-      stub_const("Sidekiq", SidekiqMock)
     end
-    after { Object.send(:remove_const, :SidekiqMock) }
+    after do
+      Object.send(:remove_const, :SidekiqStats)
+      Object.send(:remove_const, :SidekiqQueue)
+      Object.send(:remove_const, :Sidekiq6Mock)
+      Object.send(:remove_const, :Sidekiq7Mock)
+    end
+
+    def with_sidekiq7!
+      stub_const("Sidekiq", Sidekiq7Mock)
+    end
+
+    def with_sidekiq6!
+      stub_const("Sidekiq", Sidekiq6Mock)
+    end
 
     describe ".dependencies_present?" do
-      before do
-        stub_const("Redis::VERSION", version)
-      end
+      context "when Sidekiq 7" do
+        before { with_sidekiq7! }
 
-      context "when Redis version is < 3.3.5" do
-        let(:version) { "3.3.4" }
-
-        it "does not start probe" do
-          expect(described_class.dependencies_present?).to be_falsy
+        it "starts the probe" do
+          expect(described_class.dependencies_present?).to be_truthy
         end
       end
 
-      context "when Redis version is >= 3.3.5" do
-        let(:version) { "3.3.5" }
+      context "when Sidekiq 6" do
+        before do
+          with_sidekiq6!
+          stub_const("Redis::VERSION", version)
+        end
 
-        it "does not start probe" do
-          expect(described_class.dependencies_present?).to be_truthy
+        context "when Redis version is < 3.3.5" do
+          let(:version) { "3.3.4" }
+
+          it "does not start probe" do
+            expect(described_class.dependencies_present?).to be_falsy
+          end
+        end
+
+        context "when Redis version is >= 3.3.5" do
+          let(:version) { "3.3.5" }
+
+          it "starts the probe" do
+            expect(described_class.dependencies_present?).to be_truthy
+          end
         end
       end
     end
 
     it "loads Sidekiq::API" do
+      with_sidekiq7! # Version irrelevant, but requires any version
       # Hide the Sidekiq constant if it was already loaded. It will be
       # redefined by loading "sidekiq/api" in the probe.
       hide_const "Sidekiq::Stats"
@@ -125,52 +186,93 @@ describe Appsignal::Probes::SidekiqProbe do
     end
 
     it "logs config on initialize" do
+      with_sidekiq7! # Version irrelevant, but requires any version
       log = capture_logs { probe }
       expect(log).to contains_log(:debug, "Initializing Sidekiq probe\n")
     end
 
-    it "logs used hostname on call once" do
-      log = capture_logs { probe.call }
-      expect(log).to contains_log(
-        :debug,
-        %(Sidekiq probe: Using Redis server hostname "localhost" as hostname)
-      )
-      log = capture_logs { probe.call }
-      # Match more logs with incompelete message
-      expect(log).to_not contains_log(:debug, %(Sidekiq probe: ))
-    end
+    context "with Sidekiq 7" do
+      before { with_sidekiq7! }
 
-    it "collects custom metrics" do
-      expect_gauge("worker_count", 24).twice
-      expect_gauge("process_count", 25).twice
-      expect_gauge("connection_count", 2).twice
-      expect_gauge("memory_usage", 1024).twice
-      expect_gauge("memory_usage_rss", 512).twice
-      expect_gauge("job_count", 5, :status => :processed) # Gauge delta
-      expect_gauge("job_count", 3, :status => :failed) # Gauge delta
-      expect_gauge("job_count", 12, :status => :retry_queue).twice
-      expect_gauge("job_count", 2, :status => :died) # Gauge delta
-      expect_gauge("job_count", 14, :status => :scheduled).twice
-      expect_gauge("job_count", 15, :status => :enqueued).twice
-      expect_gauge("queue_length", 10, :queue => "default").twice
-      expect_gauge("queue_latency", 12_000, :queue => "default").twice
-      expect_gauge("queue_length", 1, :queue => "critical").twice
-      expect_gauge("queue_latency", 2_000, :queue => "critical").twice
-      # Call probe twice so we can calculate the delta for some gauge values
-      probe.call
-      probe.call
-    end
-
-    context "when `redis_info` is not defined" do
-      before do
-        allow(Sidekiq).to receive(:respond_to?).with(:redis_info).and_return(false)
+      it "logs used hostname on call once" do
+        log = capture_logs { probe.call }
+        expect(log).to contains_log(
+          :debug,
+          %(Sidekiq probe: Using Redis server hostname "localhost" as hostname)
+        )
+        log = capture_logs { probe.call }
+        # Match more logs with incompelete message
+        expect(log).to_not contains_log(:debug, %(Sidekiq probe: ))
       end
 
-      it "does not collect redis metrics" do
-        expect_gauge("connection_count", 2).never
-        expect_gauge("memory_usage", 1024).never
-        expect_gauge("memory_usage_rss", 512).never
+      it "collects custom metrics" do
+        expect_gauge("worker_count", 24).twice
+        expect_gauge("process_count", 25).twice
+        expect_gauge("connection_count", 2).twice
+        expect_gauge("memory_usage", 1024).twice
+        expect_gauge("memory_usage_rss", 512).twice
+        expect_gauge("job_count", 5, :status => :processed) # Gauge delta
+        expect_gauge("job_count", 3, :status => :failed) # Gauge delta
+        expect_gauge("job_count", 12, :status => :retry_queue).twice
+        expect_gauge("job_count", 2, :status => :died) # Gauge delta
+        expect_gauge("job_count", 14, :status => :scheduled).twice
+        expect_gauge("job_count", 15, :status => :enqueued).twice
+        expect_gauge("queue_length", 10, :queue => "default").twice
+        expect_gauge("queue_latency", 12_000, :queue => "default").twice
+        expect_gauge("queue_length", 1, :queue => "critical").twice
+        expect_gauge("queue_latency", 2_000, :queue => "critical").twice
+        # Call probe twice so we can calculate the delta for some gauge values
         probe.call
+        probe.call
+      end
+    end
+
+    context "with Sidekiq 6" do
+      before { with_sidekiq6! }
+
+      it "logs used hostname on call once" do
+        log = capture_logs { probe.call }
+        expect(log).to contains_log(
+          :debug,
+          %(Sidekiq probe: Using Redis server hostname "localhost" as hostname)
+        )
+        log = capture_logs { probe.call }
+        # Match more logs with incompelete message
+        expect(log).to_not contains_log(:debug, %(Sidekiq probe: ))
+      end
+
+      it "collects custom metrics" do
+        expect_gauge("worker_count", 24).twice
+        expect_gauge("process_count", 25).twice
+        expect_gauge("connection_count", 2).twice
+        expect_gauge("memory_usage", 1024).twice
+        expect_gauge("memory_usage_rss", 512).twice
+        expect_gauge("job_count", 5, :status => :processed) # Gauge delta
+        expect_gauge("job_count", 3, :status => :failed) # Gauge delta
+        expect_gauge("job_count", 12, :status => :retry_queue).twice
+        expect_gauge("job_count", 2, :status => :died) # Gauge delta
+        expect_gauge("job_count", 14, :status => :scheduled).twice
+        expect_gauge("job_count", 15, :status => :enqueued).twice
+        expect_gauge("queue_length", 10, :queue => "default").twice
+        expect_gauge("queue_latency", 12_000, :queue => "default").twice
+        expect_gauge("queue_length", 1, :queue => "critical").twice
+        expect_gauge("queue_latency", 2_000, :queue => "critical").twice
+        # Call probe twice so we can calculate the delta for some gauge values
+        probe.call
+        probe.call
+      end
+
+      context "when Sidekiq `redis_info` is not defined" do
+        before do
+          allow(Sidekiq).to receive(:respond_to?).with(:redis_info).and_return(false)
+        end
+
+        it "does not collect redis metrics" do
+          expect_gauge("connection_count", 2).never
+          expect_gauge("memory_usage", 1024).never
+          expect_gauge("memory_usage_rss", 512).never
+          probe.call
+        end
       end
     end
 
@@ -179,6 +281,8 @@ describe Appsignal::Probes::SidekiqProbe do
       let(:probe) { described_class.new(:hostname => redis_hostname) }
 
       it "uses the redis hostname for the hostname tag" do
+        with_sidekiq7! # Version irrelevant, but requires any version
+
         allow(Appsignal).to receive(:set_gauge).and_call_original
         log = capture_logs { probe }
         expect(log).to contains_log(


### PR DESCRIPTION
Sidekiq 7 changed some thing around to fetch the Sidekiq metrics. It changed Redis clients from the redis gem to the redis-client gem. Update our probe to use the new client behavior to fetch the metrics.

Closes #891