### PR TITLE
Add default logging_endpoint config option value

### DIFF
--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -29,6 +29,7 @@ module Appsignal
       :instrument_redis               => true,
       :instrument_sequel              => true,
       :log                            => "file",
+      :logging_endpoint               => "https://appsignal-endpoint.net",
       :request_headers                => %w[
         HTTP_ACCEPT HTTP_ACCEPT_CHARSET HTTP_ACCEPT_ENCODING
         HTTP_ACCEPT_LANGUAGE HTTP_CACHE_CONTROL HTTP_CONNECTION

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -170,6 +170,7 @@ describe Appsignal::Config do
         :instrument_redis               => true,
         :instrument_sequel              => true,
         :log                            => "file",
+        :logging_endpoint               => "https://appsignal-endpoint.net",
         :name                           => "TestApp",
         :push_api_key                   => "abc",
         :request_headers                => [],


### PR DESCRIPTION
In PR #890 a new logging feature was added. It relies on the `logging_endpoint` config option. This was not set with a default value, like our diagnose_tests repository expects.

Without a default value for the endpoint, I don't think the feature would work.

[skip changeset] since the feature hasn't been released yet.