### PR TITLE
Accept URI objects for HTTP integration

### DIFF
--- a/lib/appsignal/integrations/http.rb
+++ b/lib/appsignal/integrations/http.rb
@@ -4,7 +4,7 @@ module Appsignal
   module Integrations
     module HttpIntegration
       def request(verb, uri, opts = {})
-        parsed_request_uri = URI.parse(uri)
+        parsed_request_uri = uri.is_a?(URI) ? uri : URI.parse(uri.to_s)
         request_uri = "#{parsed_request_uri.scheme}://#{parsed_request_uri.host}"
 
         begin

--- a/spec/lib/appsignal/integrations/http_spec.rb
+++ b/spec/lib/appsignal/integrations/http_spec.rb
@@ -99,5 +99,46 @@ if DependencyHelper.http_present?
         )
       end
     end
+
+    context "with various URI objects" do
+      it "parses an object responding to #to_s" do
+        request_uri = Struct.new(:uri) do
+          def to_s
+            uri.to_s
+          end
+        end
+
+        stub_request(:get, "http://www.google.com")
+
+        HTTP.get(request_uri.new("http://www.google.com"))
+
+        expect(transaction.to_h["events"].first).to include(
+          "name" => "request.http_rb",
+          "title" => "GET http://www.google.com"
+        )
+      end
+
+      it "parses an URI object" do
+        stub_request(:get, "http://www.google.com")
+
+        HTTP.get(URI("http://www.google.com"))
+
+        expect(transaction.to_h["events"].first).to include(
+          "name" => "request.http_rb",
+          "title" => "GET http://www.google.com"
+        )
+      end
+
+      it "parses a String object" do
+        stub_request(:get, "http://www.google.com")
+
+        HTTP.get("http://www.google.com")
+
+        expect(transaction.to_h["events"].first).to include(
+          "name" => "request.http_rb",
+          "title" => "GET http://www.google.com"
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
The `HTTP::Client#request` allows URI objects and objects responding to `#to_s` and/or `#to_str` as a request uri.

The HTTP.rb integration doesn't take this into account and is causing failures on the client side when passing an URI object to the request method.

I missed this during the original implementation and it might cause issues for people passing an `URI` object to the HTTP gem. Also see; https://github.com/httprb/http/blob/13ce3c2710bc27b467dda68f908149a2f69643cc/lib/http/request.rb#L82

I'm looking for feedback in regard to the added test cases. I'm not sure if these add any extra value, but I'd love to hear more about your thoughts @tombruijn.