### PR TITLE
Use log formatter if set in logger

### DIFF
--- a/.changesets/use-log-formatter-if-set-in-logger.md
+++ b/.changesets/use-log-formatter-if-set-in-logger.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Use log formatter if set in logger

--- a/lib/appsignal/logger.rb
+++ b/lib/appsignal/logger.rb
@@ -5,7 +5,7 @@ require "set"
 
 module Appsignal
   # Logger that flushes logs to the AppSignal logging service
-  class Logger < ::Logger
+  class Logger < ::Logger # rubocop:disable Metrics/ClassLength
     # Create a new logger instance
     #
     # @param group Name of the group for this logger.
@@ -20,7 +20,7 @@ module Appsignal
     # We support the various methods in the Ruby
     # logger class by supplying this method.
     # @api private
-    def add(severity, message = nil, group = nil)
+    def add(severity, message = nil, group = nil) # rubocop:disable Metrics/CyclomaticComplexity
       severity ||= UNKNOWN
       return true if severity < level
       group = @group if group.nil?
@@ -33,6 +33,7 @@ module Appsignal
         end
       end
       return if message.nil?
+      message = formatter.call(severity, 0, group, message) if formatter
       severity_number = case severity
                         when DEBUG
                           2
@@ -64,6 +65,7 @@ module Appsignal
       return if DEBUG < level
       message = yield if message.nil? && block_given?
       return if message.nil?
+      message = formatter.call(DEBUG, 0, @group, message) if formatter
       Appsignal::Extension.log(
         @group,
         2,
@@ -80,6 +82,7 @@ module Appsignal
       return if INFO < level
       message = yield if message.nil? && block_given?
       return if message.nil?
+      message = formatter.call(INFO, 0, @group, message) if formatter
       Appsignal::Extension.log(
         @group,
         3,
@@ -96,6 +99,7 @@ module Appsignal
       return if WARN < level
       message = yield if message.nil? && block_given?
       return if message.nil?
+      message = formatter.call(WARN, 0, @group, message) if formatter
       Appsignal::Extension.log(
         @group,
         5,
@@ -112,6 +116,7 @@ module Appsignal
       return if ERROR < level
       message = yield if message.nil? && block_given?
       return if message.nil?
+      message = formatter.call(ERROR, 0, @group, message) if formatter
       Appsignal::Extension.log(
         @group,
         6,
@@ -128,6 +133,7 @@ module Appsignal
       return if FATAL < level
       message = yield if message.nil? && block_given?
       return if message.nil?
+      message = formatter.call(FATAL, 0, @group, message) if formatter
       Appsignal::Extension.log(
         @group,
         7,

--- a/spec/lib/appsignal/logger_spec.rb
+++ b/spec/lib/appsignal/logger_spec.rb
@@ -42,6 +42,20 @@ describe Appsignal::Logger do
         logger.add(::Logger::DEBUG, "Log message")
       end
     end
+
+    context "with a formatter set" do
+      before do
+        logger.formatter = proc do |_level, _timestamp, _appname, message|
+          "formatted: '#{message}'"
+        end
+      end
+
+      it "should log with a level, message and group" do
+        expect(Appsignal::Extension).to receive(:log)
+          .with("other_group", 3, "formatted: 'Log message'", instance_of(Appsignal::Extension::Data))
+        logger.add(::Logger::INFO, "Log message", "other_group")
+      end
+    end
   end
 
   [
@@ -87,6 +101,20 @@ describe Appsignal::Logger do
             expect(Appsignal::Extension).not_to receive(:log)
             logger.send(method[0], "Log message")
           end
+        end
+      end
+
+      context "with a formatter set" do
+        before do
+          logger.formatter = proc do |_level, _timestamp, _appname, message|
+            "formatted: '#{message}'"
+          end
+        end
+
+        it "should log with a level, message and group" do
+          expect(Appsignal::Extension).to receive(:log)
+            .with("group", method[1], "formatted: 'Log message'", instance_of(Appsignal::Extension::Data))
+          logger.send(method[0], "Log message")
         end
       end
     end


### PR DESCRIPTION
Use the log formatter if it is set. In most cases we don't need it, but some tools such as Sidekiq use the formatter to add more context to the message. In that case you'd do something like this:

```ruby
Sidekiq.configure_server do |config|
  config.logger = Appsignal::Logger.new("sidekiq")
  config.logger.formatter = Sidekiq::Logger::Formatters::WithoutTimestamp.new
end
```

With this change we use the formatter so extra context about the jobs is logged.