### PR TITLE
Fix CI build

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -52,8 +52,10 @@ blocks:
   task:
     prologue:
       commands:
-      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
       - "./support/bundler_wrapper install --jobs=3 --retry=3"
     jobs:
     - name: Validate CI setup
@@ -69,17 +71,19 @@ blocks:
     epilogue:
       on_pass:
         commands:
-        - cache store $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-          .bundle
-        - cache store $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-          $HOME/.gem
+        - cache store $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+          appsignal.gemspec) .bundle
+        - cache store $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+          appsignal.gemspec) $HOME/.gem
 - name: Ruby linters
   dependencies: []
   task:
     prologue:
       commands:
-      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
       - "./support/bundler_wrapper install --jobs=3 --retry=3"
     jobs:
     - name: RuboCop
@@ -95,10 +99,10 @@ blocks:
     epilogue:
       on_pass:
         commands:
-        - cache store $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-          .bundle
-        - cache store $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-          $HOME/.gem
+        - cache store $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+          appsignal.gemspec) .bundle
+        - cache store $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+          appsignal.gemspec) $HOME/.gem
 - name: Other linters
   dependencies: []
   task:
@@ -140,8 +144,10 @@ blocks:
   task:
     prologue:
       commands:
-      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
       - "./support/install_deps"
       - bundle config set clean 'true'
       - "./support/bundler_wrapper install --jobs=3 --retry=3"
@@ -149,10 +155,10 @@ blocks:
     epilogue: &1
       on_pass:
         commands:
-        - cache store $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-          .bundle
-        - cache store $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
-          $HOME/.gem
+        - cache store $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+          appsignal.gemspec) .bundle
+        - cache store $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)-$(checksum
+          appsignal.gemspec) $HOME/.gem
       on_fail:
         commands:
         - "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
@@ -192,8 +198,10 @@ blocks:
   task:
     prologue:
       commands:
-      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
       - "./support/install_deps"
       - bundle config set clean 'true'
       - "./support/bundler_wrapper install --jobs=3 --retry=3"
@@ -242,8 +250,10 @@ blocks:
   task:
     prologue:
       commands:
-      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
       - "./support/install_deps"
       - bundle config set clean 'true'
       - "./support/bundler_wrapper install --jobs=3 --retry=3"
@@ -275,8 +285,10 @@ blocks:
   task:
     prologue:
       commands:
-      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
       - "./support/install_deps"
       - bundle config set clean 'true'
       - "./support/bundler_wrapper install --jobs=3 --retry=3"
@@ -308,8 +320,10 @@ blocks:
   task:
     prologue:
       commands:
-      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
       - "./support/install_deps"
       - bundle config set clean 'true'
       - "./support/bundler_wrapper install --jobs=3 --retry=3"
@@ -341,8 +355,10 @@ blocks:
   task:
     prologue:
       commands:
-      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
       - "./support/install_deps"
       - bundle config set clean 'true'
       - "./support/bundler_wrapper install --jobs=3 --retry=3"
@@ -374,8 +390,10 @@ blocks:
   task:
     prologue:
       commands:
-      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
       - "./support/install_deps"
       - bundle config set clean 'true'
       - "./support/bundler_wrapper install --jobs=3 --retry=3"
@@ -407,8 +425,10 @@ blocks:
   task:
     prologue:
       commands:
-      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
       - "./support/install_deps"
       - bundle config set clean 'true'
       - "./support/bundler_wrapper install --jobs=3 --retry=3"
@@ -475,8 +495,10 @@ blocks:
   task:
     prologue:
       commands:
-      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
       - "./support/install_deps"
       - bundle config set clean 'true'
       - "./support/bundler_wrapper install --jobs=3 --retry=3"
@@ -508,8 +530,10 @@ blocks:
   task:
     prologue:
       commands:
-      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
       - "./support/install_deps"
       - bundle config set clean 'true'
       - "./support/bundler_wrapper install --jobs=3 --retry=3"
@@ -846,8 +870,10 @@ blocks:
   task:
     prologue:
       commands:
-      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
       - "./support/install_deps"
       - bundle config set clean 'true'
       - "./support/bundler_wrapper install --jobs=3 --retry=3"
@@ -879,8 +905,10 @@ blocks:
   task:
     prologue:
       commands:
-      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
       - "./support/install_deps"
       - bundle config set clean 'true'
       - "./support/bundler_wrapper install --jobs=3 --retry=3"
@@ -1235,8 +1263,10 @@ blocks:
   task:
     prologue:
       commands:
-      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
       - "./support/install_deps"
       - bundle config set clean 'true'
       - "./support/bundler_wrapper install --jobs=3 --retry=3"
@@ -1268,8 +1298,10 @@ blocks:
   task:
     prologue:
       commands:
-      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
       - "./support/install_deps"
       - bundle config set clean 'true'
       - "./support/bundler_wrapper install --jobs=3 --retry=3"
@@ -1570,8 +1602,10 @@ blocks:
   task:
     prologue:
       commands:
-      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
       - "./support/install_deps"
       - bundle config set clean 'true'
       - "./support/bundler_wrapper install --jobs=3 --retry=3"
@@ -1603,8 +1637,10 @@ blocks:
   task:
     prologue:
       commands:
-      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
       - "./support/install_deps"
       - bundle config set clean 'true'
       - "./support/bundler_wrapper install --jobs=3 --retry=3"
@@ -1887,8 +1923,10 @@ blocks:
   task:
     prologue:
       commands:
-      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
       - "./support/install_deps"
       - bundle config set clean 'true'
       - "./support/bundler_wrapper install --jobs=3 --retry=3"
@@ -1920,8 +1958,10 @@ blocks:
   task:
     prologue:
       commands:
-      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
       - "./support/install_deps"
       - bundle config set clean 'true'
       - "./support/bundler_wrapper install --jobs=3 --retry=3"
@@ -2204,8 +2244,10 @@ blocks:
   task:
     prologue:
       commands:
-      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
       - "./support/install_deps"
       - bundle config set clean 'true'
       - "./support/bundler_wrapper install --jobs=3 --retry=3"
@@ -2240,8 +2282,10 @@ blocks:
   task:
     prologue:
       commands:
-      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
       - "./support/install_deps"
       - bundle config set clean 'true'
       - "./support/bundler_wrapper install --jobs=3 --retry=3"
@@ -2311,8 +2355,10 @@ blocks:
   task:
     prologue:
       commands:
-      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
       - "./support/install_deps"
       - bundle config set clean 'true'
       - "./support/bundler_wrapper install --jobs=3 --retry=3"
@@ -2344,8 +2390,10 @@ blocks:
   task:
     prologue:
       commands:
-      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)-$(checksum
+        appsignal.gemspec)
       - "./support/install_deps"
       - bundle config set clean 'true'
       - "./support/bundler_wrapper install --jobs=3 --retry=3"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2394,3 +2394,21 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+    - name: Ruby jruby-9.4.0.0 for rails-7.0
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: jruby-9.4.0.0
+      - name: GEMSET
+        value: rails-7.0
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/rails-7.0.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2238,7 +2238,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-- name: Ruby jruby-9.2.19.0
+- name: Ruby jruby-9.3.9.0
   dependencies:
   - Validation
   task:
@@ -2254,14 +2254,14 @@ blocks:
       - "./support/bundler_wrapper exec rake extension:install"
     epilogue: *1
     jobs:
-    - name: Ruby jruby-9.2.19.0 for no_dependencies
+    - name: Ruby jruby-9.3.9.0 for no_dependencies
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: jruby-9.2.19.0
+        value: jruby-9.3.9.0
       - name: GEMSET
         value: no_dependencies
       - name: BUNDLE_GEMFILE
@@ -2270,15 +2270,12 @@ blocks:
         value: latest
       - name: _BUNDLER_VERSION
         value: latest
-      - &6
-        name: _C_VERSION
-        value: '8'
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
-- name: Ruby jruby-9.2.19.0 - Gems
+- name: Ruby jruby-9.3.9.0 - Gems
   dependencies:
-  - Ruby jruby-9.2.19.0
+  - Ruby jruby-9.3.9.0
   task:
     prologue:
       commands:
@@ -2292,14 +2289,14 @@ blocks:
       - "./support/bundler_wrapper exec rake extension:install"
     epilogue: *1
     jobs:
-    - name: Ruby jruby-9.2.19.0 for rails-5.2
+    - name: Ruby jruby-9.3.9.0 for rails-5.2
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: jruby-9.2.19.0
+        value: jruby-9.3.9.0
       - name: GEMSET
         value: rails-5.2
       - name: BUNDLE_GEMFILE
@@ -2308,48 +2305,9 @@ blocks:
         value: latest
       - name: _BUNDLER_VERSION
         value: latest
-      - *6
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby jruby-9.2.19.0 for rails-6.0
-      env_vars:
-      - *2
-      - *3
-      - *4
-      - *5
-      - name: RUBY_VERSION
-        value: jruby-9.2.19.0
-      - name: GEMSET
-        value: rails-6.0
-      - name: BUNDLE_GEMFILE
-        value: gemfiles/rails-6.0.gemfile
-      - name: _RUBYGEMS_VERSION
-        value: latest
-      - name: _BUNDLER_VERSION
-        value: latest
-      - *6
-      commands:
-      - "./support/bundler_wrapper exec rake test"
-    - name: Ruby jruby-9.2.19.0 for rails-6.1
-      env_vars:
-      - *2
-      - *3
-      - *4
-      - *5
-      - name: RUBY_VERSION
-        value: jruby-9.2.19.0
-      - name: GEMSET
-        value: rails-6.1
-      - name: BUNDLE_GEMFILE
-        value: gemfiles/rails-6.1.gemfile
-      - name: _RUBYGEMS_VERSION
-        value: latest
-      - name: _BUNDLER_VERSION
-        value: latest
-      - *6
-      commands:
-      - "./support/bundler_wrapper exec rake test"
-- name: Ruby jruby-9.3.6.0
+- name: Ruby jruby-9.4.0.0
   dependencies:
   - Validation
   task:
@@ -2365,14 +2323,14 @@ blocks:
       - "./support/bundler_wrapper exec rake extension:install"
     epilogue: *1
     jobs:
-    - name: Ruby jruby-9.3.6.0 for no_dependencies
+    - name: Ruby jruby-9.4.0.0 for no_dependencies
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: jruby-9.3.6.0
+        value: jruby-9.4.0.0
       - name: GEMSET
         value: no_dependencies
       - name: BUNDLE_GEMFILE
@@ -2384,9 +2342,9 @@ blocks:
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
-- name: Ruby jruby-9.3.6.0 - Gems
+- name: Ruby jruby-9.4.0.0 - Gems
   dependencies:
-  - Ruby jruby-9.3.6.0
+  - Ruby jruby-9.4.0.0
   task:
     prologue:
       commands:
@@ -2400,14 +2358,32 @@ blocks:
       - "./support/bundler_wrapper exec rake extension:install"
     epilogue: *1
     jobs:
-    - name: Ruby jruby-9.3.6.0 for rails-6.1
+    - name: Ruby jruby-9.4.0.0 for rails-6.0
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: jruby-9.3.6.0
+        value: jruby-9.4.0.0
+      - name: GEMSET
+        value: rails-6.0
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/rails-6.0.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+    - name: Ruby jruby-9.4.0.0 for rails-6.1
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: jruby-9.4.0.0
       - name: GEMSET
         value: rails-6.1
       - name: BUNDLE_GEMFILE

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -54,8 +54,8 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
       task:
         prologue:
           commands:
-            - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-            - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+            - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum appsignal.gemspec)
+            - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum appsignal.gemspec)
             - ./support/bundler_wrapper install --jobs=3 --retry=3
         jobs:
         - name: Validate CI setup
@@ -71,15 +71,15 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
         epilogue:
           on_pass:
             commands:
-              - cache store $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE) .bundle
-              - cache store $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE) $HOME/.gem
+              - cache store $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum appsignal.gemspec) .bundle
+              - cache store $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum appsignal.gemspec) $HOME/.gem
     - name: Ruby linters
       dependencies: []
       task:
         prologue:
           commands:
-            - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-            - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
+            - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum appsignal.gemspec)
+            - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum appsignal.gemspec)
             - ./support/bundler_wrapper install --jobs=3 --retry=3
         jobs:
         - name: RuboCop
@@ -95,8 +95,8 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
         epilogue:
           on_pass:
             commands:
-              - cache store $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE) .bundle
-              - cache store $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE) $HOME/.gem
+              - cache store $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum appsignal.gemspec) .bundle
+              - cache store $_GEMS_CACHE-gems-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum appsignal.gemspec) $HOME/.gem
     - name: Other linters
       dependencies: []
       task:
@@ -143,16 +143,16 @@ matrix:
       value: "1"
   prologue: # Shared for all jobs in the build matrix
     commands:
-      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)
-      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)
+      - cache restore $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum appsignal.gemspec)
+      - cache restore $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)-$(checksum appsignal.gemspec)
       - ./support/install_deps
       - bundle config set clean 'true'
       - ./support/bundler_wrapper install --jobs=3 --retry=3
   epilogue: # Shared for all jobs in the build matrix
     on_pass:
       commands:
-        - cache store $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE) .bundle
-        - cache store $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE) $HOME/.gem
+        - cache store $_BUNDLER_CACHE-bundler-$RUBY_VERSION-$GEMSET-$(checksum $BUNDLE_GEMFILE)-$(checksum appsignal.gemspec) .bundle
+        - cache store $_GEMS_CACHE-gems-$RUBY_VERSION-$(checksum $BUNDLE_GEMFILE)-$(checksum appsignal.gemspec) $HOME/.gem
     on_fail:
       commands:
         - "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report file found'"

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -200,12 +200,9 @@ matrix:
     - ruby: "3.0.4"
     - ruby: "3.1.2"
     - ruby: "3.2.0-preview1"
-    - ruby: "jruby-9.2.19.0"
+    - ruby: "jruby-9.3.9.0"
       gems: "minimal"
-      env_vars:
-        - name: "_C_VERSION"
-          value: "8"
-    - ruby: "jruby-9.3.6.0"
+    - ruby: "jruby-9.4.0.0"
       gems: "minimal"
   gems:
     - gem: "no_dependencies"
@@ -281,7 +278,7 @@ matrix:
           - "2.5.8"
           - "2.6.9"
           - "2.7.7"
-          - "jruby-9.2.19.0"
+          - "jruby-9.3.9.0"
     - gem: "rails-6.0"
       only:
         ruby:
@@ -289,7 +286,7 @@ matrix:
           - "2.6.9"
           - "2.7.7"
           - "3.0.4"
-          - "jruby-9.2.19.0"
+          - "jruby-9.4.0.0"
     - gem: "rails-6.1"
       only:
         ruby:
@@ -299,8 +296,7 @@ matrix:
           - "3.0.4"
           - "3.1.2"
           - "3.2.0-preview1"
-          - "jruby-9.2.19.0"
-          - "jruby-9.3.6.0"
+          - "jruby-9.4.0.0"
     - gem: "rails-7.0"
       only:
         ruby:
@@ -308,6 +304,7 @@ matrix:
           - "3.0.4"
           - "3.1.2"
           - "3.2.0-preview1"
+          - "jruby-9.4.0.0"
     - gem: "resque-1"
       bundler: "1.17.3"
       only:

--- a/spec/lib/appsignal/auth_check_spec.rb
+++ b/spec/lib/appsignal/auth_check_spec.rb
@@ -20,12 +20,7 @@ describe Appsignal::AuthCheck do
   end
 
   def build_uri_query_string(hash)
-    hash.map do |k, v|
-      k.to_s.tap do |s|
-        next unless v
-        s << "=#{v}"
-      end
-    end.join("&")
+    URI.encode_www_form(hash)
   end
 
   describe "#perform" do


### PR DESCRIPTION
## Improve caching key for CI

Include appsignal.gemspec for the cache key. The Gemfiles inherit from it, so it also affects which gems are installed.

[skip changeset]

## Bump JRuby to version 9.4 in CI

Drop 9.2 from CI. It no longer wants to install.

[skip changeset]

## Simplify the URI query string builder in tests

Use the built-in Ruby URI library to do this for us. Fixes an issue on JRuby 9.4 where we get a frozen modified string error on the previous implementation.

[skip review]