### PR TITLE
Track new Ruby 3.2 VM cache metrics

### DIFF
--- a/.changesets/track-new-ruby-3-2-vm-cache-metrics.md
+++ b/.changesets/track-new-ruby-3-2-vm-cache-metrics.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Track new Ruby 3.2 VM cache metrics. In Ruby 3.2 the `class_serial` and `global_constant_state` metrics are no longer reported for the "Ruby (VM) metrics" magic dashboard, because Ruby 3.2 removed these metrics. Instead we will now report the new `constant_cache_invalidations` and `constant_cache_misses` metrics reported by Ruby 3.2.

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -25,6 +25,12 @@ global_job_config:
     - checkout
     - rm -f $HOME/.rbenv/plugins/rbenv-gem-rehash/etc/rbenv.d/exec/~gem-rehash.bash
     - |
+      if [ -n "$_LIBYAML" ]; then
+        install-package --update libyaml-dev
+      else
+        echo Skipping libyaml-dev install
+      fi
+    - |
       if [ -n "$_C_VERSION" ]; then
         sem-version c $_C_VERSION
       else
@@ -1917,7 +1923,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-- name: Ruby 3.2.0-preview1
+- name: Ruby 3.2.0-preview3
   dependencies:
   - Validation
   task:
@@ -1933,14 +1939,14 @@ blocks:
       - "./support/bundler_wrapper exec rake extension:install"
     epilogue: *1
     jobs:
-    - name: Ruby 3.2.0-preview1 for no_dependencies
+    - name: Ruby 3.2.0-preview3 for no_dependencies
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview1
+        value: 3.2.0-preview3
       - name: GEMSET
         value: no_dependencies
       - name: BUNDLE_GEMFILE
@@ -1949,12 +1955,15 @@ blocks:
         value: latest
       - name: _BUNDLER_VERSION
         value: latest
+      - &6
+        name: _LIBYAML
+        value: '1'
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
-- name: Ruby 3.2.0-preview1 - Gems
+- name: Ruby 3.2.0-preview3 - Gems
   dependencies:
-  - Ruby 3.2.0-preview1
+  - Ruby 3.2.0-preview3
   task:
     prologue:
       commands:
@@ -1968,14 +1977,14 @@ blocks:
       - "./support/bundler_wrapper exec rake extension:install"
     epilogue: *1
     jobs:
-    - name: Ruby 3.2.0-preview1 for capistrano2
+    - name: Ruby 3.2.0-preview3 for capistrano2
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview1
+        value: 3.2.0-preview3
       - name: GEMSET
         value: capistrano2
       - name: BUNDLE_GEMFILE
@@ -1984,16 +1993,17 @@ blocks:
         value: latest
       - name: _BUNDLER_VERSION
         value: latest
+      - *6
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview1 for capistrano3
+    - name: Ruby 3.2.0-preview3 for capistrano3
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview1
+        value: 3.2.0-preview3
       - name: GEMSET
         value: capistrano3
       - name: BUNDLE_GEMFILE
@@ -2002,16 +2012,17 @@ blocks:
         value: latest
       - name: _BUNDLER_VERSION
         value: latest
+      - *6
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview1 for grape
+    - name: Ruby 3.2.0-preview3 for grape
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview1
+        value: 3.2.0-preview3
       - name: GEMSET
         value: grape
       - name: BUNDLE_GEMFILE
@@ -2020,16 +2031,17 @@ blocks:
         value: latest
       - name: _BUNDLER_VERSION
         value: latest
+      - *6
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview1 for http5
+    - name: Ruby 3.2.0-preview3 for http5
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview1
+        value: 3.2.0-preview3
       - name: GEMSET
         value: http5
       - name: BUNDLE_GEMFILE
@@ -2038,16 +2050,17 @@ blocks:
         value: latest
       - name: _BUNDLER_VERSION
         value: latest
+      - *6
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview1 for padrino
+    - name: Ruby 3.2.0-preview3 for padrino
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview1
+        value: 3.2.0-preview3
       - name: GEMSET
         value: padrino
       - name: BUNDLE_GEMFILE
@@ -2056,16 +2069,17 @@ blocks:
         value: latest
       - name: _BUNDLER_VERSION
         value: latest
+      - *6
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview1 for psych-3
+    - name: Ruby 3.2.0-preview3 for psych-3
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview1
+        value: 3.2.0-preview3
       - name: GEMSET
         value: psych-3
       - name: BUNDLE_GEMFILE
@@ -2074,16 +2088,17 @@ blocks:
         value: latest
       - name: _BUNDLER_VERSION
         value: latest
+      - *6
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview1 for psych-4
+    - name: Ruby 3.2.0-preview3 for psych-4
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview1
+        value: 3.2.0-preview3
       - name: GEMSET
         value: psych-4
       - name: BUNDLE_GEMFILE
@@ -2092,16 +2107,17 @@ blocks:
         value: latest
       - name: _BUNDLER_VERSION
         value: latest
+      - *6
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview1 for que
+    - name: Ruby 3.2.0-preview3 for que
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview1
+        value: 3.2.0-preview3
       - name: GEMSET
         value: que
       - name: BUNDLE_GEMFILE
@@ -2110,16 +2126,17 @@ blocks:
         value: latest
       - name: _BUNDLER_VERSION
         value: latest
+      - *6
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview1 for que_beta
+    - name: Ruby 3.2.0-preview3 for que_beta
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview1
+        value: 3.2.0-preview3
       - name: GEMSET
         value: que_beta
       - name: BUNDLE_GEMFILE
@@ -2128,16 +2145,17 @@ blocks:
         value: latest
       - name: _BUNDLER_VERSION
         value: latest
+      - *6
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview1 for rails-6.1
+    - name: Ruby 3.2.0-preview3 for rails-6.1
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview1
+        value: 3.2.0-preview3
       - name: GEMSET
         value: rails-6.1
       - name: BUNDLE_GEMFILE
@@ -2146,16 +2164,17 @@ blocks:
         value: latest
       - name: _BUNDLER_VERSION
         value: latest
+      - *6
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview1 for rails-7.0
+    - name: Ruby 3.2.0-preview3 for rails-7.0
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview1
+        value: 3.2.0-preview3
       - name: GEMSET
         value: rails-7.0
       - name: BUNDLE_GEMFILE
@@ -2164,16 +2183,17 @@ blocks:
         value: latest
       - name: _BUNDLER_VERSION
         value: latest
+      - *6
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview1 for resque-2
+    - name: Ruby 3.2.0-preview3 for resque-2
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview1
+        value: 3.2.0-preview3
       - name: GEMSET
         value: resque-2
       - name: BUNDLE_GEMFILE
@@ -2182,16 +2202,17 @@ blocks:
         value: latest
       - name: _BUNDLER_VERSION
         value: latest
+      - *6
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview1 for sequel
+    - name: Ruby 3.2.0-preview3 for sequel
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview1
+        value: 3.2.0-preview3
       - name: GEMSET
         value: sequel
       - name: BUNDLE_GEMFILE
@@ -2200,16 +2221,17 @@ blocks:
         value: latest
       - name: _BUNDLER_VERSION
         value: latest
+      - *6
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview1 for sinatra
+    - name: Ruby 3.2.0-preview3 for sinatra
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview1
+        value: 3.2.0-preview3
       - name: GEMSET
         value: sinatra
       - name: BUNDLE_GEMFILE
@@ -2218,16 +2240,17 @@ blocks:
         value: latest
       - name: _BUNDLER_VERSION
         value: latest
+      - *6
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview1 for webmachine
+    - name: Ruby 3.2.0-preview3 for webmachine
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview1
+        value: 3.2.0-preview3
       - name: GEMSET
         value: webmachine
       - name: BUNDLE_GEMFILE
@@ -2236,6 +2259,7 @@ blocks:
         value: latest
       - name: _BUNDLER_VERSION
         value: latest
+      - *6
       commands:
       - "./support/bundler_wrapper exec rake test"
 - name: Ruby jruby-9.3.9.0

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -26,6 +26,12 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
         - checkout
         - rm -f $HOME/.rbenv/plugins/rbenv-gem-rehash/etc/rbenv.d/exec/~gem-rehash.bash
         - |
+          if [ -n "$_LIBYAML" ]; then
+            install-package --update libyaml-dev
+          else
+            echo Skipping libyaml-dev install
+          fi
+        - |
           if [ -n "$_C_VERSION" ]; then
             sem-version c $_C_VERSION
           else
@@ -199,7 +205,10 @@ matrix:
     - ruby: "2.7.7"
     - ruby: "3.0.4"
     - ruby: "3.1.2"
-    - ruby: "3.2.0-preview1"
+    - ruby: "3.2.0-preview3"
+      env_vars:
+        - name: "_LIBYAML"
+          value: "1"
     - ruby: "jruby-9.3.9.0"
       gems: "minimal"
     - ruby: "jruby-9.4.0.0"
@@ -216,13 +225,13 @@ matrix:
         ruby:
           - "3.0.4"
           - "3.1.2"
-          - "3.2.0-preview1"
+          - "3.2.0-preview3"
     - gem: "psych-4"
       only:
         ruby:
           - "3.0.4"
           - "3.1.2"
-          - "3.2.0-preview1"
+          - "3.2.0-preview3"
     - gem: "que"
     - gem: "que_beta"
     - gem: "rails-3.2"
@@ -295,7 +304,7 @@ matrix:
           - "2.7.7"
           - "3.0.4"
           - "3.1.2"
-          - "3.2.0-preview1"
+          - "3.2.0-preview3"
           - "jruby-9.4.0.0"
     - gem: "rails-7.0"
       only:
@@ -303,7 +312,7 @@ matrix:
           - "2.7.7"
           - "3.0.4"
           - "3.1.2"
-          - "3.2.0-preview1"
+          - "3.2.0-preview3"
           - "jruby-9.4.0.0"
     - gem: "resque-1"
       bundler: "1.17.3"

--- a/lib/appsignal/probes/mri.rb
+++ b/lib/appsignal/probes/mri.rb
@@ -18,17 +18,38 @@ module Appsignal
       def call
         stat = RubyVM.stat
 
-        set_gauge(
-          "ruby_vm",
-          stat[:class_serial],
-          :metric => :class_serial
-        )
+        constant_cache_invalidations = stat[:constant_cache_invalidations]
+        if constant_cache_invalidations
+          set_gauge(
+            "ruby_vm",
+            constant_cache_invalidations,
+            :metric => :constant_cache_invalidations
+          )
+        end
 
-        set_gauge(
-          "ruby_vm",
-          stat[:constant_cache] ? stat[:constant_cache].values.sum : stat[:global_constant_state],
-          :metric => :global_constant_state
-        )
+        constant_cache_misses = stat[:constant_cache_misses]
+        if constant_cache_misses
+          set_gauge(
+            "ruby_vm",
+            constant_cache_misses,
+            :metric => :constant_cache_misses
+          )
+        end
+
+        class_serial = stat[:class_serial]
+        if class_serial
+          set_gauge("ruby_vm", class_serial, :metric => :class_serial)
+        end
+
+        global_constant_state =
+          stat[:constant_cache] ? stat[:constant_cache].values.sum : stat[:global_constant_state]
+        if global_constant_state
+          set_gauge(
+            "ruby_vm",
+            global_constant_state,
+            :metric => :global_constant_state
+          )
+        end
 
         set_gauge("thread_count", Thread.list.size)
         if Appsignal::GarbageCollection.enabled?

--- a/spec/lib/appsignal/probes/mri_spec.rb
+++ b/spec/lib/appsignal/probes/mri_spec.rb
@@ -42,10 +42,15 @@ describe Appsignal::Probes::MriProbe do
         allow(GC::Profiler).to receive(:enabled?).and_return(true)
       end
 
-      it "should track vm metrics" do
+      it "should track vm cache metrics" do
         probe.call
-        expect_gauge_value("ruby_vm", :tags => { :metric => :class_serial })
-        expect_gauge_value("ruby_vm", :tags => { :metric => :global_constant_state })
+        if DependencyHelper.ruby_3_2_or_newer?
+          expect_gauge_value("ruby_vm", :tags => { :metric => :constant_cache_invalidations })
+          expect_gauge_value("ruby_vm", :tags => { :metric => :constant_cache_misses })
+        else
+          expect_gauge_value("ruby_vm", :tags => { :metric => :class_serial })
+          expect_gauge_value("ruby_vm", :tags => { :metric => :global_constant_state })
+        end
       end
 
       it "tracks thread counts" do

--- a/spec/support/helpers/dependency_helper.rb
+++ b/spec/support/helpers/dependency_helper.rb
@@ -13,6 +13,10 @@ module DependencyHelper
     ruby_version >= Gem::Version.new("3.1.0")
   end
 
+  def ruby_3_2_or_newer?
+    ruby_version >= Gem::Version.new("3.2.0")
+  end
+
   def running_jruby?
     Appsignal::System.jruby?
   end


### PR DESCRIPTION
## Update CI to test Ruby 3.2 preview 3

With the release of Ruby 3.2 this month, let's make sure AppSignal works
in the CI with this version.

I tried to install rc1, but that doesn't work quite yet.

Make the install of preview 3 work by installing the libyaml dependency,
otherwise it will error on install.

## Track new Ruby 3.2 VM cache metrics

In Ruby 3.2 the `class_serial` and `global_constant_state` VM metrics
were removed in favor of the new `constant_cache_invalidations` and
`constant_cache_misses` metrics.

Report these new metrics when available. This does not require an update
to the "Ruby (VM) metrics" magic dashboard definition.

https://github.com/ruby/ruby/commit/13bd617ea6fdf72467c593639cf33312a06c330c
https://github.com/ruby/ruby/commit/6068da8937d7e4358943f95e7450dae7179a7763
