### PR TITLE
Track OS distro in diagnose report

### DIFF
--- a/.changesets/track-the-operating-system-release-distro-in-the-diagnose-report.md
+++ b/.changesets/track-the-operating-system-release-distro-in-the-diagnose-report.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Track the Operating System release/distro in the diagnose report. This helps us with debugging what exact version of Linux an app is running on, for example.

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -443,6 +443,9 @@ module Appsignal
             save :os, os
             puts_value "Operating System", os_label
 
+            distribution_file = "/etc/os-release"
+            save :os_distribution, File.exist?(distribution_file) ? File.read(distribution_file) : ""
+
             language_version = "#{rbconfig["RUBY_PROGRAM_VERSION"]}-p#{rbconfig["PATCHLEVEL"]}"
             save :language_version, language_version
             puts_format "Ruby version", language_version

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -636,9 +636,12 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
         run
         host_report = received_report["host"]
         host_report.delete("running_in_container") # Tested elsewhere
+        distribution_file = "/etc/os-release"
+        os_distribution = File.exist?(distribution_file) ? File.read(distribution_file) : ""
         expect(host_report).to eq(
           "architecture" => rbconfig["host_cpu"],
           "os" => rbconfig["host_os"],
+          "os_distribution" => os_distribution,
           "language_version" => language_version,
           "heroku" => false,
           "root" => false


### PR DESCRIPTION
This helps us with debugging what exact version of Linux an app is running on, for example.

Part of https://github.com/appsignal/support/issues/206

Edit: some extra context: I've decided not to show this information in the CLI output. It would break the formatting with a multi line value. We can add it another time if we feel it's necessary.