### PR TITLE
Update CI to Ruby 3.2 rc1

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1923,7 +1923,7 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
-- name: Ruby 3.2.0-preview3
+- name: Ruby 3.2.0-rc1
   dependencies:
   - Validation
   task:
@@ -1939,14 +1939,14 @@ blocks:
       - "./support/bundler_wrapper exec rake extension:install"
     epilogue: *1
     jobs:
-    - name: Ruby 3.2.0-preview3 for no_dependencies
+    - name: Ruby 3.2.0-rc1 for no_dependencies
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview3
+        value: 3.2.0-rc1
       - name: GEMSET
         value: no_dependencies
       - name: BUNDLE_GEMFILE
@@ -1958,12 +1958,15 @@ blocks:
       - &6
         name: _LIBYAML
         value: '1'
+      - &7
+        name: RUBY_CFLAGS
+        value: "-std=gnu99"
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"
-- name: Ruby 3.2.0-preview3 - Gems
+- name: Ruby 3.2.0-rc1 - Gems
   dependencies:
-  - Ruby 3.2.0-preview3
+  - Ruby 3.2.0-rc1
   task:
     prologue:
       commands:
@@ -1977,14 +1980,14 @@ blocks:
       - "./support/bundler_wrapper exec rake extension:install"
     epilogue: *1
     jobs:
-    - name: Ruby 3.2.0-preview3 for capistrano2
+    - name: Ruby 3.2.0-rc1 for capistrano2
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview3
+        value: 3.2.0-rc1
       - name: GEMSET
         value: capistrano2
       - name: BUNDLE_GEMFILE
@@ -1994,16 +1997,17 @@ blocks:
       - name: _BUNDLER_VERSION
         value: latest
       - *6
+      - *7
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview3 for capistrano3
+    - name: Ruby 3.2.0-rc1 for capistrano3
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview3
+        value: 3.2.0-rc1
       - name: GEMSET
         value: capistrano3
       - name: BUNDLE_GEMFILE
@@ -2013,16 +2017,17 @@ blocks:
       - name: _BUNDLER_VERSION
         value: latest
       - *6
+      - *7
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview3 for grape
+    - name: Ruby 3.2.0-rc1 for grape
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview3
+        value: 3.2.0-rc1
       - name: GEMSET
         value: grape
       - name: BUNDLE_GEMFILE
@@ -2032,16 +2037,17 @@ blocks:
       - name: _BUNDLER_VERSION
         value: latest
       - *6
+      - *7
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview3 for http5
+    - name: Ruby 3.2.0-rc1 for http5
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview3
+        value: 3.2.0-rc1
       - name: GEMSET
         value: http5
       - name: BUNDLE_GEMFILE
@@ -2051,16 +2057,17 @@ blocks:
       - name: _BUNDLER_VERSION
         value: latest
       - *6
+      - *7
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview3 for padrino
+    - name: Ruby 3.2.0-rc1 for padrino
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview3
+        value: 3.2.0-rc1
       - name: GEMSET
         value: padrino
       - name: BUNDLE_GEMFILE
@@ -2070,16 +2077,17 @@ blocks:
       - name: _BUNDLER_VERSION
         value: latest
       - *6
+      - *7
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview3 for psych-3
+    - name: Ruby 3.2.0-rc1 for psych-3
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview3
+        value: 3.2.0-rc1
       - name: GEMSET
         value: psych-3
       - name: BUNDLE_GEMFILE
@@ -2089,16 +2097,17 @@ blocks:
       - name: _BUNDLER_VERSION
         value: latest
       - *6
+      - *7
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview3 for psych-4
+    - name: Ruby 3.2.0-rc1 for psych-4
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview3
+        value: 3.2.0-rc1
       - name: GEMSET
         value: psych-4
       - name: BUNDLE_GEMFILE
@@ -2108,16 +2117,17 @@ blocks:
       - name: _BUNDLER_VERSION
         value: latest
       - *6
+      - *7
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview3 for que
+    - name: Ruby 3.2.0-rc1 for que
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview3
+        value: 3.2.0-rc1
       - name: GEMSET
         value: que
       - name: BUNDLE_GEMFILE
@@ -2127,16 +2137,17 @@ blocks:
       - name: _BUNDLER_VERSION
         value: latest
       - *6
+      - *7
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview3 for que_beta
+    - name: Ruby 3.2.0-rc1 for que_beta
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview3
+        value: 3.2.0-rc1
       - name: GEMSET
         value: que_beta
       - name: BUNDLE_GEMFILE
@@ -2146,16 +2157,17 @@ blocks:
       - name: _BUNDLER_VERSION
         value: latest
       - *6
+      - *7
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview3 for rails-6.1
+    - name: Ruby 3.2.0-rc1 for rails-6.1
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview3
+        value: 3.2.0-rc1
       - name: GEMSET
         value: rails-6.1
       - name: BUNDLE_GEMFILE
@@ -2165,16 +2177,17 @@ blocks:
       - name: _BUNDLER_VERSION
         value: latest
       - *6
+      - *7
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview3 for rails-7.0
+    - name: Ruby 3.2.0-rc1 for rails-7.0
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview3
+        value: 3.2.0-rc1
       - name: GEMSET
         value: rails-7.0
       - name: BUNDLE_GEMFILE
@@ -2184,16 +2197,17 @@ blocks:
       - name: _BUNDLER_VERSION
         value: latest
       - *6
+      - *7
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview3 for resque-2
+    - name: Ruby 3.2.0-rc1 for resque-2
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview3
+        value: 3.2.0-rc1
       - name: GEMSET
         value: resque-2
       - name: BUNDLE_GEMFILE
@@ -2203,16 +2217,17 @@ blocks:
       - name: _BUNDLER_VERSION
         value: latest
       - *6
+      - *7
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview3 for sequel
+    - name: Ruby 3.2.0-rc1 for sequel
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview3
+        value: 3.2.0-rc1
       - name: GEMSET
         value: sequel
       - name: BUNDLE_GEMFILE
@@ -2222,16 +2237,17 @@ blocks:
       - name: _BUNDLER_VERSION
         value: latest
       - *6
+      - *7
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview3 for sinatra
+    - name: Ruby 3.2.0-rc1 for sinatra
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview3
+        value: 3.2.0-rc1
       - name: GEMSET
         value: sinatra
       - name: BUNDLE_GEMFILE
@@ -2241,16 +2257,17 @@ blocks:
       - name: _BUNDLER_VERSION
         value: latest
       - *6
+      - *7
       commands:
       - "./support/bundler_wrapper exec rake test"
-    - name: Ruby 3.2.0-preview3 for webmachine
+    - name: Ruby 3.2.0-rc1 for webmachine
       env_vars:
       - *2
       - *3
       - *4
       - *5
       - name: RUBY_VERSION
-        value: 3.2.0-preview3
+        value: 3.2.0-rc1
       - name: GEMSET
         value: webmachine
       - name: BUNDLE_GEMFILE
@@ -2260,6 +2277,7 @@ blocks:
       - name: _BUNDLER_VERSION
         value: latest
       - *6
+      - *7
       commands:
       - "./support/bundler_wrapper exec rake test"
 - name: Ruby jruby-9.3.9.0

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -205,10 +205,12 @@ matrix:
     - ruby: "2.7.7"
     - ruby: "3.0.4"
     - ruby: "3.1.2"
-    - ruby: "3.2.0-preview3"
+    - ruby: "3.2.0-rc1"
       env_vars:
         - name: "_LIBYAML"
           value: "1"
+        - name: "RUBY_CFLAGS"
+          value: "-std=gnu99"
     - ruby: "jruby-9.3.9.0"
       gems: "minimal"
     - ruby: "jruby-9.4.0.0"
@@ -225,13 +227,13 @@ matrix:
         ruby:
           - "3.0.4"
           - "3.1.2"
-          - "3.2.0-preview3"
+          - "3.2.0-rc1"
     - gem: "psych-4"
       only:
         ruby:
           - "3.0.4"
           - "3.1.2"
-          - "3.2.0-preview3"
+          - "3.2.0-rc1"
     - gem: "que"
     - gem: "que_beta"
     - gem: "rails-3.2"
@@ -304,7 +306,7 @@ matrix:
           - "2.7.7"
           - "3.0.4"
           - "3.1.2"
-          - "3.2.0-preview3"
+          - "3.2.0-rc1"
           - "jruby-9.4.0.0"
     - gem: "rails-7.0"
       only:
@@ -312,7 +314,7 @@ matrix:
           - "2.7.7"
           - "3.0.4"
           - "3.1.2"
-          - "3.2.0-preview3"
+          - "3.2.0-rc1"
           - "jruby-9.4.0.0"
     - gem: "resque-1"
       bundler: "1.17.3"


### PR DESCRIPTION
Update Ruby 3.2 prerelease to test if the Ruby gem still works on it.

To make the installation of Ruby 3.2.0-rc1 work on Semaphore I had to configure RUBY_CFLAGS to "-std=gnu99".

This was mentioned in the bug report for the installation issue: https://bugs.ruby-lang.org/issues/19161

> From here, I found a simple workaround: ./configure
> cflags="-std=gnu99". Just FYI.

We can probably remove this for the final release, but this way we'll be able to test against the latest release candidate now.

[skip review]
[skip changeset]

Reapply of https://github.com/appsignal/appsignal-ruby/pull/900