### PR TITLE
Surppot Ruby 3.2 and RubyGems 3.4

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -349,9 +349,9 @@ blocks:
       - name: BUNDLE_GEMFILE
         value: gemfiles/no_dependencies.gemfile
       - name: _RUBYGEMS_VERSION
-        value: latest
+        value: 3.3.26
       - name: _BUNDLER_VERSION
-        value: latest
+        value: 2.3.26
       commands:
       - "./support/bundler_wrapper exec rake test"
       - "./support/bundler_wrapper exec rake test:failure"

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -197,6 +197,8 @@ matrix:
       gems: "none"
     - ruby: "2.3.8"
       gems: "none"
+      rubygems: "3.3.26"
+      bundler: "2.3.26"
     - ruby: "2.4.10"
       gems: "none"
     - ruby: "2.5.8"

--- a/lib/appsignal/extension/jruby.rb
+++ b/lib/appsignal/extension/jruby.rb
@@ -50,7 +50,12 @@ module Appsignal
       end
 
       begin
-        ffi_lib File.join(File.dirname(__FILE__), "../../../ext/libappsignal.#{lib_extension}")
+        begin
+          # RubyGems will install the extension in the gem's lib directory.
+          ffi_lib File.join(File.dirname(__FILE__), "../../../lib/libappsignal.#{lib_extension}")
+        rescue LoadError
+          ffi_lib File.join(File.dirname(__FILE__), "../../../ext/libappsignal.#{lib_extension}")
+        end
         typedef AppsignalString.by_value, :appsignal_string
 
         attach_function :appsignal_start, [], :void


### PR DESCRIPTION
👋 RubyGems 3.4 will clean-up the intermediate files for C extension. So, files under the `ext` folder will removed after installation.

So, We should call C extension from under the `lib` directory, not `ext` directory.

I fixed it.