### PR TITLE
Add Hanami 2 integration

### DIFF
--- a/.changesets/add-hanami-2-support.md
+++ b/.changesets/add-hanami-2-support.md
@@ -1,0 +1,6 @@
+---
+bump: "minor"
+type: "add"
+---
+
+Hanami 2 is now supported. Requests will now appear as performance measurements.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -88,6 +88,7 @@ Style/Alias:
 Style/ClassAndModuleChildren:
   Exclude:
     - 'lib/appsignal/integrations/padrino.rb'
+    - 'lib/appsignal/integrations/hanami.rb'
 
 # Offense count: 1
 Style/DoubleNegation:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1368,6 +1368,24 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+    - name: Ruby 3.0.4 for hanami
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.0.4
+      - name: GEMSET
+        value: hanami
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/hanami.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
     - name: Ruby 3.0.4 for http5
       env_vars:
       - *2
@@ -1707,6 +1725,24 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+    - name: Ruby 3.1.2 for hanami
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.1.2
+      - name: GEMSET
+        value: hanami
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/hanami.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
     - name: Ruby 3.1.2 for http5
       env_vars:
       - *2
@@ -2032,6 +2068,26 @@ blocks:
         value: grape
       - name: BUNDLE_GEMFILE
         value: gemfiles/grape.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      - *6
+      - *7
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+    - name: Ruby 3.2.0-rc1 for hanami
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.0-rc1
+      - name: GEMSET
+        value: hanami
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/hanami.gemfile
       - name: _RUBYGEMS_VERSION
         value: latest
       - name: _BUNDLER_VERSION

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ configurations you need to run the spec suite with a specific Gemfile.
 BUNDLE_GEMFILE=gemfiles/capistrano2.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/capistrano3.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/grape.gemfile bundle exec rspec
+BUNDLE_GEMFILE=gemfiles/hanami.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/http5.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/no_dependencies.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/padrino.gemfile bundle exec rspec

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -220,6 +220,12 @@ matrix:
     - gem: "capistrano2"
     - gem: "capistrano3"
     - gem: "grape"
+    - gem: "hanami"
+      only:
+        ruby:
+          - "3.0.4"
+          - "3.1.2"
+          - "3.2.0-rc1"
     - gem: "http5"
     - gem: "padrino"
     - gem: "psych-3"

--- a/gemfiles/hanami.gemfile
+++ b/gemfiles/hanami.gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem "hanami", "~> 2.0.0"
+gem "hanami-router", "~> 2.0.0"
+gem "hanami-controller", "~> 2.0.0"
+
+gemspec :path => '../'

--- a/lib/appsignal/cli/install.rb
+++ b/lib/appsignal/cli/install.rb
@@ -61,6 +61,8 @@ module Appsignal
             install_for_padrino(config)
           elsif installed_frameworks.include?(:grape)
             install_for_grape(config)
+          elsif installed_frameworks.include?(:hanami)
+            install_for_hanami(config)
           elsif installed_frameworks.include?(:sinatra)
             install_for_sinatra(config)
           else
@@ -162,6 +164,24 @@ module Appsignal
           done_notice
         end
 
+        def install_for_hanami(config)
+          puts "Installing for Hanami"
+          config[:name] = required_input("  Enter application name: ")
+          puts
+          configure(config, %w[development production staging], true)
+
+          puts "Finish Hanami installation"
+          puts "  Hanami requires some manual configuration."
+          puts "  After installing the gem, add the following line to config.ru:"
+          puts
+          puts "  require 'appsignal/integrations/hanami'"
+          puts
+          puts "  You can find more information in the documentation:"
+          puts "  http://docs.appsignal.com/ruby/integrations/hanami.html"
+          press_any_key
+          done_notice
+        end
+
         def install_for_capistrano
           capfile = File.join(Dir.pwd, "Capfile")
           return unless File.exist?(capfile)
@@ -256,6 +276,7 @@ module Appsignal
             out << :sinatra if framework_available? "sinatra"
             out << :padrino if framework_available? "padrino"
             out << :grape if framework_available? "grape"
+            out << :hanami if framework_available? "hanami"
           end
         end
 

--- a/lib/appsignal/integrations/hanami.rb
+++ b/lib/appsignal/integrations/hanami.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "appsignal"
+
+module Appsignal
+  module Integrations
+    module HanamiPlugin
+      def self.init
+        Appsignal.logger.debug("Loading Hanami integration")
+
+        hanami_app_config = ::Hanami.app.config
+        Appsignal.config = Appsignal::Config.new(
+          hanami_app_config.root || Dir.pwd,
+          hanami_app_config.env
+        )
+
+        Appsignal.start_logger
+        Appsignal.start
+
+        ::Hanami::Action.send(:prepend, Appsignal::Integrations::HanamiIntegration) if Appsignal.active?
+      end
+    end
+  end
+end
+
+module Appsignal::Integrations::HanamiIntegration
+  def call(env)
+    params = ::Hanami::Action::BaseParams.new(env)
+    request = ::Hanami::Action::Request.new(
+      :env => env,
+      :params => params,
+      :sessions_enabled => true
+    )
+
+    transaction = Appsignal::Transaction.create(
+      SecureRandom.uuid,
+      Appsignal::Transaction::HTTP_REQUEST,
+      request
+    )
+
+    begin
+      Appsignal.instrument("process_action.hanami") do
+        super
+      end
+    rescue Exception => error # rubocop:disable Lint/RescueException
+      transaction.set_error(error)
+      raise error
+    ensure
+      transaction.params = request.params.to_h
+      transaction.set_action_if_nil(self.class.name)
+      transaction.set_metadata("path", request.path)
+      transaction.set_metadata("method", request.request_method)
+      transaction.set_http_or_background_queue_start
+      Appsignal::Transaction.complete_current!
+    end
+  end
+end
+
+Appsignal::Integrations::HanamiPlugin.init

--- a/spec/lib/appsignal/cli/install_spec.rb
+++ b/spec/lib/appsignal/cli/install_spec.rb
@@ -660,7 +660,73 @@ describe Appsignal::CLI::Install do
     end
   end
 
-  if !rails_present? && !sinatra_present? && !padrino_present? && !grape_present?
+  if hanami2_present?
+    context "with hanami" do
+      it_behaves_like "push_api_key validation"
+      it_behaves_like "requires an application name"
+
+      describe "hanami specific tests" do
+        let(:installation_instructions) do
+          [
+            "Installing for Hanami",
+            "Hanami requires some manual configuration.",
+            "http://docs.appsignal.com/ruby/integrations/hanami.html"
+          ]
+        end
+        let(:app_name) { "Test app" }
+        before { enter_app_name app_name }
+
+        describe "configuration with environment variables" do
+          before { choose_environment_config }
+
+          it_behaves_like "windows installation"
+          it_behaves_like "capistrano install"
+          it_behaves_like "demo data"
+
+          it "prints environment variables" do
+            run
+
+            expect(output).to include_env_push_api_key(push_api_key)
+            expect(output).to include_env_app_name(app_name)
+          end
+
+          it "completes the installation" do
+            run
+
+            expect(output).to include(*installation_instructions)
+            expect(output).to include_complete_install
+          end
+        end
+
+        describe "configure with a configuration file" do
+          before { choose_config_file }
+
+          it_behaves_like "windows installation"
+          it_behaves_like "capistrano install"
+          it_behaves_like "demo data"
+
+          it "writes configuration to file" do
+            run
+            expect(output).to include_file_config
+            expect(config_file).to configure_app_name(app_name)
+            expect(config_file).to configure_push_api_key(push_api_key)
+            expect(config_file).to configure_environment("development")
+            expect(config_file).to configure_environment("staging")
+            expect(config_file).to configure_environment("production")
+          end
+
+          it "completes the installation" do
+            run
+
+            expect(output).to include(*installation_instructions)
+            expect(output).to include_complete_install
+          end
+        end
+      end
+    end
+  end
+
+  if !rails_present? && !sinatra_present? && !padrino_present? && !grape_present? && !hanami2_present?
     context "with unknown framework" do
       let(:push_api_key) { "my_key" }
 

--- a/spec/lib/appsignal/integrations/hanami_spec.rb
+++ b/spec/lib/appsignal/integrations/hanami_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+if DependencyHelper.hanami2_present?
+  describe "Hanami integration" do
+    require "appsignal/integrations/hanami"
+
+    before do
+      allow(Appsignal).to receive(:active?).and_return(true)
+      allow(Appsignal).to receive(:start).and_return(true)
+      allow(Appsignal).to receive(:start_logger).and_return(true)
+    end
+
+    describe Appsignal::Integrations::HanamiPlugin do
+      it "starts AppSignal on init" do
+        expect(Appsignal).to receive(:start)
+      end
+
+      it "starts the logger on init" do
+        expect(Appsignal).to receive(:start_logger)
+      end
+
+      it "prepends the integration to Hanami" do
+        expect(::Hanami::Action).to receive(:send).with(:prepend, Appsignal::Integrations::HanamiIntegration)
+      end
+
+      context "when not active" do
+        before { allow(Appsignal).to receive(:active?).and_return(false) }
+
+        it "does not prepend the integration" do
+          expect(::Hanami::Action).to_not receive(:send).with(:prepend, Appsignal::Integrations::HanamiIntegration)
+        end
+      end
+
+      context "when APPSIGNAL_APP_ENV ENV var is provided" do
+        it "uses this as the environment" do
+          ENV["APPSIGNAL_APP_ENV"] = "custom"
+
+          # Reset the plugin to pull down the latest data
+          Appsignal::Integrations::HanamiPlugin.init
+
+          expect(Appsignal.config.env).to eq("custom")
+        end
+      end
+
+      context "when APPSIGNAL_APP_ENV ENV var is not provided" do
+        it "uses the Hanami environment" do
+          # Reset the plugin to pull down the latest data
+          Appsignal::Integrations::HanamiPlugin.init
+
+          expect(Appsignal.config.env).to eq("test")
+        end
+      end
+
+      after { Appsignal::Integrations::HanamiPlugin.init }
+    end
+
+    describe "Hanami Actions" do
+      let(:env) do
+        Rack::MockRequest.env_for(
+          "/books",
+          "router.params" => router_params,
+          :method => "GET"
+        )
+      end
+
+      let(:router_params) { { :foo => "bar", :baz => "qux" } }
+
+      describe "#call", :error => false do
+        it "sets params" do
+          expect_any_instance_of(Appsignal::Transaction).to receive(:params=).with(router_params)
+        end
+
+        it "sets the action name" do
+          expect_any_instance_of(Appsignal::Transaction).to receive(:set_action_if_nil).with("HanamiApp::Actions::Books::Index")
+        end
+
+        it "sets the metadata" do
+          expect_any_instance_of(Appsignal::Transaction).to receive(:set_metadata).twice
+        end
+
+        it "sets the queue start" do
+          expect_any_instance_of(Appsignal::Transaction).to receive(:set_http_or_background_queue_start)
+        end
+
+        context "with error", :error => true do
+          let(:error) { HanamiApp::ExampleError }
+
+          it "records the exception" do
+            expect_any_instance_of(Appsignal::Transaction).to receive(:set_error).with(error)
+          end
+        end
+
+        after(:error => false) do
+          Appsignal::Integrations::HanamiPlugin.init
+
+          action = HanamiApp::Actions::Books::Index.new
+          action.call(env)
+        end
+
+        after(:error => true) do
+          Appsignal::Integrations::HanamiPlugin.init
+
+          action = HanamiApp::Actions::Books::Error.new
+          expect { action.call(env) }.to raise_error(error)
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,11 @@ if DependencyHelper.rails_present?
     require f
   end
 end
+if DependencyHelper.hanami2_present?
+  Dir[File.join(DirectoryHelper.support_dir, "hanami", "*.rb")].each do |f|
+    require f
+  end
+end
 require "pry" if DependencyHelper.dependency_present?("pry")
 require "appsignal"
 # Include patches of AppSignal modules and classes to make test helpers

--- a/spec/support/hanami/hanami_app.rb
+++ b/spec/support/hanami/hanami_app.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "hanami"
+require "hanami/action"
+
+module HanamiApp
+  class App < Hanami::App
+  end
+
+  class Routes < Hanami::Routes
+    get "/books", :to => "books.index"
+  end
+
+  module Actions
+    module Books
+      class Index < Hanami::Action
+        def handle(_request, response)
+          response.body = "YOU REQUESTED BOOKS!"
+        end
+      end
+
+      class Error < Hanami::Action
+        def handle(_request, _response)
+          raise ExampleError
+        end
+      end
+    end
+  end
+
+  class ExampleError < StandardError; end
+end

--- a/spec/support/helpers/dependency_helper.rb
+++ b/spec/support/helpers/dependency_helper.rb
@@ -9,6 +9,10 @@ module DependencyHelper
     ruby_version.segments.take(2) == [2, 0]
   end
 
+  def ruby_3_0_or_newer?
+    ruby_version >= Gem::Version.new("3.0.0")
+  end
+
   def ruby_3_1_or_newer?
     ruby_version >= Gem::Version.new("3.1.0")
   end
@@ -113,6 +117,14 @@ module DependencyHelper
 
   def que_present?
     dependency_present? "que"
+  end
+
+  def hanami_present?
+    dependency_present? "hanami"
+  end
+
+  def hanami2_present?
+    ruby_3_0_or_newer? && hanami_present? && Gem.loaded_specs["hanami"].version >= Gem::Version.new("2.0")
   end
 
   def dependency_present?(dependency_file)


### PR DESCRIPTION
Hanami 2 is now supported.
To load it, require the instrumentation
file after booting the Hanami 2 application.

Instead of instrumenting Rack requests, instrument calls to the `call` method in `Hanami::Action` (which receives a Rack request as an argument) so that we can use the action's class name as the action name.

---