### PR TITLE
Fix gem proxy config on Ruby <3.2 with psych 5

### DIFF
--- a/.changesets/skip--gemrc-config-during-installation-if-it-raises-an-error-loading-it.md
+++ b/.changesets/skip--gemrc-config-during-installation-if-it-raises-an-error-loading-it.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Skip the `.gemrc` config during installation if it raises an error loading it. This can be caused when the psych gem version 5 is installed on Ruby < 3.2. Use the `HTTP_PROXY` environment variable instead to configure the HTTP proxy that should be used during installation.

--- a/ext/base.rb
+++ b/ext/base.rb
@@ -34,8 +34,7 @@ def report
           "version" => "#{rbconfig["RUBY_PROGRAM_VERSION"]}-p#{rbconfig["PATCHLEVEL"]}"
         },
         "download" => {
-          "checksum" => "unverified",
-          "http_proxy" => http_proxy
+          "checksum" => "unverified"
         },
         "build" => {
           "time" => Time.now.utc,
@@ -55,7 +54,11 @@ def report
             d["libc"] = ldd_version if ldd_version
           end
         }
-      }
+      }.tap do |r|
+        proxy, error = http_proxy
+        r["download"]["http_proxy"] = proxy
+        r["download"]["http_proxy_error"] = error if error
+      end
     end
 end
 
@@ -129,10 +132,11 @@ def download_archive(type)
     report["download"]["download_url"] = download_url
 
     begin
+      proxy, _error = http_proxy
       args = [
         download_url,
         :ssl_ca_cert => CA_CERT_PATH,
-        :proxy => http_proxy
+        :proxy => proxy
       ]
       if URI.respond_to?(:open) # rubocop:disable Style/GuardClause
         return URI.open(*args)
@@ -187,14 +191,25 @@ def store_download_version_on_report
 end
 
 def http_proxy
-  proxy = try_http_proxy_value(Gem.configuration[:http_proxy])
-  return proxy if proxy
+  proxy, error =
+    begin
+      [try_http_proxy_value(Gem.configuration[:http_proxy]), nil]
+    rescue => error
+      # Ignore this setting if the `.gemrc` file can't be read. This raises an
+      # error on Rubies with psych 4 in the standard library, but also have
+      # psych 5 installed: Ruby < 3.2.
+      # https://github.com/appsignal/appsignal-ruby/issues/904
+      [nil, error]
+    end
+  return [proxy, error] if proxy
 
   proxy = try_http_proxy_value(ENV["http_proxy"])
-  return proxy if proxy
+  return [proxy, error] if proxy
 
   proxy = try_http_proxy_value(ENV["HTTP_PROXY"])
-  return proxy if proxy
+  return [proxy, error] if proxy
+
+  [nil, error]
 end
 
 def try_http_proxy_value(value)


### PR DESCRIPTION
We got several reports in issue #904 that installing the AppSignal gem on system with Ruby < 3.2 with also the psych gem version 5 installed won't work and raise an error breaking the app installation.

This related PR #913, which is also needed to fix the whole issue. This PR removes the need for YAML parsing during the installation for the extension download information.

This change silences the secondary error that is triggered when we fetch the rubygems config, specified in the `.gemrc` file. This also triggers that error from within rubygems. Instead, users can use the `HTTP_PROXY` environment variable to configure the HTTP proxy.

This is not an ideal fix. We also don't communicate that this behavior is happening with this fix. I suggest we report a bug report upstream as detailed in #904, so we can remove this rescue-statement.