### PR TITLE
Add support for NGINX metrics

### DIFF
--- a/.changesets/add-nginx-metrics-support.md
+++ b/.changesets/add-nginx-metrics-support.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add NGINX metrics support. See [our documentation](https://docs.appsignal.com/metrics/nginx.html) for details.

--- a/ext/agent.rb
+++ b/ext/agent.rb
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 APPSIGNAL_AGENT_CONFIG = {
-  "version" => "43bed91",
+  "version" => "d704afb",
   "mirrors" => [
     "https://appsignal-agent-releases.global.ssl.fastly.net",
     "https://d135dj0rjqvssy.cloudfront.net"
@@ -12,131 +12,131 @@ APPSIGNAL_AGENT_CONFIG = {
   "triples" => {
     "x86_64-darwin" => {
       "static" => {
-        "checksum" => "95faa7b95a6ef363fdd8516311257820dff31113399718f5928a923a06b5a2d1",
+        "checksum" => "56c7cc0e7464f1d8777c0909bba6c4741855af73b8af3a98d494491479575324",
         "filename" => "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "0dab74c5d3cca48202b2a1219314ae89a6505503bb816b18aea77651b1777cb3",
+        "checksum" => "497869968b96eb8daaacad98db1c133a5e3a8e1b32306badad6f633ba4c76ad5",
         "filename" => "appsignal-x86_64-darwin-all-dynamic.tar.gz"
       }
     },
     "universal-darwin" => {
       "static" => {
-        "checksum" => "95faa7b95a6ef363fdd8516311257820dff31113399718f5928a923a06b5a2d1",
+        "checksum" => "56c7cc0e7464f1d8777c0909bba6c4741855af73b8af3a98d494491479575324",
         "filename" => "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "0dab74c5d3cca48202b2a1219314ae89a6505503bb816b18aea77651b1777cb3",
+        "checksum" => "497869968b96eb8daaacad98db1c133a5e3a8e1b32306badad6f633ba4c76ad5",
         "filename" => "appsignal-x86_64-darwin-all-dynamic.tar.gz"
       }
     },
     "aarch64-darwin" => {
       "static" => {
-        "checksum" => "fd4dbb5b65051df1fd844af94f774531813f637463e06adb66db6a4401c98b8e",
+        "checksum" => "b9ece4e56246971015eb75ca41308325277c35c20173163bc2a6319147f3fcda",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "96b5e69b9672351df6a007d137c94e7d97a1516aaa38307971311043d302960f",
+        "checksum" => "122bf59545f245c742e62533b746ea2bb857c47e4a2f7cc44cbda2f99752e6fb",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "arm64-darwin" => {
       "static" => {
-        "checksum" => "fd4dbb5b65051df1fd844af94f774531813f637463e06adb66db6a4401c98b8e",
+        "checksum" => "b9ece4e56246971015eb75ca41308325277c35c20173163bc2a6319147f3fcda",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "96b5e69b9672351df6a007d137c94e7d97a1516aaa38307971311043d302960f",
+        "checksum" => "122bf59545f245c742e62533b746ea2bb857c47e4a2f7cc44cbda2f99752e6fb",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "arm-darwin" => {
       "static" => {
-        "checksum" => "fd4dbb5b65051df1fd844af94f774531813f637463e06adb66db6a4401c98b8e",
+        "checksum" => "b9ece4e56246971015eb75ca41308325277c35c20173163bc2a6319147f3fcda",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "96b5e69b9672351df6a007d137c94e7d97a1516aaa38307971311043d302960f",
+        "checksum" => "122bf59545f245c742e62533b746ea2bb857c47e4a2f7cc44cbda2f99752e6fb",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "aarch64-linux" => {
       "static" => {
-        "checksum" => "5466de9e04c99e99ef83ca67443b2a83fd53212ab80b8570788cbd9c3b69ec3c",
+        "checksum" => "abfbffbf285172d6b4677ac3cbaa94880dbaaee2be6d28326b67cd3c5cb9636e",
         "filename" => "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "2cc773e5cfb936703c0a7a6892d0f4b70a465a116b3fee714e42e57ce2f74d4b",
+        "checksum" => "7d1f346dc93faa9206c895b13b92521531c3a0869e2ee1d7b172c6b2b8996033",
         "filename" => "appsignal-aarch64-linux-all-dynamic.tar.gz"
       }
     },
     "i686-linux" => {
       "static" => {
-        "checksum" => "148a6aceb64a90f2345a7ec7ab00f6b8b3664e39301c0273751e3b36930a8b6a",
+        "checksum" => "78e0a51e8dc38aeb12791ce597a579aa1eba3060196569614309cc7597c62b03",
         "filename" => "appsignal-i686-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "43030f356388069c66170673c80cfda6e1c78154ddcab80db4033e3d0223de97",
+        "checksum" => "a5ac931e83af0c665ed518f15e18531ada434cdee64b0fb2171f37b077d9f231",
         "filename" => "appsignal-i686-linux-all-dynamic.tar.gz"
       }
     },
     "x86-linux" => {
       "static" => {
-        "checksum" => "148a6aceb64a90f2345a7ec7ab00f6b8b3664e39301c0273751e3b36930a8b6a",
+        "checksum" => "78e0a51e8dc38aeb12791ce597a579aa1eba3060196569614309cc7597c62b03",
         "filename" => "appsignal-i686-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "43030f356388069c66170673c80cfda6e1c78154ddcab80db4033e3d0223de97",
+        "checksum" => "a5ac931e83af0c665ed518f15e18531ada434cdee64b0fb2171f37b077d9f231",
         "filename" => "appsignal-i686-linux-all-dynamic.tar.gz"
       }
     },
     "x86_64-linux" => {
       "static" => {
-        "checksum" => "58fc79f612a4e3ce8da470a2170b62e53473e13e440a6e71c34720ad7daec8de",
+        "checksum" => "579410e3e41f12dfe367ff6c5e64751ed9b53699ce934f5f02e26f2119e45ef4",
         "filename" => "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "7958056e3a4b91667e729437846e3d99ded2d30b3d897ae09e42f128b6f7d6da",
+        "checksum" => "4c8aadccfad8fc7cc8ce92a71e21a7f0231b75310edb9982a96436b5bd3988f0",
         "filename" => "appsignal-x86_64-linux-all-dynamic.tar.gz"
       }
     },
     "x86_64-linux-musl" => {
       "static" => {
-        "checksum" => "138e86065dc5d61b3172e55b1ae8716936e1145225ab43bf1729172833e72c5a",
+        "checksum" => "d8994feae00a5b83736b98f96e4343aed6b5943b71da5d05a5a19edc24d8d485",
         "filename" => "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "3d5186095108140fad391c6dc968eb5073a49d71d5a92690bcdb9e596e0028d0",
+        "checksum" => "091274017017661b08aaf29bc28f8f2b4e64465b348eef83e328a427983ec2ad",
         "filename" => "appsignal-x86_64-linux-musl-all-dynamic.tar.gz"
       }
     },
     "aarch64-linux-musl" => {
       "static" => {
-        "checksum" => "6c04631683e0fa43489d04a96c7f9cec3dda0f26c182f295ac0670854fbf6233",
+        "checksum" => "931ed7052cede5efe9cd0b4cbd4ce28ba29dc82dde8a37722d72af9a867037b7",
         "filename" => "appsignal-aarch64-linux-musl-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "eee3219c446df2765dbc3600c239e5464666b367ce6b615a2b1161880463d16a",
+        "checksum" => "1dc487f3265a89a9045b2040b5c3602084efca3ce40a9481bb1a6e8e1be3b752",
         "filename" => "appsignal-aarch64-linux-musl-all-dynamic.tar.gz"
       }
     },
     "x86_64-freebsd" => {
       "static" => {
-        "checksum" => "fba005d0ca866d3436d3dfa01bfd45f672070e89be1d5b9826967bad151783e9",
+        "checksum" => "8b5aaddfa3e01bd0301d975a1f2ab5525c265267f96159b7fac32686d7d8ec2b",
         "filename" => "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "d1943ea065cee593110e880677ded0d9bdb5fc735f035a9f537692ef4ce68bca",
+        "checksum" => "f879214fa180b0ec6c227074f6ec43eaa94b8f27c6c04b9187f5aa959fe15a2d",
         "filename" => "appsignal-x86_64-freebsd-all-dynamic.tar.gz"
       }
     },
     "amd64-freebsd" => {
       "static" => {
-        "checksum" => "fba005d0ca866d3436d3dfa01bfd45f672070e89be1d5b9826967bad151783e9",
+        "checksum" => "8b5aaddfa3e01bd0301d975a1f2ab5525c265267f96159b7fac32686d7d8ec2b",
         "filename" => "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "d1943ea065cee593110e880677ded0d9bdb5fc735f035a9f537692ef4ce68bca",
+        "checksum" => "f879214fa180b0ec6c227074f6ec43eaa94b8f27c6c04b9187f5aa959fe15a2d",
         "filename" => "appsignal-x86_64-freebsd-all-dynamic.tar.gz"
       }
     }

--- a/ext/agent.rb
+++ b/ext/agent.rb
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 APPSIGNAL_AGENT_CONFIG = {
-  "version" => "c0e80b9",
+  "version" => "debb8cf",
   "mirrors" => [
     "https://appsignal-agent-releases.global.ssl.fastly.net",
     "https://d135dj0rjqvssy.cloudfront.net"
@@ -12,131 +12,131 @@ APPSIGNAL_AGENT_CONFIG = {
   "triples" => {
     "x86_64-darwin" => {
       "static" => {
-        "checksum" => "c0e1fc966eff49dd942ed07b44f5c5db6be41676f4e35530c300bac8f99e03c4",
+        "checksum" => "7597130ddfeac866b4eea69348d446603b19b25c9ebd0714a3c39546d0cb6bc3",
         "filename" => "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "38805c50262c9dbc5c4e7479d274b5e41d6df6e86e6c09d76b9f3f471dcf8787",
+        "checksum" => "4cef843a905b7d9b2c0f5ed0a3debf7351dfadf1a4afda3344719d5bbbb73163",
         "filename" => "appsignal-x86_64-darwin-all-dynamic.tar.gz"
       }
     },
     "universal-darwin" => {
       "static" => {
-        "checksum" => "c0e1fc966eff49dd942ed07b44f5c5db6be41676f4e35530c300bac8f99e03c4",
+        "checksum" => "7597130ddfeac866b4eea69348d446603b19b25c9ebd0714a3c39546d0cb6bc3",
         "filename" => "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "38805c50262c9dbc5c4e7479d274b5e41d6df6e86e6c09d76b9f3f471dcf8787",
+        "checksum" => "4cef843a905b7d9b2c0f5ed0a3debf7351dfadf1a4afda3344719d5bbbb73163",
         "filename" => "appsignal-x86_64-darwin-all-dynamic.tar.gz"
       }
     },
     "aarch64-darwin" => {
       "static" => {
-        "checksum" => "37fcdf17250ce9e2149f28a8492074f5957691636ab542c7073b323a1b9dbdd8",
+        "checksum" => "e4b4f0f3d75b576411f5fa16e1257bde2e21efcd9cadae3a05d22bbb0e094e09",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "0fe962abf0885888f38d1767b959ea25ea8c4b38813d7a23fbebe2aa62873341",
+        "checksum" => "180b3cd9f868607cc5e1b84df471e17caf2c06c7f904f345462696b8c9c32cac",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "arm64-darwin" => {
       "static" => {
-        "checksum" => "37fcdf17250ce9e2149f28a8492074f5957691636ab542c7073b323a1b9dbdd8",
+        "checksum" => "e4b4f0f3d75b576411f5fa16e1257bde2e21efcd9cadae3a05d22bbb0e094e09",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "0fe962abf0885888f38d1767b959ea25ea8c4b38813d7a23fbebe2aa62873341",
+        "checksum" => "180b3cd9f868607cc5e1b84df471e17caf2c06c7f904f345462696b8c9c32cac",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "arm-darwin" => {
       "static" => {
-        "checksum" => "37fcdf17250ce9e2149f28a8492074f5957691636ab542c7073b323a1b9dbdd8",
+        "checksum" => "e4b4f0f3d75b576411f5fa16e1257bde2e21efcd9cadae3a05d22bbb0e094e09",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "0fe962abf0885888f38d1767b959ea25ea8c4b38813d7a23fbebe2aa62873341",
+        "checksum" => "180b3cd9f868607cc5e1b84df471e17caf2c06c7f904f345462696b8c9c32cac",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "aarch64-linux" => {
       "static" => {
-        "checksum" => "ce9075ee5bc14ea786b734793b6bb6331567398cab6a21f2ceaa9062cfbdb373",
+        "checksum" => "1cfd0b66000d32e10529b61c78c2f96c217a0f1eb40ddb12869c36ba8595f94c",
         "filename" => "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "eb798538e0e32b19de0afba924c3cb8979a5e57433de4b1a12a6aeaf7233929b",
+        "checksum" => "87b37a4d4e2edc1f70c66b48bf40a0c27e7cc05433595a4744e83acd1abe5f52",
         "filename" => "appsignal-aarch64-linux-all-dynamic.tar.gz"
       }
     },
     "i686-linux" => {
       "static" => {
-        "checksum" => "ea3d1a29cf1534293738f2bd27ae29b8addf8dbe34dde77dc4ae150e109e2e4f",
+        "checksum" => "4f90a840931a9c4d0bc0b90b5a20268a0f67e87b1d9cdc4f58f874e8077e96ab",
         "filename" => "appsignal-i686-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "add159ec5bcf1b1a3362c08f9f765230d99c0431c567d845e31c51389792a51c",
+        "checksum" => "88841f6c27b486bd7eb43b72fb226f7bd3e88ff7d5afa6c9c250ffe13f8b20fc",
         "filename" => "appsignal-i686-linux-all-dynamic.tar.gz"
       }
     },
     "x86-linux" => {
       "static" => {
-        "checksum" => "ea3d1a29cf1534293738f2bd27ae29b8addf8dbe34dde77dc4ae150e109e2e4f",
+        "checksum" => "4f90a840931a9c4d0bc0b90b5a20268a0f67e87b1d9cdc4f58f874e8077e96ab",
         "filename" => "appsignal-i686-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "add159ec5bcf1b1a3362c08f9f765230d99c0431c567d845e31c51389792a51c",
+        "checksum" => "88841f6c27b486bd7eb43b72fb226f7bd3e88ff7d5afa6c9c250ffe13f8b20fc",
         "filename" => "appsignal-i686-linux-all-dynamic.tar.gz"
       }
     },
     "x86_64-linux" => {
       "static" => {
-        "checksum" => "adeceb091c4ed277c29eda018ffc61fd064e5c486b2b0a239b26873168a7fdb0",
+        "checksum" => "bbb7e29a20384ecc848291a2637ecb2653a0020a62606c19b631dbe8e04d6089",
         "filename" => "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "121abc5d34db302c130cf49ce1dad032025e6717efd63f5cf04ba0b55b5fc863",
+        "checksum" => "3cd9640f131c406c20955c23e84b91801872e2a4fb6935a015f780b94c9e38b7",
         "filename" => "appsignal-x86_64-linux-all-dynamic.tar.gz"
       }
     },
     "x86_64-linux-musl" => {
       "static" => {
-        "checksum" => "b57aec8c334b1d3646c80d87f20372287e4e2bdbd798c195e0e36ceeb2aac68a",
+        "checksum" => "69b48e0bcacbc1f2bf642800a7d5be2cf5031f2fabe567c39ac0faaa0143d8fb",
         "filename" => "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "67a918b1848f979afe01eb56ce1661fb5b5910d4c7d691fcf0e304203bd7bd7a",
+        "checksum" => "b3ae34ad2dfccff17604a5a821ff5f13c121c1967004cd994ebb7350713d749b",
         "filename" => "appsignal-x86_64-linux-musl-all-dynamic.tar.gz"
       }
     },
     "aarch64-linux-musl" => {
       "static" => {
-        "checksum" => "fc780524942fc7aeaa4cabec64dfc104c82969df7e8b5cd0fa8eae24c1c9b304",
+        "checksum" => "0db801296acce9ff11ca19a14c4a113d30e2f155fcc790af75b80a0013503484",
         "filename" => "appsignal-aarch64-linux-musl-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "92ed33ca9f402f9e822e5777b291f7a062545767ea92dea7eaa94db4f82d8130",
+        "checksum" => "de0acc4c0d91c47ff855394671917566bb910a2989f6543ce9c3a190fc56b12f",
         "filename" => "appsignal-aarch64-linux-musl-all-dynamic.tar.gz"
       }
     },
     "x86_64-freebsd" => {
       "static" => {
-        "checksum" => "574137de415487afe8d2cc29eac3b1fda2c8e1001474b8f25ebee0cbb32fb1ca",
+        "checksum" => "bba6e8f2d5492ef15a5623ee606c91d4db726f917bb2f7e86fe26afc880cafb3",
         "filename" => "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "9dcc3454c14e8a7a0d7250b35864b6f0f205d5c730ca510e7b77628e024a703f",
+        "checksum" => "dbadaa353f29216dc7165156f22301c28e39a4dc089817e2fde7349f7c443e28",
         "filename" => "appsignal-x86_64-freebsd-all-dynamic.tar.gz"
       }
     },
     "amd64-freebsd" => {
       "static" => {
-        "checksum" => "574137de415487afe8d2cc29eac3b1fda2c8e1001474b8f25ebee0cbb32fb1ca",
+        "checksum" => "bba6e8f2d5492ef15a5623ee606c91d4db726f917bb2f7e86fe26afc880cafb3",
         "filename" => "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "9dcc3454c14e8a7a0d7250b35864b6f0f205d5c730ca510e7b77628e024a703f",
+        "checksum" => "dbadaa353f29216dc7165156f22301c28e39a4dc089817e2fde7349f7c443e28",
         "filename" => "appsignal-x86_64-freebsd-all-dynamic.tar.gz"
       }
     }

--- a/ext/agent.rb
+++ b/ext/agent.rb
@@ -4,7 +4,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 APPSIGNAL_AGENT_CONFIG = {
-  "version" => "debb8cf",
+  "version" => "43bed91",
   "mirrors" => [
     "https://appsignal-agent-releases.global.ssl.fastly.net",
     "https://d135dj0rjqvssy.cloudfront.net"
@@ -12,131 +12,131 @@ APPSIGNAL_AGENT_CONFIG = {
   "triples" => {
     "x86_64-darwin" => {
       "static" => {
-        "checksum" => "7597130ddfeac866b4eea69348d446603b19b25c9ebd0714a3c39546d0cb6bc3",
+        "checksum" => "95faa7b95a6ef363fdd8516311257820dff31113399718f5928a923a06b5a2d1",
         "filename" => "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "4cef843a905b7d9b2c0f5ed0a3debf7351dfadf1a4afda3344719d5bbbb73163",
+        "checksum" => "0dab74c5d3cca48202b2a1219314ae89a6505503bb816b18aea77651b1777cb3",
         "filename" => "appsignal-x86_64-darwin-all-dynamic.tar.gz"
       }
     },
     "universal-darwin" => {
       "static" => {
-        "checksum" => "7597130ddfeac866b4eea69348d446603b19b25c9ebd0714a3c39546d0cb6bc3",
+        "checksum" => "95faa7b95a6ef363fdd8516311257820dff31113399718f5928a923a06b5a2d1",
         "filename" => "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "4cef843a905b7d9b2c0f5ed0a3debf7351dfadf1a4afda3344719d5bbbb73163",
+        "checksum" => "0dab74c5d3cca48202b2a1219314ae89a6505503bb816b18aea77651b1777cb3",
         "filename" => "appsignal-x86_64-darwin-all-dynamic.tar.gz"
       }
     },
     "aarch64-darwin" => {
       "static" => {
-        "checksum" => "e4b4f0f3d75b576411f5fa16e1257bde2e21efcd9cadae3a05d22bbb0e094e09",
+        "checksum" => "fd4dbb5b65051df1fd844af94f774531813f637463e06adb66db6a4401c98b8e",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "180b3cd9f868607cc5e1b84df471e17caf2c06c7f904f345462696b8c9c32cac",
+        "checksum" => "96b5e69b9672351df6a007d137c94e7d97a1516aaa38307971311043d302960f",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "arm64-darwin" => {
       "static" => {
-        "checksum" => "e4b4f0f3d75b576411f5fa16e1257bde2e21efcd9cadae3a05d22bbb0e094e09",
+        "checksum" => "fd4dbb5b65051df1fd844af94f774531813f637463e06adb66db6a4401c98b8e",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "180b3cd9f868607cc5e1b84df471e17caf2c06c7f904f345462696b8c9c32cac",
+        "checksum" => "96b5e69b9672351df6a007d137c94e7d97a1516aaa38307971311043d302960f",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "arm-darwin" => {
       "static" => {
-        "checksum" => "e4b4f0f3d75b576411f5fa16e1257bde2e21efcd9cadae3a05d22bbb0e094e09",
+        "checksum" => "fd4dbb5b65051df1fd844af94f774531813f637463e06adb66db6a4401c98b8e",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "180b3cd9f868607cc5e1b84df471e17caf2c06c7f904f345462696b8c9c32cac",
+        "checksum" => "96b5e69b9672351df6a007d137c94e7d97a1516aaa38307971311043d302960f",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "aarch64-linux" => {
       "static" => {
-        "checksum" => "1cfd0b66000d32e10529b61c78c2f96c217a0f1eb40ddb12869c36ba8595f94c",
+        "checksum" => "5466de9e04c99e99ef83ca67443b2a83fd53212ab80b8570788cbd9c3b69ec3c",
         "filename" => "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "87b37a4d4e2edc1f70c66b48bf40a0c27e7cc05433595a4744e83acd1abe5f52",
+        "checksum" => "2cc773e5cfb936703c0a7a6892d0f4b70a465a116b3fee714e42e57ce2f74d4b",
         "filename" => "appsignal-aarch64-linux-all-dynamic.tar.gz"
       }
     },
     "i686-linux" => {
       "static" => {
-        "checksum" => "4f90a840931a9c4d0bc0b90b5a20268a0f67e87b1d9cdc4f58f874e8077e96ab",
+        "checksum" => "148a6aceb64a90f2345a7ec7ab00f6b8b3664e39301c0273751e3b36930a8b6a",
         "filename" => "appsignal-i686-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "88841f6c27b486bd7eb43b72fb226f7bd3e88ff7d5afa6c9c250ffe13f8b20fc",
+        "checksum" => "43030f356388069c66170673c80cfda6e1c78154ddcab80db4033e3d0223de97",
         "filename" => "appsignal-i686-linux-all-dynamic.tar.gz"
       }
     },
     "x86-linux" => {
       "static" => {
-        "checksum" => "4f90a840931a9c4d0bc0b90b5a20268a0f67e87b1d9cdc4f58f874e8077e96ab",
+        "checksum" => "148a6aceb64a90f2345a7ec7ab00f6b8b3664e39301c0273751e3b36930a8b6a",
         "filename" => "appsignal-i686-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "88841f6c27b486bd7eb43b72fb226f7bd3e88ff7d5afa6c9c250ffe13f8b20fc",
+        "checksum" => "43030f356388069c66170673c80cfda6e1c78154ddcab80db4033e3d0223de97",
         "filename" => "appsignal-i686-linux-all-dynamic.tar.gz"
       }
     },
     "x86_64-linux" => {
       "static" => {
-        "checksum" => "bbb7e29a20384ecc848291a2637ecb2653a0020a62606c19b631dbe8e04d6089",
+        "checksum" => "58fc79f612a4e3ce8da470a2170b62e53473e13e440a6e71c34720ad7daec8de",
         "filename" => "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "3cd9640f131c406c20955c23e84b91801872e2a4fb6935a015f780b94c9e38b7",
+        "checksum" => "7958056e3a4b91667e729437846e3d99ded2d30b3d897ae09e42f128b6f7d6da",
         "filename" => "appsignal-x86_64-linux-all-dynamic.tar.gz"
       }
     },
     "x86_64-linux-musl" => {
       "static" => {
-        "checksum" => "69b48e0bcacbc1f2bf642800a7d5be2cf5031f2fabe567c39ac0faaa0143d8fb",
+        "checksum" => "138e86065dc5d61b3172e55b1ae8716936e1145225ab43bf1729172833e72c5a",
         "filename" => "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "b3ae34ad2dfccff17604a5a821ff5f13c121c1967004cd994ebb7350713d749b",
+        "checksum" => "3d5186095108140fad391c6dc968eb5073a49d71d5a92690bcdb9e596e0028d0",
         "filename" => "appsignal-x86_64-linux-musl-all-dynamic.tar.gz"
       }
     },
     "aarch64-linux-musl" => {
       "static" => {
-        "checksum" => "0db801296acce9ff11ca19a14c4a113d30e2f155fcc790af75b80a0013503484",
+        "checksum" => "6c04631683e0fa43489d04a96c7f9cec3dda0f26c182f295ac0670854fbf6233",
         "filename" => "appsignal-aarch64-linux-musl-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "de0acc4c0d91c47ff855394671917566bb910a2989f6543ce9c3a190fc56b12f",
+        "checksum" => "eee3219c446df2765dbc3600c239e5464666b367ce6b615a2b1161880463d16a",
         "filename" => "appsignal-aarch64-linux-musl-all-dynamic.tar.gz"
       }
     },
     "x86_64-freebsd" => {
       "static" => {
-        "checksum" => "bba6e8f2d5492ef15a5623ee606c91d4db726f917bb2f7e86fe26afc880cafb3",
+        "checksum" => "fba005d0ca866d3436d3dfa01bfd45f672070e89be1d5b9826967bad151783e9",
         "filename" => "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "dbadaa353f29216dc7165156f22301c28e39a4dc089817e2fde7349f7c443e28",
+        "checksum" => "d1943ea065cee593110e880677ded0d9bdb5fc735f035a9f537692ef4ce68bca",
         "filename" => "appsignal-x86_64-freebsd-all-dynamic.tar.gz"
       }
     },
     "amd64-freebsd" => {
       "static" => {
-        "checksum" => "bba6e8f2d5492ef15a5623ee606c91d4db726f917bb2f7e86fe26afc880cafb3",
+        "checksum" => "fba005d0ca866d3436d3dfa01bfd45f672070e89be1d5b9826967bad151783e9",
         "filename" => "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "dbadaa353f29216dc7165156f22301c28e39a4dc089817e2fde7349f7c443e28",
+        "checksum" => "d1943ea065cee593110e880677ded0d9bdb5fc735f035a9f537692ef4ce68bca",
         "filename" => "appsignal-x86_64-freebsd-all-dynamic.tar.gz"
       }
     }

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -18,6 +18,7 @@ module Appsignal
       :enable_host_metrics            => true,
       :enable_minutely_probes         => true,
       :enable_statsd                  => true,
+      :enable_nginx_metrics           => false,
       :endpoint                       => "https://push.appsignal.com",
       :files_world_accessible         => true,
       :filter_parameters              => [],
@@ -67,6 +68,7 @@ module Appsignal
       "APPSIGNAL_ENABLE_HOST_METRICS"            => :enable_host_metrics,
       "APPSIGNAL_ENABLE_MINUTELY_PROBES"         => :enable_minutely_probes,
       "APPSIGNAL_ENABLE_STATSD"                  => :enable_statsd,
+      "APPSIGNAL_ENABLE_NGINX_METRICS"           => :enable_nginx_metrics,
       "APPSIGNAL_FILES_WORLD_ACCESSIBLE"         => :files_world_accessible,
       "APPSIGNAL_FILTER_PARAMETERS"              => :filter_parameters,
       "APPSIGNAL_FILTER_SESSION_DATA"            => :filter_session_data,
@@ -120,6 +122,7 @@ module Appsignal
       APPSIGNAL_ENABLE_HOST_METRICS
       APPSIGNAL_ENABLE_MINUTELY_PROBES
       APPSIGNAL_ENABLE_STATSD
+      APPSIGNAL_ENABLE_NGINX_METRICS
       APPSIGNAL_FILES_WORLD_ACCESSIBLE
       APPSIGNAL_INSTRUMENT_HTTP_RB
       APPSIGNAL_INSTRUMENT_NET_HTTP
@@ -313,6 +316,7 @@ module Appsignal
       ENV["_APPSIGNAL_DNS_SERVERS"]                  = config_hash[:dns_servers].join(",")
       ENV["_APPSIGNAL_ENABLE_HOST_METRICS"]          = config_hash[:enable_host_metrics].to_s
       ENV["_APPSIGNAL_ENABLE_STATSD"]                = config_hash[:enable_statsd].to_s
+      ENV["_APPSIGNAL_ENABLE_NGINX_METRICS"]         = config_hash[:enable_nginx_metrics].to_s
       ENV["_APPSIGNAL_ENVIRONMENT"]                  = env
       ENV["_APPSIGNAL_FILES_WORLD_ACCESSIBLE"]       = config_hash[:files_world_accessible].to_s
       ENV["_APPSIGNAL_FILTER_PARAMETERS"]            = config_hash[:filter_parameters].join(",")

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -159,6 +159,7 @@ describe Appsignal::Config do
         :enable_host_metrics            => true,
         :enable_minutely_probes         => true,
         :enable_statsd                  => true,
+        :enable_nginx_metrics           => false,
         :endpoint                       => "https://push.appsignal.com",
         :files_world_accessible         => true,
         :filter_parameters              => [],

--- a/spec/lib/appsignal/span_spec.rb
+++ b/spec/lib/appsignal/span_spec.rb
@@ -47,7 +47,7 @@ describe Appsignal::Span do
       error = root.to_h["error"]
       expect(error["name"]).to eq "RuntimeError"
       expect(error["message"]).to eq "Error"
-      expect(error["backtrace"]).not_to be_empty
+      expect(error["backtrace_json"]).not_to be_empty
     end
   end
 


### PR DESCRIPTION
Add `enable_nginx_metrics` config option. Update the diagnose tests submodule to expect the option.

Update the agent version to support NGINX metrics.