### PR TITLE
Undefine allocation function for C extension class

### DIFF
--- a/.changesets/fix-t_data-warning-on-ruby-3-2.md
+++ b/.changesets/fix-t_data-warning-on-ruby-3-2.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix the T_DATA warning originating from the AppSignal C extension on Ruby 3.2.

--- a/ext/appsignal_extension.c
+++ b/ext/appsignal_extension.c
@@ -845,9 +845,13 @@ static VALUE set_environment_metadata(VALUE self, VALUE key, VALUE value) {
 void Init_appsignal_extension(void) {
   Appsignal = rb_define_module("Appsignal");
   Extension = rb_define_class_under(Appsignal, "Extension", rb_cObject);
+  rb_undef_alloc_func(Extension);
   Transaction = rb_define_class_under(Extension, "Transaction", rb_cObject);
+  rb_undef_alloc_func(Transaction);
   Data = rb_define_class_under(Extension, "Data", rb_cObject);
+  rb_undef_alloc_func(Data);
   Span = rb_define_class_under(Extension, "Span", rb_cObject);
+  rb_undef_alloc_func(Span);
 
   // Starting and stopping
   rb_define_singleton_method(Extension, "start",    start,    0);


### PR DESCRIPTION
Since Ruby 3.2 a new warning is printed when a Ruby class created in a C extension does not specify an allocate function or undefine it.

```
/gem/lib/appsignal/transaction.rb:98: warning: undefining the allocator of T_DATA class Appsignal::Extension::Transaction
/gem/lib/appsignal/utils/data.rb:19: warning: undefining the allocator of T_DATA class Appsignal::Extension::Data
```

From my understanding, we only need to define an allocate function if the class uses a C struct and stores any values on it. Our classes don't do that in C, that's done in our Rust extension.

Closes #909

## Resources

https://bugs.ruby-lang.org/issues/18007
https://github.com/ruby/ruby/blob/6963f8f743b42f9004a0879cd66c550f18987352/doc/extension.rdoc#label-Write+the+C+Code