### PR TITLE
Load RACK_ENV or RAILS_ENV in diagnose report

### DIFF
--- a/.changesets/load-rails_env-in-diagnose-cli.md
+++ b/.changesets/load-rails_env-in-diagnose-cli.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Configure AppSignal with the RACK_ENV or RAILS_ENV environment variable in diagnose CLI, if present. Makes it easier to run the diagnose CLI in production, without having to always specify the environment with the `--environment` CLI option.

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -196,7 +196,7 @@ module Appsignal
 
           Appsignal.config = Appsignal::Config.new(
             current_path,
-            options[:environment],
+            options.fetch(:environment, ENV.fetch("RACK_ENV", ENV.fetch("RAILS_ENV", nil))),
             initial_config
           )
           Appsignal.config.write_to_environment

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -802,6 +802,39 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
             end
           end
 
+          context "when the source is the RACK_ENV env variable", :send_report => :no_cli_option do
+            let(:config) { project_fixture_config("rack_env") }
+            let(:options) { {} }
+            before do
+              ENV["RACK_ENV"] = "rack_env"
+              run
+            end
+            after { ENV.delete("RACK_ENV") }
+
+            it "outputs the RACK_ENV variable value" do
+              expect(output).to include(
+                %(environment: "rack_env" (Loaded from: initial)\n)
+              )
+            end
+          end
+
+          context "when the source is the RAILS_ENV env variable", :send_report => :no_cli_option do
+            let(:config) { project_fixture_config("rails_env") }
+            let(:options) { {} }
+            before do
+              ENV.delete("RACK_ENV")
+              ENV["RAILS_ENV"] = "rails_env"
+              run
+            end
+            after { ENV.delete("RAILS_ENV") }
+
+            it "outputs the RAILS_ENV variable value" do
+              expect(output).to include(
+                %(environment: "rails_env" (Loaded from: initial)\n)
+              )
+            end
+          end
+
           context "when the source is multiple sources" do
             let(:options) { { :environment => "development" } }
             before do

--- a/spec/support/fixtures/projects/valid/config/appsignal.yml
+++ b/spec/support/fixtures/projects/valid/config/appsignal.yml
@@ -52,3 +52,9 @@ old_config_mixed_with_new_config:
     "REQUEST_METHOD", "REQUEST_URI", "SERVER_NAME", "SERVER_PORT",
     "SERVER_PROTOCOL", "HTTP_USER_AGENT"
   ]
+
+rack_env:
+  <<: *defaults
+
+rails_env:
+  <<: *defaults


### PR DESCRIPTION
When the RACK_ENV or RAILS_ENV var is set, use it to configure AppSignal in the diagnose report CLI. Makes it easier to run the diagnose report in a production environment that uses the RACK_ENV or RAILS_ENV var to configure the app env.

RACK_ENV is loaded first, then RAILS_ENV.