### PR TITLE
don't continue if a config file is present and invalid

### DIFF
--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -395,7 +395,7 @@ module Appsignal
         logger.error "Not loading from config file: config for '#{env}' not found"
         nil
       end
-    rescue => e
+    rescue
       message = "\n\nAn error occured while loading the AppSignal config file." \
         "File: #{config_file.inspect}\n\n\n"
       Kernel.warn "appsignal: #{message}"

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -396,13 +396,10 @@ module Appsignal
         nil
       end
     rescue => e
-      message = "An error occured while loading the AppSignal config file." \
-        " Skipping file config.\n" \
-        "File: #{config_file.inspect}\n" \
-        "#{e.class.name}: #{e}"
-      Kernel.warn "appsignal: #{message}"
-      logger.error "#{message}\n#{e.backtrace.join("\n")}"
-      nil
+      message = "\n\nAn error occured while loading the AppSignal config file." \
+        "File: #{config_file.inspect}\n\n\n"
+      Kernel.error "appsignal: #{message}"
+      raise
     end
 
     # Maintain backwards compatibility with deprecated config options.

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -398,7 +398,7 @@ module Appsignal
     rescue => e
       message = "\n\nAn error occured while loading the AppSignal config file." \
         "File: #{config_file.inspect}\n\n\n"
-      Kernel.error "appsignal: #{message}"
+      Kernel.warn "appsignal: #{message}"
       raise
     end
 


### PR DESCRIPTION
An invalid config file caused problems for us in prod and it was difficult to diagnose.

I can't think of a reason why the gem should support the scenario where a file is present and invalid and it just continues on ignoring the file. I'm guessing the vast majority of users would want things to fail loudly in this scenario. But maybe i'm not aware of other scenarios! 😅 

The proposed code in this PR is just made quickly and for discussion - if you're open to this new behavior, give me feedback on how to improve the code, or feel free to close this out and make your own.

Let me know what you think!