### PR TITLE
support "warning" alias for WARN log level

### DIFF
--- a/.changesets/support-warning-log_level.md
+++ b/.changesets/support-warning-log_level.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Support "warning" value for `log_level` config option. This option was documented, but wasn't accepted and fell back on the "info" log level if used. Now it works to configure it to the "warn"/"warning" log level.

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -53,6 +53,7 @@ module Appsignal
     LOG_LEVEL_MAP = {
       "error" => ::Logger::ERROR,
       "warn" => ::Logger::WARN,
+      "warning" => ::Logger::WARN,
       "info" => ::Logger::INFO,
       "debug" => ::Logger::DEBUG,
       "trace" => ::Logger::DEBUG


### PR DESCRIPTION
There are probably people who have "warning" configured but are actually running at "info", and depending on it for alerting, stats, etc, without realizing it, so this might break their instrumentation, so maybe should be in a major version.