### PR TITLE
Fix default Ruby logger formatter usage

### DIFF
--- a/.changesets/fix-default-ruby-logger-formatter-usage.md
+++ b/.changesets/fix-default-ruby-logger-formatter-usage.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fixed an error when using our Logging feature with Ruby's default logger formatter.


### PR DESCRIPTION
The default Ruby logger formatter expects a timestamp as a second argument to format it and include it in the message. We were passing an integer instead to the present formatter, making it fail if the present formatter is the default Ruby one.

This commit substitutes those 0s with `Time.now` calls.

[Intercom conversation](https://app.intercom.com/a/inbox/yzor8gyw/inbox/admin/4356044/conversation/16410700202410?view=List)
[Slack conversation](https://appsignal.slack.com/archives/CNPP953E2/p1680242502648619)