### PR TITLE
Upgrade Rubocop version and fix offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.0
+  TargetRubyVersion: 3.0
   Include:
     - "**/*.cap"
     - "**/Gemfile"
@@ -18,7 +18,7 @@ AllCops:
   UseCache: true
   CacheRootDirectory: ./tmp
 
-Lint/RescueWithoutErrorClass:
+Style/RescueStandardError:
   Enabled: false
 
 Style/Documentation:
@@ -30,7 +30,7 @@ Style/StringLiterals:
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
 
 Layout/MultilineMethodCallIndentation:
@@ -42,16 +42,16 @@ Layout/MultilineOperationIndentation:
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
 
-Layout/AlignHash:
+Layout/HashAlignment:
   EnforcedLastArgumentHashStyle: ignore_implicit
 
-Layout/IndentArray:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
 Style/EmptyMethod:
   EnforcedStyle: expanded
 
-Style/MethodMissing:
+Style/MissingRespondToMissing:
   Exclude:
     - "lib/appsignal/extension.rb"
     - "lib/appsignal/transaction.rb"

--- a/bin/appsignal
+++ b/bin/appsignal
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 $LOAD_PATH << File.expand_path(File.join(File.dirname(__FILE__), "..", "lib"))
 require "appsignal/cli"
@@ -7,7 +8,8 @@ begin
   Appsignal::CLI.run
 rescue => e
   raise e if $DEBUG
-  STDERR.puts e.message
-  STDERR.puts e.backtrace.join("\n")
+
+  warn e.message
+  warn e.backtrace.join("\n")
   exit 1
 end

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -1,4 +1,6 @@
-require File.expand_path("../base.rb", __FILE__)
+# frozen_string_literal: true
+
+require File.expand_path("base.rb", __dir__)
 
 def local_build?
   File.exist?(ext_path("appsignal-agent")) &&
@@ -10,27 +12,26 @@ def local_build?
 end
 
 task :default do
-  begin
-    fail_install_on_purpose_in_test!
+  fail_install_on_purpose_in_test!
 
-    library_type = "dynamic"
-    report["language"]["implementation"] = "jruby"
-    report["build"]["library_type"] = library_type
-    next unless check_architecture
+  library_type = "dynamic"
+  report["language"]["implementation"] = "jruby"
+  report["build"]["library_type"] = library_type
+  next unless check_architecture
 
-    if local_build?
-      report["build"]["source"] = "local"
-    else
-      archive = download_archive(library_type)
-      next unless archive
-      next unless verify_archive(archive, library_type)
-      unarchive(archive)
-    end
-    successful_installation
-  rescue => error
-    fail_installation_with_error(error)
-  ensure
-    create_dummy_makefile unless installation_succeeded?
-    write_report
+  if local_build?
+    report["build"]["source"] = "local"
+  else
+    archive = download_archive(library_type)
+    next unless archive
+    next unless verify_archive(archive, library_type)
+
+    unarchive(archive)
   end
+  successful_installation
+rescue => e
+  fail_installation_with_error(e)
+ensure
+  create_dummy_makefile unless installation_succeeded?
+  write_report
 end

--- a/lib/appsignal/integrations/capistrano/appsignal.cap
+++ b/lib/appsignal/integrations/capistrano/appsignal.cap
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :appsignal do
   task :deploy do
     appsignal_env = fetch(:appsignal_env, fetch(:stage, fetch(:rails_env, fetch(:rack_env, "production"))))
@@ -16,7 +18,7 @@ namespace :appsignal do
       c.validate
     end
 
-    if appsignal_config && appsignal_config.active?
+    if appsignal_config&.active?
       marker_data = {
         :revision => revision,
         :user => user


### PR DESCRIPTION
Now that we've deprecated EoL versions, Rubocop is upgraded and newer offenses addressed.

[skip changeset]