### PR TITLE
Extract Rails instrumentation metadata earlier

### DIFF
--- a/.changesets/set-appsignal-transaction-namespace--action-name-and-some-tags-earlier-.md
+++ b/.changesets/set-appsignal-transaction-namespace--action-name-and-some-tags-earlier-.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Set the AppSignal transaction namespace, action name and some tags, before requests and Active Job jobs are performed. This allows us to check what the namespace, action name and some tags are during the instrumentation itself.

--- a/lib/appsignal/rack/rails_instrumentation.rb
+++ b/lib/appsignal/rack/rails_instrumentation.rb
@@ -28,23 +28,26 @@ module Appsignal
           request,
           :params_method => :filtered_parameters
         )
+
+        controller = env["action_controller.instance"]
+        if controller
+          transaction.set_action_if_nil("#{controller.class}##{controller.action_name}")
+        end
+        transaction.set_http_or_background_queue_start
+        transaction.set_metadata("path", request.path)
+
+        begin
+          transaction.set_metadata("method", request.request_method)
+        rescue => error
+          Appsignal.logger.error("Unable to report HTTP request method: '#{error}'")
+        end
+
         begin
           @app.call(env)
         rescue Exception => error # rubocop:disable Lint/RescueException
           transaction.set_error(error)
           raise error
         ensure
-          controller = env["action_controller.instance"]
-          if controller
-            transaction.set_action_if_nil("#{controller.class}##{controller.action_name}")
-          end
-          transaction.set_http_or_background_queue_start
-          transaction.set_metadata("path", request.path)
-          begin
-            transaction.set_metadata("method", request.request_method)
-          rescue => error
-            Appsignal.logger.error("Unable to report HTTP request method: '#{error}'")
-          end
           Appsignal::Transaction.complete_current!
         end
       end


### PR DESCRIPTION
In issue #779, I'm looking at supporting the Rails error reporter. For this I want to copy the context (transaction namespace, action name and tags) from the current transaction when an error is reported by Rails.

To have the context available to the error handler, it needs to be set on the transaction before the controller action or job is performed. Move those parts of the instrumentation up to above the `super` call, and not within the `ensure` block at the very end.

Otherwise the context is most likely empty and there is nothing to copy.