### PR TITLE
Extract Active Job metadata earlier

### DIFF
--- a/.changesets/set-appsignal-transaction-namespace--action-name-and-some-tags-earlier-.md
+++ b/.changesets/set-appsignal-transaction-namespace--action-name-and-some-tags-earlier-.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Set the AppSignal transaction namespace, action name and some tags, before Active Job jobs are performed. This allows us to check what the namespace, action name and some tags are during the instrumentation itself.


### PR DESCRIPTION
In issue #779, I'm looking at supporting the Rails error reporter. For this I want to copy the context (transaction namespace, action name and tags) from the current transaction when an error is reported by Rails.

This will make determining the namespace and action name for the transaction easier for Active Job jobs, in the error reporter.

To have the context available to the error handler, it needs to be set on the transaction before the Active Job job is performed. I have moved those parts of the instrumentation up to above the `super` call, and not within the `ensure` block at the very end. The job will already know what job is run and with what arguments at the start of the instrumentation.

I can't apply the same improvement for Rails controllers. We only have the necessary request env values to determine this the controller name and action after the request has been processed, which is too late for the error reporter.