### PR TITLE
Fix Railtie specs usage of the Rails app

### DIFF
--- a/spec/lib/appsignal/integrations/railtie_spec.rb
+++ b/spec/lib/appsignal/integrations/railtie_spec.rb
@@ -10,11 +10,7 @@ if DependencyHelper.rails_present?
     end
 
     describe "#initialize_appsignal" do
-      let(:app) { MyApp::Application }
-      before do
-        allow(app.middleware).to receive(:insert_before)
-        allow(app.middleware).to receive(:insert_after)
-      end
+      let(:app) { MyApp::Application.new }
 
       describe ".logger" do
         before  { Appsignal::Integrations::Railtie.initialize_appsignal(app) }
@@ -75,9 +71,8 @@ if DependencyHelper.rails_present?
             ActionDispatch::DebugExceptions,
             Appsignal::Rack::RailsInstrumentation
           )
+          Appsignal::Integrations::Railtie.initialize_appsignal(app)
         end
-
-        after { Appsignal::Integrations::Railtie.initialize_appsignal(app) }
       end
     end
   end


### PR DESCRIPTION
Initialize the Rails app in the Railtie spec. This way we we don't need to stub calls to the middleware object.

When the app isn't initialized the middleware object is a frozen object that can't be modified. In a real app, the `app` variable in the Railtie is also an instance of the app, not the constant.

[skip changeset]