### PR TITLE
Report GVL global timer metrics if disabled

### DIFF
--- a/lib/appsignal/probes/gvl.rb
+++ b/lib/appsignal/probes/gvl.rb
@@ -25,7 +25,7 @@ module Appsignal
       end
 
       def call
-        probe_global_timer if @gvl_tools::GlobalTimer.enabled?
+        probe_global_timer
         probe_waiting_threads if @gvl_tools::WaitingThreads.enabled?
       end
 
@@ -34,8 +34,10 @@ module Appsignal
       def probe_global_timer
         monotonic_time_ns = @gvl_tools::GlobalTimer.monotonic_time
         gauge_delta :gvl_global_timer, monotonic_time_ns do |time_delta_ns|
-          time_delta_ms = time_delta_ns / 1_000_000
-          set_gauge_with_hostname("gvl_global_timer", time_delta_ms)
+          if time_delta_ns > 0
+            time_delta_ms = time_delta_ns / 1_000_000
+            set_gauge_with_hostname("gvl_global_timer", time_delta_ms)
+          end
         end
       end
 

--- a/spec/support/mocks/fake_gvl_tools.rb
+++ b/spec/support/mocks/fake_gvl_tools.rb
@@ -1,32 +1,24 @@
 module FakeGVLTools
   def self.reset
-    self::GlobalTimer.enabled = false
     self::GlobalTimer.monotonic_time = 0
-    self::WaitingThreads.enabled = false
     self::WaitingThreads.count = 0
   end
 
   module GlobalTimer
-    @enabled = false
     @monotonic_time = 0
 
     class << self
-      attr_writer :enabled
       attr_accessor :monotonic_time
-
-      def enabled?
-        @enabled
-      end
     end
   end
 
   module WaitingThreads
-    @enabled = false
     @count = 0
+    @enabled = false
 
     class << self
-      attr_writer :enabled
       attr_accessor :count
+      attr_writer :enabled
 
       def enabled?
         @enabled


### PR DESCRIPTION
We want to document the possibility of enabling and disabling these metrics on demand. This is why the GVL probe is started even when `enable_gvl_global_timer` and `enable_gvl_waiting_threads` are both set to false.

However, this is somewhat undermined by the probe only reporting values when it is enabled. Meaning, if you only enable it for specific contexts that you wish to track (for example, for a specific job or request) and disable it afterwards, the value will only be reported if the GVL metric happens to be enabled when the probe runs.

There is no actual reason to not report the value that is given by the GVL global timer, due to its monotonic nature. When disabled, it will not be incremented, which is fine -- the reported value will be for the intervals during which it was enabled. Because it can be reset, do not report the value if the delta goes negative.

The situation is different for the GVL waiting threads. If it is disabled while threads are waiting, the counter will not decrease for those threads, essentially raising the baseline for the counter. Similarly, if it is reset when a thread stops waiting, the counter can underflow. For now, we won't document disabling the waiting threads metric, report it only if it's enabled, and hope that it's not been messed with.

Relates to https://github.com/appsignal/appsignal-docs/issues/1203.