### PR TITLE
Remove ruby v2 version checks

### DIFF
--- a/.changesets/remove-ruby-2-version-checks.md
+++ b/.changesets/remove-ruby-2-version-checks.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+The Appsignal gem requires Ruby 3 or higher to run. We should be able to remove any Ruby version checks that query Ruby 2.7 or lower.

--- a/lib/appsignal/cli/helpers.rb
+++ b/lib/appsignal/cli/helpers.rb
@@ -16,10 +16,6 @@ module Appsignal
         :default => 0
       }.freeze
 
-      def ruby_2_6_or_up?
-        Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.6.0")
-      end
-
       def coloring=(value)
         @coloring = value
       end

--- a/lib/appsignal/cli/install.rb
+++ b/lib/appsignal/cli/install.rb
@@ -299,11 +299,7 @@ module Appsignal
             "../../../resources/appsignal.yml.erb"
           )
           file_contents = File.read(filename)
-          template = if ruby_2_6_or_up?
-                       ERB.new(file_contents, :trim_mode => "-")
-                     else
-                       ERB.new(file_contents, nil, "-")
-                     end
+          template = ERB.new(file_contents, :trim_mode => "-")
           config = template.result(OpenStruct.new(data).instance_eval { binding })
 
           FileUtils.mkdir_p(File.join(Dir.pwd, "config"))

--- a/spec/lib/appsignal/probes/mri_spec.rb
+++ b/spec/lib/appsignal/probes/mri_spec.rb
@@ -4,7 +4,7 @@ describe Appsignal::Probes::MriProbe do
   let(:probe) { described_class.new(:appsignal => appsignal_mock, :gc_profiler => gc_profiler_mock) }
 
   describe ".dependencies_present?" do
-    if DependencyHelper.running_jruby? || DependencyHelper.running_ruby_2_0?
+    if DependencyHelper.running_jruby?
       it "should not be present" do
         expect(described_class.dependencies_present?).to be_falsy
       end
@@ -15,7 +15,7 @@ describe Appsignal::Probes::MriProbe do
     end
   end
 
-  unless DependencyHelper.running_jruby? || DependencyHelper.running_ruby_2_0?
+  unless DependencyHelper.running_jruby?
     describe "#call" do
       let(:hostname) { nil }
       before do

--- a/spec/support/helpers/dependency_helper.rb
+++ b/spec/support/helpers/dependency_helper.rb
@@ -5,14 +5,6 @@ module DependencyHelper
     Gem::Version.new(RUBY_VERSION)
   end
 
-  def running_ruby_2_0?
-    ruby_version.segments.take(2) == [2, 0]
-  end
-
-  def ruby_3_0_or_newer?
-    ruby_version >= Gem::Version.new("3.0.0")
-  end
-
   def ruby_3_1_or_newer?
     ruby_version >= Gem::Version.new("3.1.0")
   end
@@ -124,7 +116,7 @@ module DependencyHelper
   end
 
   def hanami2_present?
-    ruby_3_0_or_newer? && hanami_present? && Gem.loaded_specs["hanami"].version >= Gem::Version.new("2.0")
+    hanami_present? && Gem.loaded_specs["hanami"].version >= Gem::Version.new("2.0")
   end
 
   def dependency_present?(dependency_file)


### PR DESCRIPTION
Since gemspec requires Ruby 3 or higher I think it should be safe to remove some checks that were looking for Ruby 2.6.. and so on.