### PR TITLE
Enable new RuboCop rules and apply fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ inherit_from: .rubocop_todo.yml
 
 AllCops:
   TargetRubyVersion: 3.0
+  NewCops: enable
   Include:
     - "**/*.cap"
     - "**/Gemfile"
@@ -48,6 +49,9 @@ Layout/HashAlignment:
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
+Layout/LineEndStringConcatenationIndentation:
+  EnforcedStyle: indented
+
 Style/EmptyMethod:
   EnforcedStyle: expanded
 
@@ -78,6 +82,9 @@ Style/FrozenStringLiteralComment:
 
 Style/SymbolArray:
   EnforcedStyle: brackets
+
+Gemspec/DevelopmentDependencies:
+  Enabled: false
 
 # Metrics/LineLength:
 #   Max: 80

--- a/Rakefile
+++ b/Rakefile
@@ -157,9 +157,7 @@ namespace :build_matrix do
 
         script = "bundle_and_spec_all_#{version_manager}"
         FileUtils.rm_f(script)
-        File.open(script, "w") do |file|
-          file.write out.join("\n")
-        end
+        File.write(script, out.join("\n"))
         File.chmod(0o775, script)
         puts "Generated #{script}"
       end
@@ -229,7 +227,7 @@ namespace :build do
 
   namespace :ruby do
     # Extension default set in `appsignal.gemspec`
-    define_build_task(:ruby, base_gemspec) { |_pkg| }
+    define_build_task(:ruby, base_gemspec) { |_pkg| } # rubocop:disable Lint/EmptyBlock
   end
 
   namespace :jruby do
@@ -241,7 +239,7 @@ namespace :build do
       s.add_dependency "ffi"
     end
 
-    define_build_task(:jruby, spec) { |_pkg| }
+    define_build_task(:jruby, spec) { |_pkg| } # rubocop:disable Lint/EmptyBlock
   end
 
   desc "Build all gem versions"

--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -10,14 +10,13 @@ Gem::Specification.new do |gem| # rubocop:disable Metrics/BlockLength
   ]
   gem.email                 = ["support@appsignal.com"]
   gem.description           = "The official appsignal.com gem"
-  gem.summary               = "Logs performance and exception data from your app to "\
-                              "appsignal.com"
+  gem.summary               = "Logs performance and exception data from your app to " \
+    "appsignal.com"
   gem.homepage              = "https://github.com/appsignal/appsignal-ruby"
   gem.license               = "MIT"
 
   gem.files                 = `git ls-files`.split($\).reject { |f| f.start_with?(".changesets/") } # rubocop:disable Style/SpecialGlobalVars
   gem.executables           = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
-  gem.test_files            = gem.files.grep(%r{^(test|spec|features)/})
   gem.name                  = "appsignal"
   gem.require_paths         = %w[lib ext]
   gem.version               = Appsignal::VERSION

--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |gem| # rubocop:disable Metrics/BlockLength
   gem.add_development_dependency "pry"
   gem.add_development_dependency "rake", ">= 12"
   gem.add_development_dependency "rspec", "~> 3.8"
-  gem.add_development_dependency "rubocop"
+  gem.add_development_dependency "rubocop", "1.50.0"
   gem.add_development_dependency "timecop"
   gem.add_development_dependency "webmock"
   gem.add_development_dependency "yard", ">= 0.9.20"

--- a/lib/appsignal/integrations/capistrano/appsignal.cap
+++ b/lib/appsignal/integrations/capistrano/appsignal.cap
@@ -3,7 +3,7 @@
 namespace :appsignal do
   task :deploy do
     appsignal_env = fetch(:appsignal_env, fetch(:stage, fetch(:rails_env, fetch(:rack_env, "production"))))
-    user = fetch(:appsignal_user, ENV["USER"] || ENV["USERNAME"])
+    user = fetch(:appsignal_user, ENV["USER"] || ENV.fetch("USERNAME", nil))
     revision = fetch(:appsignal_revision, fetch(:current_revision))
 
     appsignal_config = Appsignal::Config.new(


### PR DESCRIPTION
## Enable new RuboCop rules and apply fixes

I've disabled the Gemspec/DevelopmentDependencies rule, because I don't know why we shouldn't add our development dependencies to the gemspec.

If I remove the empty block from the `define_build_task` method, the tasks for the gem package build are not created. It needs a block argument, even when empty.

## Lock Rubocop version in gemspec

This way we are sure we use the same version of Rubocop locally and on the CI.

We can manually upgrade it, or have Depfu/Dependabot update it for us.
