### PR TITLE
Update log level config in tests

### DIFF
--- a/spec/support/fixtures/projects/valid/config/appsignal.yml
+++ b/spec/support/fixtures/projects/valid/config/appsignal.yml
@@ -21,7 +21,7 @@ development:
 test:
   <<: *defaults
   endpoint: "http://localhost:3000"
-  debug: true
+  log_level: debug
   active: true
 
 old_config:


### PR DESCRIPTION
Use the log_level config option, not the deprecated `debug` option to configure the log level. This removes some deprecation warnings from the test output.

[skip changeset]
[skip review]