### PR TITLE
Rails error reporter Sidekiq action and namespace

### DIFF
--- a/.changesets/support-sidekiq-in-rails-error-reporter.md
+++ b/.changesets/support-sidekiq-in-rails-error-reporter.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Support Sidekiq in Rails error reporter. Track errors reported using `Rails.error.handle` in Sidekiq jobs, in the correct action. Previously it would report no action name for the incident, now it will use the worker name by default.

--- a/lib/appsignal/hooks/active_job.rb
+++ b/lib/appsignal/hooks/active_job.rb
@@ -50,7 +50,7 @@ module Appsignal
             transaction_tags[:provider_job_id] = provider_job_id if provider_job_id
             transaction.set_tags(transaction_tags)
 
-            transaction.set_action_if_nil(ActiveJobHelpers.action_name(job))
+            transaction.set_action(ActiveJobHelpers.action_name(job))
           end
 
           super

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -120,6 +120,17 @@ RSpec.configure do |config|
 
     # Stub system_tmp_dir to something in the project dir for specs
     allow(Appsignal::Config).to receive(:system_tmp_dir).and_return(spec_system_tmp_dir)
+
+    # Unsubscribe Rails error reporter if present to avoid it reporting errors
+    # multiple times through multiple subscriptions.
+    if defined?(Rails) && Rails.respond_to?(:error)
+      if Rails.error.respond_to?(:unsubscribe) # Future Rails version after 7.0.4.3
+        Rails.error.unsubscribe(Appsignal::Integrations::RailsErrorReporterSubscriber)
+      else
+        Rails.error.instance_variable_get(:@subscribers)
+          .delete(Appsignal::Integrations::RailsErrorReporterSubscriber)
+      end
+    end
   end
 
   # These tests are not run by default. They require a failed extension


### PR DESCRIPTION
Report the Sidekiq worker's action name, namespace and tags for Sidekiq jobs.

Move the order in which these are set to before the Sidekiq job is performed. That way that information is available to the Rails error reporter context and we can copy the action, namespace and tags to the error reported with `Appsignal.send_error`.

Change the Active Job instrumentation, to use `set_action`, rather than `set_action_if_nil`. This will overwrite the action name, rather than only set it if not already set. Because it's set before the job, this will not overwrite any action name set by the user. This is needed for the Active Job + Sidekiq instrumentation to work again and use the Active Job's instrumentation naming for Active Job jobs, run with Sidekiq.

Part of #779