### PR TITLE
Exclude diagnose path from normal RSpec tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,6 +70,7 @@ RSpec.configure do |config|
 
   config.example_status_persistence_file_path = "spec/examples.txt"
   config.fail_if_no_examples = true
+  config.exclude_pattern = "spec/integration/diagnose/**/*_spec.rb"
   config.filter_run_excluding(
     :extension_installation_failure => true,
     :jruby => !DependencyHelper.running_jruby?


### PR DESCRIPTION
The diagnose tests are in the `spec/integration/diagnose` directory, which RSpec picks up and tries to run. If I run `rspec` on the command line, these integration tests are always failing, because they're not supposed to be run like that, but from within that submodule instead.

Configure RSpec to exclude that directory by default, so it's easier to run locally without always failing tests.

This isn't an issue on the CI, because we don't checkout the submodule there, but only for the specific diagnose tests job, so the spec files aren't available for most jobs.

[skip changeset]