### PR TITLE
Disable RuboCop Style/NumericPredicate

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -109,6 +109,9 @@ Style/FrozenStringLiteralComment:
   Exclude:
     - "spec/**/*.rb"
 
+Style/NumericPredicate:
+  Enabled: false
+
 Style/SymbolArray:
   EnforcedStyle: brackets
 

--- a/lib/appsignal/extension/jruby.rb
+++ b/lib/appsignal/extension/jruby.rb
@@ -272,7 +272,7 @@ module Appsignal
 
       def get_server_state(key)
         state = appsignal_get_server_state(make_appsignal_string(key))
-        make_ruby_string state if (state[:len]).positive?
+        make_ruby_string state if state[:len] > 0
       end
 
       def log(group, level, message, attributes)
@@ -451,7 +451,7 @@ module Appsignal
 
         def to_json # rubocop:disable Lint/ToJSON
           json = Extension.appsignal_transaction_to_json(pointer)
-          make_ruby_string(json) if (json[:len]).positive?
+          make_ruby_string(json) if json[:len] > 0
         end
       end
 
@@ -535,7 +535,7 @@ module Appsignal
 
         def to_json # rubocop:disable Lint/ToJSON
           json = Extension.appsignal_span_to_json(pointer)
-          make_ruby_string(json) if (json[:len]).positive?
+          make_ruby_string(json) if json[:len] > 0
         end
 
         def close

--- a/lib/appsignal/probes/mri.rb
+++ b/lib/appsignal/probes/mri.rb
@@ -54,7 +54,7 @@ module Appsignal
         set_gauge_with_hostname("thread_count", Thread.list.size)
         if Appsignal::GarbageCollection.enabled?
           gauge_delta(:gc_time, @gc_profiler.total_time) do |gc_time|
-            set_gauge_with_hostname("gc_time", gc_time) if gc_time.positive?
+            set_gauge_with_hostname("gc_time", gc_time) if gc_time > 0
           end
         end
 


### PR DESCRIPTION
Revert some changes from #952, where `value > 0` was changed to `value.positive?`. I don't think it reads that much easier. Also fixes the build after merging #947.

[skip changeset]