### PR TITLE
Do not run minutely probes on console

### DIFF
--- a/.changesets/do-not-run-minutely-probes-on-rails-console.md
+++ b/.changesets/do-not-run-minutely-probes-on-rails-console.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Do not run minutely probes on Rails console

--- a/lib/appsignal/integrations/railtie.rb
+++ b/lib/appsignal/integrations/railtie.rb
@@ -13,6 +13,10 @@ module Appsignal
         Appsignal::Integrations::Railtie.initialize_appsignal(app)
       end
 
+      console do
+        Appsignal::Minutely.stop
+      end
+
       def self.initialize_appsignal(app)
         # Load config
         Appsignal.config = Appsignal::Config.new(


### PR DESCRIPTION
When running the Rails console, the minutely probes should not be active.

Fixes #962.