### PR TITLE
Add more debug info to contain_log matcher

### DIFF
--- a/spec/support/matchers/contains_log.rb
+++ b/spec/support/matchers/contains_log.rb
@@ -1,6 +1,18 @@
 RSpec::Matchers.define :contains_log do |level, message|
+  expected_log_line = "[#{level.upcase}] #{message}"
+
   match do |actual|
-    actual.include?("[#{level.upcase}] #{message}")
+    actual.include?(expected_log_line)
+  end
+
+  failure_message do |actual|
+    <<~MESSAGE
+      Did not contain log line:
+      #{expected_log_line}
+
+      Received logs:
+      #{actual}
+    MESSAGE
   end
 
   diffable


### PR DESCRIPTION
The minutely_spec.rb spec sometimes fails with a mismatch in log lines, but I can't tell what is wrong. Print more complete output so it's hopefully easier to debug when it happens again.

[skip changeset]
[skip review]