### PR TITLE
More compatibility with ActiveSupport Logger broadcast usage

### DIFF
--- a/lib/appsignal/logger.rb
+++ b/lib/appsignal/logger.rb
@@ -43,7 +43,7 @@ module Appsignal
         if block_given?
           message = yield
         else
-          message = progname
+          message = group
           group = @group
         end
       end

--- a/spec/lib/appsignal/logger_spec.rb
+++ b/spec/lib/appsignal/logger_spec.rb
@@ -33,6 +33,14 @@ describe Appsignal::Logger do
       logger.add(::Logger::INFO, nil)
     end
 
+    # This is what the convenience methods in `Logger` do.
+    # See: https://github.com/ruby/logger/blob/v1.5.3/lib/logger.rb#L700-L702
+    it "should log when using `group` for the log message" do
+      expect(Appsignal::Extension).to receive(:log)
+        .with("group", 3, 0, "Log message", instance_of(Appsignal::Extension::Data))
+      logger.add(::Logger::INFO, nil, "Log message")
+    end
+
     context "with info log level" do
       let(:logger) { Appsignal::Logger.new("group", :level => ::Logger::INFO) }
 

--- a/spec/lib/appsignal/logger_spec.rb
+++ b/spec/lib/appsignal/logger_spec.rb
@@ -28,11 +28,6 @@ describe Appsignal::Logger do
       logger.add(::Logger::INFO, "Log message", "other_group")
     end
 
-    it "should return with a nil message" do
-      expect(Appsignal::Extension).not_to receive(:log)
-      logger.add(::Logger::INFO, nil)
-    end
-
     # This is what the convenience methods in `Logger` do.
     # See: https://github.com/ruby/logger/blob/v1.5.3/lib/logger.rb#L700-L702
     it "should log when using `group` for the log message" do


### PR DESCRIPTION
#935 allows the usage of `ActiveSupport::Logger.broadcast`. There still seems to be an issue when using the convenience methods from logger. `Logger.warn("Something happened")` won't show up in AppSignal.

(There already is a detailed description what happens when adding a broadcast in #930.)

A new Rails App would create an ActiveSupport Logger in production if logging to the console is requested (which a Twelve-Factor App would do).

[`config/environments/production.rb`](https://github.com/railsdiff/rails-new-output/blob/0b0e0a360b3e3b80701095e66950adfe420d3712/config/environments/production.rb#L85-L89):
```rb
if ENV["RAILS_LOG_TO_STDOUT"].present?
  logger = ActiveSupport::Logger.new($stdout)
  logger.formatter = config.log_formatter
  config.logger = ActiveSupport::TaggedLogging.new(logger)
end
```

I want to keep the console output and broadcast to an AppSignal logger:

```rb
appsignal_logger = ActiveSupport::TaggedLogging.new(Appsignal::Logger.new("rails"))
config.logger.extend(ActiveSupport::Logger.broadcast(appsignal_logger))
```

At first glance this seems to work. All requests are logged in AppSignal. But using the convenience methods would log to the console but not to AppSignal.

```rb
# Won't show up on appsignal.com
> Rails.logger.warn("Something happened")
Something happened
=> 19

# Will show up on appsignal.com
Rails.logger.add(Logger::WARN, "Something happened")
Something happened
=> 19
```

This is because the convenience methods [are calling `add`](https://github.com/ruby/logger/blob/4e8d9e27fd3b8f916cd3b370b97359f67e02c4bb/lib/logger.rb#L700-L702) with the log message in the third argument. But `Appsignal::Logger#add` won't take the message from `group` as a fallback if `message` is `nil`. It looks like you forgot to rename `progname` to `group` as well:
https://github.com/appsignal/appsignal-ruby/blob/05dc9fee6291d2671c11563f2405f5cdca2f63a6/lib/appsignal/logger.rb#L46

After the fixes in this PR `Rails.logger.warn("Something happened")` works for me as expected.