### PR TITLE
Add statsd_port config option

### DIFF
--- a/.changesets/bump-agent-to-fd8ee9e.md
+++ b/.changesets/bump-agent-to-fd8ee9e.md
@@ -1,0 +1,10 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Bump agent to fd8ee9e.
+
+- Rely on APPSIGNAL_RUNNING_IN_CONTAINER config option value before other environment factors to determine if the app is running in a container.
+- Fix container detection for hosts running Docker itself.
+- Add APPSIGNAL_STATSD_PORT config option.

--- a/.changesets/statsd-port-config-option.md
+++ b/.changesets/statsd-port-config-option.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Allow configuration of the agent's StatsD server port through the `statsd_port` option.

--- a/ext/agent.rb
+++ b/ext/agent.rb
@@ -6,7 +6,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 APPSIGNAL_AGENT_CONFIG = {
-  "version" => "6f29190",
+  "version" => "fd8ee9e",
   "mirrors" => [
     "https://appsignal-agent-releases.global.ssl.fastly.net",
     "https://d135dj0rjqvssy.cloudfront.net"
@@ -14,131 +14,131 @@ APPSIGNAL_AGENT_CONFIG = {
   "triples" => {
     "x86_64-darwin" => {
       "static" => {
-        "checksum" => "022896c1f1e86376dab439b80c5c29075b8ee57e13bb53254b1d2724567e434d",
+        "checksum" => "38731cb50e31377053618cd3687ab99d10cc991171b73ea81a40aab49d415fe1",
         "filename" => "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "2dd81e0481da2aa7e160b071c0961607b8ec1ad609f79b835c2a9a5bb8e914ad",
+        "checksum" => "d86f34a30a2cfc613f3af9bd84ddec0955af0644204cc394e0141860b201506a",
         "filename" => "appsignal-x86_64-darwin-all-dynamic.tar.gz"
       }
     },
     "universal-darwin" => {
       "static" => {
-        "checksum" => "022896c1f1e86376dab439b80c5c29075b8ee57e13bb53254b1d2724567e434d",
+        "checksum" => "38731cb50e31377053618cd3687ab99d10cc991171b73ea81a40aab49d415fe1",
         "filename" => "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "2dd81e0481da2aa7e160b071c0961607b8ec1ad609f79b835c2a9a5bb8e914ad",
+        "checksum" => "d86f34a30a2cfc613f3af9bd84ddec0955af0644204cc394e0141860b201506a",
         "filename" => "appsignal-x86_64-darwin-all-dynamic.tar.gz"
       }
     },
     "aarch64-darwin" => {
       "static" => {
-        "checksum" => "551dfefd447ceb0bda5ea1d94cc2809296a5ae41789e96330fe9b88c4afe29f1",
+        "checksum" => "ee791758b84b56ce01482c1c3f65db926457558275f22673442e19a4e9b9c43e",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "ae3b1c1aae93a28843cddcd10fdc9e253f035be8decbde30ca0a74a5771139c1",
+        "checksum" => "99bbb1d7072849196b7581abf3fbe8e060b6a794a868302988d38eb049b42352",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "arm64-darwin" => {
       "static" => {
-        "checksum" => "551dfefd447ceb0bda5ea1d94cc2809296a5ae41789e96330fe9b88c4afe29f1",
+        "checksum" => "ee791758b84b56ce01482c1c3f65db926457558275f22673442e19a4e9b9c43e",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "ae3b1c1aae93a28843cddcd10fdc9e253f035be8decbde30ca0a74a5771139c1",
+        "checksum" => "99bbb1d7072849196b7581abf3fbe8e060b6a794a868302988d38eb049b42352",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "arm-darwin" => {
       "static" => {
-        "checksum" => "551dfefd447ceb0bda5ea1d94cc2809296a5ae41789e96330fe9b88c4afe29f1",
+        "checksum" => "ee791758b84b56ce01482c1c3f65db926457558275f22673442e19a4e9b9c43e",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "ae3b1c1aae93a28843cddcd10fdc9e253f035be8decbde30ca0a74a5771139c1",
+        "checksum" => "99bbb1d7072849196b7581abf3fbe8e060b6a794a868302988d38eb049b42352",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "aarch64-linux" => {
       "static" => {
-        "checksum" => "860dc4079f1bf2a9608523bef8d0cb8b6fadff7e83332fc09658eeb5d32eb3bc",
+        "checksum" => "65ccb3ed4fdc7f55671ca4ff04beaa97bb01835e0f30b6a5f2e02dbe8b5c31f4",
         "filename" => "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "dc28aa9accf67043c49e2233ad1e7e03ec89a7f2eff9e2621a3dd11f8d03c5d0",
+        "checksum" => "2dfd4991a4607d5a240d8c46e8449e7dc979ed07155519cb60b840ac264e1daa",
         "filename" => "appsignal-aarch64-linux-all-dynamic.tar.gz"
       }
     },
     "i686-linux" => {
       "static" => {
-        "checksum" => "fbf5d2869c9cce9ac35cffee6b139bd8d9b01018a7173417febff7c77599a7b2",
+        "checksum" => "849d2a2ff27814961e1ce9183877a0aedda263f538b0dbfa5e17357e2af00ba4",
         "filename" => "appsignal-i686-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "ffb3d663d56fe6813d1431f3c0e849534a9d03c24b1b660ac3680ea53dc49b7c",
+        "checksum" => "3d5f513d9e6a98a2619b798ead5edeef232654eefa1dabe55930acc662bc69b1",
         "filename" => "appsignal-i686-linux-all-dynamic.tar.gz"
       }
     },
     "x86-linux" => {
       "static" => {
-        "checksum" => "fbf5d2869c9cce9ac35cffee6b139bd8d9b01018a7173417febff7c77599a7b2",
+        "checksum" => "849d2a2ff27814961e1ce9183877a0aedda263f538b0dbfa5e17357e2af00ba4",
         "filename" => "appsignal-i686-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "ffb3d663d56fe6813d1431f3c0e849534a9d03c24b1b660ac3680ea53dc49b7c",
+        "checksum" => "3d5f513d9e6a98a2619b798ead5edeef232654eefa1dabe55930acc662bc69b1",
         "filename" => "appsignal-i686-linux-all-dynamic.tar.gz"
       }
     },
     "x86_64-linux" => {
       "static" => {
-        "checksum" => "8c4f2b96e2dd5c158bf46f46608901b9163998b6377a1795318ea9f366337eb1",
+        "checksum" => "907889dbc50c5f670c1edce503b6f1cdacc52127217611df56b4913137e814f1",
         "filename" => "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "990f476e4fd7700e8582f4cace229e33b0d8365033762a4a48a6a7cee76eba42",
+        "checksum" => "7b4ef01a26aec35d892f4c89ac246b0e44d22f8e75b4fb60ed82d458f00e0a71",
         "filename" => "appsignal-x86_64-linux-all-dynamic.tar.gz"
       }
     },
     "x86_64-linux-musl" => {
       "static" => {
-        "checksum" => "2f3c5dfa997d9399032039e03ed8bd627892fecd3331367a3b83dc29d0c28497",
+        "checksum" => "f4b26fbee43be4bf15033cd3594d8a79d5cd73a95aa62e1949e3a0836345af03",
         "filename" => "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "f2468258a714ec86b6b5e653b33267185c27df6d8798d379f1536a4bb9b54059",
+        "checksum" => "b7e0885ce6a19c42781b36c7876e729320df16492630972b47a12096333d9e46",
         "filename" => "appsignal-x86_64-linux-musl-all-dynamic.tar.gz"
       }
     },
     "aarch64-linux-musl" => {
       "static" => {
-        "checksum" => "abbc61bfe1009de9a7e11534647c7b60b38c2b35357e77356d7dfb1067acb4d0",
+        "checksum" => "d316c1a6a92963ba88c1c578a070eba505e1a466e3af768362122d935af31ccd",
         "filename" => "appsignal-aarch64-linux-musl-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "f061aee38dec433561de16d3ca9565d54b592457cda899807ce4264549745247",
+        "checksum" => "fcfcfc277e44b87057221e34813146f614a3509128fcd3fe7bc9d8eaf7959a2c",
         "filename" => "appsignal-aarch64-linux-musl-all-dynamic.tar.gz"
       }
     },
     "x86_64-freebsd" => {
       "static" => {
-        "checksum" => "d286e1338c80ec5e6f0104e53f27dfe420b3994eb7bb16ac4b32c06ec1405f33",
+        "checksum" => "c2d8f903e683ce77f608d7e8d1eadc98a0fd29d19f07110e04cc73c5d2cb887c",
         "filename" => "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "c68d8ae09378736f0d55ac60344446da7e6ed1485c9aaf070eeaccc505af1599",
+        "checksum" => "7d07f06c7a1d86b78cc134213f1c797f1fab4454c274e1e148764f145e1ec30a",
         "filename" => "appsignal-x86_64-freebsd-all-dynamic.tar.gz"
       }
     },
     "amd64-freebsd" => {
       "static" => {
-        "checksum" => "d286e1338c80ec5e6f0104e53f27dfe420b3994eb7bb16ac4b32c06ec1405f33",
+        "checksum" => "c2d8f903e683ce77f608d7e8d1eadc98a0fd29d19f07110e04cc73c5d2cb887c",
         "filename" => "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "c68d8ae09378736f0d55ac60344446da7e6ed1485c9aaf070eeaccc505af1599",
+        "checksum" => "7d07f06c7a1d86b78cc134213f1c797f1fab4454c274e1e148764f145e1ec30a",
         "filename" => "appsignal-x86_64-freebsd-all-dynamic.tar.gz"
       }
     }

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -100,6 +100,7 @@ module Appsignal
       "APPSIGNAL_SEND_PARAMS" => :send_params,
       "APPSIGNAL_SEND_SESSION_DATA" => :send_session_data,
       "APPSIGNAL_SKIP_SESSION_DATA" => :skip_session_data,
+      "APPSIGNAL_STATSD_PORT" => :statsd_port,
       "APPSIGNAL_TRANSACTION_DEBUG_MODE" => :transaction_debug_mode,
       "APPSIGNAL_WORKING_DIRECTORY_PATH" => :working_directory_path,
       "APPSIGNAL_WORKING_DIR_PATH" => :working_dir_path,
@@ -117,6 +118,7 @@ module Appsignal
       APPSIGNAL_LOGGING_ENDPOINT
       APPSIGNAL_PUSH_API_ENDPOINT
       APPSIGNAL_PUSH_API_KEY
+      APPSIGNAL_STATSD_PORT
       APPSIGNAL_WORKING_DIRECTORY_PATH
       APPSIGNAL_WORKING_DIR_PATH
       APP_REVISION
@@ -343,6 +345,7 @@ module Appsignal
       ENV["_APPSIGNAL_PUSH_API_KEY"]                 = config_hash[:push_api_key]
       ENV["_APPSIGNAL_RUNNING_IN_CONTAINER"]         = config_hash[:running_in_container].to_s
       ENV["_APPSIGNAL_SEND_ENVIRONMENT_METADATA"]    = config_hash[:send_environment_metadata].to_s
+      ENV["_APPSIGNAL_STATSD_PORT"]                  = config_hash[:statsd_port].to_s
       ENV["_APPSIGNAL_TRANSACTION_DEBUG_MODE"]       = config_hash[:transaction_debug_mode].to_s
       if config_hash[:working_directory_path]
         ENV["_APPSIGNAL_WORKING_DIRECTORY_PATH"] = config_hash[:working_directory_path]

--- a/lib/puma/plugin/appsignal.rb
+++ b/lib/puma/plugin/appsignal.rb
@@ -140,7 +140,7 @@ class AppsignalPumaPlugin
     def initialize
       # StatsD server location as configured in AppSignal agent StatsD server.
       @host = "127.0.0.1"
-      @port = 8125
+      @port = ENV.fetch("APPSIGNAL_STATSD_PORT", 8125)
     end
 
     def gauge(metric_name, value, tags)

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -643,6 +643,7 @@ describe Appsignal::Config do
       expect(ENV.fetch("_APPSIGNAL_FILES_WORLD_ACCESSIBLE", nil)).to eq "true"
       expect(ENV.fetch("_APPSIGNAL_TRANSACTION_DEBUG_MODE", nil)).to eq "true"
       expect(ENV.fetch("_APPSIGNAL_SEND_ENVIRONMENT_METADATA", nil)).to eq "false"
+      expect(ENV.fetch("_APPSIGNAL_STATSD_PORT", nil)).to eq ""
       expect(ENV.fetch("_APPSIGNAL_FILTER_PARAMETERS", nil)).to eq "password,confirm_password"
       expect(ENV.fetch("_APPSIGNAL_FILTER_SESSION_DATA", nil)).to eq "key1,key2"
       expect(ENV.fetch("_APP_REVISION", nil)).to eq "v2.5.1"
@@ -680,6 +681,17 @@ describe Appsignal::Config do
 
       it "sets the modified :working_directory_path" do
         expect(ENV.fetch("_APPSIGNAL_WORKING_DIRECTORY_PATH", nil)).to eq "/tmp/appsignal2"
+      end
+    end
+
+    context "with :statsd_port" do
+      before do
+        config[:statsd_port] = "1000"
+        config.write_to_environment
+      end
+
+      it "sets the statsd_port env var" do
+        expect(ENV.fetch("_APPSIGNAL_STATSD_PORT", nil)).to eq "1000"
       end
     end
   end


### PR DESCRIPTION
## Add statsd_port config option

Allow configuration of the agent's statsd server port through the statsd_port option.

Configure the Puma plugin using env vars. It cannot access the normal AppSignal config, because the gem isn't loaded in the main process.

Requires an agent update from https://github.com/appsignal/appsignal-agent/pull/995

## Bump agent to fd8ee9e

- Rely on APPSIGNAL_RUNNING_IN_CONTAINER config option value before
  other environment factors to determine if the app is running in a
  container.
- Fix container detection for hosts running Docker itself.
- Add APPSIGNAL_STATSD_PORT config option.
