### PR TITLE
Fix ActiveSupport Logger broadcast compatibility

### DIFF
--- a/.changesets/fix-activesupport-logger-broadcast-compatibility.md
+++ b/.changesets/fix-activesupport-logger-broadcast-compatibility.md
@@ -1,0 +1,10 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fixed a bug that prevented log messages from getting to AppSignal when using the convenience methods as in:
+
+```ruby
+Rails.logger.warn("Warning message")
+```

--- a/lib/appsignal/logger.rb
+++ b/lib/appsignal/logger.rb
@@ -43,7 +43,7 @@ module Appsignal
         if block_given?
           message = yield
         else
-          message = progname
+          message = group
           group = @group
         end
       end

--- a/spec/lib/appsignal/logger_spec.rb
+++ b/spec/lib/appsignal/logger_spec.rb
@@ -28,9 +28,10 @@ describe Appsignal::Logger do
       logger.add(::Logger::INFO, "Log message", "other_group")
     end
 
-    it "should return with a nil message" do
-      expect(Appsignal::Extension).not_to receive(:log)
-      logger.add(::Logger::INFO, nil)
+    it "should log when using `group` for the log message" do
+      expect(Appsignal::Extension).to receive(:log)
+        .with("group", 3, 0, "Log message", instance_of(Appsignal::Extension::Data))
+      logger.add(::Logger::INFO, nil, "Log message")
     end
 
     context "with info log level" do


### PR DESCRIPTION
We were using `progname` instead of group in the AppSignal Logger `add` method. Making the convenience methods such as `warn`, `info`, etc. Not logging anything when called as in:

```ruby
Rails.logger.warn("Warning message")
```

This commits updates that to use `group` instead of `progname` as in the original Ruby Logger implementation.

---

Based on the contents of: https://github.com/appsignal/appsignal-ruby/pull/967