### PR TITLE
Refactor Sinatra spec to Transaction#to_h usage + bug fix

### DIFF
--- a/.changesets/fix-sinatra-request-custom-params-method.md
+++ b/.changesets/fix-sinatra-request-custom-params-method.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix Sinatra request custom request parameters method. If the Sinatra option `params_method` is set, a different method than `params` will be called on the request object to fetch the request parameters. This can be used to add custom filtering to parameters recorded by AppSignal.

--- a/lib/appsignal/rack/sinatra_instrumentation.rb
+++ b/lib/appsignal/rack/sinatra_instrumentation.rb
@@ -47,13 +47,14 @@ module Appsignal
       end
 
       def call_with_appsignal_monitoring(env)
-        env[:params_method] = @options[:params_method] if @options[:params_method]
+        options = { :force => @options.include?(:force) && @options[:force] }
+        options.merge!(:params_method => @options[:params_method]) if @options[:params_method]
         request = @options.fetch(:request_class, Sinatra::Request).new(env)
         transaction = Appsignal::Transaction.create(
           SecureRandom.uuid,
           Appsignal::Transaction::HTTP_REQUEST,
           request,
-          :force => @options.include?(:force) && @options[:force]
+          options
         )
         begin
           Appsignal.instrument("process_action.sinatra") do


### PR DESCRIPTION
## Refactor Sinatra spec to Transaction#to_h usage

Refactor the Sinatra specs to use the updated method of testing, using `Transaction#to_h` rather than asserting method calls.

This highlights a bug in the filtered_params option for the Transaction, which breaks the spec. I will fix this in the next commit.

## Fix filtered params behavior for Sinatra

The Sinatra middleware didn't set the `params_method` option for the Transaction correctly. It added it to the request env, but it should be set on the Transaction options to properly get picked up by the transaction when fetching the request params.
