### PR TITLE
Add option to set route definition as Sinatra path

### DIFF
--- a/.changesets/add-sinatra_sanitized_routes-option.md
+++ b/.changesets/add-sinatra_sanitized_routes-option.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add sinatra_sanitized_routes option to store sanitized routes instead of the real request path in the Transaction's metadata. This can be useful if there's PII or other sensitive data in the app's request paths. Set `sinatra_sanitized_routes` to `true` in the AppSignal config to enable this behavior and store the route definition rather than the real request path as metadata. We also recommend changing the `request_headers` config option to not include any headers that also include the real request path.

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -44,6 +44,7 @@ module Appsignal
       ],
       :send_environment_metadata => true,
       :send_params => true,
+      :sinatra_sanitized_routes => false,
       :transaction_debug_mode => false
     }.freeze
 
@@ -99,6 +100,7 @@ module Appsignal
       "APPSIGNAL_SEND_ENVIRONMENT_METADATA" => :send_environment_metadata,
       "APPSIGNAL_SEND_PARAMS" => :send_params,
       "APPSIGNAL_SEND_SESSION_DATA" => :send_session_data,
+      "APPSIGNAL_SINATRA_SANITIZED_ROUTES" => :sinatra_sanitized_routes,
       "APPSIGNAL_SKIP_SESSION_DATA" => :skip_session_data,
       "APPSIGNAL_STATSD_PORT" => :statsd_port,
       "APPSIGNAL_TRANSACTION_DEBUG_MODE" => :transaction_debug_mode,
@@ -144,6 +146,7 @@ module Appsignal
       APPSIGNAL_SEND_ENVIRONMENT_METADATA
       APPSIGNAL_SEND_PARAMS
       APPSIGNAL_SEND_SESSION_DATA
+      APPSIGNAL_SINATRA_SANITIZED_ROUTES
       APPSIGNAL_SKIP_SESSION_DATA
       APPSIGNAL_TRANSACTION_DEBUG_MODE
     ].freeze

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -183,6 +183,7 @@ describe Appsignal::Config do
         :send_environment_metadata      => true,
         :send_params                    => true,
         :send_session_data              => true,
+        :sinatra_sanitized_routes       => false,
         :transaction_debug_mode         => false
       )
     end

--- a/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
@@ -260,6 +260,24 @@ if DependencyHelper.sinatra_present?
             )
           )
         end
+
+        context "with sinatra_sanitized_routes=true" do
+          before { Appsignal.config[:sinatra_sanitized_routes] = true }
+          after { Appsignal.config[:sinatra_sanitized_routes] = false }
+          let(:env) { { "sinatra.route" => "GET /some/:path", "REQUEST_METHOD" => "GET" } }
+
+          it "sets the path as the sanitized defined route" do
+            make_request(env)
+
+            expect(created_transactions.count).to eq(1)
+            expect(last_transaction.to_h).to include(
+              "metadata" => {
+                "method" => "GET",
+                "path" => "/some/:path"
+              }
+            )
+          end
+        end
       end
 
       context "with queue start" do


### PR DESCRIPTION
We had a report of an app that contains sensitive information in the request path and the desire to filter this out. We have no system in place to filter metadata like path and request method, as set by the Sinatra middleware.

Add a config option `sinatra_sanitized_routes` that can be set to `true` to set the route definition rather than the real request path as the `path` metadata.

## To do

To do after merge

- [ ] Document config option
- [ ] Add mention of config option on Sinatra docs page

---

Based on #971