### PR TITLE
Add filter_metadata config option

### DIFF
--- a/.changesets/add-filter_metadata-config-option.md
+++ b/.changesets/add-filter_metadata-config-option.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add `filter_metadata` config option to filter metadata set on Transactions set by default. Metadata like `path`, (request)  `method`, `request_id`, `hostname`, etc. This can be useful if there's PII or other sensitive data in any of the app's metadata.

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -24,6 +24,7 @@ module Appsignal
       :enable_rails_error_reporter => true,
       :endpoint => "https://push.appsignal.com",
       :files_world_accessible => true,
+      :filter_metadata => [],
       :filter_parameters => [],
       :filter_session_data => [],
       :ignore_actions => [],
@@ -77,6 +78,7 @@ module Appsignal
       "APPSIGNAL_ENABLE_GVL_WAITING_THREADS" => :enable_gvl_waiting_threads,
       "APPSIGNAL_ENABLE_RAILS_ERROR_REPORTER" => :enable_rails_error_reporter,
       "APPSIGNAL_FILES_WORLD_ACCESSIBLE" => :files_world_accessible,
+      "APPSIGNAL_FILTER_METADATA" => :filter_metadata,
       "APPSIGNAL_FILTER_PARAMETERS" => :filter_parameters,
       "APPSIGNAL_FILTER_SESSION_DATA" => :filter_session_data,
       "APPSIGNAL_HOSTNAME" => :hostname,
@@ -150,6 +152,7 @@ module Appsignal
     # @api private
     ENV_ARRAY_KEYS = %w[
       APPSIGNAL_DNS_SERVERS
+      APPSIGNAL_FILTER_METADATA
       APPSIGNAL_FILTER_PARAMETERS
       APPSIGNAL_FILTER_SESSION_DATA
       APPSIGNAL_IGNORE_ACTIONS

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -165,6 +165,7 @@ describe Appsignal::Config do
         :enable_rails_error_reporter    => true,
         :endpoint                       => "https://push.appsignal.com",
         :files_world_accessible         => true,
+        :filter_metadata                => [],
         :filter_parameters              => [],
         :filter_session_data            => [],
         :ignore_actions                 => [],

--- a/spec/lib/appsignal/rack/streaming_listener_spec.rb
+++ b/spec/lib/appsignal/rack/streaming_listener_spec.rb
@@ -1,6 +1,7 @@
 require "appsignal/rack/streaming_listener"
 
 describe Appsignal::Rack::StreamingListener do
+  before(:context) { start_agent }
   let(:headers) { {} }
   let(:env) do
     {


### PR DESCRIPTION
We had a report of an app that contains sensitive information in the request path and the desire to filter this out. We have no system in place to filter metadata like path and request method, as set by the Sinatra middleware.

This change allow apps to filter out some metadata that's set by default, like `path`, to avoid sending PII or other sensitive data, using the `filter_metadata` config option.

Filtering is done with String based keys, like all the other `filter_*` config options are, so the keys need to be transformed to keys beforehand to make sure they're filtered out.

I didn't merge how we set the metadata, now it's set using `Transaction#set_metadata` and through `sample_data` when the Transaction is being sampled as sample data. I've left the behavior the same as much as possible to avoid breaking things.

See also this internal discussion: https://appsignal.slack.com/archives/CNPP953E2/p1687785270464119

## To do

To do after merge

- [ ] Document config option