### PR TITLE
Fix issue with invalid breadcrumb metadata

### DIFF
--- a/.changesets/check-argument-type-of-breadcrumb-metadata.md
+++ b/.changesets/check-argument-type-of-breadcrumb-metadata.md
@@ -1,0 +1,15 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Log error when the argument type of the breadcrumb metadata is invalid. This metadata argument should be a Hash, and other values are not supported. More information can be found in the [Ruby gem breadcrumb documentation](https://docs.appsignal.com/ruby/instrumentation/breadcrumbs.html).
+
+```ruby
+Appsignal.add_breadcrumb(
+  "breadcrumb category",
+  "breadcrumb action",
+  "some message",
+  { :metadata_key => "some value" } # This needs to be a Hash object
+)
+```

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -186,6 +186,12 @@ module Appsignal
     # @see https://docs.appsignal.com/ruby/instrumentation/breadcrumbs.html
     #   Breadcrumb reference
     def add_breadcrumb(category, action, message = "", metadata = {}, time = Time.now.utc)
+      unless metadata.is_a? Hash
+        Appsignal.logger.error "add_breadcrumb: Cannot add breadcrumb. " \
+          "The given metadata argument is not a Hash."
+        return
+      end
+
       @breadcrumbs.push(
         :time => time.to_i,
         :category => category,

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -432,6 +432,19 @@ describe Appsignal::Transaction do
           expect(breadcrumb["metadata"]).to eq({})
         end
       end
+
+      context "with metadata argument that's not a Hash" do
+        it "does not add the breadcrumb and logs and error" do
+          transaction.add_breadcrumb("category", "action", "message", "invalid metadata")
+          transaction.sample_data
+
+          expect(transaction.to_h["sample_data"]["breadcrumbs"]).to be_empty
+          expect(log_contents(log)).to contains_log(
+            :error,
+            "add_breadcrumb: Cannot add breadcrumb. The given metadata argument is not a Hash."
+          )
+        end
+      end
     end
 
     describe "#set_action" do


### PR DESCRIPTION
We had a report of breadcrumbs not working when the metadata was invalid. This required some manual intervention from us to fix the data. Avoid this occurring in the future by not allowing any other metadata than a Hash object.

Closes https://github.com/appsignal/support/issues/269