### PR TITLE
Ignore recursively nested values on sanitize

### DIFF
--- a/.changesets/ignore-recursively-nested-values-on-sanitize.md
+++ b/.changesets/ignore-recursively-nested-values-on-sanitize.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+When sanitizing an array or hash, ignore recursively nested values. This fixes a SystemStackError issue when sanitising arrays and hashes.

--- a/.changesets/ignore-recursively-nested-values-on-sanitize.md
+++ b/.changesets/ignore-recursively-nested-values-on-sanitize.md
@@ -3,4 +3,4 @@ bump: "patch"
 type: "change"
 ---
 
-When sanitizing an array or hash, ignore recursively nested values. This fixes a SystemStackError issue when sanitising arrays and hashes.
+When sanitizing an array or hash, replace recursively nested values with a placeholder string. This fixes a SystemStackError issue when sanitising arrays and hashes.

--- a/lib/appsignal/utils/hash_sanitizer.rb
+++ b/lib/appsignal/utils/hash_sanitizer.rb
@@ -27,7 +27,8 @@ module Appsignal
         end
 
         def sanitize_hash(source, filter_keys, seen)
-          seen << source.object_id
+          seen = seen.clone << source.object_id
+
           {}.tap do |hash|
             source.each_pair do |key, value|
               next if seen.include?(value.object_id)
@@ -43,7 +44,8 @@ module Appsignal
         end
 
         def sanitize_array(source, filter_keys, seen)
-          seen << source.object_id
+          seen = seen.clone << source.object_id
+
           [].tap do |array|
             source.each_with_index do |item, index|
               next if seen.include?(item.object_id)

--- a/lib/appsignal/utils/hash_sanitizer.rb
+++ b/lib/appsignal/utils/hash_sanitizer.rb
@@ -27,24 +27,28 @@ module Appsignal
         end
 
         def sanitize_hash(source, filter_keys, seen)
-          seen << source
+          seen << source.object_id
           {}.tap do |hash|
             source.each_pair do |key, value|
+              next if seen.include?(value.object_id)
+
               hash[key] =
                 if filter_keys.include?(key.to_s)
                   FILTERED
                 else
                   sanitize_value(value, filter_keys, seen)
-                end unless seen.include?(value)
+                end
             end
           end
         end
 
         def sanitize_array(source, filter_keys, seen)
-          seen << source
+          seen << source.object_id
           [].tap do |array|
             source.each_with_index do |item, index|
-              array[index] = sanitize_value(item, filter_keys, seen) unless seen.include?(item)
+              next if seen.include?(item.object_id)
+
+              array[index] = sanitize_value(item, filter_keys, seen)
             end
           end
         end

--- a/spec/lib/appsignal/utils/hash_sanitizer_spec.rb
+++ b/spec/lib/appsignal/utils/hash_sanitizer_spec.rb
@@ -1,5 +1,7 @@
 describe Appsignal::Utils::HashSanitizer do
   let(:file) { uploaded_file }
+  let(:some_array) { [1, 2, 3] }
+  let(:some_hash) { { :a => 1, :b => 2 } }
   let(:params) do
     {
       :text => "string",
@@ -8,6 +10,10 @@ describe Appsignal::Utils::HashSanitizer do
       :float => 0.0,
       :bool_true => true,
       :bool_false => false,
+      # Non-recursive appearances of the same array instance
+      :some_arrays => [some_array, some_array],
+      # Non-recursive appearances of the same hash instance
+      :some_hashes => { :a => some_hash, :b => some_hash },
       :nil => nil,
       :int => 1, # Fixnum
       :int64 => 1 << 64, # Bignum
@@ -54,6 +60,9 @@ describe Appsignal::Utils::HashSanitizer do
       expect(subject[:nil]).to be_nil
       expect(subject[:int]).to eq(1)
       expect(subject[:int64]).to eq(1 << 64)
+      expect(subject[:some_arrays]).to eq([[1, 2, 3], [1, 2, 3]])
+      expect(subject[:some_hashes]).to eq({ :a => { :a => 1, :b => 2 },
+:b => { :a => 1, :b => 2 } })
     end
 
     it "does not change the original params" do

--- a/spec/lib/appsignal/utils/hash_sanitizer_spec.rb
+++ b/spec/lib/appsignal/utils/hash_sanitizer_spec.rb
@@ -103,22 +103,22 @@ describe Appsignal::Utils::HashSanitizer do
             expect(subject[:file]).to include "::UploadedFile"
           end
 
-          it "ignores a recursive array" do
-            expect(subject[:recursive_array]).to be_nil
+          it "replaces a recursive array" do
+            expect(subject[:recursive_array]).to eq("[RECURSIVE VALUE]")
           end
 
-          it "ignores a recursive hash" do
-            expect(subject[:recursive_hash]).to be_nil
+          it "replaces a recursive hash" do
+            expect(subject[:recursive_hash]).to eq("[RECURSIVE VALUE]")
           end
         end
 
         describe "nested array" do
-          it "ignores a recursive array" do
-            expect(sanitized_params[:hash][:nested_array][4]).to be_nil
+          it "replaces a recursive array" do
+            expect(sanitized_params[:hash][:nested_array][4]).to eq("[RECURSIVE VALUE]")
           end
 
-          it "ignores a recursive hash" do
-            expect(sanitized_params[:hash][:nested_array][5]).to be_nil
+          it "replaces a recursive hash" do
+            expect(sanitized_params[:hash][:nested_array][5]).to eq("[RECURSIVE VALUE]")
           end
         end
       end


### PR DESCRIPTION
Fixes #975.

### [Ignore recursively nested values on sanitize](https://github.com/appsignal/appsignal-ruby/pull/976/commits/4be639faec4bf4cc8695333735b0b243bee6acc2)

When sanitizing an array or hash, remove the values (or key-value
pairs) in nested arrays and hashes that correspond to recursively
nested arrays and hashes.

### [Use object_id to compare by identity](https://github.com/appsignal/appsignal-ruby/pull/976/commits/9e8f24a1e3dee88763a64a397edea2baecf08a71)

The `include?` method compares by hash, meaning `[[]].include?([])`
is `true` despite the two arrays that are being compared not being
the same array instance. Use `object_id` to compare by identity
instead.

### [Do not remove non-recursive identical values](https://github.com/appsignal/appsignal-ruby/pull/976/commits/74fd723973bd2bbf18ab121631514bfa7bb77ed3)

Because the `seen` list instance was being passed along, not just
down the recursion chain, but from previous to next values, this
meant that non-recursive appearances of the same (as in same
instance) array or hash would be removed.

This commit clones the `seen` array before appending an element to
it. The clone is passed down the recursion chain, but not shared to
adjacent values.

---

This is a less complicated version of [what we did to solve the same problem in the JavaScript integration](https://github.com/appsignal/appsignal-javascript/blob/488c6766b625b7c2bac0f4e2d6a2bf7cf3a05d09/packages/plugin-window-events/src/index.ts#L114C1-L131). I think it's fine to not leave placeholders for the removed recursive values, but do let me know if you disagree and I'll do something similar to what the JavaScript integration does for that case.