### PR TITLE
Add bind_address config option for the agent

### DIFF
--- a/.changesets/allow-bind_address-configuration.md
+++ b/.changesets/allow-bind_address-configuration.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Allow configuration of the agent's TCP and UDP servers using the `bind_address` config option. This is by default set to `127.0.0.1`, which only makes it accessible from the same host. If you want it to be accessible from other machines, use `0.0.0.0` or a specific IP address.

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -66,6 +66,7 @@ module Appsignal
     ENV_TO_KEY_MAPPING = {
       "APPSIGNAL_ACTIVE" => :active,
       "APPSIGNAL_APP_NAME" => :name,
+      "APPSIGNAL_BIND_ADDRESS" => :bind_address,
       "APPSIGNAL_CA_FILE_PATH" => :ca_file_path,
       "APPSIGNAL_DEBUG" => :debug,
       "APPSIGNAL_DNS_SERVERS" => :dns_servers,
@@ -111,6 +112,7 @@ module Appsignal
     # @api private
     ENV_STRING_KEYS = %w[
       APPSIGNAL_APP_NAME
+      APPSIGNAL_BIND_ADDRESS
       APPSIGNAL_CA_FILE_PATH
       APPSIGNAL_HOSTNAME
       APPSIGNAL_HTTP_PROXY
@@ -323,6 +325,7 @@ module Appsignal
       ENV["_APPSIGNAL_AGENT_PATH"]                   = File.expand_path("../../ext", __dir__).to_s
       ENV["_APPSIGNAL_APP_NAME"]                     = config_hash[:name]
       ENV["_APPSIGNAL_APP_PATH"]                     = root_path.to_s
+      ENV["_APPSIGNAL_BIND_ADDRESS"]                 = config_hash[:bind_address].to_s
       ENV["_APPSIGNAL_CA_FILE_PATH"]                 = config_hash[:ca_file_path].to_s
       ENV["_APPSIGNAL_DEBUG_LOGGING"]                = config_hash[:debug].to_s
       ENV["_APPSIGNAL_DNS_SERVERS"]                  = config_hash[:dns_servers].join(",")

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -383,6 +383,7 @@ describe Appsignal::Config do
         :running_in_container => true,
         :push_api_key => "aaa-bbb-ccc",
         :active => true,
+        :bind_address => "0.0.0.0",
         :name => "App name",
         :debug => true,
         :dns_servers => ["8.8.8.8", "8.8.4.4"],
@@ -404,6 +405,7 @@ describe Appsignal::Config do
       ENV["APPSIGNAL_PUSH_API_KEY"]            = "aaa-bbb-ccc"
       ENV["APPSIGNAL_ACTIVE"]                  = "true"
       ENV["APPSIGNAL_APP_NAME"]                = "App name"
+      ENV["APPSIGNAL_BIND_ADDRESS"]            = "0.0.0.0"
       ENV["APPSIGNAL_DEBUG"]                   = "true"
       ENV["APPSIGNAL_DNS_SERVERS"]             = "8.8.8.8,8.8.4.4"
       ENV["APPSIGNAL_IGNORE_ACTIONS"]          = "action1,action2"
@@ -598,6 +600,7 @@ describe Appsignal::Config do
   describe "#write_to_environment" do
     let(:config) { project_fixture_config(:production) }
     before do
+      config[:bind_address] = "0.0.0.0"
       config[:logging_endpoint] = "http://localhost:123"
       config[:http_proxy] = "http://localhost"
       config[:ignore_actions] = %w[action1 action2]
@@ -620,6 +623,7 @@ describe Appsignal::Config do
       expect(ENV.fetch("_APPSIGNAL_APP_PATH", nil))
         .to end_with("spec/support/fixtures/projects/valid")
       expect(ENV.fetch("_APPSIGNAL_AGENT_PATH", nil)).to end_with("/ext")
+      expect(ENV.fetch("_APPSIGNAL_BIND_ADDRESS", nil)).to eq("0.0.0.0")
       expect(ENV.fetch("_APPSIGNAL_DEBUG_LOGGING", nil)).to eq "false"
       expect(ENV.fetch("_APPSIGNAL_LOG", nil)).to eq "stdout"
       expect(ENV.fetch("_APPSIGNAL_LOG_FILE_PATH", nil)).to end_with("/tmp/appsignal.log")


### PR DESCRIPTION
This feature has been available in the agent's standalone mode for a while now.

I'm cleaning up old issues and picking up this small one.

Part of https://github.com/appsignal/appsignal-agent/issues/915