### PR TITLE
Send array and hash tags as custom_data

### DIFF
--- a/.changesets/send-custom-data-via-rails-error-reporter.md
+++ b/.changesets/send-custom-data-via-rails-error-reporter.md
@@ -1,0 +1,13 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Allow passing custom data using the `appsignal` context via the Rails error reporter:
+
+```ruby
+custom_data = { :hash => { :one => 1, :two => 2 }, :array => [1, 2] }
+Rails.error.handle(:context => { :appsignal => { :custom_data => custom_data } }) do
+  raise "Test"
+end
+```

--- a/lib/appsignal/integrations/railtie.rb
+++ b/lib/appsignal/integrations/railtie.rb
@@ -55,9 +55,10 @@ module Appsignal
           return unless handled
 
           Appsignal.send_error(error) do |transaction|
-            namespace, action_name, tags = context_for(context.dup)
+            namespace, action_name, tags, custom_data = context_for(context.dup)
             transaction.set_namespace(namespace) if namespace
             transaction.set_action(action_name) if action_name
+            transaction.set_sample_data("custom_data", custom_data) if custom_data
 
             tags[:severity] = severity
             tags[:source] = source.to_s if source
@@ -69,6 +70,7 @@ module Appsignal
 
         def context_for(context)
           tags = {}
+          custom_data = nil
 
           appsignal_context = context.delete(:appsignal)
           # Fetch the namespace and action name based on the Rails execution
@@ -102,10 +104,13 @@ module Appsignal
 
             context_action_name = appsignal_context[:action]
             action_name = context_action_name if context_action_name
+
+            context_custom_data = appsignal_context[:custom_data]
+            custom_data = context_custom_data if context_custom_data
           end
           tags.merge!(context)
 
-          [namespace, action_name, tags]
+          [namespace, action_name, tags, custom_data]
         end
       end
     end

--- a/spec/lib/appsignal/integrations/railtie_spec.rb
+++ b/spec/lib/appsignal/integrations/railtie_spec.rb
@@ -196,6 +196,33 @@ if DependencyHelper.rails_present?
                 end
               end
 
+              it "sends tags stored in :appsignal -> :custom_data as custom data" do
+                current_transaction = http_request_transaction
+
+                with_current_transaction current_transaction do
+                  given_context = {
+                    :appsignal => {
+                      :custom_data => {
+                        :array => [1, 2],
+                        :hash => { :one => 1, :two => 2 }
+                      }
+                    }
+                  }
+                  Rails.error.handle(:context => given_context) { raise ExampleStandardError }
+
+                  transaction = last_transaction
+                  transaction_hash = transaction.to_h
+                  expect(transaction_hash).to include(
+                    "sample_data" => hash_including(
+                      "custom_data" => {
+                        "array" => [1, 2],
+                        "hash" => { "one" => 1, "two" => 2 }
+                      }
+                    )
+                  )
+                end
+              end
+
               it "overwrites duplicated namespace and action with custom from context" do
                 current_transaction = http_request_transaction
                 current_transaction.set_namespace "custom"


### PR DESCRIPTION
When reporting via the Rails reporter subsytem, context values that were not of String/Symbol/Numeric types were ignored. With this change they will be sent as `custom_data`.