### PR TITLE
Use new notifications handlers on Rails edge

### DIFF
--- a/.changesets/handle-upcoming-rails-notification-handler.md
+++ b/.changesets/handle-upcoming-rails-notification-handler.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Handle upcoming Rails notification handler

--- a/lib/appsignal/integrations/active_support_notifications.rb
+++ b/lib/appsignal/integrations/active_support_notifications.rb
@@ -54,6 +54,32 @@ module Appsignal
         end
       end
 
+      module StartFinishHandlerIntegration
+        def start
+          instrument_this = @name[0] != ActiveSupportNotificationsIntegration::BANG
+
+          Appsignal::Transaction.current.start_event if instrument_this
+          super
+        end
+
+        def finish_with_values(name, id, payload={})
+          # Events that start with a bang are internal to Rails
+          instrument_this = name[0] != ActiveSupportNotificationsIntegration::BANG
+
+          if instrument_this
+            title, body, body_format = Appsignal::EventFormatter.format(name, payload)
+            Appsignal::Transaction.current.finish_event(
+              name.to_s,
+              title,
+              body,
+              body_format
+            )
+          end
+
+          super
+        end
+      end
+
       module FinishStateIntegration
         def finish_with_state(listeners_state, name, payload = {})
           # Events that start with a bang are internal to Rails

--- a/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
@@ -22,6 +22,12 @@ describe Appsignal::Hooks::ActiveSupportNotificationsHook do
 
     it_behaves_like "activesupport instrument override"
 
+    if defined?(::ActiveSupport::Notifications::Fanout::Handle)
+      require_relative "./active_support_notifications/start_finish_shared_examples"
+
+      it_behaves_like "activesupport start finish override"
+    end
+
     if ::ActiveSupport::Notifications::Instrumenter.method_defined?(:start)
       require_relative "./active_support_notifications/start_finish_shared_examples"
 


### PR DESCRIPTION
Since
https://github.com/rails/rails/commit/dbf2edb7f2ebb0bd7e194e735ba9be4bd4844176, ActiveSupport::Notifications adds
ActiveSupport::Notifications::Fanout::Handle, which is now used to route instrumentation calls through.

This patch switches to the new module when it's available, while keeping backward compatibility for older versions.

Closes https://github.com/appsignal/support/issues/280.