### PR TITLE
Add host_role config option

### DIFF
--- a/.changesets/add-role-config-option.md
+++ b/.changesets/add-role-config-option.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add the `host_role` config option. This config option can be set per host to generate some metrics automatically per host and possibly do things like grouping in the future.

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -83,6 +83,7 @@ module Appsignal
       "APPSIGNAL_FILTER_PARAMETERS" => :filter_parameters,
       "APPSIGNAL_FILTER_SESSION_DATA" => :filter_session_data,
       "APPSIGNAL_HOSTNAME" => :hostname,
+      "APPSIGNAL_HOST_ROLE" => :host_role,
       "APPSIGNAL_HTTP_PROXY" => :http_proxy,
       "APPSIGNAL_IGNORE_ACTIONS" => :ignore_actions,
       "APPSIGNAL_IGNORE_ERRORS" => :ignore_errors,
@@ -115,6 +116,7 @@ module Appsignal
       APPSIGNAL_BIND_ADDRESS
       APPSIGNAL_CA_FILE_PATH
       APPSIGNAL_HOSTNAME
+      APPSIGNAL_HOST_ROLE
       APPSIGNAL_HTTP_PROXY
       APPSIGNAL_LOG
       APPSIGNAL_LOG_LEVEL
@@ -337,6 +339,7 @@ module Appsignal
       ENV["_APPSIGNAL_FILTER_PARAMETERS"]            = config_hash[:filter_parameters].join(",")
       ENV["_APPSIGNAL_FILTER_SESSION_DATA"]          = config_hash[:filter_session_data].join(",")
       ENV["_APPSIGNAL_HOSTNAME"]                     = config_hash[:hostname].to_s
+      ENV["_APPSIGNAL_HOST_ROLE"]                    = config_hash[:host_role].to_s
       ENV["_APPSIGNAL_HTTP_PROXY"]                   = config_hash[:http_proxy]
       ENV["_APPSIGNAL_IGNORE_ACTIONS"]               = config_hash[:ignore_actions].join(",")
       ENV["_APPSIGNAL_IGNORE_ERRORS"]                = config_hash[:ignore_errors].join(",")

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -641,6 +641,7 @@ describe Appsignal::Config do
       expect(ENV.fetch("_APPSIGNAL_RUNNING_IN_CONTAINER", nil)).to eq "false"
       expect(ENV.fetch("_APPSIGNAL_ENABLE_HOST_METRICS", nil)).to eq "true"
       expect(ENV.fetch("_APPSIGNAL_HOSTNAME", nil)).to eq ""
+      expect(ENV.fetch("_APPSIGNAL_HOST_ROLE", nil)).to eq ""
       expect(ENV.fetch("_APPSIGNAL_PROCESS_NAME", nil)).to include "rspec"
       expect(ENV.fetch("_APPSIGNAL_CA_FILE_PATH", nil))
         .to eq File.join(resources_dir, "cacert.pem")
@@ -664,6 +665,17 @@ describe Appsignal::Config do
 
       it "sets the modified :hostname" do
         expect(ENV.fetch("_APPSIGNAL_HOSTNAME", nil)).to eq "Alices-MBP.example.com"
+      end
+    end
+
+    context "with :host_role" do
+      before do
+        config[:host_role] = "host role"
+        config.write_to_environment
+      end
+
+      it "sets the modified :host_role" do
+        expect(ENV.fetch("_APPSIGNAL_HOST_ROLE", nil)).to eq "host role"
       end
     end
 


### PR DESCRIPTION
Allow users to configure a role for a host. It's not used a lot in the product yet, but we generate a metric for it and we can do some more stuff with it in the future.

Part of https://github.com/appsignal/appsignal-agent/issues/1020