### PR TITLE
Add behavior to not start on config file error

### DIFF
--- a/.changesets/add-option-to-not-start-appsignal-on-config-file-errors.md
+++ b/.changesets/add-option-to-not-start-appsignal-on-config-file-errors.md
@@ -1,0 +1,8 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add an option to not start AppSignal on config file errors. When the `config/appsignal.yml` file raises an error (due to ERB syntax issues or ERB errors), it will currently ignore the config file and try to make a configuration work from the other config sources (default, auto detection and system environment variables). This can cause unexpected behavior, because the config from the config file is not part of the loaded config.
+
+In future versions of the Ruby gem, AppSignal will not start when the config file contains an error. To opt-in to this new behavior, set the `APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR` system environment variable to either `1` or `true`.


### PR DESCRIPTION
When the `config/appsignal.yml` file triggers an error while parsing it, we ignore the config file source. This can cause some unexpected behavior, like missing config and reporting it as the wrong app name. More importantly, any filter config options in the config file are missing and we may send PII data that's supposed to be filtered out.

We don't want to change the behavior now, as it's a breaking change. Add a flag to opt-in to this new behavior, using the
`APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR` config option. Then for the next major version we should make this the new default behavior.

If accepted, I'll make this more visible in the diagnose report.

Part of #926