### PR TITLE
Log error when sample data is invalid type

### DIFF
--- a/.changesets/log-error-when-sample-data-is-invalid-format.md
+++ b/.changesets/log-error-when-sample-data-is-invalid-format.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Log an error when sample data is of an invalid type. Accepted types are Array and Hash. If any other types are given, it will log an error to the `appsignal.log` file.

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -320,7 +320,14 @@ module Appsignal
     end
 
     def set_sample_data(key, data)
-      return unless key && data && (data.is_a?(Array) || data.is_a?(Hash))
+      return unless key && data
+
+      if !data.is_a?(Array) && !data.is_a?(Hash)
+        Appsignal.logger.error(
+          "Invalid sample data for '#{key}'. Value is not an Array or Hash: '#{data.inspect}'"
+        )
+        return
+      end
 
       @ext.set_sample_data(
         key.to_s,

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -688,6 +688,8 @@ describe Appsignal::Transaction do
           transaction.set_sample_data("params", "string")
 
           expect(transaction.to_h["sample_data"]).to eq({})
+          expect(log_contents(log)).to contains_log :error,
+            %(Invalid sample data for 'params'. Value is not an Array or Hash: '"string"')
         end
       end
 


### PR DESCRIPTION
Log an error when a value other than an Array or Hash is given to sample data to help debug why the sample data is not appearing.

Related Slack conversation:
https://appsignal.slack.com/archives/CNPP953E2/p1693295505307779