### PR TITLE
Bump agent to 6133900

### DIFF
--- a/.changesets/bump-agent-to-6133900.md
+++ b/.changesets/bump-agent-to-6133900.md
@@ -1,0 +1,8 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Bump agent to 6133900.
+
+- Fix `disk_inodes_usage` metric name format to not be interpreted as a JSON object.

--- a/ext/agent.rb
+++ b/ext/agent.rb
@@ -6,7 +6,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 APPSIGNAL_AGENT_CONFIG = {
-  "version" => "d789895",
+  "version" => "6133900",
   "mirrors" => [
     "https://appsignal-agent-releases.global.ssl.fastly.net",
     "https://d135dj0rjqvssy.cloudfront.net"
@@ -14,131 +14,131 @@ APPSIGNAL_AGENT_CONFIG = {
   "triples" => {
     "x86_64-darwin" => {
       "static" => {
-        "checksum" => "8ea76b7d011c728b7988d017a39fc3a432d9c86392e6e46767ecc931e583777a",
+        "checksum" => "19cfea536fc6c4a8fe335a26d14ce955b422c23217902642f95d7df670152238",
         "filename" => "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "beacdcd579bcc06a69da279dbca2f363395ea4b1846fa4b6e49de612beb07a8a",
+        "checksum" => "f5c4b66b45faac47473befdbe286a037d8fca9386339b00f59be9e9505d15b13",
         "filename" => "appsignal-x86_64-darwin-all-dynamic.tar.gz"
       }
     },
     "universal-darwin" => {
       "static" => {
-        "checksum" => "8ea76b7d011c728b7988d017a39fc3a432d9c86392e6e46767ecc931e583777a",
+        "checksum" => "19cfea536fc6c4a8fe335a26d14ce955b422c23217902642f95d7df670152238",
         "filename" => "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "beacdcd579bcc06a69da279dbca2f363395ea4b1846fa4b6e49de612beb07a8a",
+        "checksum" => "f5c4b66b45faac47473befdbe286a037d8fca9386339b00f59be9e9505d15b13",
         "filename" => "appsignal-x86_64-darwin-all-dynamic.tar.gz"
       }
     },
     "aarch64-darwin" => {
       "static" => {
-        "checksum" => "535fed60ac1484e40bbfe77cd4fe9131c67f25e6362a2fe31d987c36ec82ba08",
+        "checksum" => "4fa0dbccba79f70edc6844a86bfd047ccdd612d752b65aff46fe0e21d8a610ea",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "6c984f53a07788ebb469ede014ac8732d9db1ef43736825690492e7c12e3fb83",
+        "checksum" => "f86e88647be6c64f0f1f56b1ac15e0e4453c7e4a6c997fd5e510cf459c572a57",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "arm64-darwin" => {
       "static" => {
-        "checksum" => "535fed60ac1484e40bbfe77cd4fe9131c67f25e6362a2fe31d987c36ec82ba08",
+        "checksum" => "4fa0dbccba79f70edc6844a86bfd047ccdd612d752b65aff46fe0e21d8a610ea",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "6c984f53a07788ebb469ede014ac8732d9db1ef43736825690492e7c12e3fb83",
+        "checksum" => "f86e88647be6c64f0f1f56b1ac15e0e4453c7e4a6c997fd5e510cf459c572a57",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "arm-darwin" => {
       "static" => {
-        "checksum" => "535fed60ac1484e40bbfe77cd4fe9131c67f25e6362a2fe31d987c36ec82ba08",
+        "checksum" => "4fa0dbccba79f70edc6844a86bfd047ccdd612d752b65aff46fe0e21d8a610ea",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "6c984f53a07788ebb469ede014ac8732d9db1ef43736825690492e7c12e3fb83",
+        "checksum" => "f86e88647be6c64f0f1f56b1ac15e0e4453c7e4a6c997fd5e510cf459c572a57",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "aarch64-linux" => {
       "static" => {
-        "checksum" => "35f96e0adf408fd8ac3e89c6cb3c5506eb4250643199aad3ba298ab131d773c8",
+        "checksum" => "cdd75637940fcfd369b569e873048c7d37a3844d9d31d783e4459b375b78ee0e",
         "filename" => "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "6f4e5431c50c947f9fdeb92b7536780277bebb75327cfa5ee9c27659a9d20b5e",
+        "checksum" => "99b52c29d497d63f02a4ff7162152641b51e7ecd292d07f0330e7d4f3abc8075",
         "filename" => "appsignal-aarch64-linux-all-dynamic.tar.gz"
       }
     },
     "i686-linux" => {
       "static" => {
-        "checksum" => "f4a1c9a67a0a4cde7e13ef555a6782e5d4f15bfbce9277c2aaf8e248a0fb858e",
+        "checksum" => "a9374d1fd4baae84f1c4a74957cbb8c919b29ae2ab05a571ff75b9ca483717ab",
         "filename" => "appsignal-i686-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "26a3fa059874d76897e6a4c709048789f531d7e84e6b8ae4e7fbcdfb26cdef40",
+        "checksum" => "d643c72add6fe1054faff034101cf5a2676a169c7bff479f3d79e71875598b8a",
         "filename" => "appsignal-i686-linux-all-dynamic.tar.gz"
       }
     },
     "x86-linux" => {
       "static" => {
-        "checksum" => "f4a1c9a67a0a4cde7e13ef555a6782e5d4f15bfbce9277c2aaf8e248a0fb858e",
+        "checksum" => "a9374d1fd4baae84f1c4a74957cbb8c919b29ae2ab05a571ff75b9ca483717ab",
         "filename" => "appsignal-i686-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "26a3fa059874d76897e6a4c709048789f531d7e84e6b8ae4e7fbcdfb26cdef40",
+        "checksum" => "d643c72add6fe1054faff034101cf5a2676a169c7bff479f3d79e71875598b8a",
         "filename" => "appsignal-i686-linux-all-dynamic.tar.gz"
       }
     },
     "x86_64-linux" => {
       "static" => {
-        "checksum" => "016c962727e31a07eee7a221944ff9c4bbb054eada7e87bbe4602233364f380c",
+        "checksum" => "bd625ed84100d0632b298ac602b152463628c41afe56a8621745cdae626f8413",
         "filename" => "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "d286a8bcc4a876057a14a90cc6ceecdc75230e1c4d721ea3f3138c58c748e602",
+        "checksum" => "0daa644acfee46848282ad733b175e4994e7faf64c8bc046d2efff2b8fc1afdd",
         "filename" => "appsignal-x86_64-linux-all-dynamic.tar.gz"
       }
     },
     "x86_64-linux-musl" => {
       "static" => {
-        "checksum" => "2ce9e34b283c76c6b25028d3a770a942f4975cd071c586438a8765948237ca42",
+        "checksum" => "7988c4a2a6ba5d59be2186ce9bf51ab50b6537a60888b08c8e9066172516e59d",
         "filename" => "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "0eebe8cd448bce5386cdce1039e7f74c60208408108af9537a80e8e8737f7aec",
+        "checksum" => "93e47c9400ddae42a8cd2b80c09c9134ee96a76bf622c3ad5d53b776fec1a3f0",
         "filename" => "appsignal-x86_64-linux-musl-all-dynamic.tar.gz"
       }
     },
     "aarch64-linux-musl" => {
       "static" => {
-        "checksum" => "017da79e62a2875c0384898c9160cd83acd712faba05154fd8a0627fec1b5ba4",
+        "checksum" => "8e5fe2a8bc4cb7de4ba7d61fec48f15aa0cd580050f67752f07625853636eb16",
         "filename" => "appsignal-aarch64-linux-musl-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "507d4fa0f3d6168f905404b4b36fe494c5479606d77f50d2d2d3d27b6c645ea1",
+        "checksum" => "01f993b3320f0377ef9f652bb215ce268da208f46a6f59ad0c0e71f57257b4ef",
         "filename" => "appsignal-aarch64-linux-musl-all-dynamic.tar.gz"
       }
     },
     "x86_64-freebsd" => {
       "static" => {
-        "checksum" => "13d27afcb68aff5e164e05fc4fd8874e73f14c0154301f2e6e6e75f67fa9182c",
+        "checksum" => "09e21821eb98ad6afdb5d3708b67ea25799aedbee2ccb0d566b99d9c5703cb1e",
         "filename" => "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "dafa25a73cd79e269466d5129dd7b61ac88e09d87c3f253fc9705e1d9469fa2b",
+        "checksum" => "e77592de9dd7ff41efb6c1d2d88e06fa7b663e9ff009392bb971b1333e0f28d7",
         "filename" => "appsignal-x86_64-freebsd-all-dynamic.tar.gz"
       }
     },
     "amd64-freebsd" => {
       "static" => {
-        "checksum" => "13d27afcb68aff5e164e05fc4fd8874e73f14c0154301f2e6e6e75f67fa9182c",
+        "checksum" => "09e21821eb98ad6afdb5d3708b67ea25799aedbee2ccb0d566b99d9c5703cb1e",
         "filename" => "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "dafa25a73cd79e269466d5129dd7b61ac88e09d87c3f253fc9705e1d9469fa2b",
+        "checksum" => "e77592de9dd7ff41efb6c1d2d88e06fa7b663e9ff009392bb971b1333e0f28d7",
         "filename" => "appsignal-x86_64-freebsd-all-dynamic.tar.gz"
       }
     }


### PR DESCRIPTION
- Fix `disk_inodes_usage` metric name format to not be interpreted as a JSON object.

[skip review]