### PR TITLE
Run CI on Rails Edge

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -442,6 +442,24 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+    - name: Ruby 3.0.5 for rails-edge
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.0.5
+      - name: GEMSET
+        value: rails-edge
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/rails-edge.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
     - name: Ruby 3.0.5 for sequel
       env_vars:
       - *2
@@ -775,6 +793,24 @@ blocks:
         value: rails-7.0
       - name: BUNDLE_GEMFILE
         value: gemfiles/rails-7.0.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+    - name: Ruby 3.1.3 for rails-edge
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.1.3
+      - name: GEMSET
+        value: rails-edge
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/rails-edge.gemfile
       - name: _RUBYGEMS_VERSION
         value: latest
       - name: _BUNDLER_VERSION
@@ -1120,6 +1156,24 @@ blocks:
         value: latest
       commands:
       - "./support/bundler_wrapper exec rake test"
+    - name: Ruby 3.2.1 for rails-edge
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: 3.2.1
+      - name: GEMSET
+        value: rails-edge
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/rails-edge.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
     - name: Ruby 3.2.1 for sequel
       env_vars:
       - *2
@@ -1291,6 +1345,24 @@ blocks:
         value: rails-7.0
       - name: BUNDLE_GEMFILE
         value: gemfiles/rails-7.0.gemfile
+      - name: _RUBYGEMS_VERSION
+        value: latest
+      - name: _BUNDLER_VERSION
+        value: latest
+      commands:
+      - "./support/bundler_wrapper exec rake test"
+    - name: Ruby jruby-9.4.1.0 for rails-edge
+      env_vars:
+      - *2
+      - *3
+      - *4
+      - *5
+      - name: RUBY_VERSION
+        value: jruby-9.4.1.0
+      - name: GEMSET
+        value: rails-edge
+      - name: BUNDLE_GEMFILE
+        value: gemfiles/rails-edge.gemfile
       - name: _RUBYGEMS_VERSION
         value: latest
       - name: _BUNDLER_VERSION

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -170,6 +170,7 @@ matrix:
       - "rails-6.0"
       - "rails-6.1"
       - "rails-7.0"
+      - "rails-edge"
 
   ruby:
     - ruby: "3.0.5"
@@ -217,6 +218,13 @@ matrix:
           - "3.2.1"
           - "jruby-9.4.1.0"
     - gem: "rails-7.0"
+      only:
+        ruby:
+          - "3.0.5"
+          - "3.1.3"
+          - "3.2.1"
+          - "jruby-9.4.1.0"
+    - gem: "rails-edge"
       only:
         ruby:
           - "3.0.5"

--- a/gemfiles/rails-edge.gemfile
+++ b/gemfiles/rails-edge.gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'rails', github: "rails/rails"
+gem "sidekiq"
+gem "rake", "> 12.2"
+
+gemspec :path => '../'


### PR DESCRIPTION
To test on the upcoming version of Rails, this patch adds a rails-edge gemfile which sources rails from GitHub directly, to be used on CI.

[skip changeset]