### PR TITLE
Add configuration modifiers to Ruby diagnose

### DIFF
--- a/.changesets/add-config-load-modifiers-to-diagnose-report.md
+++ b/.changesets/add-config-load-modifiers-to-diagnose-report.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Add configuration load modifiers to diagnose report. Track if the `APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR` environment variable was set.

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -477,6 +477,10 @@ module Appsignal
               :file => config.file_config,
               :env => config.env_config,
               :override => config.override_config
+            },
+            :modifiers => {
+              "APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR" =>
+                ENV.fetch("APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR", "")
             }
           }
           print_config_options(config)
@@ -518,6 +522,11 @@ module Appsignal
               puts "  #{key}: #{format_config_option(value)}#{sources_label}"
             end
           end
+
+          puts
+          puts "Configuration modifiers"
+          puts "  APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR: " \
+            "#{data[:config][:modifiers]["APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR"].inspect}"
 
           puts "\nRead more about how the diagnose config output is rendered\n" \
             "https://docs.appsignal.com/ruby/command-line/diagnose.html"

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -781,6 +781,9 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
               "file" => {},
               "env" => {},
               "override" => { "send_session_data" => true }
+            },
+            "modifiers" => {
+              "APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR" => ""
             }
           )
         end
@@ -912,6 +915,28 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
           end
         end
 
+        describe "modifiers" do
+          before do
+            ENV["APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR"] = "1"
+            run
+          end
+
+          it "outputs config modifiers" do
+            expect(output).to include(
+              "Configuration modifiers\n" \
+                "  APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR: \"1\""
+            )
+          end
+
+          it "transmits config modifiers in report" do
+            expect(received_report["config"]).to include(
+              "modifiers" => {
+                "APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR" => "1"
+              }
+            )
+          end
+        end
+
         it "transmits config in report" do
           run
           additional_initial_config = {}
@@ -935,6 +960,9 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
               "file" => hash_with_string_keys(config.file_config),
               "env" => {},
               "override" => { "send_session_data" => true }
+            },
+            "modifiers" => {
+              "APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR" => ""
             }
           )
         end
@@ -963,6 +991,9 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
               "file" => hash_with_string_keys(config.file_config),
               "env" => {},
               "override" => { "send_session_data" => true }
+            },
+            "modifiers" => {
+              "APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR" => ""
             }
           )
         end


### PR DESCRIPTION
Since PR #991 we have a configuration load modifier that does not active the Ruby gem when this modifier is set.
Update the report to include this modifier for better debugging. This will also require a server change to show this modifier section.

Closes #926