### PR TITLE
Mark `Config#[]=` as a private API

### DIFF
--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -284,6 +284,12 @@ module Appsignal
       config_hash[key]
     end
 
+    # Update the internal config hash.
+    #
+    # This method does not update the config in the extension and agent. It
+    # should not be used to update the config after AppSignal has started.
+    #
+    # @api private
     def []=(key, value)
       config_hash[key] = value
     end


### PR DESCRIPTION
There should be no expectation this method updates the config. Update the method docs to match.

[skip changeset] because it's a small doc change for a private API that doesn't require a release on its own.

[skip review]