### PR TITLE
Bump agent to e8207c1

### DIFF
--- a/.changesets/bump-agent-to-e8207c1.md
+++ b/.changesets/bump-agent-to-e8207c1.md
@@ -1,0 +1,11 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Bump agent to e8207c1.
+
+- Add `memory_in_percentages` and `swap_in_percentages` host metrics that represents metrics in percentages.
+- Ignore `/snap/` disk mountpoints.
+- Fix issue with the open span count in logs being logged as a negative number.
+- Fix agent's TCP server getting stuck when two requests are made within the same fraction of a second.

--- a/ext/agent.rb
+++ b/ext/agent.rb
@@ -6,7 +6,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 APPSIGNAL_AGENT_CONFIG = {
-  "version" => "6133900",
+  "version" => "e8207c1",
   "mirrors" => [
     "https://appsignal-agent-releases.global.ssl.fastly.net",
     "https://d135dj0rjqvssy.cloudfront.net"
@@ -14,131 +14,131 @@ APPSIGNAL_AGENT_CONFIG = {
   "triples" => {
     "x86_64-darwin" => {
       "static" => {
-        "checksum" => "19cfea536fc6c4a8fe335a26d14ce955b422c23217902642f95d7df670152238",
+        "checksum" => "b4f9460cee052fb278e854abd0253c62844cf872c1be8fec6f04474fbdbab6b7",
         "filename" => "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "f5c4b66b45faac47473befdbe286a037d8fca9386339b00f59be9e9505d15b13",
+        "checksum" => "58278abef93445374fd7d9b66c1004f61fc8c9b0a0a6c98627bf576df71f76f0",
         "filename" => "appsignal-x86_64-darwin-all-dynamic.tar.gz"
       }
     },
     "universal-darwin" => {
       "static" => {
-        "checksum" => "19cfea536fc6c4a8fe335a26d14ce955b422c23217902642f95d7df670152238",
+        "checksum" => "b4f9460cee052fb278e854abd0253c62844cf872c1be8fec6f04474fbdbab6b7",
         "filename" => "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "f5c4b66b45faac47473befdbe286a037d8fca9386339b00f59be9e9505d15b13",
+        "checksum" => "58278abef93445374fd7d9b66c1004f61fc8c9b0a0a6c98627bf576df71f76f0",
         "filename" => "appsignal-x86_64-darwin-all-dynamic.tar.gz"
       }
     },
     "aarch64-darwin" => {
       "static" => {
-        "checksum" => "4fa0dbccba79f70edc6844a86bfd047ccdd612d752b65aff46fe0e21d8a610ea",
+        "checksum" => "47ab9a2778483ed7c35844778eaa983809679a70642739f30ad8d18c2cd7a578",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "f86e88647be6c64f0f1f56b1ac15e0e4453c7e4a6c997fd5e510cf459c572a57",
+        "checksum" => "f8b6d8409e7fbc451891cfcfdb49b87b7b11f3bd619021ac54647ea5f552eee7",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "arm64-darwin" => {
       "static" => {
-        "checksum" => "4fa0dbccba79f70edc6844a86bfd047ccdd612d752b65aff46fe0e21d8a610ea",
+        "checksum" => "47ab9a2778483ed7c35844778eaa983809679a70642739f30ad8d18c2cd7a578",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "f86e88647be6c64f0f1f56b1ac15e0e4453c7e4a6c997fd5e510cf459c572a57",
+        "checksum" => "f8b6d8409e7fbc451891cfcfdb49b87b7b11f3bd619021ac54647ea5f552eee7",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "arm-darwin" => {
       "static" => {
-        "checksum" => "4fa0dbccba79f70edc6844a86bfd047ccdd612d752b65aff46fe0e21d8a610ea",
+        "checksum" => "47ab9a2778483ed7c35844778eaa983809679a70642739f30ad8d18c2cd7a578",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "f86e88647be6c64f0f1f56b1ac15e0e4453c7e4a6c997fd5e510cf459c572a57",
+        "checksum" => "f8b6d8409e7fbc451891cfcfdb49b87b7b11f3bd619021ac54647ea5f552eee7",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "aarch64-linux" => {
       "static" => {
-        "checksum" => "cdd75637940fcfd369b569e873048c7d37a3844d9d31d783e4459b375b78ee0e",
+        "checksum" => "dfecb037362aac064d6a697c3e4ce293136a8e459894b2928c0120c6393db22a",
         "filename" => "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "99b52c29d497d63f02a4ff7162152641b51e7ecd292d07f0330e7d4f3abc8075",
+        "checksum" => "897f71d3c155cbce0149ea6c5e2e9592795c5979ddd2fc1fd235e133556fe420",
         "filename" => "appsignal-aarch64-linux-all-dynamic.tar.gz"
       }
     },
     "i686-linux" => {
       "static" => {
-        "checksum" => "a9374d1fd4baae84f1c4a74957cbb8c919b29ae2ab05a571ff75b9ca483717ab",
+        "checksum" => "a98181bfc8c7557468253c863185f68907b0d2283023f318da26dae8f997b566",
         "filename" => "appsignal-i686-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "d643c72add6fe1054faff034101cf5a2676a169c7bff479f3d79e71875598b8a",
+        "checksum" => "2ed7cce986083d7e354c519a3f102a7e939ebc3e116d1653ecba2819c728a222",
         "filename" => "appsignal-i686-linux-all-dynamic.tar.gz"
       }
     },
     "x86-linux" => {
       "static" => {
-        "checksum" => "a9374d1fd4baae84f1c4a74957cbb8c919b29ae2ab05a571ff75b9ca483717ab",
+        "checksum" => "a98181bfc8c7557468253c863185f68907b0d2283023f318da26dae8f997b566",
         "filename" => "appsignal-i686-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "d643c72add6fe1054faff034101cf5a2676a169c7bff479f3d79e71875598b8a",
+        "checksum" => "2ed7cce986083d7e354c519a3f102a7e939ebc3e116d1653ecba2819c728a222",
         "filename" => "appsignal-i686-linux-all-dynamic.tar.gz"
       }
     },
     "x86_64-linux" => {
       "static" => {
-        "checksum" => "bd625ed84100d0632b298ac602b152463628c41afe56a8621745cdae626f8413",
+        "checksum" => "3350aec725af61a3eeb83971c0ee1da6dee761df3f2099945dd5ced9a0193a50",
         "filename" => "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "0daa644acfee46848282ad733b175e4994e7faf64c8bc046d2efff2b8fc1afdd",
+        "checksum" => "cb8e94badcd8c56941bf43353b65cf57908e4f804d08c85df62f31b8b48844a0",
         "filename" => "appsignal-x86_64-linux-all-dynamic.tar.gz"
       }
     },
     "x86_64-linux-musl" => {
       "static" => {
-        "checksum" => "7988c4a2a6ba5d59be2186ce9bf51ab50b6537a60888b08c8e9066172516e59d",
+        "checksum" => "eaab36b010bdc5b06ac4646b6d4ebb94523a9f852a2a2cbaba7738b3fade64d1",
         "filename" => "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "93e47c9400ddae42a8cd2b80c09c9134ee96a76bf622c3ad5d53b776fec1a3f0",
+        "checksum" => "b8c6082bd8ee6619854436c3395355f364d8a91d6edec64e0a37c098f26e9e3f",
         "filename" => "appsignal-x86_64-linux-musl-all-dynamic.tar.gz"
       }
     },
     "aarch64-linux-musl" => {
       "static" => {
-        "checksum" => "8e5fe2a8bc4cb7de4ba7d61fec48f15aa0cd580050f67752f07625853636eb16",
+        "checksum" => "ad371eabe4e2484f7fb980e8bb53d7b079a473d615cbb738271d36f7ad81c71f",
         "filename" => "appsignal-aarch64-linux-musl-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "01f993b3320f0377ef9f652bb215ce268da208f46a6f59ad0c0e71f57257b4ef",
+        "checksum" => "9d609cecbaf90b8ad233efae5bc04e973f15077a9c361f6a4c9febcfff57fcb0",
         "filename" => "appsignal-aarch64-linux-musl-all-dynamic.tar.gz"
       }
     },
     "x86_64-freebsd" => {
       "static" => {
-        "checksum" => "09e21821eb98ad6afdb5d3708b67ea25799aedbee2ccb0d566b99d9c5703cb1e",
+        "checksum" => "b1b86d145b07b030788e1e5f21089efbda103f11ec3c11ff77c388aaa1856d4d",
         "filename" => "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "e77592de9dd7ff41efb6c1d2d88e06fa7b663e9ff009392bb971b1333e0f28d7",
+        "checksum" => "80550ade93ad62974f620e40f2ceb31b3b6304acc7d134964095ea7df4d3887f",
         "filename" => "appsignal-x86_64-freebsd-all-dynamic.tar.gz"
       }
     },
     "amd64-freebsd" => {
       "static" => {
-        "checksum" => "09e21821eb98ad6afdb5d3708b67ea25799aedbee2ccb0d566b99d9c5703cb1e",
+        "checksum" => "b1b86d145b07b030788e1e5f21089efbda103f11ec3c11ff77c388aaa1856d4d",
         "filename" => "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "e77592de9dd7ff41efb6c1d2d88e06fa7b663e9ff009392bb971b1333e0f28d7",
+        "checksum" => "80550ade93ad62974f620e40f2ceb31b3b6304acc7d134964095ea7df4d3887f",
         "filename" => "appsignal-x86_64-freebsd-all-dynamic.tar.gz"
       }
     }


### PR DESCRIPTION
- Add `memory_in_percentages` and `swap_in_percentages` host metrics that represents metrics in percentages.
- Ignore `/snap/` disk mountpoints.
- Fix issue with the open span count in logs being logged as a negative number.
- Fix agent's TCP server getting stuck when two requests are made within the same fraction of a second.

[skip review]