### PR TITLE
Fix deprecation for Sidekiq 8.0 error handler changes

### DIFF
--- a/lib/appsignal/integrations/sidekiq.rb
+++ b/lib/appsignal/integrations/sidekiq.rb
@@ -9,7 +9,7 @@ module Appsignal
     #
     # @api private
     class SidekiqErrorHandler
-      def call(exception, sidekiq_context)
+      def call(exception, sidekiq_context, _sidekiq_config = nil)
         transaction =
           if Appsignal::Transaction.current?
             Appsignal::Transaction.current


### PR DESCRIPTION
Sidekiq 7.1.5 introduces a change where the Sidekiq config is not passed in the context hash anymore, but as a separate positional argument. If the handler takes two arguments a deprecation warning is logged. In 8.0 this backwards compatibility will be dropped.

Since the config is not used at all, we can simply add an optional 3rd argument that works with old and new versions.

Fixes #1001 

## To do

- [x] Add changeset
- [x] Test on a Sidekiq version 7.1.6 / 8 app