### PR TITLE
Bump agent to b604345

### DIFF
--- a/.changesets/bump-agent-to-b604345.md
+++ b/.changesets/bump-agent-to-b604345.md
@@ -1,0 +1,12 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Bump agent to b604345.
+
+- Add an exponential backoff to the retry sleep time to bind to the StatsD, NGINX and OpenTelemetry exporter ports. This gives the agent a longer time to connect to the ports if they become available within a 4 minute window.
+- Changes to the agent logger:
+  - Logs from the agent and extension now use a more consistent format in logs for spans and transactions.
+  - Logs that are for more internal use are moved to the trace log level and logs that are useful for debugging most support issues are moved to the debug log level. It should not be necessary to use log level 'trace' as often anymore. The 'debug' log level should be enough.
+- Add `running_in_container` to agent diagnose report, to be used primarily by the Python package as a way to detect if an app's host is a container or not.

--- a/ext/agent.rb
+++ b/ext/agent.rb
@@ -6,7 +6,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 APPSIGNAL_AGENT_CONFIG = {
-  "version" => "e8207c1",
+  "version" => "b604345",
   "mirrors" => [
     "https://appsignal-agent-releases.global.ssl.fastly.net",
     "https://d135dj0rjqvssy.cloudfront.net"
@@ -14,131 +14,131 @@ APPSIGNAL_AGENT_CONFIG = {
   "triples" => {
     "x86_64-darwin" => {
       "static" => {
-        "checksum" => "b4f9460cee052fb278e854abd0253c62844cf872c1be8fec6f04474fbdbab6b7",
+        "checksum" => "98ac31aa2ca05a18e5eb94a8ecee75b83bb7d973f0f7565a36815b95577aa727",
         "filename" => "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "58278abef93445374fd7d9b66c1004f61fc8c9b0a0a6c98627bf576df71f76f0",
+        "checksum" => "8e8558136ae11a4e29062a553555cbbf2097401b423a49d252dcac715b9e5ca6",
         "filename" => "appsignal-x86_64-darwin-all-dynamic.tar.gz"
       }
     },
     "universal-darwin" => {
       "static" => {
-        "checksum" => "b4f9460cee052fb278e854abd0253c62844cf872c1be8fec6f04474fbdbab6b7",
+        "checksum" => "98ac31aa2ca05a18e5eb94a8ecee75b83bb7d973f0f7565a36815b95577aa727",
         "filename" => "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "58278abef93445374fd7d9b66c1004f61fc8c9b0a0a6c98627bf576df71f76f0",
+        "checksum" => "8e8558136ae11a4e29062a553555cbbf2097401b423a49d252dcac715b9e5ca6",
         "filename" => "appsignal-x86_64-darwin-all-dynamic.tar.gz"
       }
     },
     "aarch64-darwin" => {
       "static" => {
-        "checksum" => "47ab9a2778483ed7c35844778eaa983809679a70642739f30ad8d18c2cd7a578",
+        "checksum" => "228810d4d6c344cf6346d889b5eab4d23140a310d4e93465fb2bd461e4e4652e",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "f8b6d8409e7fbc451891cfcfdb49b87b7b11f3bd619021ac54647ea5f552eee7",
+        "checksum" => "09e7f98873a890284b97b70cdc2ac4c2556ecefcc4b3f41238caad81ad3af10c",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "arm64-darwin" => {
       "static" => {
-        "checksum" => "47ab9a2778483ed7c35844778eaa983809679a70642739f30ad8d18c2cd7a578",
+        "checksum" => "228810d4d6c344cf6346d889b5eab4d23140a310d4e93465fb2bd461e4e4652e",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "f8b6d8409e7fbc451891cfcfdb49b87b7b11f3bd619021ac54647ea5f552eee7",
+        "checksum" => "09e7f98873a890284b97b70cdc2ac4c2556ecefcc4b3f41238caad81ad3af10c",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "arm-darwin" => {
       "static" => {
-        "checksum" => "47ab9a2778483ed7c35844778eaa983809679a70642739f30ad8d18c2cd7a578",
+        "checksum" => "228810d4d6c344cf6346d889b5eab4d23140a310d4e93465fb2bd461e4e4652e",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "f8b6d8409e7fbc451891cfcfdb49b87b7b11f3bd619021ac54647ea5f552eee7",
+        "checksum" => "09e7f98873a890284b97b70cdc2ac4c2556ecefcc4b3f41238caad81ad3af10c",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "aarch64-linux" => {
       "static" => {
-        "checksum" => "dfecb037362aac064d6a697c3e4ce293136a8e459894b2928c0120c6393db22a",
+        "checksum" => "aa36f82e040b86743fed514268dc1c7d83b14739dd65337a05bf2d994b83a3aa",
         "filename" => "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "897f71d3c155cbce0149ea6c5e2e9592795c5979ddd2fc1fd235e133556fe420",
+        "checksum" => "99f0c57c2ebb7677512284a11cc375ac95d97b0ec89d6f5b33243a81bcd0123b",
         "filename" => "appsignal-aarch64-linux-all-dynamic.tar.gz"
       }
     },
     "i686-linux" => {
       "static" => {
-        "checksum" => "a98181bfc8c7557468253c863185f68907b0d2283023f318da26dae8f997b566",
+        "checksum" => "7ce2f5ed5a0f0b4ad574e897d6cd0e5912928b211b307b20b6837c1bcbfaf640",
         "filename" => "appsignal-i686-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "2ed7cce986083d7e354c519a3f102a7e939ebc3e116d1653ecba2819c728a222",
+        "checksum" => "5ba15d9836b0db556a55919b32995a2c10eaf9433050ae4a1d0bd2baf8ce70fb",
         "filename" => "appsignal-i686-linux-all-dynamic.tar.gz"
       }
     },
     "x86-linux" => {
       "static" => {
-        "checksum" => "a98181bfc8c7557468253c863185f68907b0d2283023f318da26dae8f997b566",
+        "checksum" => "7ce2f5ed5a0f0b4ad574e897d6cd0e5912928b211b307b20b6837c1bcbfaf640",
         "filename" => "appsignal-i686-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "2ed7cce986083d7e354c519a3f102a7e939ebc3e116d1653ecba2819c728a222",
+        "checksum" => "5ba15d9836b0db556a55919b32995a2c10eaf9433050ae4a1d0bd2baf8ce70fb",
         "filename" => "appsignal-i686-linux-all-dynamic.tar.gz"
       }
     },
     "x86_64-linux" => {
       "static" => {
-        "checksum" => "3350aec725af61a3eeb83971c0ee1da6dee761df3f2099945dd5ced9a0193a50",
+        "checksum" => "a597e674a8285871df3c42dc98400a8adff969737d23f8336b10d68a5d70081b",
         "filename" => "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "cb8e94badcd8c56941bf43353b65cf57908e4f804d08c85df62f31b8b48844a0",
+        "checksum" => "b07785881c68016ac037f81ce577e800ac809333bad03e0d53229e81ac9a5dda",
         "filename" => "appsignal-x86_64-linux-all-dynamic.tar.gz"
       }
     },
     "x86_64-linux-musl" => {
       "static" => {
-        "checksum" => "eaab36b010bdc5b06ac4646b6d4ebb94523a9f852a2a2cbaba7738b3fade64d1",
+        "checksum" => "ce8e4aa510880f533f17d62c53386ddf8222d2e5cd325b29f53c68661e76eea3",
         "filename" => "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "b8c6082bd8ee6619854436c3395355f364d8a91d6edec64e0a37c098f26e9e3f",
+        "checksum" => "e8a1c627b02a955f3f86ac4a24fc8ec23d0f88f6228f5415c468d18ca29268e5",
         "filename" => "appsignal-x86_64-linux-musl-all-dynamic.tar.gz"
       }
     },
     "aarch64-linux-musl" => {
       "static" => {
-        "checksum" => "ad371eabe4e2484f7fb980e8bb53d7b079a473d615cbb738271d36f7ad81c71f",
+        "checksum" => "2923da7c60ffc78f22c583e4653d904c11254c2ddd030face089b5e22e15ede2",
         "filename" => "appsignal-aarch64-linux-musl-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "9d609cecbaf90b8ad233efae5bc04e973f15077a9c361f6a4c9febcfff57fcb0",
+        "checksum" => "53277ba0f7fcc110c685964ace8605f83c828c626c5124febca377f667a6c2c0",
         "filename" => "appsignal-aarch64-linux-musl-all-dynamic.tar.gz"
       }
     },
     "x86_64-freebsd" => {
       "static" => {
-        "checksum" => "b1b86d145b07b030788e1e5f21089efbda103f11ec3c11ff77c388aaa1856d4d",
+        "checksum" => "59d341ed55ae705f034fbfa0007488e2e4c92c8e8ce0cc20604e467f252c9fd1",
         "filename" => "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "80550ade93ad62974f620e40f2ceb31b3b6304acc7d134964095ea7df4d3887f",
+        "checksum" => "0e68eb5bee50577a7c163d4bbe9d8e80732add069dacf0fdd6f76ab40846fea6",
         "filename" => "appsignal-x86_64-freebsd-all-dynamic.tar.gz"
       }
     },
     "amd64-freebsd" => {
       "static" => {
-        "checksum" => "b1b86d145b07b030788e1e5f21089efbda103f11ec3c11ff77c388aaa1856d4d",
+        "checksum" => "59d341ed55ae705f034fbfa0007488e2e4c92c8e8ce0cc20604e467f252c9fd1",
         "filename" => "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "80550ade93ad62974f620e40f2ceb31b3b6304acc7d134964095ea7df4d3887f",
+        "checksum" => "0e68eb5bee50577a7c163d4bbe9d8e80732add069dacf0fdd6f76ab40846fea6",
         "filename" => "appsignal-x86_64-freebsd-all-dynamic.tar.gz"
       }
     }

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -436,7 +436,8 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
             "boot" => { "started" => { "result" => true } },
             "host" => {
               "uid" => { "result" => Process.uid },
-              "gid" => { "result" => Process.gid }
+              "gid" => { "result" => Process.gid },
+              "running_in_container" => { "result" => Appsignal::Extension.running_in_container? }
             },
             "config" => { "valid" => { "result" => true } },
             "logger" => { "started" => { "result" => true } },


### PR DESCRIPTION
Include changelog notes for this release, but not release 8260fa1 as it was OpenTelemetry specific, which the Ruby gem doesn't support.

[skip review]