### PR TITLE
Fix error in Sidekiq probe on missing Redis info

### DIFF
--- a/.changesets/fix-internal-error-on-missing-redis-info.md
+++ b/.changesets/fix-internal-error-on-missing-redis-info.md
@@ -3,4 +3,4 @@ bump: "patch"
 type: "fix"
 ---
 
-Fix an internal error when some Redis info keys we're expecting is missing. This will fix the Sidekiq dashboard showing much less data than we can report when Redis is configured to not report all the data points we expect. You'll still miss out of metrics like used memory, but miss less data than before.
+Fix an internal error when some Redis info keys we're expecting are missing. This will fix the Sidekiq dashboard showing much less data than we can report when Redis is configured to not report all the data points we expect. You'll still miss out of metrics like used memory, but miss less data than before.

--- a/.changesets/fix-internal-error-on-missing-redis-info.md
+++ b/.changesets/fix-internal-error-on-missing-redis-info.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix an internal error when some Redis info keys we're expecting is missing. This will fix the Sidekiq dashboard showing much less data than we can report when Redis is configured to not report all the data points we expect. You'll still miss out of metrics like used memory, but miss less data than before.

--- a/lib/appsignal/probes/sidekiq.rb
+++ b/lib/appsignal/probes/sidekiq.rb
@@ -78,9 +78,9 @@ module Appsignal
         redis_info = adapter.redis_info
         return unless redis_info
 
-        gauge "connection_count", redis_info.fetch("connected_clients")
-        gauge "memory_usage", redis_info.fetch("used_memory")
-        gauge "memory_usage_rss", redis_info.fetch("used_memory_rss")
+        gauge "connection_count", redis_info["connected_clients"]
+        gauge "memory_usage", redis_info["used_memory"]
+        gauge "memory_usage_rss", redis_info["used_memory_rss"]
       end
 
       def track_stats
@@ -112,6 +112,8 @@ module Appsignal
 
       # Track a gauge metric with the `sidekiq_` prefix
       def gauge(key, value, tags = {})
+        return if value.nil?
+
         tags[:hostname] = hostname if hostname
         Appsignal.set_gauge "sidekiq_#{key}", value, tags
       end


### PR DESCRIPTION
We've seen a user report that the Redis `INFO` command on their server doesn't report the `used_memory_rss` key. Update the probe to not error when no value is set for that key or the key is not present. That way it will continue to report all the other data, just not the missing data points.

Fixes #1005