### PR TITLE
Add error causes tree as transaction metadata

### DIFF
--- a/.changesets/store-error-causes-as-transaction-metadata.md
+++ b/.changesets/store-error-causes-as-transaction-metadata.md
@@ -1,0 +1,6 @@
+---
+bump: "minor"
+type: "add"
+---
+
+Nested errors are now supported. The causes tree is stored as metadata on the transaction so it can be displayed in the UI.

--- a/.changesets/store-error-causes-as-transaction-metadata.md
+++ b/.changesets/store-error-causes-as-transaction-metadata.md
@@ -1,6 +1,0 @@
----
-bump: "minor"
-type: "add"
----
-
-Nested errors are now supported. The causes tree is stored as metadata on the transaction so it can be displayed in the UI.

--- a/.changesets/store-error-causes-as-transaction-sample-data.md
+++ b/.changesets/store-error-causes-as-transaction-sample-data.md
@@ -1,0 +1,6 @@
+---
+bump: "minor"
+type: "add"
+---
+
+Nested errors are now supported. The error causes are stored as sample data on the transaction so they can be displayed in the UI.

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -374,6 +374,24 @@ module Appsignal
         cleaned_error_message(error),
         backtrace ? Appsignal::Utils::Data.generate(backtrace) : Appsignal::Extension.data_array_new
       )
+
+      causes = []
+      while error
+        error = error.cause
+        causes << error if error
+      end
+
+      return if causes.empty?
+
+      set_sample_data(
+        "error_causes",
+        causes.map do |e|
+          {
+            :name => e.class.name,
+            :message => cleaned_error_message(e)
+          }
+        end
+      )
     end
     alias_method :add_exception, :set_error
 

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -788,6 +788,14 @@ describe Appsignal::Transaction do
         end
       end
 
+      context "when the error has no causes" do
+        it "should not send the causes information as sample data" do
+          expect(transaction.ext).to_not receive(:set_sample_data)
+
+          transaction.set_error(error)
+        end
+      end
+
       context "when the error has multiple causes" do
         let(:error) do
           e = ExampleStandardError.new("test message")
@@ -799,7 +807,7 @@ describe Appsignal::Transaction do
           e
         end
 
-        it "sends the causes information as metadata" do
+        it "sends the causes information as sample data" do
           expect(transaction.ext).to receive(:set_error).with(
             "ExampleStandardError",
             "test message",
@@ -820,6 +828,53 @@ describe Appsignal::Transaction do
                 }
               ]
             )
+          )
+
+          expect(Appsignal.logger).to_not receive(:debug)
+
+          transaction.set_error(error)
+        end
+      end
+
+      context "when the error has too many causes" do
+        let(:error) do
+          e = ExampleStandardError.new("root cause error")
+
+          11.times do |i|
+            next_e = ExampleStandardError.new("wrapper error #{i}")
+            allow(next_e).to receive(:cause).and_return(e)
+            e = next_e
+          end
+
+          allow(e).to receive(:backtrace).and_return(["line 1"])
+          e
+        end
+
+        it "sends only the first causes as sample data" do
+          expect(transaction.ext).to receive(:set_error).with(
+            "ExampleStandardError",
+            "wrapper error 10",
+            Appsignal::Utils::Data.generate(["line 1"])
+          )
+
+          expected_error_causes = Array.new(10) do |i|
+            {
+              :name => "ExampleStandardError",
+              :message => "wrapper error #{9 - i}"
+            }
+          end
+
+          expected_error_causes.last[:is_root_cause] = false
+
+          expect(transaction.ext).to receive(:set_sample_data).with(
+            "error_causes",
+            Appsignal::Utils::Data.generate(expected_error_causes)
+          )
+
+          expect(Appsignal.logger).to receive(:debug).with(
+            "Appsignal::Transaction#set_error: Error has more " \
+              "than 10 error causes. Only the first 10 " \
+              "will be reported."
           )
 
           transaction.set_error(error)


### PR DESCRIPTION
All the error causes available for a given error are now sent as transaction metadata so the UI can display it on its own section.

Part of: #1009 