### PR TITLE
Fix diagnose file read error on illegal seeks

### DIFF
--- a/.changesets/fix-error-in-diagnose-report-path-read.md
+++ b/.changesets/fix-error-in-diagnose-report-path-read.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix an error in the diagnose report when reading a file's contents results in an "Invalid seek" error. This could happen when the log path is configured to `/dev/stdout`, which is not supported.

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -631,6 +631,11 @@ module Appsignal
           else
             print_empty_line
           end
+
+          return unless path.key?(:read_error)
+
+          puts "    Read error: #{path[:read_error]}"
+          print_empty_line
         end
 
         def print_empty_line

--- a/lib/appsignal/cli/diagnose/paths.rb
+++ b/lib/appsignal/cli/diagnose/paths.rb
@@ -71,10 +71,14 @@ module Appsignal
               :group => Utils.group_for_gid(path_gid)
             }
             if info[:type] == "file"
-              info[:content] = Utils.read_file_content(
-                path,
-                BYTES_TO_READ_FOR_FILES
-              ).split("\n")
+              begin
+                info[:content] = Utils.read_file_content(
+                  path,
+                  BYTES_TO_READ_FOR_FILES
+                ).split("\n")
+              rescue => error
+                info[:read_error] = "#{error.class}: #{error.message}"
+              end
             end
           end
         end

--- a/spec/lib/appsignal/cli/diagnose/utils_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose/utils_spec.rb
@@ -71,5 +71,16 @@ describe Appsignal::CLI::Diagnose::Utils do
         is_expected.to eq(file_contents)
       end
     end
+
+    context "when reading the file raises an illegal seek error" do
+      let(:file_contents) { "line 1\n" }
+      before do
+        expect(File).to receive(:binread).and_raise(Errno::ESPIPE)
+      end
+
+      it "returns the error as the content" do
+        expect { subject }.to raise_error(Errno::ESPIPE)
+      end
+    end
   end
 end

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -1424,6 +1424,26 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
             )
           end
         end
+
+        context "when reading the file returns a illegal seek error" do
+          before do
+            File.write(file_path, "Some content")
+            allow(File).to receive(:binread).and_call_original
+            expect(File).to receive(:binread).with(file_path, anything,
+              anything).and_raise(Errno::ESPIPE)
+            run
+          end
+
+          it "outputs file does not exists" do
+            expect(output).to include %(Read error: Errno::ESPIPE: Illegal seek)
+          end
+
+          it "transmits file data in report" do
+            expect(received_report["paths"][filename]).to include(
+              "read_error" => "Errno::ESPIPE: Illegal seek"
+            )
+          end
+        end
       end
 
       describe "mkmf.log" do


### PR DESCRIPTION
When an app configured the log_file_path to something like `/dev/stdout` we can read from that source, but it will return an illegal seek error. Catch any such IO errors with SystemCallError and store the error.

Requires a server update on the viewer to display the error.