### PR TITLE
Fix compatibility for Ruby Logger 1.6.0

### DIFF
--- a/.changesets/fix-ruby-logger-1-6-0-compatibility.md
+++ b/.changesets/fix-ruby-logger-1-6-0-compatibility.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix Ruby Logger 1.6.0 compatibility

--- a/lib/appsignal/logger.rb
+++ b/lib/appsignal/logger.rb
@@ -17,6 +17,8 @@ module Appsignal
       FATAL => 7
     }.freeze
 
+    attr_reader :level
+
     # Create a new logger instance
     #
     # @param group Name of the group for this logger.
@@ -24,8 +26,6 @@ module Appsignal
     # @return [void]
     def initialize(group, level: INFO, format: PLAINTEXT)
       raise TypeError, "group must be a string" unless group.is_a? String
-
-      super(group, :level => level)
 
       @group = group
       @level = level


### PR DESCRIPTION
The way the Ruby Logger fetches the level now wasn't compatible with our logger. This commit adds an attribute reader for our log level to skip the Ruby Logger's current logic. This change works with olders version as it just replicates the behaviour prior to 1.6.

Fixes the reported bug on: https://github.com/appsignal/appsignal-ruby/pull/1019