### PR TITLE
Log a warning when no disk mountpoints are found

### DIFF
--- a/.changesets/log-disk-mountpoints-empty.md
+++ b/.changesets/log-disk-mountpoints-empty.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Log a warning when no mountpoints are found to report the disk usage metrics. This scenario shouldn't happen (it should log an error, message about skipping a mountpoint or log the disk usage). Log a warning to detect if this issue really occurs.

--- a/ext/agent.rb
+++ b/ext/agent.rb
@@ -6,7 +6,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 APPSIGNAL_AGENT_CONFIG = {
-  "version" => "aa4daed",
+  "version" => "c4fa9c0",
   "mirrors" => [
     "https://appsignal-agent-releases.global.ssl.fastly.net",
     "https://d135dj0rjqvssy.cloudfront.net"
@@ -14,131 +14,131 @@ APPSIGNAL_AGENT_CONFIG = {
   "triples" => {
     "x86_64-darwin" => {
       "static" => {
-        "checksum" => "8216a8c083ffb7f286fd249c82fb63fe45527276a8a616c0921da3f3e8b9073a",
+        "checksum" => "b0b1efb83588879f3c55958a5ff686b921e8ebe4705c8efe39bb7517dc686ca3",
         "filename" => "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "7d6a5dee8ff1e485a955871ea00a8b7fb407ad7f00b79fac1cd97e97ebc01598",
+        "checksum" => "bddfe70a2279bcac77716a45108968ce6f326422f1b491b2fdafbf1f64e30535",
         "filename" => "appsignal-x86_64-darwin-all-dynamic.tar.gz"
       }
     },
     "universal-darwin" => {
       "static" => {
-        "checksum" => "8216a8c083ffb7f286fd249c82fb63fe45527276a8a616c0921da3f3e8b9073a",
+        "checksum" => "b0b1efb83588879f3c55958a5ff686b921e8ebe4705c8efe39bb7517dc686ca3",
         "filename" => "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "7d6a5dee8ff1e485a955871ea00a8b7fb407ad7f00b79fac1cd97e97ebc01598",
+        "checksum" => "bddfe70a2279bcac77716a45108968ce6f326422f1b491b2fdafbf1f64e30535",
         "filename" => "appsignal-x86_64-darwin-all-dynamic.tar.gz"
       }
     },
     "aarch64-darwin" => {
       "static" => {
-        "checksum" => "5f1782b53f24e2d8f8e0681eb7934af93532f84475c44b7389b2fe88ac34630d",
+        "checksum" => "5297eb3de8b32ad8dd048f6589105fe07ffc770c97f528e7b95c4b9da760e619",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "bee286947c121768a5746130016b4d54063332498e27793e97989ac6b65ca02a",
+        "checksum" => "84ad539adb57a85e5377c227b868bd82d835b1e23d96b0fa21df5fd23a52897d",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "arm64-darwin" => {
       "static" => {
-        "checksum" => "5f1782b53f24e2d8f8e0681eb7934af93532f84475c44b7389b2fe88ac34630d",
+        "checksum" => "5297eb3de8b32ad8dd048f6589105fe07ffc770c97f528e7b95c4b9da760e619",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "bee286947c121768a5746130016b4d54063332498e27793e97989ac6b65ca02a",
+        "checksum" => "84ad539adb57a85e5377c227b868bd82d835b1e23d96b0fa21df5fd23a52897d",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "arm-darwin" => {
       "static" => {
-        "checksum" => "5f1782b53f24e2d8f8e0681eb7934af93532f84475c44b7389b2fe88ac34630d",
+        "checksum" => "5297eb3de8b32ad8dd048f6589105fe07ffc770c97f528e7b95c4b9da760e619",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "bee286947c121768a5746130016b4d54063332498e27793e97989ac6b65ca02a",
+        "checksum" => "84ad539adb57a85e5377c227b868bd82d835b1e23d96b0fa21df5fd23a52897d",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "aarch64-linux" => {
       "static" => {
-        "checksum" => "0743450b2ad48971ec3251565898e33b9af214b4d2db36e12b7089ff3d3b8f3e",
+        "checksum" => "a236dd63b9d3731cd2446e4d9a40b9326313aa9e907189f0c2d5aef57c88c65a",
         "filename" => "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "8382787ff417a7c89f8679504e0e748eb68e4623ca50b1d6f2a740ba8ee8bbb9",
+        "checksum" => "09e6e5bfedb01f2c0510a8ace4a1d83330b7cc860b8af6067647ba55459642e7",
         "filename" => "appsignal-aarch64-linux-all-dynamic.tar.gz"
       }
     },
     "i686-linux" => {
       "static" => {
-        "checksum" => "32a72c3a9745348251fe20e8e8d10f52476e8cec47ea3b2495c14d1ca4a30ac5",
+        "checksum" => "967d122b0ad911e23d8dbd433ae519e4e05e9f848a084b0f8ef31f2b8fdc38b2",
         "filename" => "appsignal-i686-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "0d383ee9d9781d6ddb09e89e2e3f24d43d5fe228d5a5a5c89f13de14715ccfe3",
+        "checksum" => "3dd9de5d6941c84e0aaaf5d56696c6bfab73edef6f8fcf9ae2a737dd574c1493",
         "filename" => "appsignal-i686-linux-all-dynamic.tar.gz"
       }
     },
     "x86-linux" => {
       "static" => {
-        "checksum" => "32a72c3a9745348251fe20e8e8d10f52476e8cec47ea3b2495c14d1ca4a30ac5",
+        "checksum" => "967d122b0ad911e23d8dbd433ae519e4e05e9f848a084b0f8ef31f2b8fdc38b2",
         "filename" => "appsignal-i686-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "0d383ee9d9781d6ddb09e89e2e3f24d43d5fe228d5a5a5c89f13de14715ccfe3",
+        "checksum" => "3dd9de5d6941c84e0aaaf5d56696c6bfab73edef6f8fcf9ae2a737dd574c1493",
         "filename" => "appsignal-i686-linux-all-dynamic.tar.gz"
       }
     },
     "x86_64-linux" => {
       "static" => {
-        "checksum" => "8804bdd137e87576f0f32e565ecafc395da118e1d427155c38f27cc7d222777d",
+        "checksum" => "6519f8344fe6915b25c9e38b5839680d6df5268a6610608f8bb89c05aed9b4ce",
         "filename" => "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "bc545a567ba98a63fe838faf4c6ddcc039295774f936b83d9038a3846b636131",
+        "checksum" => "477cc6891d7cd02ac0b248e6d8ce01a67f9493c8749890923503588cc8c03ebd",
         "filename" => "appsignal-x86_64-linux-all-dynamic.tar.gz"
       }
     },
     "x86_64-linux-musl" => {
       "static" => {
-        "checksum" => "09f97d946a7d1c45f24824e8c0c296ac49fdbf0a8e9869e45176838bc82929c5",
+        "checksum" => "2fa6d7224d3a0af7f9205f61f580f6d786ce070254897d1538d3e48991f353cf",
         "filename" => "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "eea4f2e4ebec0c44435c6185c005722fdf33aa69ed70c836a61090e577d4825a",
+        "checksum" => "456b5723be546944307cc124f2421a72a6677b59d99a52f3884a2e30c6f1fd68",
         "filename" => "appsignal-x86_64-linux-musl-all-dynamic.tar.gz"
       }
     },
     "aarch64-linux-musl" => {
       "static" => {
-        "checksum" => "e0f942c8053e2939cffce722c35160d8798d867d91902b6cb9b6ccf7513d0059",
+        "checksum" => "2aa31ff5929823c0564b30afac7fbbe6930792066247a2a94e4aa0b6e1d56661",
         "filename" => "appsignal-aarch64-linux-musl-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "c94dc32400270d90db73277d790c26601f743dbda549314ecf3282b0d96a547b",
+        "checksum" => "f829ccc04c7bcd10ca096ea7d566fcf36d7a12423a61edf537a642995b137dc2",
         "filename" => "appsignal-aarch64-linux-musl-all-dynamic.tar.gz"
       }
     },
     "x86_64-freebsd" => {
       "static" => {
-        "checksum" => "c105e18399df06884983ec58602a848369a98806ba8264e6dc2b7a06476dd582",
+        "checksum" => "bf683c6d3cd39263b5e37b0b2b0e697f3e8a1f7e5a76d2ab1d25f42a973e69c2",
         "filename" => "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "f7fc985a47123a88498d0ab541e842e9acb02464400cef8e6937d7ea0daf4df4",
+        "checksum" => "23aa6f6ee7df1cc720a9bb600807629a6dbc83c6ee6634071c9f11fb423bd46c",
         "filename" => "appsignal-x86_64-freebsd-all-dynamic.tar.gz"
       }
     },
     "amd64-freebsd" => {
       "static" => {
-        "checksum" => "c105e18399df06884983ec58602a848369a98806ba8264e6dc2b7a06476dd582",
+        "checksum" => "bf683c6d3cd39263b5e37b0b2b0e697f3e8a1f7e5a76d2ab1d25f42a973e69c2",
         "filename" => "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "f7fc985a47123a88498d0ab541e842e9acb02464400cef8e6937d7ea0daf4df4",
+        "checksum" => "23aa6f6ee7df1cc720a9bb600807629a6dbc83c6ee6634071c9f11fb423bd46c",
         "filename" => "appsignal-x86_64-freebsd-all-dynamic.tar.gz"
       }
     }


### PR DESCRIPTION
Log a warning when no mountpoints are found to report the disk usage metrics. This scenario shouldn't happen (it should log an error, message about skipping a mountpoint or log the disk usage). Log a warning to detect if this issue really occurs.

Related to https://github.com/appsignal/appsignal-agent/pull/1091

[skip review]