### PR TITLE
Fix Ruby and JRuby versions in install report

### DIFF
--- a/.changesets/track-ruby-and-jruby-versions-in-install-report-better.md
+++ b/.changesets/track-ruby-and-jruby-versions-in-install-report-better.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix reporting of the Ruby syntax version and JRuby version in install report better.

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -16,6 +16,7 @@ task :default do
 
   library_type = "dynamic"
   report["language"]["implementation"] = "jruby"
+  report["language"]["implementation_version"] = JRUBY_VERSION
   report["build"]["library_type"] = library_type
   next unless check_architecture
 

--- a/ext/base.rb
+++ b/ext/base.rb
@@ -26,13 +26,16 @@ def report
   @report ||=
     begin
       rbconfig = RbConfig::CONFIG
+      patchlevel = rbconfig["PATCHLEVEL"]
+      patchlevel_label = "-p#{patchlevel}" if patchlevel
+      ruby_version = "#{RUBY_VERSION}#{patchlevel_label}"
       {
         "result" => {
           "status" => "incomplete"
         },
         "language" => {
           "name" => "ruby",
-          "version" => "#{rbconfig["RUBY_PROGRAM_VERSION"]}-p#{rbconfig["PATCHLEVEL"]}"
+          "version" => ruby_version
         },
         "download" => {
           "checksum" => "unverified"

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -253,15 +253,17 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
       it "adds the installation report to the diagnostics report" do
         run
         jruby = Appsignal::System.jruby?
+        language = {
+          "name" => "ruby",
+          "version" => "#{RUBY_VERSION}#{"-p#{rbconfig["PATCHLEVEL"]}" unless jruby}",
+          "implementation" => jruby ? "jruby" : "ruby"
+        }
+        language["implementation_version"] = JRUBY_VERSION if jruby
         expect(received_report["installation"]).to match(
           "result" => {
             "status" => "success"
           },
-          "language" => {
-            "name" => "ruby",
-            "version" => "#{rbconfig["RUBY_PROGRAM_VERSION"]}-p#{rbconfig["PATCHLEVEL"]}",
-            "implementation" => jruby ? "jruby" : "ruby"
-          },
+          "language" => language,
           "download" => {
             "download_url" => kind_of(String),
             "checksum" => "verified",


### PR DESCRIPTION
The Ruby version for JRuby was reported as `-p` because it didn't have the `RUBY_PROGRAM_VERSION` and `PATCHLEVEL` values from RbConfig. Instead use the `ruby_version` value that seems available on both implementations.

For JRuby, also track the implementation version so we can see which JRuby is being used. This will require a server update to show this field.