### PR TITLE
Update Semaphore CI to Ubuntu 20.04

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -8,7 +8,7 @@ name: AppSignal Ruby Build and Tests
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 auto_cancel:
   running:
     when: branch != 'main' AND branch != 'develop'
@@ -17,9 +17,9 @@ global_job_config:
   - name: RUNNING_IN_CI
     value: 'true'
   - name: _BUNDLER_CACHE
-    value: v2
+    value: v3
   - name: _GEMS_CACHE
-    value: v2
+    value: v3
   prologue:
     commands:
     - checkout

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -5,7 +5,7 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
   agent:
     machine:
       type: e1-standard-2
-      os_image: ubuntu1804
+      os_image: ubuntu2004
 
   # Cancel all running and queued workflows before this one
   auto_cancel:
@@ -18,9 +18,9 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
       - name: RUNNING_IN_CI
         value: "true"
       - name: _BUNDLER_CACHE
-        value: "v2"
+        value: "v3"
       - name: _GEMS_CACHE
-        value: "v2"
+        value: "v3"
     prologue:
       commands:
         - checkout


### PR DESCRIPTION
Use a different cache tag, as native extensions built against library versions provided by Ubuntu 18.04 need to be rebuilt.

This works around an issue with the OpenSSL extension on the Ruby 2.7.8 build provided by Semaphore CI on Ubuntu 18.04, which caused a test failure on #1028. [The test failure no longer takes place on Ubuntu 20.04](https://appsignal.semaphoreci.com/workflows/47b8a548-0f65-4621-9e8e-21595196b332?pipeline_id=4328f959-21fe-4267-8842-0ac6a84770c7).