### PR TITLE
Test extension during JRuby install

### DIFF
--- a/.changesets/jruby-extension-installation-test.md
+++ b/.changesets/jruby-extension-installation-test.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Add more testing to JRuby extension installation to better report the installation result and any possible failures.

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -29,8 +29,14 @@ task :default do
 
     unarchive(archive)
   end
+
+  # Have the extension loader raise the error if it encountes a problem
+  ENV["_APPSIGNAL_EXTENSION_INSTALL"] = "true"
+  # Load the extension to test if all functions can be "attached" with FFI
+  require File.expand_path("../lib/appsignal/extension/jruby.rb", __dir__)
+
   successful_installation
-rescue => e
+rescue StandardError, LoadError => e
   fail_installation_with_error(e)
 ensure
   create_dummy_makefile unless installation_succeeded?

--- a/lib/appsignal/extension/jruby.rb
+++ b/lib/appsignal/extension/jruby.rb
@@ -242,14 +242,15 @@ module Appsignal
           [:pointer],
           :appsignal_string
 
-        Appsignal.extension_loaded = true
+        Appsignal.extension_loaded = true if Appsignal.respond_to? :extension_loaded=
       rescue LoadError => error
         error_message = "ERROR: AppSignal failed to load extension. " \
           "Please run `appsignal diagnose` and email us at support@appsignal.com\n" \
           "#{error.class}: #{error.message}"
-        Appsignal.logger.error(error_message)
+        Appsignal.logger.error(error_message) if Appsignal.respond_to? :logger
         Kernel.warn error_message
-        Appsignal.extension_loaded = false
+        Appsignal.extension_loaded = false if Appsignal.respond_to? :extension_loaded=
+        raise error if ENV["_APPSIGNAL_EXTENSION_INSTALL"] == "true"
       end
 
       def start


### PR DESCRIPTION
When installing the extension for JRuby we didn't actually test if the extension was working or not. The `install.report` would report the extension was installed successfully if the artifact archive was downloaded and extracted. We didn't test if the extension functions could be "attached" using FFI.

Load the JRuby extension during installation to test if the functions could be attached without issues.

When it fails, raise the error rather than logging it, so that the installer can detect and rescue the error to store the installation failure in the `install.report` file.