### PR TITLE
Remove unused C version selector on CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -25,12 +25,6 @@ global_job_config:
     - checkout
     - rm -f $HOME/.rbenv/plugins/rbenv-gem-rehash/etc/rbenv.d/exec/~gem-rehash.bash
     - |
-      if [ -n "$_C_VERSION" ]; then
-        sem-version c $_C_VERSION
-      else
-        echo Skipping C-lang install
-      fi
-    - |
       if [ -n "$RUBY_VERSION" ]; then
         if ! (sem-version ruby "$RUBY_VERSION"); then
           ruby_key="rbenv-ruby-$RUBY_VERSION"

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -26,12 +26,6 @@ semaphore: # Default `.semaphore/semaphore.yml` contents
         - checkout
         - rm -f $HOME/.rbenv/plugins/rbenv-gem-rehash/etc/rbenv.d/exec/~gem-rehash.bash
         - |
-          if [ -n "$_C_VERSION" ]; then
-            sem-version c $_C_VERSION
-          else
-            echo Skipping C-lang install
-          fi
-        - |
           if [ -n "$RUBY_VERSION" ]; then
             if ! (sem-version ruby "$RUBY_VERSION"); then
               ruby_key="rbenv-ruby-$RUBY_VERSION"


### PR DESCRIPTION
Its last usage was removed in commit
5bd5104b3a7d459c4dd74ca36df3bd407657c718.

[skip changeset]
[skip review]