### PR TITLE
Rename the internal logger method

### DIFF
--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -201,7 +201,7 @@ module Appsignal
           )
           Appsignal.config.write_to_environment
           Appsignal.start_logger
-          Appsignal.logger.info("Starting AppSignal diagnose")
+          Appsignal.internal_logger.info("Starting AppSignal diagnose")
         end
 
         def run_agent_diagnose_mode

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -219,8 +219,8 @@ module Appsignal
     #   use. This will be overwritten by the file config and environment
     #   variables config.
     # @param logger [Logger] The logger to use for the AppSignal gem. This is
-    #   used by the configuration class only. Default: {Appsignal.logger}. See
-    #   also {Appsignal.start_logger}.
+    #   used by the configuration class only. Default:
+    #   {Appsignal.internal_logger}. See also {Appsignal.start_logger}.
     # @param config_file [String] Custom config file location. Default
     #   `config/appsignal.yml`.
     #
@@ -230,8 +230,13 @@ module Appsignal
     #   Configuration load order
     # @see https://docs.appsignal.com/ruby/instrumentation/integrating-appsignal.html
     #   How to integrate AppSignal manually
-    def initialize(root_path, env, initial_config = {}, logger = Appsignal.logger,
-      config_file = nil)
+    def initialize(
+      root_path,
+      env,
+      initial_config = {},
+      logger = Appsignal.internal_logger,
+      config_file = nil
+    )
       @config_file_error = false
       @root_path = root_path
       @config_file = config_file

--- a/lib/appsignal/environment.rb
+++ b/lib/appsignal/environment.rb
@@ -10,9 +10,9 @@ module Appsignal
     #
     # The value of the environment metadata is given as a block that captures
     # errors that might be raised while fetching the value. It will not
-    # re-raise errors, but instead log them using the {Appsignal.logger}. This
-    # ensures AppSignal will not cause an error in the application when
-    # collecting this metadata.
+    # re-raise errors, but instead log them using the
+    # {Appsignal.internal_logger}. This ensures AppSignal will not cause an
+    # error in the application when collecting this metadata.
     #
     # @example Reporting a key and value
     #   Appsignal::Environment.report("ruby_version") { RUBY_VERSION }
@@ -34,8 +34,8 @@ module Appsignal
         when String
           key
         else
-          Appsignal.logger.error "Unable to report on environment metadata: " \
-            "Unsupported value type for #{key.inspect}"
+          Appsignal.internal_logger.error "Unable to report on environment " \
+            "metadata: Unsupported value type for #{key.inspect}"
           return
         end
 
@@ -43,7 +43,7 @@ module Appsignal
         begin
           yield
         rescue => e
-          Appsignal.logger.error \
+          Appsignal.internal_logger.error \
             "Unable to report on environment metadata #{key.inspect}:\n" \
               "#{e.class}: #{e}"
           return
@@ -56,16 +56,16 @@ module Appsignal
         when String
           yielded_value
         else
-          Appsignal.logger.error "Unable to report on environment metadata " \
-            "#{key.inspect}: Unsupported value type for " \
+          Appsignal.internal_logger.error "Unable to report on environment " \
+            "metadata #{key.inspect}: Unsupported value type for " \
             "#{yielded_value.inspect}"
           return
         end
 
       Appsignal::Extension.set_environment_metadata(key, value)
     rescue => e
-      Appsignal.logger.error "Unable to report on environment metadata:\n" \
-        "#{e.class}: #{e}"
+      Appsignal.internal_logger.error "Unable to report on environment " \
+        "metadata:\n#{e.class}: #{e}"
     end
 
     # @see report_supported_gems
@@ -114,15 +114,15 @@ module Appsignal
         report("ruby_#{gem_name}_version") { gem_spec.version.to_s }
       end
     rescue => e
-      Appsignal.logger.error "Unable to report supported gems:\n" \
+      Appsignal.internal_logger.error "Unable to report supported gems:\n" \
         "#{e.class}: #{e}"
     end
 
     def self.report_enabled(feature)
       Appsignal::Environment.report("ruby_#{feature}_enabled") { true }
     rescue => e
-      Appsignal.logger.error "Unable to report integration enabled:\n" \
-        "#{e.class}: #{e}"
+      Appsignal.internal_logger.error "Unable to report integration " \
+        "enabled:\n#{e.class}: #{e}"
     end
   end
 end

--- a/lib/appsignal/event_formatter.rb
+++ b/lib/appsignal/event_formatter.rb
@@ -73,7 +73,7 @@ module Appsignal
       end
 
       def logger
-        Appsignal.logger
+        Appsignal.internal_logger
       end
     end
 

--- a/lib/appsignal/extension.rb
+++ b/lib/appsignal/extension.rb
@@ -12,7 +12,7 @@ rescue LoadError => error
   error_message = "ERROR: AppSignal failed to load extension. " \
     "Please run `appsignal diagnose` and email us at support@appsignal.com\n" \
     "#{error.class}: #{error.message}"
-  Appsignal.logger.error(error_message)
+  Appsignal.internal_logger.error(error_message)
   Kernel.warn error_message
   Appsignal.extension_loaded = false
 end

--- a/lib/appsignal/extension/jruby.rb
+++ b/lib/appsignal/extension/jruby.rb
@@ -247,7 +247,7 @@ module Appsignal
         error_message = "ERROR: AppSignal failed to load extension. " \
           "Please run `appsignal diagnose` and email us at support@appsignal.com\n" \
           "#{error.class}: #{error.message}"
-        Appsignal.logger.error(error_message) if Appsignal.respond_to? :logger
+        Appsignal.internal_logger.error(error_message) if Appsignal.respond_to? :internal_logger
         Kernel.warn error_message
         Appsignal.extension_loaded = false if Appsignal.respond_to? :extension_loaded=
         raise error if ENV["_APPSIGNAL_EXTENSION_INSTALL"] == "true"

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -68,9 +68,9 @@ module Appsignal
           namespace = Appsignal::Transaction::HTTP_REQUEST
           request   = ::Rack::Request.new(env)
         else
-          logger.error "Unrecognized name '#{name}': names must start with " \
-            "either 'perform_job' (for jobs and tasks) or 'process_action' " \
-            "(for HTTP requests)"
+          internal_logger.error "Unrecognized name '#{name}': names must " \
+            "start with either 'perform_job' (for jobs and tasks) or " \
+            "'process_action' (for HTTP requests)"
           return yield
         end
 
@@ -228,8 +228,8 @@ module Appsignal
         return unless active?
 
         unless error.is_a?(Exception)
-          logger.error "Appsignal.send_error: Cannot send error. The given " \
-            "value is not an exception: #{error.inspect}"
+          internal_logger.error "Appsignal.send_error: Cannot send error. " \
+            "The given value is not an exception: #{error.inspect}"
           return
         end
         transaction = Appsignal::Transaction.new(
@@ -319,8 +319,8 @@ module Appsignal
               "Appsignal.set_error called on location: #{call_location}"
         end
         unless exception.is_a?(Exception)
-          logger.error "Appsignal.set_error: Cannot set error. The given " \
-            "value is not an exception: #{exception.inspect}"
+          internal_logger.error "Appsignal.set_error: Cannot set error. " \
+            "The given value is not an exception: #{exception.inspect}"
           return
         end
         return if !active? || !Appsignal::Transaction.current?

--- a/lib/appsignal/helpers/metrics.rb
+++ b/lib/appsignal/helpers/metrics.rb
@@ -10,7 +10,7 @@ module Appsignal
           Appsignal::Utils::Data.generate(tags)
         )
       rescue RangeError
-        Appsignal.logger
+        Appsignal.internal_logger
           .warn("Gauge value #{value} for key '#{key}' is too big")
       end
 
@@ -37,7 +37,7 @@ module Appsignal
           Appsignal::Utils::Data.generate(tags)
         )
       rescue RangeError
-        Appsignal.logger
+        Appsignal.internal_logger
           .warn("Counter value #{value} for key '#{key}' is too big")
       end
 
@@ -48,7 +48,7 @@ module Appsignal
           Appsignal::Utils::Data.generate(tags)
         )
       rescue RangeError
-        Appsignal.logger
+        Appsignal.internal_logger
           .warn("Distribution value #{value} for key '#{key}' is too big")
       end
     end

--- a/lib/appsignal/hooks.rb
+++ b/lib/appsignal/hooks.rb
@@ -32,12 +32,12 @@ module Appsignal
         return unless dependencies_present?
         return if installed?
 
-        Appsignal.logger.debug("Installing #{name} hook")
+        Appsignal.internal_logger.debug("Installing #{name} hook")
         begin
           install
           @installed = true
         rescue => ex
-          logger = Appsignal.logger
+          logger = Appsignal.internal_logger
           logger.error("Error while installing #{name} hook: #{ex}")
           logger.debug ex.backtrace.join("\n")
         end

--- a/lib/appsignal/integrations/hanami.rb
+++ b/lib/appsignal/integrations/hanami.rb
@@ -6,7 +6,7 @@ module Appsignal
   module Integrations
     module HanamiPlugin
       def self.init
-        Appsignal.logger.debug("Loading Hanami integration")
+        Appsignal.internal_logger.debug("Loading Hanami integration")
 
         hanami_app_config = ::Hanami.app.config
         Appsignal.config = Appsignal::Config.new(

--- a/lib/appsignal/integrations/padrino.rb
+++ b/lib/appsignal/integrations/padrino.rb
@@ -7,7 +7,7 @@ module Appsignal
     # @api private
     module PadrinoPlugin
       def self.init
-        Appsignal.logger.debug("Loading Padrino (#{Padrino::VERSION}) integration")
+        Appsignal.internal_logger.debug("Loading Padrino (#{Padrino::VERSION}) integration")
 
         root = Padrino.mounted_root
         Appsignal.config = Appsignal::Config.new(root, Padrino.env)

--- a/lib/appsignal/integrations/railtie.rb
+++ b/lib/appsignal/integrations/railtie.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Appsignal.logger.debug("Loading Rails (#{Rails.version}) integration")
+Appsignal.internal_logger.debug("Loading Rails (#{Rails.version}) integration")
 
 require "appsignal/utils/rails_helper"
 require "appsignal/rack/rails_instrumentation"

--- a/lib/appsignal/integrations/sidekiq.rb
+++ b/lib/appsignal/integrations/sidekiq.rb
@@ -168,7 +168,7 @@ module Appsignal
         # Sidekiq issue #1761: in dev mode, it's possible to have jobs enqueued
         # which haven't been loaded into memory yet so the YAML can't be
         # loaded.
-        Appsignal.logger.warn "Unable to load YAML: #{error.message}"
+        Appsignal.internal_logger.warn "Unable to load YAML: #{error.message}"
         default
       end
     end

--- a/lib/appsignal/integrations/sinatra.rb
+++ b/lib/appsignal/integrations/sinatra.rb
@@ -3,7 +3,7 @@
 require "appsignal"
 require "appsignal/rack/sinatra_instrumentation"
 
-Appsignal.logger.debug("Loading Sinatra (#{Sinatra::VERSION}) integration")
+Appsignal.internal_logger.debug("Loading Sinatra (#{Sinatra::VERSION}) integration")
 
 app_settings = ::Sinatra::Application.settings
 Appsignal.config = Appsignal::Config.new(

--- a/lib/appsignal/minutely.rb
+++ b/lib/appsignal/minutely.rb
@@ -108,7 +108,7 @@ module Appsignal
       attr_reader :probes
 
       def logger
-        Appsignal.logger
+        Appsignal.internal_logger
       end
     end
 
@@ -132,7 +132,7 @@ module Appsignal
           sleep initial_wait_time
           initialize_probes
           loop do
-            logger = Appsignal.logger
+            logger = Appsignal.internal_logger
             logger.debug("Gathering minutely metrics with #{probe_instances.count} probes")
             probe_instances.each do |name, probe|
               logger.debug("Gathering minutely metrics with '#{name}' probe")
@@ -181,13 +181,13 @@ module Appsignal
           klass = instance.class
         end
         unless dependencies_present?(klass)
-          Appsignal.logger.debug "Skipping '#{name}' probe, " \
+          Appsignal.internal_logger.debug "Skipping '#{name}' probe, " \
             "#{klass}.dependency_present? returned falsy"
           return
         end
         probe_instances[name] = instance
       rescue => error
-        logger = Appsignal.logger
+        logger = Appsignal.internal_logger
         logger.error "Error while initializing minutely probe '#{name}': #{error}"
         logger.debug error.backtrace.join("\n")
       end

--- a/lib/appsignal/probes/gvl.rb
+++ b/lib/appsignal/probes/gvl.rb
@@ -22,7 +22,7 @@ module Appsignal
       end
 
       def initialize(appsignal: Appsignal, gvl_tools: ::GVLTools)
-        Appsignal.logger.debug("Initializing GVL probe")
+        Appsignal.internal_logger.debug("Initializing GVL probe")
         @appsignal = appsignal
         @gvl_tools = gvl_tools
       end

--- a/lib/appsignal/probes/helpers.rb
+++ b/lib/appsignal/probes/helpers.rb
@@ -47,7 +47,7 @@ module Appsignal
         # Auto detect hostname as fallback. May be inaccurate.
         @hostname =
           config[:hostname] || Socket.gethostname
-        Appsignal.logger.debug "Probe helper: Using hostname config " \
+        Appsignal.internal_logger.debug "Probe helper: Using hostname config " \
           "option '#{@hostname.inspect}' as hostname"
 
         @hostname

--- a/lib/appsignal/probes/mri.rb
+++ b/lib/appsignal/probes/mri.rb
@@ -11,7 +11,7 @@ module Appsignal
       end
 
       def initialize(appsignal: Appsignal, gc_profiler: Appsignal::GarbageCollection.profiler)
-        Appsignal.logger.debug("Initializing VM probe")
+        Appsignal.internal_logger.debug("Initializing VM probe")
         @appsignal = appsignal
         @gc_profiler = gc_profiler
       end

--- a/lib/appsignal/probes/sidekiq.rb
+++ b/lib/appsignal/probes/sidekiq.rb
@@ -59,7 +59,7 @@ module Appsignal
         @adapter = is_sidekiq7 ? Sidekiq7Adapter : Sidekiq6Adapter
 
         config_string = " with config: #{config}" unless config.empty?
-        Appsignal.logger.debug("Initializing Sidekiq probe#{config_string}")
+        Appsignal.internal_logger.debug("Initializing Sidekiq probe#{config_string}")
         require "sidekiq/api"
       end
 
@@ -123,14 +123,14 @@ module Appsignal
 
         if config.key?(:hostname)
           @hostname = config[:hostname]
-          Appsignal.logger.debug "Sidekiq probe: Using hostname config " \
-            "option #{@hostname.inspect} as hostname"
+          Appsignal.internal_logger.debug "Sidekiq probe: Using hostname " \
+            "config option #{@hostname.inspect} as hostname"
           return @hostname
         end
 
         host = adapter.hostname
-        Appsignal.logger.debug "Sidekiq probe: Using Redis server hostname " \
-          "#{host.inspect} as hostname"
+        Appsignal.internal_logger.debug "Sidekiq probe: Using Redis server " \
+          "hostname #{host.inspect} as hostname"
         @hostname = host
       end
     end

--- a/lib/appsignal/rack/generic_instrumentation.rb
+++ b/lib/appsignal/rack/generic_instrumentation.rb
@@ -7,7 +7,7 @@ module Appsignal
   module Rack
     class GenericInstrumentation
       def initialize(app, options = {})
-        Appsignal.logger.debug "Initializing Appsignal::Rack::GenericInstrumentation"
+        Appsignal.internal_logger.debug "Initializing Appsignal::Rack::GenericInstrumentation"
         @app = app
         @options = options
       end

--- a/lib/appsignal/rack/rails_instrumentation.rb
+++ b/lib/appsignal/rack/rails_instrumentation.rb
@@ -7,7 +7,7 @@ module Appsignal
   module Rack
     class RailsInstrumentation
       def initialize(app, options = {})
-        Appsignal.logger.debug "Initializing Appsignal::Rack::RailsInstrumentation"
+        Appsignal.internal_logger.debug "Initializing Appsignal::Rack::RailsInstrumentation"
         @app = app
         @options = options
       end
@@ -43,7 +43,7 @@ module Appsignal
           begin
             transaction.set_metadata("method", request.request_method)
           rescue => error
-            Appsignal.logger.error("Unable to report HTTP request method: '#{error}'")
+            Appsignal.internal_logger.error("Unable to report HTTP request method: '#{error}'")
           end
           Appsignal::Transaction.complete_current!
         end

--- a/lib/appsignal/rack/sinatra_instrumentation.rb
+++ b/lib/appsignal/rack/sinatra_instrumentation.rb
@@ -15,7 +15,7 @@ module Appsignal
       def initialize(app, options = {})
         @app = app
         @options = options
-        Appsignal.logger.warn "Please remove Appsignal::Rack::SinatraInstrumentation " \
+        Appsignal.internal_logger.warn "Please remove Appsignal::Rack::SinatraInstrumentation " \
           "from your Sinatra::Base class. This is no longer needed."
       end
 
@@ -32,7 +32,7 @@ module Appsignal
       attr_reader :raise_errors_on
 
       def initialize(app, options = {})
-        Appsignal.logger.debug "Initializing Appsignal::Rack::SinatraBaseInstrumentation"
+        Appsignal.internal_logger.debug "Initializing Appsignal::Rack::SinatraBaseInstrumentation"
         @app = app
         @options = options
         @raise_errors_on = raise_errors?(@app)

--- a/lib/appsignal/rack/streaming_listener.rb
+++ b/lib/appsignal/rack/streaming_listener.rb
@@ -7,7 +7,7 @@ module Appsignal
     # @api private
     class StreamingListener
       def initialize(app, options = {})
-        Appsignal.logger.debug "Initializing Appsignal::Rack::StreamingListener"
+        Appsignal.internal_logger.debug "Initializing Appsignal::Rack::StreamingListener"
         @app = app
         @options = options
       end

--- a/lib/appsignal/span.rb
+++ b/lib/appsignal/span.rb
@@ -16,8 +16,8 @@ module Appsignal
 
     def add_error(error)
       unless error.is_a?(Exception)
-        Appsignal.logger.error "Appsignal::Span#add_error: Cannot add error. " \
-          "The given value is not an exception: #{error.inspect}"
+        Appsignal.internal_logger.error "Appsignal::Span#add_error: Cannot " \
+          "add error. The given value is not an exception: #{error.inspect}"
         return
       end
       return unless error

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -26,7 +26,7 @@ module Appsignal
             Appsignal::Transaction.new(id, namespace, request, options)
         else
           # Otherwise, log the issue about trying to start another transaction
-          Appsignal.logger.warn_once_then_debug(
+          Appsignal.internal_logger.warn_once_then_debug(
             :transaction_id,
             "Trying to start new transaction with id " \
               "'#{id}', but a transaction with id '#{current.transaction_id}' " \
@@ -59,7 +59,7 @@ module Appsignal
       def complete_current!
         current.complete
       rescue => e
-        Appsignal.logger.error(
+        Appsignal.internal_logger.error(
           "Failed to complete transaction ##{current.transaction_id}. #{e.message}"
         )
       ensure
@@ -114,7 +114,7 @@ module Appsignal
 
     def complete
       if discarded?
-        Appsignal.logger.debug "Skipping transaction '#{transaction_id}' " \
+        Appsignal.internal_logger.debug "Skipping transaction '#{transaction_id}' " \
           "because it was manually discarded."
         return
       end
@@ -188,7 +188,7 @@ module Appsignal
     #   Breadcrumb reference
     def add_breadcrumb(category, action, message = "", metadata = {}, time = Time.now.utc)
       unless metadata.is_a? Hash
-        Appsignal.logger.error "add_breadcrumb: Cannot add breadcrumb. " \
+        Appsignal.internal_logger.error "add_breadcrumb: Cannot add breadcrumb. " \
           "The given metadata argument is not a Hash."
         return
       end
@@ -287,7 +287,7 @@ module Appsignal
 
       @ext.set_queue_start(start)
     rescue RangeError
-      Appsignal.logger.warn("Queue start value #{start} is too big")
+      Appsignal.internal_logger.warn("Queue start value #{start} is too big")
     end
 
     # Set the queue time based on the HTTP header or `:queue_start` env key
@@ -324,7 +324,7 @@ module Appsignal
       return unless key && data
 
       if !data.is_a?(Array) && !data.is_a?(Hash)
-        Appsignal.logger.error(
+        Appsignal.internal_logger.error(
           "Invalid sample data for '#{key}'. Value is not an Array or Hash: '#{data.inspect}'"
         )
         return
@@ -337,11 +337,11 @@ module Appsignal
     rescue RuntimeError => e
       begin
         inspected_data = data.inspect
-        Appsignal.logger.error(
+        Appsignal.internal_logger.error(
           "Error generating data (#{e.class}: #{e.message}) for '#{inspected_data}'"
         )
       rescue => e
-        Appsignal.logger.error(
+        Appsignal.internal_logger.error(
           "Error generating data (#{e.class}: #{e.message}). Can't inspect data."
         )
       end
@@ -362,7 +362,7 @@ module Appsignal
 
     def set_error(error)
       unless error.is_a?(Exception)
-        Appsignal.logger.error "Appsignal::Transaction#set_error: Cannot set error. " \
+        Appsignal.internal_logger.error "Appsignal::Transaction#set_error: Cannot set error. " \
           "The given value is not an exception: #{error.inspect}"
         return
       end
@@ -385,7 +385,7 @@ module Appsignal
         break unless error
 
         if causes.length >= ERROR_CAUSES_LIMIT
-          Appsignal.logger.debug "Appsignal::Transaction#set_error: Error has more " \
+          Appsignal.internal_logger.debug "Appsignal::Transaction#set_error: Error has more " \
             "than #{ERROR_CAUSES_LIMIT} error causes. Only the first #{ERROR_CAUSES_LIMIT} " \
             "will be reported."
           root_cause_missing = true
@@ -529,7 +529,7 @@ module Appsignal
         request.send options[:params_method]
       rescue => e
         # Getting params from the request has been know to fail.
-        Appsignal.logger.debug "Exception while getting params: #{e}"
+        Appsignal.internal_logger.debug "Exception while getting params: #{e}"
         nil
       end
     end

--- a/lib/appsignal/utils/deprecation_message.rb
+++ b/lib/appsignal/utils/deprecation_message.rb
@@ -3,12 +3,12 @@
 module Appsignal
   module Utils
     module DeprecationMessage
-      def self.message(message, logger = Appsignal.logger)
+      def self.message(message, logger = Appsignal.internal_logger)
         Kernel.warn "appsignal WARNING: #{message}"
         logger.warn message
       end
 
-      def deprecation_message(message, logger = Appsignal.logger)
+      def deprecation_message(message, logger = Appsignal.internal_logger)
         Appsignal::Utils::DeprecationMessage.message(message, logger)
       end
     end

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -265,7 +265,7 @@ describe Appsignal::Config do
 
     context "with an overriden config file" do
       let(:config) do
-        project_fixture_config("production", {}, Appsignal.logger,
+        project_fixture_config("production", {}, Appsignal.internal_logger,
           File.join(project_fixture_path, "config", "appsignal.yml"))
       end
 
@@ -276,7 +276,7 @@ describe Appsignal::Config do
 
       context "with an invalid overriden config file" do
         let(:config) do
-          project_fixture_config("production", {}, Appsignal.logger,
+          project_fixture_config("production", {}, Appsignal.internal_logger,
             File.join(project_fixture_path, "config", "missing.yml"))
         end
 

--- a/spec/lib/appsignal/hooks/activejob_spec.rb
+++ b/spec/lib/appsignal/hooks/activejob_spec.rb
@@ -76,7 +76,7 @@ if DependencyHelper.active_job_present?
       ActiveJob::Base.queue_adapter = :inline
 
       start_agent
-      Appsignal.logger = test_logger(log)
+      Appsignal.internal_logger = test_logger(log)
       class ActiveJobTestJob < ActiveJob::Base
         def perform(*_args)
         end

--- a/spec/lib/appsignal/hooks_spec.rb
+++ b/spec/lib/appsignal/hooks_spec.rb
@@ -67,12 +67,12 @@ describe Appsignal::Hooks do
     expect(Appsignal::Hooks.hooks[:mock_error_hook]).to be_instance_of(MockErrorHook)
     expect(Appsignal::Hooks.hooks[:mock_error_hook].installed?).to be_falsy
 
-    expect(Appsignal.logger).to receive(:error)
+    expect(Appsignal.internal_logger).to receive(:error)
       .with("Error while installing mock_error_hook hook: error").once
-    expect(Appsignal.logger).to receive(:debug).ordered do |message|
+    expect(Appsignal.internal_logger).to receive(:debug).ordered do |message|
       expect(message).to eq("Installing mock_error_hook hook")
     end
-    expect(Appsignal.logger).to receive(:debug).ordered do |message|
+    expect(Appsignal.internal_logger).to receive(:debug).ordered do |message|
       # Start of the error backtrace as debug log
       expect(message).to start_with(File.expand_path("../../..", __dir__))
     end
@@ -89,7 +89,7 @@ describe Appsignal::Hooks do
     let(:log_stream) { std_stream }
     let(:log) { log_contents(log_stream) }
     before do
-      Appsignal.logger = test_logger(log_stream)
+      Appsignal.internal_logger = test_logger(log_stream)
     end
 
     def call_constant(&block)

--- a/spec/lib/appsignal/integrations/railtie_spec.rb
+++ b/spec/lib/appsignal/integrations/railtie_spec.rb
@@ -18,9 +18,9 @@ if DependencyHelper.rails_present?
     describe "#initialize_appsignal" do
       let(:app) { MyApp::Application.new }
 
-      describe ".logger" do
+      describe ".internal_logger" do
         before  { Appsignal::Integrations::Railtie.initialize_appsignal(app) }
-        subject { Appsignal.logger }
+        subject { Appsignal.internal_logger }
 
         it { is_expected.to be_a Logger }
       end

--- a/spec/lib/appsignal/integrations/sidekiq_spec.rb
+++ b/spec/lib/appsignal/integrations/sidekiq_spec.rb
@@ -4,7 +4,7 @@ describe Appsignal::Integrations::SidekiqErrorHandler do
   let(:log) { StringIO.new }
   before do
     start_agent
-    Appsignal.logger = test_logger(log)
+    Appsignal.internal_logger = test_logger(log)
   end
   around { |example| keep_transactions { example.run } }
 
@@ -86,7 +86,7 @@ describe Appsignal::Integrations::SidekiqMiddleware, :with_yaml_parse_error => f
   let(:log) { StringIO.new }
   before do
     start_agent
-    Appsignal.logger = test_logger(log)
+    Appsignal.internal_logger = test_logger(log)
   end
   around { |example| keep_transactions { example.run } }
   after :with_yaml_parse_error => false do
@@ -423,7 +423,7 @@ if DependencyHelper.active_job_present?
     end
     around do |example|
       start_agent
-      Appsignal.logger = test_logger(log)
+      Appsignal.internal_logger = test_logger(log)
       ActiveJob::Base.queue_adapter = :sidekiq
 
       class ActiveJobSidekiqTestJob < ActiveJob::Base

--- a/spec/lib/appsignal/integrations/sinatra_spec.rb
+++ b/spec/lib/appsignal/integrations/sinatra_spec.rb
@@ -16,8 +16,8 @@ if DependencyHelper.sinatra_present?
     before { allow(Appsignal).to receive(:active?).and_return(true) }
     after { uninstall_sinatra_integration }
 
-    context "Appsignal.logger" do
-      subject { Appsignal.logger }
+    context "Appsignal.internal_logger" do
+      subject { Appsignal.internal_logger }
 
       it "sets a logger" do
         install_sinatra_integration

--- a/spec/lib/appsignal/minutely_spec.rb
+++ b/spec/lib/appsignal/minutely_spec.rb
@@ -42,7 +42,7 @@ describe Appsignal::Minutely do
     let(:log_stream) { StringIO.new }
     let(:log) { log_contents(log_stream) }
     before do
-      Appsignal.logger = test_logger(log_stream)
+      Appsignal.internal_logger = test_logger(log_stream)
       # Speed up test time
       allow(Appsignal::Minutely).to receive(:initial_wait_time).and_return(0.001)
       allow(Appsignal::Minutely).to receive(:wait_time).and_return(0.001)
@@ -287,7 +287,7 @@ describe Appsignal::Minutely do
     describe "#register" do
       let(:log_stream) { std_stream }
       let(:log) { log_contents(log_stream) }
-      before { Appsignal.logger = test_logger(log_stream) }
+      before { Appsignal.internal_logger = test_logger(log_stream) }
 
       it "adds the by key probe" do
         probe = lambda {}

--- a/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
@@ -6,7 +6,7 @@ if DependencyHelper.rails_present?
     let(:log) { StringIO.new }
     before do
       start_agent
-      Appsignal.logger = test_logger(log)
+      Appsignal.internal_logger = test_logger(log)
     end
 
     let(:params) do

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -580,7 +580,7 @@ describe Appsignal::Transaction do
       it "does not raise an error when the queue start is too big" do
         expect(transaction.ext).to receive(:set_queue_start).and_raise(RangeError)
 
-        expect(Appsignal.logger).to receive(:warn).with("Queue start value 10 is too big")
+        expect(Appsignal.internal_logger).to receive(:warn).with("Queue start value 10 is too big")
 
         expect do
           transaction.set_queue_start(10)
@@ -766,7 +766,7 @@ describe Appsignal::Transaction do
         let(:error) { Object.new }
 
         it "does not add the error" do
-          expect(Appsignal.logger).to receive(:error).with(
+          expect(Appsignal.internal_logger).to receive(:error).with(
             "Appsignal::Transaction#set_error: Cannot set error. " \
               "The given value is not an exception: #{error.inspect}"
           )
@@ -830,7 +830,7 @@ describe Appsignal::Transaction do
             )
           )
 
-          expect(Appsignal.logger).to_not receive(:debug)
+          expect(Appsignal.internal_logger).to_not receive(:debug)
 
           transaction.set_error(error)
         end
@@ -871,7 +871,7 @@ describe Appsignal::Transaction do
             Appsignal::Utils::Data.generate(expected_error_causes)
           )
 
-          expect(Appsignal.logger).to receive(:debug).with(
+          expect(Appsignal.internal_logger).to receive(:debug).with(
             "Appsignal::Transaction#set_error: Error has more " \
               "than 10 error causes. Only the first 10 " \
               "will be reported."

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -165,7 +165,7 @@ RSpec.configure do |config|
   config.after :context do
     FileUtils.rm_f(File.join(project_fixture_path, "log/appsignal.log"))
     Appsignal.config = nil
-    Appsignal.logger = nil
+    Appsignal.internal_logger = nil
   end
 
   def stop_minutely_probes

--- a/spec/support/helpers/config_helpers.rb
+++ b/spec/support/helpers/config_helpers.rb
@@ -5,8 +5,12 @@ module ConfigHelpers
     )
   end
 
-  def project_fixture_config(env = "production", initial_config = {}, logger = Appsignal.logger, # rubocop:disable Metrics/ParameterLists
-    config_file = nil)
+  def project_fixture_config( # rubocop:disable Metrics/ParameterLists
+    env = "production",
+    initial_config = {},
+    logger = Appsignal.internal_logger,
+    config_file = nil
+  )
     Appsignal::Config.new(
       project_fixture_path,
       env,

--- a/spec/support/helpers/log_helpers.rb
+++ b/spec/support/helpers/log_helpers.rb
@@ -6,9 +6,9 @@ module LogHelpers
   end
 
   def use_logger_with(log)
-    Appsignal.logger = test_logger(log)
+    Appsignal.internal_logger = test_logger(log)
     yield
-    Appsignal.logger = nil
+    Appsignal.internal_logger = nil
   end
 
   def test_logger(log)


### PR DESCRIPTION
To avoid confusion and potential misuse of the AppSignal internal logger rename `Appsignal.logger` to `Appsignal.internal_logger`.

We are worried some people may be using `Appsignal.logger` to log messages to our logging feature, which are two different things. Hopefully the name "internal" in the method call should make it clear it's not meant to be called directly.

[skip changeset] This is the change of a private API. People should already not be calling it.

Closes #1033