### PR TITLE
Update supported gems in environment metadata

### DIFF
--- a/lib/appsignal/environment.rb
+++ b/lib/appsignal/environment.rb
@@ -71,11 +71,20 @@ module Appsignal
     # @see report_supported_gems
     SUPPORTED_GEMS = %w[
       actioncable
+      actionmailer
       activejob
+      activerecord
       capistrano
       celluloid
       data_mapper
       delayed_job
+      dry-monitor
+      elasticsearch
+      excon
+      faraday
+      gvltools
+      hanami
+      hiredis
       mongo_ruby_driver
       padrino
       passenger
@@ -85,7 +94,9 @@ module Appsignal
       rails
       rake
       redis
+      redis-client
       resque
+      rom
       sequel
       shoryuken
       sidekiq


### PR DESCRIPTION
Update which gems we support in the environment metadata system, since this was last updated. This way we have a better idea of what versions to support of those gems.

I've also added more Rails gems that could be used outside of Rails. That way we don't miss those gems when they're not part of a Rails app.

[skip changeset] as it's not a public facing change.