### PR TITLE
Monitor serving of Rack response bodies

### DIFF
--- a/.changesets/add-instrumentation-for-streaming-rack-responses.md
+++ b/.changesets/add-instrumentation-for-streaming-rack-responses.md
@@ -1,0 +1,21 @@
+---
+bump: "minor"
+type: "add"
+---
+
+Add instrumentation for all Rack responses, including streaming responses. New `response_body_each.rack`, `response_body_call.rack` and `response_body_to_ary.rack` events will be shown in the event timeline. This will show how long it takes to complete responses, depending on the response implementation.
+
+This Sinatra route with a streaming response will be better instrumented, for example:
+
+```ruby
+get "/stream" do
+  stream do |out|
+    sleep 1
+    out << "1"
+    sleep 1
+    out << "2"
+    sleep 1
+    out << "3"
+  end
+end
+```

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -305,5 +305,6 @@ require "appsignal/garbage_collection"
 require "appsignal/integrations/railtie" if defined?(::Rails)
 require "appsignal/transaction"
 require "appsignal/version"
+require "appsignal/rack/body_wrapper"
 require "appsignal/rack/generic_instrumentation"
 require "appsignal/transmitter"

--- a/lib/appsignal/rack/body_wrapper.rb
+++ b/lib/appsignal/rack/body_wrapper.rb
@@ -31,7 +31,7 @@ module Appsignal
           # this is not going to work since the SPEC says that if both are available,
           # `each` should be used and `call` should be ignored.
           # So for that case we can drop by to our default EnumerableBodyWrapper
-          CallableBodyWrapper.new(original_body, appsignal_transaction_or_nil)
+          CallableBodyWrapper.new(original_body, appsignal_transaction)
         else
           EnumerableBodyWrapper.new(original_body, appsignal_transaction)
         end

--- a/lib/appsignal/rack/body_wrapper.rb
+++ b/lib/appsignal/rack/body_wrapper.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+module Appsignal
+  # @api private
+  module Rack
+    class BodyWrapper
+      def self.wrap(original_body, appsignal_transaction_or_nil)
+        # The logic of how Rack treats a response body differs based on which methods
+        # the body responds to. This means that to support the Rack 3.x spec in full
+        # we need to return a wrapper which matches the API of the wrapped body as closely
+        # as possible. Pick the wrapper from the most specific to the least specific.
+        # See https://github.com/rack/rack/blob/main/SPEC.rdoc#the-body-
+        #
+        # What is important is that our Body wrapper responds to the same methods Rack
+        # (or a webserver) would be checking and calling, and passes through that functionality
+        # to the original body. This can be done using delegation via i.e. SimpleDelegate
+        # but we also need "close" to get called correctly so that the Appsignal transaction
+        # gets completed - which will not happen, for example, when #to_ary gets called
+        # just on the delegated Rack body.
+        #
+        # This comment https://github.com/rails/rails/pull/49627#issuecomment-1769802573
+        # is of particular interest to understand why this has to be somewhat complicated.
+        if original_body.respond_to?(:to_path)
+          PathableBodyWrapper.new(original_body, appsignal_transaction_or_nil)
+        elsif original_body.respond_to?(:to_ary)
+          ArrayableBodyWrapper.new(original_body, appsignal_transaction_or_nil)
+        elsif !original_body.respond_to?(:each) && original_body.respond_to?(:call)
+          CallableBodyWrapper.new(original_body, appsignal_transaction_or_nil)
+        else
+          EnumerableBodyWrapper.new(original_body, appsignal_transaction_or_nil)
+        end
+      end
+
+      def initialize(body, appsignal_transaction)
+        @body_already_closed = false
+        @body = body
+        @transaction = appsignal_transaction
+      end
+
+      # This must be present in all Rack bodies and will be called by the serving adapter
+      def close
+        # The @body_already_closed check is needed so that if `to_ary`
+        # of the body has already closed itself (as prescribed) we do not
+        # attempt to close it twice
+        @body.close if !@body_already_closed && @body.respond_to?(:close)
+        @body_already_closed = true
+      rescue Exception => error # rubocop:disable Lint/RescueException
+        @transaction&.set_error(error)
+        raise error
+      ensure
+        @transaction&.complete
+      end
+    end
+
+    # The standard Rack body wrapper which exposes "each" for iterating
+    # over the response body. This is supported across all 3 major Rack
+    # versions.
+    #
+    # @api private
+    class EnumerableBodyWrapper < BodyWrapper
+      def each(&blk)
+        # This is a workaround for the Rails bug when there was a bit too much
+        # eagerness in implementing to_ary, see:
+        # https://github.com/rails/rails/pull/44953
+        # https://github.com/rails/rails/pull/47092
+        # https://github.com/rails/rails/pull/49627
+        # https://github.com/rails/rails/issues/49588
+        # While the Rack SPEC does not mandate `each` to be callable
+        # in a blockless way it is still a good idea to have it in place.
+        return enum_for(:each) unless block_given?
+
+        @body.each(&blk)
+      rescue Exception => error # rubocop:disable Lint/RescueException
+        @transaction&.set_error(error)
+        raise error
+      end
+    end
+
+    # The callable response bodies are a new Rack 3.x feature, and would not work
+    # with older Rack versions. They must not respond to `each` because
+    # "If it responds to each, you must call each and not call". This is why
+    # it inherits from BodyWrapper directly and not from EnumerableBodyWrapper
+    #
+    # @api private
+    class CallableBodyWrapper < BodyWrapper
+      def call(stream)
+        # `stream` will be closed by the app we are calling, no need for us
+        # to close it ourselves
+        @body.call(stream)
+      rescue Exception => error # rubocop:disable Lint/RescueException
+        @transaction&.set_error(error)
+        raise error
+      end
+    end
+
+    # "to_ary" takes precedence over "each" and allows the response body
+    # to be read eagerly. If the body supports that method, it takes precedence
+    # over "each":
+    # "Middleware may call to_ary directly on the Body and return a new Body in its place"
+    # One could "fold" both the to_ary API and the each() API into one Body object, but
+    # to_ary must also call "close" after it executes - and in the Rails implementation
+    # this pecularity was not handled properly.
+    #
+    # @api private
+    class ArrayableBodyWrapper < EnumerableBodyWrapper
+      def to_ary
+        @body_already_closed = true
+        @body.to_ary
+      rescue Exception => error # rubocop:disable Lint/RescueException
+        @transaction&.set_error(error)
+        raise error
+      ensure
+        close
+      end
+    end
+
+    # Having "to_path" on a body allows Rack to serve out a static file, or to
+    # pass that file to the downstream webserver for sending using X-Sendfile
+    class PathableBodyWrapper < EnumerableBodyWrapper
+      def to_path
+        @body.to_path
+      rescue Exception => error # rubocop:disable Lint/RescueException
+        @transaction&.set_error(error)
+        raise error
+      end
+    end
+  end
+end

--- a/lib/appsignal/rack/body_wrapper.rb
+++ b/lib/appsignal/rack/body_wrapper.rb
@@ -48,7 +48,12 @@ module Appsignal
         @transaction&.set_error(error)
         raise error
       ensure
-        @transaction&.complete
+        # We need to call the Transaction class method and not
+        # @transaction.complete because the transaction is still
+        # thread-local and it needs to remove itself from the
+        # thread variables correctly, which does not happen on
+        # Transaction#complete.
+        Appsignal::Transaction.complete_current! if @transaction
       end
     end
 
@@ -110,7 +115,15 @@ module Appsignal
         @transaction&.set_error(error)
         raise error
       ensure
-        close
+        # We do not call "close" on ourselves as the only action
+        # we need to complete is completing the transaction.
+        #
+        # We need to call the Transaction class method and not
+        # @transaction.complete because the transaction is still
+        # thread-local and it needs to remove itself from the
+        # thread variables correctly, which does not happen on
+        # Transaction#complete.
+        Appsignal::Transaction.complete_current! if @transaction
       end
     end
 

--- a/lib/appsignal/rack/body_wrapper.rb
+++ b/lib/appsignal/rack/body_wrapper.rb
@@ -59,7 +59,12 @@ module Appsignal
         # thread-local and it needs to remove itself from the
         # thread variables correctly, which does not happen on
         # Transaction#complete.
-        Appsignal::Transaction.complete_current! unless @transaction.nil_transaction?
+        #
+        # In the future it would be a good idea to ensure
+        # that the current transaction is the same as @transaction,
+        # or allow @transaction to complete itself and remove
+        # itself from Thread.current
+        Appsignal::Transaction.complete_current!
       end
     end
 

--- a/lib/appsignal/rack/body_wrapper.rb
+++ b/lib/appsignal/rack/body_wrapper.rb
@@ -91,7 +91,9 @@ module Appsignal
         # in a blockless way it is still a good idea to have it in place.
         return enum_for(:each) unless block_given?
 
-        Appsignal.instrument("response_body_each.rack") { @body.each(&blk) }
+        Appsignal.instrument("process_response_body.rack", "Process Rack response body (#each)") do
+          @body.each(&blk)
+        end
       rescue Exception => error # rubocop:disable Lint/RescueException
         @transaction.set_error(error)
         raise error
@@ -108,7 +110,9 @@ module Appsignal
       def call(stream)
         # `stream` will be closed by the app we are calling, no need for us
         # to close it ourselves
-        Appsignal.instrument("response_body_call.rack") { @body.call(stream) }
+        Appsignal.instrument("process_response_body.rack", "Stream response body (#call)") do
+          @body.call(stream)
+        end
       rescue Exception => error # rubocop:disable Lint/RescueException
         @transaction.set_error(error)
         raise error
@@ -127,7 +131,9 @@ module Appsignal
     class ArrayableBodyWrapper < EnumerableBodyWrapper
       def to_ary
         @body_already_closed = true
-        Appsignal.instrument("response_body_to_ary.rack") { @body.to_ary }
+        Appsignal.instrument("process_response_body.rack", "Stream response body (#to_ary)") do
+          @body.to_ary
+        end
       rescue Exception => error # rubocop:disable Lint/RescueException
         @transaction.set_error(error)
         raise error

--- a/lib/appsignal/rack/body_wrapper.rb
+++ b/lib/appsignal/rack/body_wrapper.rb
@@ -110,7 +110,7 @@ module Appsignal
       def call(stream)
         # `stream` will be closed by the app we are calling, no need for us
         # to close it ourselves
-        Appsignal.instrument("process_response_body.rack", "Stream response body (#call)") do
+        Appsignal.instrument("process_response_body.rack", "Process Rack response body (#call)") do
           @body.call(stream)
         end
       rescue Exception => error # rubocop:disable Lint/RescueException
@@ -131,7 +131,10 @@ module Appsignal
     class ArrayableBodyWrapper < EnumerableBodyWrapper
       def to_ary
         @body_already_closed = true
-        Appsignal.instrument("process_response_body.rack", "Stream response body (#to_ary)") do
+        Appsignal.instrument(
+          "process_response_body.rack",
+          "Process Rack response body (#to_ary)"
+        ) do
           @body.to_ary
         end
       rescue Exception => error # rubocop:disable Lint/RescueException

--- a/lib/appsignal/rack/body_wrapper.rb
+++ b/lib/appsignal/rack/body_wrapper.rb
@@ -43,7 +43,7 @@ module Appsignal
         # of the body has already closed itself (as prescribed) we do not
         # attempt to close it twice
         if !@body_already_closed && @body.respond_to?(:close)
-          Appsignal.instrument("process_action.response_body_close") { @body.close }
+          Appsignal.instrument("response_body_close.rack") { @body.close }
         end
         @body_already_closed = true
       rescue Exception => error # rubocop:disable Lint/RescueException
@@ -76,7 +76,7 @@ module Appsignal
         # in a blockless way it is still a good idea to have it in place.
         return enum_for(:each) unless block_given?
 
-        Appsignal.instrument("process_action.response_body_each") { @body.each(&blk) }
+        Appsignal.instrument("response_body_each.rack") { @body.each(&blk) }
       rescue Exception => error # rubocop:disable Lint/RescueException
         @transaction&.set_error(error)
         raise error
@@ -93,7 +93,7 @@ module Appsignal
       def call(stream)
         # `stream` will be closed by the app we are calling, no need for us
         # to close it ourselves
-        Appsignal.instrument("process_action.response_body_call") { @body.call(stream) }
+        Appsignal.instrument("response_body_call.rack") { @body.call(stream) }
       rescue Exception => error # rubocop:disable Lint/RescueException
         @transaction&.set_error(error)
         raise error
@@ -112,7 +112,7 @@ module Appsignal
     class ArrayableBodyWrapper < EnumerableBodyWrapper
       def to_ary
         @body_already_closed = true
-        Appsignal.instrument("process_action.response_body_to_ary") { @body.to_ary }
+        Appsignal.instrument("response_body_to_ary.rack") { @body.to_ary }
       rescue Exception => error # rubocop:disable Lint/RescueException
         @transaction&.set_error(error)
         raise error
@@ -133,7 +133,7 @@ module Appsignal
     # pass that file to the downstream webserver for sending using X-Sendfile
     class PathableBodyWrapper < EnumerableBodyWrapper
       def to_path
-        Appsignal.instrument("process_action.response_body_to_path") { @body.to_path }
+        Appsignal.instrument("response_body_to_path.rack") { @body.to_path }
       rescue Exception => error # rubocop:disable Lint/RescueException
         @transaction&.set_error(error)
         raise error

--- a/lib/appsignal/rack/generic_instrumentation.rb
+++ b/lib/appsignal/rack/generic_instrumentation.rb
@@ -28,7 +28,7 @@ module Appsignal
           Appsignal::Transaction::HTTP_REQUEST,
           request
         )
-        # We need to complete the transaction if there is an exception exception inside the `call`
+        # We need to complete the transaction if there is an exception inside the `call`
         # of the app. If there isn't one and the app returns us a Rack response triplet, we let
         # the BodyWrapper complete the transaction when #close gets called on it
         # (guaranteed by the webserver)

--- a/lib/appsignal/rack/generic_instrumentation.rb
+++ b/lib/appsignal/rack/generic_instrumentation.rb
@@ -16,7 +16,8 @@ module Appsignal
         if Appsignal.active?
           call_with_appsignal_monitoring(env)
         else
-          @app.call(env)
+          status, headers, obody = @app.call(env)
+          [status, headers, Appsignal::Rack::BodyWrapper.wrap(obody, _transaction = nil)]
         end
       end
 
@@ -29,17 +30,19 @@ module Appsignal
         )
         begin
           Appsignal.instrument("process_action.generic") do
-            @app.call(env)
+            status, headers, obody = @app.call(env)
+            [status, headers, Appsignal::Rack::BodyWrapper.wrap(obody, transaction)]
           end
         rescue Exception => error # rubocop:disable Lint/RescueException
           transaction.set_error(error)
           raise error
         ensure
-          transaction.set_action_if_nil(env["appsignal.route"] || "unknown")
+          default_action = env["appsignal.route"] || env["appsignal.action"] || "unknown"
+          transaction.set_action_if_nil(default_action)
           transaction.set_metadata("path", request.path)
           transaction.set_metadata("method", request.request_method)
           transaction.set_http_or_background_queue_start
-          Appsignal::Transaction.complete_current!
+          # Transaction gets completed when the body gets read out
         end
       end
     end

--- a/lib/appsignal/rack/generic_instrumentation.rb
+++ b/lib/appsignal/rack/generic_instrumentation.rb
@@ -16,8 +16,9 @@ module Appsignal
         if Appsignal.active?
           call_with_appsignal_monitoring(env)
         else
+          nil_transaction = Appsignal::Transaction::NilTransaction.new
           status, headers, obody = @app.call(env)
-          [status, headers, Appsignal::Rack::BodyWrapper.wrap(obody, _transaction = nil)]
+          [status, headers, Appsignal::Rack::BodyWrapper.wrap(obody, nil_transaction)]
         end
       end
 

--- a/lib/appsignal/rack/generic_instrumentation.rb
+++ b/lib/appsignal/rack/generic_instrumentation.rb
@@ -28,6 +28,11 @@ module Appsignal
           Appsignal::Transaction::HTTP_REQUEST,
           request
         )
+        # We need to complete the transaction if there is an exception exception inside the `call`
+        # of the app. If there isn't one and the app returns us a Rack response triplet, we let
+        # the BodyWrapper complete the transaction when #close gets called on it
+        # (guaranteed by the webserver)
+        complete_transaction_without_body = false
         begin
           Appsignal.instrument("process_action.generic") do
             status, headers, obody = @app.call(env)
@@ -35,6 +40,7 @@ module Appsignal
           end
         rescue Exception => error # rubocop:disable Lint/RescueException
           transaction.set_error(error)
+          complete_transaction_without_body = true
           raise error
         ensure
           default_action = env["appsignal.route"] || env["appsignal.action"] || "unknown"
@@ -42,7 +48,10 @@ module Appsignal
           transaction.set_metadata("path", request.path)
           transaction.set_metadata("method", request.request_method)
           transaction.set_http_or_background_queue_start
-          # Transaction gets completed when the body gets read out
+
+          # Transaction gets completed when the body gets read out, except in cases when
+          # the app failed before returning us the Rack response triplet.
+          Appsignal::Transaction.complete_current! if complete_transaction_without_body
         end
       end
     end

--- a/lib/appsignal/rack/rails_instrumentation.rb
+++ b/lib/appsignal/rack/rails_instrumentation.rb
@@ -16,8 +16,9 @@ module Appsignal
         if Appsignal.active?
           call_with_appsignal_monitoring(env)
         else
+          nil_transaction = Appsignal::Transaction::NilTransaction.new
           status, headers, obody = @app.call(env)
-          [status, headers, Appsignal::Rack::BodyWrapper.wrap(obody, _transaction = nil)]
+          [status, headers, Appsignal::Rack::BodyWrapper.wrap(obody, nil_transaction)]
         end
       end
 

--- a/lib/appsignal/rack/sinatra_instrumentation.rb
+++ b/lib/appsignal/rack/sinatra_instrumentation.rb
@@ -42,8 +42,9 @@ module Appsignal
         if Appsignal.active?
           call_with_appsignal_monitoring(env)
         else
+          nil_transaction = Appsignal::Transaction::NilTransaction.new
           status, headers, obody = @app.call(env)
-          [status, headers, Appsignal::Rack::BodyWrapper.wrap(obody, _transaction = nil)]
+          [status, headers, Appsignal::Rack::BodyWrapper.wrap(obody, nil_transaction)]
         end
       end
 

--- a/lib/appsignal/rack/sinatra_instrumentation.rb
+++ b/lib/appsignal/rack/sinatra_instrumentation.rb
@@ -42,7 +42,8 @@ module Appsignal
         if Appsignal.active?
           call_with_appsignal_monitoring(env)
         else
-          @app.call(env)
+          status, headers, obody = @app.call(env)
+          [status, headers, Appsignal::Rack::BodyWrapper.wrap(obody, _transaction = nil)]
         end
       end
 
@@ -56,12 +57,19 @@ module Appsignal
           request,
           options
         )
+        # We need to complete the transaction if there is an exception exception inside the `call`
+        # of the app. If there isn't one and the app returns us a Rack response triplet, we let
+        # the BodyWrapper complete the transaction when #close gets called on it
+        # (guaranteed by the webserver)
+        complete_transaction_without_body = false
         begin
           Appsignal.instrument("process_action.sinatra") do
-            @app.call(env)
+            status, headers, obody = @app.call(env)
+            [status, headers, Appsignal::Rack::BodyWrapper.wrap(obody, transaction)]
           end
         rescue Exception => error # rubocop:disable Lint/RescueException
           transaction.set_error(error)
+          complete_transaction_without_body = true
           raise error
         ensure
           # If raise_error is off versions of Sinatra don't raise errors, but store
@@ -73,7 +81,10 @@ module Appsignal
           transaction.set_metadata("path", request.path)
           transaction.set_metadata("method", request.request_method)
           transaction.set_http_or_background_queue_start
-          Appsignal::Transaction.complete_current!
+
+          # Transaction gets completed when the body gets read out, except in cases when
+          # the app failed before returning us the Rack response triplet.
+          Appsignal::Transaction.complete_current! if complete_transaction_without_body
         end
       end
 

--- a/lib/appsignal/rack/streaming_listener.rb
+++ b/lib/appsignal/rack/streaming_listener.rb
@@ -16,7 +16,8 @@ module Appsignal
         if Appsignal.active?
           call_with_appsignal_monitoring(env)
         else
-          @app.call(env)
+          status, headers, obody = @app.call(env)
+          [status, headers, Appsignal::Rack::BodyWrapper.wrap(obody, _transaction = nil)]
         end
       end
 
@@ -43,31 +44,10 @@ module Appsignal
           end
 
         # Wrap the result body with our StreamWrapper
-        [status, headers, StreamWrapper.new(body, transaction)]
+        [status, headers, Appsignal::Rack::BodyWrapper.wrap(body, transaction)]
       end
     end
   end
 
-  class StreamWrapper
-    def initialize(stream, transaction)
-      @stream = stream
-      @transaction = transaction
-    end
-
-    def each(&block)
-      @stream.each(&block)
-    rescue Exception => e # rubocop:disable Lint/RescueException
-      @transaction.set_error(e)
-      raise e
-    end
-
-    def close
-      @stream.close if @stream.respond_to?(:close)
-    rescue Exception => e # rubocop:disable Lint/RescueException
-      @transaction.set_error(e)
-      raise e
-    ensure
-      Appsignal::Transaction.complete_current!
-    end
-  end
+  StreamWrapper = Rack::EnumerableBodyWrapper
 end

--- a/lib/appsignal/rack/streaming_listener.rb
+++ b/lib/appsignal/rack/streaming_listener.rb
@@ -16,8 +16,9 @@ module Appsignal
         if Appsignal.active?
           call_with_appsignal_monitoring(env)
         else
+          nil_transaction = Appsignal::Transaction::NilTransaction.new
           status, headers, obody = @app.call(env)
-          [status, headers, Appsignal::Rack::BodyWrapper.wrap(obody, _transaction = nil)]
+          [status, headers, Appsignal::Rack::BodyWrapper.wrap(obody, nil_transaction)]
         end
       end
 

--- a/lib/appsignal/rack/streaming_listener.rb
+++ b/lib/appsignal/rack/streaming_listener.rb
@@ -29,22 +29,32 @@ module Appsignal
           request
         )
 
-        # Instrument a `process_action`, to set params/action name
-        status, headers, body =
-          Appsignal.instrument("process_action.rack") do
-            @app.call(env)
-          rescue Exception => e # rubocop:disable Lint/RescueException
-            transaction.set_error(e)
-            raise e
-          ensure
-            transaction.set_action_if_nil(env["appsignal.action"])
-            transaction.set_metadata("path", request.path)
-            transaction.set_metadata("method", request.request_method)
-            transaction.set_http_or_background_queue_start
-          end
+        # We need to complete the transaction if there is an exception exception inside the `call`
+        # of the app. If there isn't one and the app returns us a Rack response triplet, we let
+        # the BodyWrapper complete the transaction when #close gets called on it
+        # (guaranteed by the webserver)
+        complete_transaction_without_body = false
 
-        # Wrap the result body with our StreamWrapper
-        [status, headers, Appsignal::Rack::BodyWrapper.wrap(body, transaction)]
+        # Instrument a `process_action`, to set params/action name
+        begin
+          Appsignal.instrument("process_action.rack") do
+            status, headers, obody = @app.call(env)
+            [status, headers, Appsignal::Rack::BodyWrapper.wrap(obody, transaction)]
+          end
+        rescue Exception => error # rubocop:disable Lint/RescueException
+          transaction.set_error(error)
+          complete_transaction_without_body = true
+          raise error
+        ensure
+          transaction.set_action_if_nil(env["appsignal.action"])
+          transaction.set_metadata("path", request.path)
+          transaction.set_metadata("method", request.request_method)
+          transaction.set_http_or_background_queue_start
+
+          # Transaction gets completed when the body gets read out, except in cases when
+          # the app failed before returning us the Rack response triplet.
+          Appsignal::Transaction.complete_current! if complete_transaction_without_body
+        end
       end
     end
   end

--- a/spec/lib/appsignal/rack/body_wrapper_spec.rb
+++ b/spec/lib/appsignal/rack/body_wrapper_spec.rb
@@ -47,7 +47,7 @@ describe Appsignal::Rack::BodyWrapper do
       fake_body = double
       expect(fake_body).to receive(:each).once.and_raise(Exception.new("Oops"))
 
-      txn = double("Appsignal transaction", nil_transaction?: false)
+      txn = double("Appsignal transaction", "nil_transaction?" =>  false)
       expect(txn).to receive(:set_error).once.with(instance_of(Exception))
 
       wrapped = described_class.wrap(fake_body, txn)
@@ -60,7 +60,7 @@ describe Appsignal::Rack::BodyWrapper do
       fake_body = double
       expect(fake_body).to receive(:each).once.and_yield("a").and_yield("b").and_yield("c")
 
-      txn = double("Appsignal transaction", nil_transaction?: false)
+      txn = double("Appsignal transaction", "nil_transaction?" =>  false)
       expect(Appsignal::Transaction).to receive(:complete_current!).once
 
       wrapped = described_class.wrap(fake_body, txn)
@@ -105,7 +105,7 @@ describe Appsignal::Rack::BodyWrapper do
     it "sets the exception raised inside each() into the Appsignal transaction" do
       expect(fake_body).to receive(:each).once.and_raise(Exception.new("Oops"))
 
-      txn = double("Appsignal transaction", nil_transaction?: false)
+      txn = double("Appsignal transaction", "nil_transaction?" =>  false)
       expect(txn).to receive(:set_error).once.with(instance_of(Exception))
 
       wrapped = described_class.wrap(fake_body, txn)
@@ -127,7 +127,7 @@ describe Appsignal::Rack::BodyWrapper do
       expect(fake_body).to receive(:to_ary).once.and_raise(Exception.new("Oops"))
       expect(fake_body).not_to receive(:close) # Per spec we expect the body has closed itself
 
-      txn = double("Appsignal transaction", nil_transaction?: false)
+      txn = double("Appsignal transaction", "nil_transaction?" =>  false)
       expect(txn).to receive(:set_error).once.with(instance_of(Exception))
       expect(Appsignal::Transaction).to receive(:complete_current!).once
 
@@ -158,7 +158,7 @@ describe Appsignal::Rack::BodyWrapper do
     it "sets the exception raised inside each() into the Appsignal transaction" do
       expect(fake_body).to receive(:each).once.and_raise(Exception.new("Oops"))
 
-      txn = double("Appsignal transaction", nil_transaction?: false)
+      txn = double("Appsignal transaction", "nil_transaction?" =>  false)
       expect(txn).to receive(:set_error).once.with(instance_of(Exception))
 
       wrapped = described_class.wrap(fake_body, txn)
@@ -170,7 +170,7 @@ describe Appsignal::Rack::BodyWrapper do
     it "sets the exception raised inside to_path() into the Appsignal transaction" do
       allow(fake_body).to receive(:to_path).once.and_raise(Exception.new("Oops"))
 
-      txn = double("Appsignal transaction", nil_transaction?: false)
+      txn = double("Appsignal transaction", "nil_transaction?" =>  false)
       expect(txn).to receive(:set_error).once.with(instance_of(Exception))
       expect(txn).not_to receive(:complete) # gets called by the caller via close()
 
@@ -209,7 +209,7 @@ describe Appsignal::Rack::BodyWrapper do
       fake_rack_stream = double
       allow(fake_body).to receive(:call).with(fake_rack_stream).and_raise(Exception.new("Oopsie"))
 
-      txn = double("Appsignal transaction", nil_transaction?: false)
+      txn = double("Appsignal transaction", "nil_transaction?" =>  false)
       expect(txn).to receive(:set_error).once.with(instance_of(Exception))
       expect(txn).not_to receive(:complete) # gets called by the caller via close()
       wrapped = described_class.wrap(fake_body, txn)

--- a/spec/lib/appsignal/rack/body_wrapper_spec.rb
+++ b/spec/lib/appsignal/rack/body_wrapper_spec.rb
@@ -1,10 +1,12 @@
 describe Appsignal::Rack::BodyWrapper do
+  let(:nil_txn) { Appsignal::Transaction::NilTransaction.new }
+
   describe "with a body that supports all possible features" do
     it "reduces the supported methods to just each()" do
       # which is the safest thing to do, since the body is likely broken
       fake_body = double(:each => nil, :call => nil, :to_ary => [], :to_path => "/tmp/foo.bin",
         :close => nil)
-      wrapped = described_class.wrap(fake_body, _txn = nil)
+      wrapped = described_class.wrap(fake_body, nil_txn)
       expect(wrapped).to respond_to(:each)
       expect(wrapped).not_to respond_to(:to_ary)
       expect(wrapped).not_to respond_to(:call)
@@ -17,7 +19,7 @@ describe Appsignal::Rack::BodyWrapper do
       fake_body = double
       allow(fake_body).to receive(:each)
 
-      wrapped = described_class.wrap(fake_body, _txn = nil)
+      wrapped = described_class.wrap(fake_body, nil_txn)
       expect(wrapped).to respond_to(:each)
       expect(wrapped).not_to respond_to(:to_ary)
       expect(wrapped).not_to respond_to(:call)
@@ -27,7 +29,7 @@ describe Appsignal::Rack::BodyWrapper do
     it "reads out the body in full using each" do
       fake_body = double
       expect(fake_body).to receive(:each).once.and_yield("a").and_yield("b").and_yield("c")
-      wrapped = described_class.wrap(fake_body, _txn = nil)
+      wrapped = described_class.wrap(fake_body, nil_txn)
       expect { |b| wrapped.each(&b) }.to yield_successive_args("a", "b", "c")
     end
 
@@ -35,7 +37,7 @@ describe Appsignal::Rack::BodyWrapper do
       fake_body = double
       expect(fake_body).to receive(:each).once.and_yield("a").and_yield("b").and_yield("c")
 
-      wrapped = described_class.wrap(fake_body, _txn = nil)
+      wrapped = described_class.wrap(fake_body, nil_txn)
       enum = wrapped.each
       expect(enum).to be_kind_of(Enumerator)
       expect { |b| enum.each(&b) }.to yield_successive_args("a", "b", "c")
@@ -45,7 +47,7 @@ describe Appsignal::Rack::BodyWrapper do
       fake_body = double
       expect(fake_body).to receive(:each).once.and_raise(Exception.new("Oops"))
 
-      txn = double("Appsignal transaction")
+      txn = double("Appsignal transaction", nil_transaction?: false)
       expect(txn).to receive(:set_error).once.with(instance_of(Exception))
 
       wrapped = described_class.wrap(fake_body, txn)
@@ -58,7 +60,7 @@ describe Appsignal::Rack::BodyWrapper do
       fake_body = double
       expect(fake_body).to receive(:each).once.and_yield("a").and_yield("b").and_yield("c")
 
-      txn = double("Appsignal transaction")
+      txn = double("Appsignal transaction", nil_transaction?: false)
       expect(Appsignal::Transaction).to receive(:complete_current!).once
 
       wrapped = described_class.wrap(fake_body, txn)
@@ -73,7 +75,7 @@ describe Appsignal::Rack::BodyWrapper do
       allow(fake_body).to receive(:each)
       allow(fake_body).to receive(:call)
 
-      wrapped = described_class.wrap(fake_body, _txn = nil)
+      wrapped = described_class.wrap(fake_body, nil_txn)
       expect(wrapped).to respond_to(:each)
       expect(wrapped).not_to respond_to(:to_ary)
       expect(wrapped).not_to respond_to(:call)
@@ -85,7 +87,7 @@ describe Appsignal::Rack::BodyWrapper do
   describe "with a body supporting both to_ary and each" do
     let(:fake_body) { double(:each => nil, :to_ary => []) }
     it "wraps with appropriate class" do
-      wrapped = described_class.wrap(fake_body, _txn = nil)
+      wrapped = described_class.wrap(fake_body, nil_txn)
       expect(wrapped).to respond_to(:each)
       expect(wrapped).to respond_to(:to_ary)
       expect(wrapped).not_to respond_to(:call)
@@ -96,14 +98,14 @@ describe Appsignal::Rack::BodyWrapper do
     it "reads out the body in full using each" do
       expect(fake_body).to receive(:each).once.and_yield("a").and_yield("b").and_yield("c")
 
-      wrapped = described_class.wrap(fake_body, _txn = nil)
+      wrapped = described_class.wrap(fake_body, nil_txn)
       expect { |b| wrapped.each(&b) }.to yield_successive_args("a", "b", "c")
     end
 
     it "sets the exception raised inside each() into the Appsignal transaction" do
       expect(fake_body).to receive(:each).once.and_raise(Exception.new("Oops"))
 
-      txn = double("Appsignal transaction")
+      txn = double("Appsignal transaction", nil_transaction?: false)
       expect(txn).to receive(:set_error).once.with(instance_of(Exception))
 
       wrapped = described_class.wrap(fake_body, txn)
@@ -115,7 +117,7 @@ describe Appsignal::Rack::BodyWrapper do
     it "reads out the body in full using to_ary" do
       expect(fake_body).to receive(:to_ary).and_return(["one", "two", "three"])
 
-      wrapped = described_class.wrap(fake_body, _txn = nil)
+      wrapped = described_class.wrap(fake_body, nil_txn)
       expect(wrapped.to_ary).to eq(["one", "two", "three"])
     end
 
@@ -125,7 +127,7 @@ describe Appsignal::Rack::BodyWrapper do
       expect(fake_body).to receive(:to_ary).once.and_raise(Exception.new("Oops"))
       expect(fake_body).not_to receive(:close) # Per spec we expect the body has closed itself
 
-      txn = double("Appsignal transaction")
+      txn = double("Appsignal transaction", nil_transaction?: false)
       expect(txn).to receive(:set_error).once.with(instance_of(Exception))
       expect(Appsignal::Transaction).to receive(:complete_current!).once
 
@@ -138,7 +140,7 @@ describe Appsignal::Rack::BodyWrapper do
     let(:fake_body) { double(:each => nil, :to_path => nil) }
 
     it "wraps with appropriate class" do
-      wrapped = described_class.wrap(fake_body, _txn = nil)
+      wrapped = described_class.wrap(fake_body, nil_txn)
       expect(wrapped).to respond_to(:each)
       expect(wrapped).not_to respond_to(:to_ary)
       expect(wrapped).not_to respond_to(:call)
@@ -149,14 +151,14 @@ describe Appsignal::Rack::BodyWrapper do
     it "reads out the body in full using each()" do
       expect(fake_body).to receive(:each).once.and_yield("a").and_yield("b").and_yield("c")
 
-      wrapped = described_class.wrap(fake_body, _txn = nil)
+      wrapped = described_class.wrap(fake_body, nil_txn)
       expect { |b| wrapped.each(&b) }.to yield_successive_args("a", "b", "c")
     end
 
     it "sets the exception raised inside each() into the Appsignal transaction" do
       expect(fake_body).to receive(:each).once.and_raise(Exception.new("Oops"))
 
-      txn = double("Appsignal transaction")
+      txn = double("Appsignal transaction", nil_transaction?: false)
       expect(txn).to receive(:set_error).once.with(instance_of(Exception))
 
       wrapped = described_class.wrap(fake_body, txn)
@@ -168,7 +170,7 @@ describe Appsignal::Rack::BodyWrapper do
     it "sets the exception raised inside to_path() into the Appsignal transaction" do
       allow(fake_body).to receive(:to_path).once.and_raise(Exception.new("Oops"))
 
-      txn = double("Appsignal transaction")
+      txn = double("Appsignal transaction", nil_transaction?: false)
       expect(txn).to receive(:set_error).once.with(instance_of(Exception))
       expect(txn).not_to receive(:complete) # gets called by the caller via close()
 
@@ -179,7 +181,7 @@ describe Appsignal::Rack::BodyWrapper do
     it "exposes to_path to the sender" do
       allow(fake_body).to receive(:to_path).and_return("/tmp/file.bin")
 
-      wrapped = described_class.wrap(fake_body, _txn = nil)
+      wrapped = described_class.wrap(fake_body, nil_txn)
       expect(wrapped.to_path).to eq("/tmp/file.bin")
     end
   end
@@ -187,7 +189,7 @@ describe Appsignal::Rack::BodyWrapper do
   describe "with a body only supporting call()" do
     let(:fake_body) { double(:call => nil) }
     it "wraps with appropriate class" do
-      wrapped = described_class.wrap(fake_body, _txn = nil)
+      wrapped = described_class.wrap(fake_body, nil_txn)
       expect(wrapped).not_to respond_to(:each)
       expect(wrapped).not_to respond_to(:to_ary)
       expect(wrapped).to respond_to(:call)
@@ -199,7 +201,7 @@ describe Appsignal::Rack::BodyWrapper do
       fake_rack_stream = double("stream")
       expect(fake_body).to receive(:call).with(fake_rack_stream)
 
-      wrapped = described_class.wrap(fake_body, _txn = nil)
+      wrapped = described_class.wrap(fake_body, nil_txn)
       expect { wrapped.call(fake_rack_stream) }.not_to raise_error
     end
 
@@ -207,7 +209,7 @@ describe Appsignal::Rack::BodyWrapper do
       fake_rack_stream = double
       allow(fake_body).to receive(:call).with(fake_rack_stream).and_raise(Exception.new("Oopsie"))
 
-      txn = double("Appsignal transaction")
+      txn = double("Appsignal transaction", nil_transaction?: false)
       expect(txn).to receive(:set_error).once.with(instance_of(Exception))
       expect(txn).not_to receive(:complete) # gets called by the caller via close()
       wrapped = described_class.wrap(fake_body, txn)

--- a/spec/lib/appsignal/rack/body_wrapper_spec.rb
+++ b/spec/lib/appsignal/rack/body_wrapper_spec.rb
@@ -47,7 +47,7 @@ describe Appsignal::Rack::BodyWrapper do
       fake_body = double
       expect(fake_body).to receive(:each).once.and_raise(Exception.new("Oops"))
 
-      txn = double("Appsignal transaction", "nil_transaction?" =>  false)
+      txn = double("Appsignal transaction", "nil_transaction?" => false)
       expect(txn).to receive(:set_error).once.with(instance_of(Exception))
 
       wrapped = described_class.wrap(fake_body, txn)
@@ -60,7 +60,7 @@ describe Appsignal::Rack::BodyWrapper do
       fake_body = double
       expect(fake_body).to receive(:each).once.and_yield("a").and_yield("b").and_yield("c")
 
-      txn = double("Appsignal transaction", "nil_transaction?" =>  false)
+      txn = double("Appsignal transaction", "nil_transaction?" => false)
       expect(Appsignal::Transaction).to receive(:complete_current!).once
 
       wrapped = described_class.wrap(fake_body, txn)
@@ -105,7 +105,7 @@ describe Appsignal::Rack::BodyWrapper do
     it "sets the exception raised inside each() into the Appsignal transaction" do
       expect(fake_body).to receive(:each).once.and_raise(Exception.new("Oops"))
 
-      txn = double("Appsignal transaction", "nil_transaction?" =>  false)
+      txn = double("Appsignal transaction", "nil_transaction?" => false)
       expect(txn).to receive(:set_error).once.with(instance_of(Exception))
 
       wrapped = described_class.wrap(fake_body, txn)
@@ -127,7 +127,7 @@ describe Appsignal::Rack::BodyWrapper do
       expect(fake_body).to receive(:to_ary).once.and_raise(Exception.new("Oops"))
       expect(fake_body).not_to receive(:close) # Per spec we expect the body has closed itself
 
-      txn = double("Appsignal transaction", "nil_transaction?" =>  false)
+      txn = double("Appsignal transaction", "nil_transaction?" => false)
       expect(txn).to receive(:set_error).once.with(instance_of(Exception))
       expect(Appsignal::Transaction).to receive(:complete_current!).once
 
@@ -158,7 +158,7 @@ describe Appsignal::Rack::BodyWrapper do
     it "sets the exception raised inside each() into the Appsignal transaction" do
       expect(fake_body).to receive(:each).once.and_raise(Exception.new("Oops"))
 
-      txn = double("Appsignal transaction", "nil_transaction?" =>  false)
+      txn = double("Appsignal transaction", "nil_transaction?" => false)
       expect(txn).to receive(:set_error).once.with(instance_of(Exception))
 
       wrapped = described_class.wrap(fake_body, txn)
@@ -170,7 +170,7 @@ describe Appsignal::Rack::BodyWrapper do
     it "sets the exception raised inside to_path() into the Appsignal transaction" do
       allow(fake_body).to receive(:to_path).once.and_raise(Exception.new("Oops"))
 
-      txn = double("Appsignal transaction", "nil_transaction?" =>  false)
+      txn = double("Appsignal transaction", "nil_transaction?" => false)
       expect(txn).to receive(:set_error).once.with(instance_of(Exception))
       expect(txn).not_to receive(:complete) # gets called by the caller via close()
 
@@ -209,7 +209,7 @@ describe Appsignal::Rack::BodyWrapper do
       fake_rack_stream = double
       allow(fake_body).to receive(:call).with(fake_rack_stream).and_raise(Exception.new("Oopsie"))
 
-      txn = double("Appsignal transaction", "nil_transaction?" =>  false)
+      txn = double("Appsignal transaction", "nil_transaction?" => false)
       expect(txn).to receive(:set_error).once.with(instance_of(Exception))
       expect(txn).not_to receive(:complete) # gets called by the caller via close()
       wrapped = described_class.wrap(fake_body, txn)

--- a/spec/lib/appsignal/rack/body_wrapper_spec.rb
+++ b/spec/lib/appsignal/rack/body_wrapper_spec.rb
@@ -59,7 +59,7 @@ describe Appsignal::Rack::BodyWrapper do
       expect(fake_body).to receive(:each).once.and_yield("a").and_yield("b").and_yield("c")
 
       txn = double("Appsignal transaction")
-      expect(txn).to receive(:complete).once
+      expect(Appsignal::Transaction).to receive(:complete_current!).once
 
       wrapped = described_class.wrap(fake_body, txn)
       expect { |b| wrapped.each(&b) }.to yield_successive_args("a", "b", "c")
@@ -127,7 +127,7 @@ describe Appsignal::Rack::BodyWrapper do
 
       txn = double("Appsignal transaction")
       expect(txn).to receive(:set_error).once.with(instance_of(Exception))
-      expect(txn).to receive(:complete).once
+      expect(Appsignal::Transaction).to receive(:complete_current!).once
 
       wrapped = described_class.wrap(fake_body, txn)
       expect { wrapped.to_ary }.to raise_error(/Oops/)

--- a/spec/lib/appsignal/rack/body_wrapper_spec.rb
+++ b/spec/lib/appsignal/rack/body_wrapper_spec.rb
@@ -1,0 +1,218 @@
+describe Appsignal::Rack::BodyWrapper do
+  describe "with a body that supports all possible features" do
+    it "reduces the supported methods to just each()" do
+      # which is the safest thing to do, since the body is likely broken
+      fake_body = double(:each => nil, :call => nil, :to_ary => [], :to_path => "/tmp/foo.bin",
+        :close => nil)
+      wrapped = described_class.wrap(fake_body, _txn = nil)
+      expect(wrapped).to respond_to(:each)
+      expect(wrapped).not_to respond_to(:to_ary)
+      expect(wrapped).not_to respond_to(:call)
+      expect(wrapped).to respond_to(:close)
+    end
+  end
+
+  describe "with a body only supporting each()" do
+    it "wraps with appropriate class" do
+      fake_body = double
+      allow(fake_body).to receive(:each)
+
+      wrapped = described_class.wrap(fake_body, _txn = nil)
+      expect(wrapped).to respond_to(:each)
+      expect(wrapped).not_to respond_to(:to_ary)
+      expect(wrapped).not_to respond_to(:call)
+      expect(wrapped).to respond_to(:close)
+    end
+
+    it "reads out the body in full using each" do
+      fake_body = double
+      expect(fake_body).to receive(:each).once.and_yield("a").and_yield("b").and_yield("c")
+      wrapped = described_class.wrap(fake_body, _txn = nil)
+      expect { |b| wrapped.each(&b) }.to yield_successive_args("a", "b", "c")
+    end
+
+    it "returns an Enumerator if each() gets called without a block" do
+      fake_body = double
+      expect(fake_body).to receive(:each).once.and_yield("a").and_yield("b").and_yield("c")
+
+      wrapped = described_class.wrap(fake_body, _txn = nil)
+      enum = wrapped.each
+      expect(enum).to be_kind_of(Enumerator)
+      expect { |b| enum.each(&b) }.to yield_successive_args("a", "b", "c")
+    end
+
+    it "sets the exception raised inside each() into the Appsignal transaction" do
+      fake_body = double
+      expect(fake_body).to receive(:each).once.and_raise(Exception.new("Oops"))
+
+      txn = double("Appsignal transaction")
+      expect(txn).to receive(:set_error).once.with(instance_of(Exception))
+
+      wrapped = described_class.wrap(fake_body, txn)
+      expect do
+        expect { |b| wrapped.each(&b) }.to yield_control
+      end.to raise_error(/Oops/)
+    end
+
+    it "closes the body and the transaction when it gets closed" do
+      fake_body = double
+      expect(fake_body).to receive(:each).once.and_yield("a").and_yield("b").and_yield("c")
+
+      txn = double("Appsignal transaction")
+      expect(txn).to receive(:complete).once
+
+      wrapped = described_class.wrap(fake_body, txn)
+      expect { |b| wrapped.each(&b) }.to yield_successive_args("a", "b", "c")
+      expect { wrapped.close }.not_to raise_error
+    end
+  end
+
+  describe "with a body supporting both each() and call" do
+    it "wraps with the wrapper that conceals call() and exposes each" do
+      fake_body = double
+      allow(fake_body).to receive(:each)
+      allow(fake_body).to receive(:call)
+
+      wrapped = described_class.wrap(fake_body, _txn = nil)
+      expect(wrapped).to respond_to(:each)
+      expect(wrapped).not_to respond_to(:to_ary)
+      expect(wrapped).not_to respond_to(:call)
+      expect(wrapped).not_to respond_to(:to_path)
+      expect(wrapped).to respond_to(:close)
+    end
+  end
+
+  describe "with a body supporting both to_ary and each" do
+    let(:fake_body) { double(:each => nil, :to_ary => []) }
+    it "wraps with appropriate class" do
+      wrapped = described_class.wrap(fake_body, _txn = nil)
+      expect(wrapped).to respond_to(:each)
+      expect(wrapped).to respond_to(:to_ary)
+      expect(wrapped).not_to respond_to(:call)
+      expect(wrapped).not_to respond_to(:to_path)
+      expect(wrapped).to respond_to(:close)
+    end
+
+    it "reads out the body in full using each" do
+      expect(fake_body).to receive(:each).once.and_yield("a").and_yield("b").and_yield("c")
+
+      wrapped = described_class.wrap(fake_body, _txn = nil)
+      expect { |b| wrapped.each(&b) }.to yield_successive_args("a", "b", "c")
+    end
+
+    it "sets the exception raised inside each() into the Appsignal transaction" do
+      expect(fake_body).to receive(:each).once.and_raise(Exception.new("Oops"))
+
+      txn = double("Appsignal transaction")
+      expect(txn).to receive(:set_error).once.with(instance_of(Exception))
+
+      wrapped = described_class.wrap(fake_body, txn)
+      expect do
+        expect { |b| wrapped.each(&b) }.to yield_control
+      end.to raise_error(/Oops/)
+    end
+
+    it "reads out the body in full using to_ary" do
+      expect(fake_body).to receive(:to_ary).and_return(["one", "two", "three"])
+
+      wrapped = described_class.wrap(fake_body, _txn = nil)
+      expect(wrapped.to_ary).to eq(["one", "two", "three"])
+    end
+
+    it "sends the exception raised inside to_ary() into the Appsignal and closes txn" do
+      fake_body = double
+      allow(fake_body).to receive(:each)
+      expect(fake_body).to receive(:to_ary).once.and_raise(Exception.new("Oops"))
+      expect(fake_body).not_to receive(:close) # Per spec we expect the body has closed itself
+
+      txn = double("Appsignal transaction")
+      expect(txn).to receive(:set_error).once.with(instance_of(Exception))
+      expect(txn).to receive(:complete).once
+
+      wrapped = described_class.wrap(fake_body, txn)
+      expect { wrapped.to_ary }.to raise_error(/Oops/)
+    end
+  end
+
+  describe "with a body supporting both to_path and each" do
+    let(:fake_body) { double(:each => nil, :to_path => nil) }
+
+    it "wraps with appropriate class" do
+      wrapped = described_class.wrap(fake_body, _txn = nil)
+      expect(wrapped).to respond_to(:each)
+      expect(wrapped).not_to respond_to(:to_ary)
+      expect(wrapped).not_to respond_to(:call)
+      expect(wrapped).to respond_to(:to_path)
+      expect(wrapped).to respond_to(:close)
+    end
+
+    it "reads out the body in full using each()" do
+      expect(fake_body).to receive(:each).once.and_yield("a").and_yield("b").and_yield("c")
+
+      wrapped = described_class.wrap(fake_body, _txn = nil)
+      expect { |b| wrapped.each(&b) }.to yield_successive_args("a", "b", "c")
+    end
+
+    it "sets the exception raised inside each() into the Appsignal transaction" do
+      expect(fake_body).to receive(:each).once.and_raise(Exception.new("Oops"))
+
+      txn = double("Appsignal transaction")
+      expect(txn).to receive(:set_error).once.with(instance_of(Exception))
+
+      wrapped = described_class.wrap(fake_body, txn)
+      expect do
+        expect { |b| wrapped.each(&b) }.to yield_control
+      end.to raise_error(/Oops/)
+    end
+
+    it "sets the exception raised inside to_path() into the Appsignal transaction" do
+      allow(fake_body).to receive(:to_path).once.and_raise(Exception.new("Oops"))
+
+      txn = double("Appsignal transaction")
+      expect(txn).to receive(:set_error).once.with(instance_of(Exception))
+      expect(txn).not_to receive(:complete) # gets called by the caller via close()
+
+      wrapped = described_class.wrap(fake_body, txn)
+      expect { wrapped.to_path }.to raise_error(/Oops/)
+    end
+
+    it "exposes to_path to the sender" do
+      allow(fake_body).to receive(:to_path).and_return("/tmp/file.bin")
+
+      wrapped = described_class.wrap(fake_body, _txn = nil)
+      expect(wrapped.to_path).to eq("/tmp/file.bin")
+    end
+  end
+
+  describe "with a body only supporting call()" do
+    let(:fake_body) { double(:call => nil) }
+    it "wraps with appropriate class" do
+      wrapped = described_class.wrap(fake_body, _txn = nil)
+      expect(wrapped).not_to respond_to(:each)
+      expect(wrapped).not_to respond_to(:to_ary)
+      expect(wrapped).to respond_to(:call)
+      expect(wrapped).not_to respond_to(:to_path)
+      expect(wrapped).to respond_to(:close)
+    end
+
+    it "passes the stream into the call() of the body" do
+      fake_rack_stream = double("stream")
+      expect(fake_body).to receive(:call).with(fake_rack_stream)
+
+      wrapped = described_class.wrap(fake_body, _txn = nil)
+      expect { wrapped.call(fake_rack_stream) }.not_to raise_error
+    end
+
+    it "sets the exception raised inside call() into the Appsignal transaction" do
+      fake_rack_stream = double
+      allow(fake_body).to receive(:call).with(fake_rack_stream).and_raise(Exception.new("Oopsie"))
+
+      txn = double("Appsignal transaction")
+      expect(txn).to receive(:set_error).once.with(instance_of(Exception))
+      expect(txn).not_to receive(:complete) # gets called by the caller via close()
+      wrapped = described_class.wrap(fake_body, txn)
+
+      expect { wrapped.call(fake_rack_stream) }.to raise_error(/Oopsie/)
+    end
+  end
+end

--- a/spec/lib/appsignal/rack/generic_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/generic_instrumentation_spec.rb
@@ -50,7 +50,7 @@ describe Appsignal::Rack::GenericInstrumentation do
       expect(app).to receive(:call).with(env)
     end
 
-    context "with an exception", :error => true do
+    context "with an exception raised from call()", :error => true do
       let(:error) { ExampleException }
       let(:app) do
         double.tap do |d|
@@ -58,8 +58,9 @@ describe Appsignal::Rack::GenericInstrumentation do
         end
       end
 
-      it "records the exception" do
+      it "records the exception and completes the transaction" do
         expect_any_instance_of(Appsignal::Transaction).to receive(:set_error).with(error)
+        expect(Appsignal::Transaction).to receive(:complete_current!)
       end
     end
 

--- a/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
@@ -127,7 +127,8 @@ if DependencyHelper.rails_present?
           end
         end
 
-        it "records the exception" do
+        it "records the exception and completes the transaction" do
+          expect(Appsignal::Transaction).to receive(:complete_current!)
           expect { run }.to raise_error(error)
 
           transaction_hash = last_transaction.to_h

--- a/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
@@ -65,7 +65,8 @@ if DependencyHelper.rails_present?
 
     describe "#call_with_appsignal_monitoring" do
       def run
-        middleware.call(env)
+        _status, _headers, body = middleware.call(env)
+        body.close # Rack will always call close() on the body
       end
 
       it "calls the wrapped app" do

--- a/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
@@ -3,7 +3,9 @@ if DependencyHelper.sinatra_present?
 
   module SinatraRequestHelpers
     def make_request(env)
-      middleware.call(env)
+      _status, _headers, body = middleware.call(env)
+      # Close the body so that the transaction gets completed
+      body&.close
     end
 
     def make_request_with_error(env, error)

--- a/spec/lib/appsignal/rack/streaming_listener_spec.rb
+++ b/spec/lib/appsignal/rack/streaming_listener_spec.rb
@@ -101,64 +101,19 @@ describe Appsignal::Rack::StreamingListener do
       end
     end
 
-    it "should wrap the body in a wrapper" do
-      expect(Appsignal::StreamWrapper).to receive(:new)
-        .with("body", transaction)
-        .and_return(wrapper)
-
+    it "should wrap the response body in a wrapper" do
       body = listener.call_with_appsignal_monitoring(env)[2]
 
-      expect(body).to be_a(Appsignal::StreamWrapper)
+      expect(body).to be_kind_of(Appsignal::Rack::BodyWrapper)
     end
   end
 end
 
 describe Appsignal::StreamWrapper do
-  let(:stream)      { double }
-  let(:transaction) do
-    Appsignal::Transaction.create(SecureRandom.uuid, Appsignal::Transaction::HTTP_REQUEST, {})
-  end
-  let(:wrapper) { Appsignal::StreamWrapper.new(stream, transaction) }
-
-  describe "#each" do
-    it "calls the original stream" do
-      expect(stream).to receive(:each)
-
-      wrapper.each
-    end
-
-    context "when #each raises an error" do
-      let(:error) { ExampleException }
-
-      it "records the exception" do
-        allow(stream).to receive(:each).and_raise(error)
-
-        expect(transaction).to receive(:set_error).with(error)
-
-        expect { wrapper.send(:each) }.to raise_error(error)
-      end
-    end
-  end
-
-  describe "#close" do
-    it "closes the original stream and completes the transaction" do
-      expect(stream).to receive(:close)
-      expect(Appsignal::Transaction).to receive(:complete_current!)
-
-      wrapper.close
-    end
-
-    context "when #close raises an error" do
-      let(:error) { ExampleException }
-
-      it "records the exception and completes the transaction" do
-        allow(stream).to receive(:close).and_raise(error)
-
-        expect(transaction).to receive(:set_error).with(error)
-        expect(transaction).to receive(:complete)
-
-        expect { wrapper.send(:close) }.to raise_error(error)
-      end
-    end
+  it ".new returns an EnumerableWrapper" do
+    fake_body = double(:each => nil)
+    fake_txn = double
+    stream_wrapper = Appsignal::StreamWrapper.new(fake_body, fake_txn)
+    expect(stream_wrapper).to be_kind_of(Appsignal::Rack::EnumerableBodyWrapper)
   end
 end

--- a/spec/lib/appsignal/rack/streaming_listener_spec.rb
+++ b/spec/lib/appsignal/rack/streaming_listener_spec.rb
@@ -90,10 +90,11 @@ describe Appsignal::Rack::StreamingListener do
     context "with an exception in the instrumentation call" do
       let(:error) { ExampleException }
 
-      it "should add the exception to the transaction" do
+      it "should add the exception to the transaction and complete the transaction" do
         allow(app).to receive(:call).and_raise(error)
 
         expect(transaction).to receive(:set_error).with(error)
+        expect(Appsignal::Transaction).to receive(:complete_current!).and_call_original
 
         expect do
           listener.call_with_appsignal_monitoring(env)


### PR DESCRIPTION
Some work might be getting done within a Rack response body. For example, when ActionController::Streaming is used, or when a Rack app elects to stream a response.

The Rack SPEC doc actually defines the behavior in sufficient detail to wrap this into the same Appsignal transaction.

The Rails instrumentation may also inherit from the more generic one as most methods and constants are shared then

## To do

- [x] Add a changeset before merge