### PR TITLE
Allow gem users to customize behavior on errors in ActiveJob

### DIFF
--- a/.changesets/add-activejob_report_errors-option.md
+++ b/.changesets/add-activejob_report_errors-option.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add `activejob_report_errors` config option. When set to `"none"`, ActiveJob jobs will no longer report errors. This can be used in combination with [custom exception reporting](https://docs.appsignal.com/ruby/instrumentation/exception-handling.html). By default, the config option has the value `"all"`, which reports all errors.

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -11,6 +11,7 @@ module Appsignal
     include Appsignal::Utils::DeprecationMessage
 
     DEFAULT_CONFIG = {
+      :activejob_report_errors => "all",
       :ca_file_path => File.expand_path(File.join("../../../resources/cacert.pem"), __FILE__),
       :debug => false,
       :dns_servers => [],
@@ -65,6 +66,7 @@ module Appsignal
 
     ENV_TO_KEY_MAPPING = {
       "APPSIGNAL_ACTIVE" => :active,
+      "APPSIGNAL_ACTIVE_JOB_REPORT_ERRORS" => :activejob_report_errors,
       "APPSIGNAL_APP_NAME" => :name,
       "APPSIGNAL_BIND_ADDRESS" => :bind_address,
       "APPSIGNAL_CA_FILE_PATH" => :ca_file_path,
@@ -112,6 +114,7 @@ module Appsignal
     }.freeze
     # @api private
     ENV_STRING_KEYS = %w[
+      APPSIGNAL_ACTIVE_JOB_REPORT_ERRORS
       APPSIGNAL_APP_NAME
       APPSIGNAL_BIND_ADDRESS
       APPSIGNAL_CA_FILE_PATH

--- a/lib/appsignal/hooks/active_job.rb
+++ b/lib/appsignal/hooks/active_job.rb
@@ -56,7 +56,7 @@ module Appsignal
           super
         rescue Exception => exception # rubocop:disable Lint/RescueException
           job_status = :failed
-          transaction.set_error(exception)
+          transaction_set_error(transaction, exception)
           raise exception
         ensure
           if transaction
@@ -81,6 +81,14 @@ module Appsignal
             ActiveJobHelpers.increment_counter metric_name, 1,
               tags.merge(:status => :processed)
           end
+        end
+
+        private
+
+        def transaction_set_error(transaction, exception)
+          return if Appsignal.config[:activejob_report_errors] == "none"
+
+          transaction.set_error(exception)
         end
       end
 

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -152,6 +152,7 @@ describe Appsignal::Config do
     it "merges with the default config" do
       expect(config.config_hash).to eq(
         :active                         => true,
+        :activejob_report_errors        => "all",
         :ca_file_path                   => File.join(resources_dir, "cacert.pem"),
         :debug                          => false,
         :dns_servers                    => [],

--- a/spec/lib/appsignal/hooks/activejob_spec.rb
+++ b/spec/lib/appsignal/hooks/activejob_spec.rb
@@ -222,6 +222,29 @@ if DependencyHelper.active_job_present?
         expect(events).to eq(expected_perform_events)
       end
 
+      context "with activejob_report_errors set to none" do
+        it "does not report the error" do
+          allow(Appsignal).to receive(:config).and_return({ :activejob_report_errors => "none" })
+          # Other calls we're testing in another test
+          allow(Appsignal).to receive(:increment_counter)
+          tags = { :queue => queue }
+          expect(Appsignal).to receive(:increment_counter)
+            .with("active_job_queue_job_count", 1, tags.merge(:status => :failed))
+          expect(Appsignal).to receive(:increment_counter)
+            .with("active_job_queue_job_count", 1, tags.merge(:status => :processed))
+
+          expect do
+            perform_job(ActiveJobErrorTestJob)
+          end.to raise_error(RuntimeError, "uh oh")
+
+          transaction = last_transaction
+          transaction_hash = transaction.to_h
+          expect(transaction_hash).to include(
+            "error" => nil
+          )
+        end
+      end
+
       if DependencyHelper.rails_version >= Gem::Version.new("5.0.0")
         context "with priority" do
           before do

--- a/spec/lib/appsignal/hooks/activejob_spec.rb
+++ b/spec/lib/appsignal/hooks/activejob_spec.rb
@@ -224,7 +224,9 @@ if DependencyHelper.active_job_present?
 
       context "with activejob_report_errors set to none" do
         it "does not report the error" do
-          allow(Appsignal).to receive(:config).and_return({ :activejob_report_errors => "none" })
+          Appsignal.config = project_fixture_config("production")
+          Appsignal.config[:activejob_report_errors] = "none"
+
           # Other calls we're testing in another test
           allow(Appsignal).to receive(:increment_counter)
           tags = { :queue => queue }


### PR DESCRIPTION
Considering the following setup using shoryuken, appsignal and our own custom queue adapter (raven):

```ruby
Shoryuken.configure_server do |server|
  server.server_middleware do |chain|
    chain.clear
    chain.add Appsignal::Hooks::ShoryukenMiddleware
    chain.add Raven::ShoryukenMiddleware
  end
end
```

Our `Raven::ShoryukenMiddleware` will perform the job and if it errors more than X times it will exhaust the job and report the error to appsignal. We 'swallow' the exception so the `Appsignal::Hooks::ShoryukenMiddleware` will not report is as well. This doesn't work though since the `::Appsignal::Hooks::ActiveJobHook::ActiveJobClassInstrumentation` already reported the error during the performing of the job since it overrides active_job's execute method. ~~To allow more fine-grained programmatic control the actual setting of the error is moved to a method which gem users can override and customize. The method name is prefixed with `appsignal` to minimize the chance on unwanted naming collisions.~~

Update:

Implemented this via a config setting like suggested:

```
production:
  activejob_report_errors: "all"/"none
```

For now `"discard"` is not yet implemented as we do not require it, but other are free to implement this.
