### PR TITLE
Fix undefined method `id' for nil:NilClass Redis Client

### DIFF
--- a/lib/appsignal/integrations/redis_client.rb
+++ b/lib/appsignal/integrations/redis_client.rb
@@ -11,7 +11,7 @@ module Appsignal
             "#{command[0]}#{" ?" * (command.size - 1)}"
           end
 
-        Appsignal.instrument "query.redis", @config.id, sanitized_command do
+        Appsignal.instrument "query.redis", id, sanitized_command do
           super
         end
       end


### PR DESCRIPTION
The Redis Client Integration does not have an instance variable named 'config' at this point. I changed it to 'id' like the other Redis integration and it worked for me. This change only resolves the error of undefined method 'id' for nil:NilClass.