### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1459,7 +1459,7 @@ Yanked
 - Support for arrays, literal value types and function arguments in sql lexer
 
 ## 1.2.2
-- Handle out of range numbers in queue lenght and metrics api
+- Handle out of range numbers in queue length and metrics api
 
 ## 1.2.1
 - Use Dir.pwd in CLI install wizard
@@ -1484,7 +1484,7 @@ Yanked
 ## 1.1.7
 - Make logging resilient for closing FD's (daemons gem does this)
 - Add support for using Resque through ActiveJob
-- Rescue more expections in json generation
+- Rescue more exceptions in json generation
 
 ## 1.1.6
 - Generic Rack instrumentation middleware
@@ -1534,7 +1534,7 @@ Yanked
 - Improved sql sanitization
 - Improved mongoid/mongodb sanitization
 - Minor performance improvements
-- Better handling for non-utf8 convertable strings
+- Better handling for non-utf8 convertible strings
 - Make gem installable (but not functional) on JRuby
 
 ## 1.0.4
@@ -1715,7 +1715,7 @@ Yanked
 Yanked
 
 ## 0.8.8
-- Explicitely require securerandom
+- Explicitly require securerandom
 
 ## 0.8.7
 - Dup process action event to avoid threading issue

--- a/Rakefile
+++ b/Rakefile
@@ -219,7 +219,7 @@ namespace :build do
     Gem::PackageTask.new(base_gemspec, &block)
   rescue StandardError => e
     puts "Warning: An error occurred defining `build:#{task_name}:gem` Rake task."
-    puts "This task will not be availble."
+    puts "This task will not be available."
     if ENV["DEBUG"]
       puts "#{e}: #{e.message}"
       puts e.backtrace

--- a/lib/appsignal/auth_check.rb
+++ b/lib/appsignal/auth_check.rb
@@ -40,7 +40,7 @@ module Appsignal
     # @return [Array<String/nil, String>] response tuple.
     #   - First value is the response status code.
     #   - Second value is a description of the response and the exception error
-    #     message if an exception occured.
+    #     message if an exception occurred.
     def perform_with_result
       status = perform
       result =

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -444,7 +444,7 @@ module Appsignal
             "'APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR=1' in your system " \
             "environment."
         end
-      message = "An error occured while loading the AppSignal config file. " \
+      message = "An error occurred while loading the AppSignal config file. " \
         "#{extra_message}\n" \
         "File: #{config_file.inspect}\n" \
         "#{e.class.name}: #{e}"

--- a/lib/appsignal/event_formatter/sequel/sql_formatter.rb
+++ b/lib/appsignal/event_formatter/sequel/sql_formatter.rb
@@ -4,7 +4,7 @@ module Appsignal
   class EventFormatter
     # @api private
     module Sequel
-      # Compatability with the sequel-rails gem.
+      # Compatibility with the sequel-rails gem.
       # The sequel-rails gem adds its own ActiveSupport::Notifications events
       # that conflict with our own sequel instrumentor. Without this event
       # formatter the sequel-rails events are recorded without the SQL query

--- a/lib/appsignal/logger.rb
+++ b/lib/appsignal/logger.rb
@@ -64,7 +64,7 @@ module Appsignal
     alias log add
 
     # Log a debug level message
-    # @param message Mesage to log
+    # @param message Message to log
     # @param attributes Attributes to tag the log with
     # @return [void]
     def debug(message = nil, attributes = {})
@@ -77,7 +77,7 @@ module Appsignal
     end
 
     # Log an info level message
-    # @param message Mesage to log
+    # @param message Message to log
     # @param attributes Attributes to tag the log with
     # @return [void]
     def info(message = nil, attributes = {})
@@ -90,7 +90,7 @@ module Appsignal
     end
 
     # Log a warn level message
-    # @param message Mesage to log
+    # @param message Message to log
     # @param attributes Attributes to tag the log with
     # @return [void]
     def warn(message = nil, attributes = {})
@@ -103,7 +103,7 @@ module Appsignal
     end
 
     # Log an error level message
-    # @param message Mesage to log
+    # @param message Message to log
     # @param attributes Attributes to tag the log with
     # @return [void]
     def error(message = nil, attributes = {})
@@ -116,7 +116,7 @@ module Appsignal
     end
 
     # Log a fatal level message
-    # @param message Mesage to log
+    # @param message Message to log
     # @param attributes Attributes to tag the log with
     # @return [void]
     def fatal(message = nil, attributes = {})

--- a/lib/puma/plugin/appsignal.rb
+++ b/lib/puma/plugin/appsignal.rb
@@ -18,7 +18,7 @@ Puma::Plugin.create do # rubocop:disable Metrics/BlockLength
 
       loop do
         # Implement similar behavior to minutely probes.
-        # Initial sleep to wait until the app is fully initalized.
+        # Initial sleep to wait until the app is fully initialized.
         # Then loop every 60 seconds and collect the Puma stats as AppSignal
         # metrics.
         sleep sleep_time

--- a/spec/lib/appsignal/capistrano2_spec.rb
+++ b/spec/lib/appsignal/capistrano2_spec.rb
@@ -160,7 +160,7 @@ if DependencyHelper.capistrano2_present?
               run
             end
 
-            it "transmits the overriden revision" do
+            it "transmits the overridden revision" do
               expect(output).to include \
                 "Notifying AppSignal of deploy with: revision: abc123, user: batman",
                 "AppSignal has been notified of this deploy!"
@@ -174,7 +174,7 @@ if DependencyHelper.capistrano2_present?
               run
             end
 
-            it "transmits the overriden deploy user" do
+            it "transmits the overridden deploy user" do
               expect(output).to include \
                 "Notifying AppSignal of deploy with: revision: 503ce0923ed177a3ce000005," \
                   " user: robin",

--- a/spec/lib/appsignal/capistrano3_spec.rb
+++ b/spec/lib/appsignal/capistrano3_spec.rb
@@ -172,7 +172,7 @@ if DependencyHelper.capistrano3_present?
               run
             end
 
-            it "transmits the overriden revision" do
+            it "transmits the overridden revision" do
               expect(output).to include \
                 "Notifying AppSignal of deploy with: revision: abc123, user: batman",
                 "AppSignal has been notified of this deploy!"
@@ -186,7 +186,7 @@ if DependencyHelper.capistrano3_present?
               run
             end
 
-            it "transmits the overriden deploy user" do
+            it "transmits the overridden deploy user" do
               expect(output).to include \
                 "Notifying AppSignal of deploy with: revision: 503ce0923ed177a3ce000005, " \
                   "user: robin",

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -466,7 +466,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
         end
       end
 
-      context "when the extention returns invalid JSON" do
+      context "when the extension returns invalid JSON" do
         before do
           expect(Appsignal::Extension).to receive(:diagnose).and_return("invalid agent\njson")
           run

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -264,7 +264,7 @@ describe Appsignal::Config do
       end
     end
 
-    context "with an overriden config file" do
+    context "with an overridden config file" do
       let(:config) do
         project_fixture_config("production", {}, Appsignal.internal_logger,
           File.join(project_fixture_path, "config", "appsignal.yml"))
@@ -275,7 +275,7 @@ describe Appsignal::Config do
         expect(config.active?).to be_truthy
       end
 
-      context "with an invalid overriden config file" do
+      context "with an invalid overridden config file" do
         let(:config) do
           project_fixture_config("production", {}, Appsignal.internal_logger,
             File.join(project_fixture_path, "config", "missing.yml"))
@@ -300,7 +300,7 @@ describe Appsignal::Config do
           stdout = std_stream
           stderr = std_stream
           log = capture_logs { capture_std_streams(stdout, stderr) { config } }
-          message = "An error occured while loading the AppSignal config file. " \
+          message = "An error occurred while loading the AppSignal config file. " \
             "Skipping file config. " \
             "In future versions AppSignal will not start on a config file " \
             "error. To opt-in to this new behavior set " \
@@ -326,7 +326,7 @@ describe Appsignal::Config do
           ENV["APPSIGNAL_PUSH_API_KEY"] = "something valid"
           ENV["APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR"] = "1"
           log = capture_logs { capture_std_streams(stdout, stderr) { config } }
-          message = "An error occured while loading the AppSignal config file. " \
+          message = "An error occurred while loading the AppSignal config file. " \
             "Not starting AppSignal because APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR is set.\n" \
             "File: #{File.join(config_path, "config", "appsignal.yml").inspect}\n" \
             "KeyError: key not found"

--- a/spec/lib/appsignal/environment_spec.rb
+++ b/spec/lib/appsignal/environment_spec.rb
@@ -90,7 +90,7 @@ describe Appsignal::Environment do
       end
     end
 
-    context "when something unforseen errors" do
+    context "when something unforeseen errors" do
       it "does not re-raise the error and writes it to the log" do
         klass = Class.new do
           def inspect
@@ -127,7 +127,7 @@ describe Appsignal::Environment do
       expect(rake_spec.version.to_s).to_not be_empty
     end
 
-    context "when something unforseen errors" do
+    context "when something unforeseen errors" do
       it "does not re-raise the error and writes it to the log" do
         expect(Bundler).to receive(:rubygems).and_raise(RuntimeError, "bundler error")
 
@@ -148,7 +148,7 @@ describe Appsignal::Environment do
       expect_environment_metadata("ruby_a_test_enabled", "true")
     end
 
-    context "when something unforseen errors" do
+    context "when something unforeseen errors" do
       it "does not re-raise the error and writes it to the log" do
         klass = Class.new do
           def to_s

--- a/spec/lib/appsignal/event_formatter/mongo_ruby_driver/query_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/mongo_ruby_driver/query_formatter_spec.rb
@@ -21,7 +21,7 @@ describe Appsignal::EventFormatter::MongoRubyDriver::QueryFormatter do
       formatter.format(strategy, command)
     end
 
-    context "when strategy is unkown" do
+    context "when strategy is unknown" do
       let(:strategy) { :bananas }
 
       it "should return an empty hash" do

--- a/spec/lib/appsignal/hooks/resque_spec.rb
+++ b/spec/lib/appsignal/hooks/resque_spec.rb
@@ -160,7 +160,7 @@ describe Appsignal::Hooks::ResqueHook do
         end
         after { Object.send(:remove_const, :ActiveJobMock) }
 
-        it "does not set arguments but lets the ActiveJob intergration handle it" do
+        it "does not set arguments but lets the ActiveJob integration handle it" do
           perform_job(
             ResqueTestJob,
             "class" => "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper",

--- a/spec/lib/appsignal/hooks_spec.rb
+++ b/spec/lib/appsignal/hooks_spec.rb
@@ -47,7 +47,7 @@ describe Appsignal::Hooks do
     Appsignal::Hooks.hooks.delete(:mock_present_hook)
   end
 
-  it "should not install if depencies are not present" do
+  it "should not install if dependencies are not present" do
     Appsignal::Hooks::Hook.register(:mock_not_present_hook, MockNotPresentHook)
 
     expect(Appsignal::Hooks.hooks[:mock_not_present_hook]).to be_instance_of(MockNotPresentHook)

--- a/spec/lib/appsignal/integrations/sidekiq_spec.rb
+++ b/spec/lib/appsignal/integrations/sidekiq_spec.rb
@@ -8,7 +8,7 @@ describe Appsignal::Integrations::SidekiqErrorHandler do
   end
   around { |example| keep_transactions { example.run } }
 
-  context "without a current transction" do
+  context "without a current transaction" do
     let(:exception) do
       raise ExampleStandardError, "uh oh"
     rescue => error

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -303,7 +303,7 @@ describe Appsignal::Transaction do
         context "with overridden options" do
           let(:options) { { :params_method => :filtered_params } }
 
-          it "sets the overriden :params_method" do
+          it "sets the overridden :params_method" do
             expect(subject[:params_method]).to eq :filtered_params
           end
         end
@@ -751,7 +751,7 @@ describe Appsignal::Transaction do
         e
       end
 
-      it "should also respond to add_exception for backwords compatibility" do
+      it "should also respond to add_exception for backwards compatibility" do
         expect(transaction).to respond_to(:add_exception)
       end
 

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -258,7 +258,7 @@ describe Appsignal do
     end
 
     describe ".listen_for_error" do
-      it "does not record anyhing" do
+      it "does not record anything" do
         error = RuntimeError.new("specific error")
         expect do
           Appsignal.listen_for_error do

--- a/spec/lib/puma/appsignal_spec.rb
+++ b/spec/lib/puma/appsignal_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe "Puma plugin" do
       }
     end
 
-    it "collects puma stats as guage metrics with the (summed) worker metrics" do
+    it "collects puma stats as gauge metrics with the (summed) worker metrics" do
       run_plugin(stats_data, appsignal_plugin) do
         expect(logs).to_not include([:error, kind_of(String)])
         expect_gauge(:workers, 2, "type" => "count")


### PR DESCRIPTION
Found via `codespell -L fo,reenable,renabled`