### PR TITLE
Add params, path and method to errors reported via Rails

### DIFF
--- a/.changesets/add-params-path-and-method-to-errors-reported-via-rails.md
+++ b/.changesets/add-params-path-and-method-to-errors-reported-via-rails.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Add params, path and method to errors reported via `Rails.error` in controllers.

--- a/spec/lib/appsignal/integrations/railtie_spec.rb
+++ b/spec/lib/appsignal/integrations/railtie_spec.rb
@@ -256,9 +256,27 @@ if DependencyHelper.rails_present?
             end
 
             context "when no transaction is active" do
+              class ExampleRailsRequestMock
+                def path
+                  "path"
+                end
+
+                def method
+                  "GET"
+                end
+
+                def filtered_parameters
+                  { :user_id => 123, :password => "[FILTERED]" }
+                end
+              end
+
               class ExampleRailsControllerMock
                 def action_name
                   "index"
+                end
+
+                def request
+                  @request ||= ExampleRailsRequestMock.new
                 end
               end
 
@@ -275,7 +293,7 @@ if DependencyHelper.rails_present?
                 clear_current_transaction!
               end
 
-              it "fetches the action from the controller in the context" do
+              it "fetches the action, path and method from the controller in the context" do
                 # The controller key is set by Rails when raised in a controller
                 given_context = { :controller => ExampleRailsControllerMock.new }
                 with_rails_error_reporter do
@@ -285,7 +303,14 @@ if DependencyHelper.rails_present?
                 transaction = last_transaction
                 transaction_hash = transaction.to_h
                 expect(transaction_hash).to include(
-                  "action" => "ExampleRailsControllerMock#index"
+                  "action" => "ExampleRailsControllerMock#index",
+                  "metadata" => hash_including(
+                    "path" => "path",
+                    "method" => "GET"
+                  ),
+                  "sample_data" => hash_including(
+                    "params" => { "user_id" => 123, "password" => "[FILTERED]" }
+                  )
                 )
               end
 


### PR DESCRIPTION
Ref https://github.com/appsignal/appsignal-ruby/issues/1051

This closes most of the gaps between our previous usage of `Appsignal.set_error` and using the Rails error reporter interface. The only thing missing are the headers (environment), I'm getting a bit lost in how `Appsignal::Transaction` has various ways to set/read things when trying to add it myself. FFT take this over and improve it.