### PR TITLE
Check redis-client gem version to prevent error

### DIFF
--- a/.changesets/check-redis-client-version.md
+++ b/.changesets/check-redis-client-version.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Check the redis-client gem version before installing instrumentation. This prevents errors from being raised on redis-client gem versions older than 0.14.0.

--- a/lib/appsignal/hooks/redis_client.rb
+++ b/lib/appsignal/hooks/redis_client.rb
@@ -8,6 +8,7 @@ module Appsignal
 
       def dependencies_present?
         defined?(::RedisClient) &&
+          Gem::Version.new(::RedisClient::VERSION) >= Gem::Version.new("0.14.0") &&
           Appsignal.config &&
           Appsignal.config[:instrument_redis]
       end

--- a/spec/lib/appsignal/hooks/redis_client_spec.rb
+++ b/spec/lib/appsignal/hooks/redis_client_spec.rb
@@ -4,12 +4,28 @@ describe Appsignal::Hooks::RedisClientHook do
   end
 
   if DependencyHelper.redis_client_present?
-    context "with redis_client" do
+    context "with redis-client" do
       context "with instrumentation enabled" do
         describe "#dependencies_present?" do
           subject { described_class.new.dependencies_present? }
 
-          it { is_expected.to be_truthy }
+          context "with gem version new than 0.14.0" do
+            before { stub_const("RedisClient::VERSION", "1.2.3") }
+
+            it { is_expected.to be_truthy }
+          end
+
+          context "with gem version 0.14.0" do
+            before { stub_const("RedisClient::VERSION", "0.14.0") }
+
+            it { is_expected.to be_truthy }
+          end
+
+          context "with gem version older than 0.14.0" do
+            before { stub_const("RedisClient::VERSION", "0.13.9") }
+
+            it { is_expected.to be_falsy }
+          end
         end
 
         context "with rest-client gem" do
@@ -211,7 +227,7 @@ describe Appsignal::Hooks::RedisClientHook do
       end
     end
   else
-    context "without redis" do
+    context "without redis-client" do
       describe "#dependencies_present?" do
         subject { described_class.new.dependencies_present? }
 


### PR DESCRIPTION
Version 0.14.0 of the redis-client gem introduced the `@config` object we rely on in our instrumentation. Add a check using the version number to make sure we only include our instrumentation on versions that include this. This will avoid errors from occurring in the instrumentation itself.

Fixes #1048