### PR TITLE
Clear in memory log on logger start

### DIFF
--- a/.changesets/clear-in-memory-log-after-logger-start.md
+++ b/.changesets/clear-in-memory-log-after-logger-start.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Clear the AppSignal in memory logger, used during the gem start, after the file/STDOUT logger is started. This reduces memory usage of the AppSignal Ruby gem by a tiny bit, and prevent stale logs being logged whenever a process gets forked and starts AppSignal.

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -218,7 +218,10 @@ module Appsignal
         else
           Appsignal::Config::DEFAULT_LOG_LEVEL
         end
-      internal_logger << @in_memory_log.string if @in_memory_log
+      return unless @in_memory_log
+
+      internal_logger << @in_memory_log.string
+      @in_memory_log = nil
     end
 
     # Returns if the C-extension was loaded properly.


### PR DESCRIPTION
The `@in_memory_log` would continue to keep the messages in memory that were logged during the gem start, before a logger was initialized. This keeps memory allocated while apps are running.

This issue was reported in #645, where it also kept logging those in memory logged messages whenever a process was forked and AppSignal started.

Clear the in memory log so it uses less memory and doesn't result in stale logs being logged on process forks.

Fix issues with the test suite where state on the `Appsignal` module persisted between tests by removing the `@in_memory_log` variable and clearing the `@internal_logger` variable.

Closes #645