### PR TITLE
Log log_file_path warning only once

### DIFF
--- a/.changesets/print-log-path-warning-only-once.md
+++ b/.changesets/print-log-path-warning-only-once.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+If the gem can't find a valid log path in the app's `log/` directory, it will no longer print the warning more than once.

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -320,20 +320,29 @@ module Appsignal
     end
 
     def log_file_path
+      return @log_file_path if defined? @log_file_path
+
       path = config_hash[:log_path] || (root_path && File.join(root_path, "log"))
-      return File.join(File.realpath(path), "appsignal.log") if path && File.writable?(path)
+      if path && File.writable?(path)
+        @log_file_path = File.join(File.realpath(path), "appsignal.log")
+        return @log_file_path
+      end
 
       system_tmp_dir = self.class.system_tmp_dir
       if File.writable? system_tmp_dir
         $stdout.puts "appsignal: Unable to log to '#{path}'. Logging to " \
-          "'#{system_tmp_dir}' instead. Please check the " \
-          "permissions for the application's (log) directory."
-        File.join(system_tmp_dir, "appsignal.log")
+          "'#{system_tmp_dir}' instead. " \
+          "Please check the permissions for the application's (log) " \
+          "directory."
+        @log_file_path = File.join(system_tmp_dir, "appsignal.log")
       else
         $stdout.puts "appsignal: Unable to log to '#{path}' or the " \
           "'#{system_tmp_dir}' fallback. Please check the permissions " \
           "for the application's (log) directory."
+        @log_file_path = nil
       end
+
+      @log_file_path
     end
 
     def valid?


### PR DESCRIPTION
Avoid printing the warning more than once if `log_file_path` is called more than once. Only print the warning once to avoid confusion.

Fixes #776