### PR TITLE
Listen to APPSIGNAL_HTTP_PROXY in installer

### DIFF
--- a/.changesets/listen-to-appsignal_http_proxy-in-extension-installer.md
+++ b/.changesets/listen-to-appsignal_http_proxy-in-extension-installer.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Listen to the `APPSIGNAL_HTTP_PROXY` environment variable in the extension installer. When `APPSIGNAL_HTTP_PROXY` is set during `gem instal appsignal` or `bundle install`, it will use the proxy specified in the `APPSIGNAL_HTTP_PROXY` environment variable to download the extension and agent.

--- a/ext/base.rb
+++ b/ext/base.rb
@@ -190,6 +190,9 @@ def store_download_version_on_report
 end
 
 def http_proxy
+  proxy = try_http_proxy_value(ENV.fetch("APPSIGNAL_HTTP_PROXY", nil))
+  return [proxy, nil] if proxy
+
   proxy, error =
     begin
       [try_http_proxy_value(Gem.configuration[:http_proxy]), nil]


### PR DESCRIPTION
Other than the Ruby gem config, HTTP_PROXY and http_proxy env vars, also listen to our own env var APPSIGNAL_HTTP_PROXY so people who use that env var, don't also need to add another configuration.

Closes #787