### PR TITLE
Start probes registered after thread is started

### DIFF
--- a/.changesets/add-probes-register-method.md
+++ b/.changesets/add-probes-register-method.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Add `Appsignal::Probes.register` method as the preferred method to register probes. The `Appsignal::Probes.probes.register` is now deprecated.

--- a/.changesets/automatically-start-new-probes-on-register.md
+++ b/.changesets/automatically-start-new-probes-on-register.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Automatically start new probes when registered with `Appsignal::Probes.register` when the gem has already started the probes thread. Previously, the late registered probes would not be run.

--- a/lib/appsignal/probes.rb
+++ b/lib/appsignal/probes.rb
@@ -25,72 +25,17 @@ module Appsignal
         probes[key]
       end
 
-      # Register a new minutely probe.
-      #
-      # Supported probe types are:
-      #
-      # - Lambda - A lambda is an object that listens to a `call` method call.
-      #   This `call` method is called every minute.
-      # - Class - A class object is an object that listens to a `new` and
-      #   `call` method call. The `new` method is called when the minutely
-      #   probe thread is started to initialize all probes. This allows probes
-      #   to load dependencies once beforehand. Their `call` method is called
-      #   every minute.
-      # - Class instance - A class instance object is an object that listens to
-      #   a `call` method call. The `call` method is called every minute.
-      #
-      # @example Register a new probe
-      #   Appsignal::Probes.probes.register :my_probe, lambda {}
-      #
-      # @example Overwrite an existing registered probe
-      #   Appsignal::Probes.probes.register :my_probe, lambda {}
-      #   Appsignal::Probes.probes.register :my_probe, lambda { puts "hello" }
-      #
-      # @example Add a lambda as a probe
-      #   Appsignal::Probes.probes.register :my_probe, lambda { puts "hello" }
-      #   # "hello" # printed every minute
-      #
-      # @example Add a probe instance
-      #   class MyProbe
-      #     def initialize
-      #       puts "started"
-      #     end
-      #
-      #     def call
-      #       puts "called"
-      #     end
-      #   end
-      #
-      #   Appsignal::Probes.probes.register :my_probe, MyProbe.new
-      #   # "started" # printed immediately
-      #   # "called" # printed every minute
-      #
-      # @example Add a probe class
-      #   class MyProbe
-      #     def initialize
-      #       # Add things that only need to be done on start up for this probe
-      #       require "some/library/dependency"
-      #       @cache = {} # initialize a local cache variable
-      #       puts "started"
-      #     end
-      #
-      #     def call
-      #       puts "called"
-      #     end
-      #   end
-      #
-      #   Appsignal::Probes.probes.register :my_probe, MyProbe
-      #   Appsignal::Probes.start # This is called for you
-      #   # "started" # Printed on Appsignal::Probes.start
-      #   # "called" # Repeated every minute
-      #
-      # @param name [Symbol/String] Name of the probe. Can be used with {[]}.
-      #   This name will be used in errors in the log and allows overwriting of
-      #   probes by registering new ones with the same name.
-      # @param probe [Object] Any object that listens to the `call` method will
-      #   be used as a probe.
-      # @return [void]
+      # @deprecated Use {Appsignal::Probes.register} instead.
       def register(name, probe)
+        Appsignal::Utils::StdoutAndLoggerMessage.warning(
+          "The method 'Appsignal::Probes.probes.register' is deprecated. " \
+            "Use 'Appsignal::Probes.register' instead."
+        )
+        Appsignal::Probes.register(name, probe)
+      end
+
+      # @api private
+      def internal_register(name, probe)
         if probes.key?(name)
           logger.debug "A probe with the name `#{name}` is already " \
             "registered. Overwriting the entry with the new probe."
@@ -117,6 +62,75 @@ module Appsignal
       # @return [ProbeCollection] Returns list of probes.
       def probes
         @probes ||= ProbeCollection.new
+      end
+
+      # Register a new minutely probe.
+      #
+      # Supported probe types are:
+      #
+      # - Lambda - A lambda is an object that listens to a `call` method call.
+      #   This `call` method is called every minute.
+      # - Class - A class object is an object that listens to a `new` and
+      #   `call` method call. The `new` method is called when the minutely
+      #   probe thread is started to initialize all probes. This allows probes
+      #   to load dependencies once beforehand. Their `call` method is called
+      #   every minute.
+      # - Class instance - A class instance object is an object that listens to
+      #   a `call` method call. The `call` method is called every minute.
+      #
+      # @example Register a new probe
+      #   Appsignal::Probes.register :my_probe, lambda {}
+      #
+      # @example Overwrite an existing registered probe
+      #   Appsignal::Probes.register :my_probe, lambda {}
+      #   Appsignal::Probes.register :my_probe, lambda { puts "hello" }
+      #
+      # @example Add a lambda as a probe
+      #   Appsignal::Probes.register :my_probe, lambda { puts "hello" }
+      #   # "hello" # printed every minute
+      #
+      # @example Add a probe instance
+      #   class MyProbe
+      #     def initialize
+      #       puts "started"
+      #     end
+      #
+      #     def call
+      #       puts "called"
+      #     end
+      #   end
+      #
+      #   Appsignal::Probes.register :my_probe, MyProbe.new
+      #   # "started" # printed immediately
+      #   # "called" # printed every minute
+      #
+      # @example Add a probe class
+      #   class MyProbe
+      #     def initialize
+      #       # Add things that only need to be done on start up for this probe
+      #       require "some/library/dependency"
+      #       @cache = {} # initialize a local cache variable
+      #       puts "started"
+      #     end
+      #
+      #     def call
+      #       puts "called"
+      #     end
+      #   end
+      #
+      #   Appsignal::Probes.register :my_probe, MyProbe
+      #   Appsignal::Probes.start # This is called for you
+      #   # "started" # Printed on Appsignal::Probes.start
+      #   # "called" # Repeated every minute
+      #
+      # @param name [Symbol/String] Name of the probe. Can be used with {[]}.
+      #   This name will be used in errors in the log and allows overwriting of
+      #   probes by registering new ones with the same name.
+      # @param probe [Object] Any object that listens to the `call` method will
+      #   be used as a probe.
+      # @return [void]
+      def register(name, probe)
+        probes.internal_register(name, probe)
       end
 
       # @api private

--- a/lib/appsignal/probes.rb
+++ b/lib/appsignal/probes.rb
@@ -136,6 +136,7 @@ module Appsignal
       # @api private
       def start
         stop
+        @started = true
         @thread = Thread.new do
           # Advise multi-threaded app servers to ignore this thread
           # for the purposes of fork safety warnings
@@ -160,9 +161,18 @@ module Appsignal
         end
       end
 
+      # Returns if the probes thread has been started. If the value is false or
+      # nil, it has not been started yet.
+      #
+      # @return [Boolean, nil]
+      def started?
+        @started
+      end
+
       # @api private
       def stop
         defined?(@thread) && @thread.kill
+        @started = false
         probe_instances.clear
       end
 

--- a/spec/lib/appsignal/probes_spec.rb
+++ b/spec/lib/appsignal/probes_spec.rb
@@ -77,6 +77,23 @@ describe Appsignal::Probes do
       allow(Appsignal::Probes).to receive(:wait_time).and_return(0.001)
     end
 
+    describe ".started?" do
+      it "returns true when the probes thread has been started" do
+        expect(Appsignal::Probes.started?).to be_falsy
+        Appsignal::Probes.register :my_probe, (lambda {})
+        Appsignal::Probes.start
+        expect(Appsignal::Probes.started?).to be_truthy
+      end
+
+      it "returns false when the probes thread has been stopped" do
+        Appsignal::Probes.register :my_probe, lambda {}
+        Appsignal::Probes.start
+        expect(Appsignal::Probes.started?).to be_truthy
+        Appsignal::Probes.stop
+        expect(Appsignal::Probes.started?).to be_falsy
+      end
+    end
+
     context "with an instance of a class" do
       it "calls the probe every <wait_time>" do
         probe = MockProbe.new


### PR DESCRIPTION
## Move Probes registration to main Probes module

Deprecate the `Appsignal::Probes.probes.register` method in favor of directly calling it on `Appsignal::Probes.register`. Users don't need to know about the `probes` collection. At least not to register probes. With the register method on the Probes module we also have a bit more control if we want to do extra things after registration. See next commit.

The old method of `Appsignal::Probes.probes.register` still works, it's just deprecated now.

## Add Probes.started? method

Add the `Appsignal::Probes.started?` method that can be used to check if the minutely probes thread is currently running.

## Start probes registered after thread is started

When the AppSignal gem starts, it is no longer possible to register probes. If AppSignal is started by one of our framework integration, it may be difficult to register a probe before then.

It was required that people manually called `Appsignal::Probes.start` again.

This change auto initializes newly registered probes if the minutely probes thread has already started. It will then be included in the next iteration of the thread's loop.

Closes #812
