### PR TITLE
Stop minutely probes thread on Appsignal.stop

### DIFF
--- a/.changesets/stop-minutely-probes-on-appsignal-stop.md
+++ b/.changesets/stop-minutely-probes-on-appsignal-stop.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Stop the minutely probes when `Appsignal.stop` is called. When `Appsignal.stop` is called, the probes thread will no longer continue running in the app process.

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -152,6 +152,7 @@ module Appsignal
         internal_logger.debug("Stopping appsignal")
       end
       Appsignal::Extension.stop
+      Appsignal::Probes.stop
     end
 
     def forked

--- a/lib/appsignal/probes.rb
+++ b/lib/appsignal/probes.rb
@@ -178,7 +178,8 @@ module Appsignal
         @started
       end
 
-      # @api private
+      # Stop the minutely probes mechanism. Stop the thread and clear all probe
+      # instances.
       def stop
         defined?(@thread) && @thread.kill
         @started = false

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -151,11 +151,18 @@ describe Appsignal do
   end
 
   describe ".stop" do
-    it "should call stop on the extension" do
+    it "calls stop on the extension" do
       expect(Appsignal.internal_logger).to receive(:debug).with("Stopping appsignal")
       expect(Appsignal::Extension).to receive(:stop)
       Appsignal.stop
       expect(Appsignal.active?).to be_falsy
+    end
+
+    it "stops the minutely probes" do
+      Appsignal::Probes.start
+      expect(Appsignal::Probes.started?).to be_truthy
+      Appsignal.stop
+      expect(Appsignal::Probes.started?).to be_falsy
     end
 
     context "with context specified" do


### PR DESCRIPTION
Make sure the minutely probes thread is stopped when calling `Appsignal.stop`. This makes sure nothing of the AppSignal gem is running after you call stop.

This only affects apps that call stop manually (like in test suites), because the thread is also stopped when the Ruby process stops.

Closes #815