### PR TITLE
Allow probes to be unregistered

### DIFF
--- a/.changesets/unregister-probes.md
+++ b/.changesets/unregister-probes.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Allow unregistering minutely probes. Use `Appsignal::Probes.unregister` to unregister probes registered with `Appsignal::Probes.register` if you do not need a certain probe, including default probes.

--- a/lib/appsignal/probes.rb
+++ b/lib/appsignal/probes.rb
@@ -133,9 +133,10 @@ module Appsignal
       #   # "started" # Printed on Appsignal::Probes.start
       #   # "called" # Repeated every minute
       #
-      # @param name [Symbol/String] Name of the probe. Can be used with {[]}.
-      #   This name will be used in errors in the log and allows overwriting of
-      #   probes by registering new ones with the same name.
+      # @param name [Symbol/String] Name of the probe. Can be used with
+      #   {ProbeCollection#[]}. This name will be used in errors in the log and
+      #   allows overwriting of probes by registering new ones with the same
+      #   name.
       # @param probe [Object] Any object that listens to the `call` method will
       #   be used as a probe.
       # @return [void]


### PR DESCRIPTION
## Allow probes to be unregistered

Add a mechanism to unregister probes. This also removes probe instances, so that they're not still called after removing them from the ProbeCollection.

Part of #807

## Fix broken reference in ProbeCollection

This broke when moving things around in #1067.
