### PR TITLE
Fix deprecation warning

### DIFF
--- a/.changesets/fix-deprecation-warnings-for-probes-probes.md
+++ b/.changesets/fix-deprecation-warnings-for-probes-probes.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix deprecation warnings for Probes.probes introduced in 3.7.1 for internally registered probes.

--- a/lib/appsignal/hooks/gvl.rb
+++ b/lib/appsignal/hooks/gvl.rb
@@ -16,7 +16,7 @@ module Appsignal
       end
 
       def install
-        Appsignal::Probes.probes.register :gvl, Appsignal::Probes::GvlProbe
+        Appsignal::Probes.register :gvl, Appsignal::Probes::GvlProbe
         ::GVLTools::GlobalTimer.enable if Appsignal.config[:enable_gvl_global_timer]
         ::GVLTools::WaitingThreads.enable if Appsignal.config[:enable_gvl_waiting_threads]
       end

--- a/lib/appsignal/hooks/mri.rb
+++ b/lib/appsignal/hooks/mri.rb
@@ -11,7 +11,7 @@ module Appsignal
       end
 
       def install
-        Appsignal::Probes.probes.register :mri, Appsignal::Probes::MriProbe
+        Appsignal::Probes.register :mri, Appsignal::Probes::MriProbe
       end
     end
   end

--- a/lib/appsignal/hooks/sidekiq.rb
+++ b/lib/appsignal/hooks/sidekiq.rb
@@ -11,7 +11,7 @@ module Appsignal
 
       def install
         require "appsignal/integrations/sidekiq"
-        Appsignal::Probes.probes.register :sidekiq, Appsignal::Probes::SidekiqProbe
+        Appsignal::Probes.register :sidekiq, Appsignal::Probes::SidekiqProbe
 
         ::Sidekiq.configure_server do |config|
           config.error_handlers <<


### PR DESCRIPTION
`Appsignal::Probes.probes.register` was [deprecated](https://github.com/appsignal/appsignal-ruby/commit/1230502525004d324f3dbcf0ee61eb0e6fe7fdb5) in favor of `Appsignal::Probes.register`. The former method however is still used in some built-in hooks, resulting in deprecation warnings. This PR updates the method calls accordingly.