### PR TITLE
Rename perform_job methods in spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,7 @@
 source "https://rubygems.org"
 
 gemspec
+
+# Fix install issue for jruby on gem 3.1.8.
+# No java stub is published.
+gem "bigdecimal", "3.1.7" if RUBY_PLATFORM == "java"

--- a/gemfiles/no_dependencies.gemfile
+++ b/gemfiles/no_dependencies.gemfile
@@ -1,8 +1,10 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 ruby_version = Gem::Version.new(RUBY_VERSION)
-if ruby_version < Gem::Version.new("2.3.0")
-  gem 'rack', '~> 1.6'
-end
+gem "rack", "~> 1.6" if ruby_version < Gem::Version.new("2.3.0")
 
-gemspec :path => '../'
+# Fix install issue for jruby on gem 3.1.8.
+# No java stub is published.
+gem "bigdecimal", "3.1.7" if RUBY_PLATFORM == "java"
+
+gemspec :path => "../"

--- a/gemfiles/rails-6.0.gemfile
+++ b/gemfiles/rails-6.0.gemfile
@@ -1,6 +1,10 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'rails', '~> 6.0.0'
+gem "rails", "~> 6.0.0"
 gem "sidekiq"
 
-gemspec :path => '../'
+# Fix install issue for jruby on gem 3.1.8.
+# No java stub is published.
+gem "bigdecimal", "3.1.7" if RUBY_PLATFORM == "java"
+
+gemspec :path => "../"

--- a/gemfiles/rails-6.1.gemfile
+++ b/gemfiles/rails-6.1.gemfile
@@ -1,7 +1,11 @@
 source "https://rubygems.org"
 
+gem "net-smtp", :require => false
 gem "rails", "~> 6.1.0"
-gem "net-smtp", require: false
 gem "sidekiq"
+
+# Fix install issue for jruby on gem 3.1.8.
+# No java stub is published.
+gem "bigdecimal", "3.1.7" if RUBY_PLATFORM == "java"
 
 gemspec :path => "../"

--- a/gemfiles/rails-7.0.gemfile
+++ b/gemfiles/rails-7.0.gemfile
@@ -1,7 +1,11 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'rails', "~> 7.0.1"
-gem "sidekiq"
+gem "rails", "~> 7.0.1"
 gem "rake", "> 12.2"
+gem "sidekiq"
 
-gemspec :path => '../'
+# Fix install issue for jruby on gem 3.1.8.
+# No java stub is published.
+gem "bigdecimal", "3.1.7" if RUBY_PLATFORM == "java"
+
+gemspec :path => "../"

--- a/gemfiles/rails-7.1.gemfile
+++ b/gemfiles/rails-7.1.gemfile
@@ -4,4 +4,8 @@ gem "rails", "~> 7.1.0"
 gem "rake", "> 12.2"
 gem "sidekiq"
 
+# Fix install issue for jruby on gem 3.1.8.
+# No java stub is published.
+gem "bigdecimal", "3.1.7" if RUBY_PLATFORM == "java"
+
 gemspec :path => "../"

--- a/spec/lib/appsignal/hooks/activejob_spec.rb
+++ b/spec/lib/appsignal/hooks/activejob_spec.rb
@@ -107,7 +107,7 @@ if DependencyHelper.active_job_present?
       expect(Appsignal).to receive(:increment_counter)
         .with("active_job_queue_job_count", 1, tags.merge(:status => :processed))
 
-      perform_job(ActiveJobTestJob)
+      queue_job(ActiveJobTestJob)
 
       transaction = last_transaction
       transaction_hash = transaction.to_h
@@ -136,7 +136,7 @@ if DependencyHelper.active_job_present?
         tags = { :queue => "custom_queue" }
         expect(Appsignal).to receive(:increment_counter)
           .with("active_job_queue_job_count", 1, tags.merge(:status => :processed))
-        perform_job(ActiveJobCustomQueueTestJob)
+        queue_job(ActiveJobCustomQueueTestJob)
 
         transaction = last_transaction
         transaction_hash = transaction.to_h
@@ -170,7 +170,7 @@ if DependencyHelper.active_job_present?
             .with("active_job_queue_priority_job_count", 1, tags.merge(:priority => 10,
               :status => :processed))
 
-          perform_job(ActiveJobPriorityTestJob)
+          queue_job(ActiveJobPriorityTestJob)
 
           transaction = last_transaction
           transaction_hash = transaction.to_h
@@ -193,7 +193,7 @@ if DependencyHelper.active_job_present?
           .with("active_job_queue_job_count", 1, tags.merge(:status => :processed))
 
         expect do
-          perform_job(ActiveJobErrorTestJob)
+          queue_job(ActiveJobErrorTestJob)
         end.to raise_error(RuntimeError, "uh oh")
 
         transaction = last_transaction
@@ -236,7 +236,7 @@ if DependencyHelper.active_job_present?
             .with("active_job_queue_job_count", 1, tags.merge(:status => :processed))
 
           expect do
-            perform_job(ActiveJobErrorTestJob)
+            queue_job(ActiveJobErrorTestJob)
           end.to raise_error(RuntimeError, "uh oh")
 
           transaction = last_transaction
@@ -276,7 +276,7 @@ if DependencyHelper.active_job_present?
                 :status => :failed))
 
             expect do
-              perform_job(ActiveJobErrorPriorityTestJob)
+              queue_job(ActiveJobErrorPriorityTestJob)
             end.to raise_error(RuntimeError, "uh oh")
 
             transaction = last_transaction
@@ -297,7 +297,7 @@ if DependencyHelper.active_job_present?
         allow(current_transaction).to receive(:complete).and_call_original
         set_current_transaction current_transaction
 
-        perform_job(ActiveJobTestJob)
+        queue_job(ActiveJobTestJob)
 
         expect(created_transactions.count).to eql(1)
         expect(current_transaction).to_not have_received(:complete)
@@ -333,7 +333,7 @@ if DependencyHelper.active_job_present?
       it "filters the configured params" do
         Appsignal.config = project_fixture_config("production")
         Appsignal.config[:filter_parameters] = ["foo"]
-        perform_job(ActiveJobTestJob, method_given_args)
+        queue_job(ActiveJobTestJob, method_given_args)
 
         transaction = last_transaction
         transaction_hash = transaction.to_h
@@ -382,7 +382,7 @@ if DependencyHelper.active_job_present?
       end
 
       it "sets provider_job_id as tag" do
-        perform_job(ProviderWrappedActiveJobTestJob)
+        queue_job(ProviderWrappedActiveJobTestJob)
 
         transaction = last_transaction
         transaction_hash = transaction.to_h
@@ -424,7 +424,7 @@ if DependencyHelper.active_job_present?
 
       it "sets queue time on transaction" do
         allow_any_instance_of(Appsignal::Transaction).to receive(:set_queue_start).and_call_original
-        perform_job(ProviderWrappedActiveJobTestJob)
+        queue_job(ProviderWrappedActiveJobTestJob)
 
         transaction = last_transaction
         queue_time = Time.parse("2020-10-10T10:10:10Z")
@@ -611,7 +611,7 @@ if DependencyHelper.active_job_present?
       Timecop.freeze(time, &block)
     end
 
-    def perform_job(job_class, args = nil)
+    def queue_job(job_class, args = nil)
       perform_active_job do
         if args
           job_class.perform_later(args)

--- a/spec/lib/appsignal/hooks/resque_spec.rb
+++ b/spec/lib/appsignal/hooks/resque_spec.rb
@@ -17,7 +17,7 @@ describe Appsignal::Hooks::ResqueHook do
 
   if DependencyHelper.resque_present?
     describe "#install" do
-      def perform_job(klass, options = {})
+      def perform_rescue_job(klass, options = {})
         payload = { "class" => klass.to_s }.merge(options)
         job = ::Resque::Job.new(queue, payload)
         keep_transactions { job.perform }
@@ -50,7 +50,7 @@ describe Appsignal::Hooks::ResqueHook do
       end
 
       it "tracks a transaction on perform" do
-        perform_job(ResqueTestJob)
+        perform_rescue_job(ResqueTestJob)
 
         transaction = last_transaction
         transaction_hash = transaction.to_h
@@ -72,7 +72,7 @@ describe Appsignal::Hooks::ResqueHook do
       context "with error" do
         it "tracks the error on the transaction" do
           expect do
-            perform_job(ResqueErrorTestJob)
+            perform_rescue_job(ResqueErrorTestJob)
           end.to raise_error(RuntimeError, "resque job error")
 
           transaction = last_transaction
@@ -102,7 +102,7 @@ describe Appsignal::Hooks::ResqueHook do
         end
 
         it "filters out configured arguments" do
-          perform_job(
+          perform_rescue_job(
             ResqueTestJob,
             "args" => [
               "foo",
@@ -161,7 +161,7 @@ describe Appsignal::Hooks::ResqueHook do
         after { Object.send(:remove_const, :ActiveJobMock) }
 
         it "does not set arguments but lets the ActiveJob integration handle it" do
-          perform_job(
+          perform_rescue_job(
             ResqueTestJob,
             "class" => "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper",
             "args" => [

--- a/spec/lib/appsignal/hooks/shoryuken_spec.rb
+++ b/spec/lib/appsignal/hooks/shoryuken_spec.rb
@@ -10,7 +10,7 @@ describe Appsignal::Hooks::ShoryukenMiddleware do
   before(:context) { start_agent }
   around { |example| keep_transactions { example.run } }
 
-  def perform_job(&block)
+  def perform_shoryuken_job(&block)
     block ||= lambda {}
     Timecop.freeze(Time.parse(time)) do
       Appsignal::Hooks::ShoryukenMiddleware.new.call(
@@ -34,7 +34,7 @@ describe Appsignal::Hooks::ShoryukenMiddleware do
 
       it "wraps the job in a transaction with the correct params" do
         allow_any_instance_of(Appsignal::Transaction).to receive(:set_queue_start).and_call_original
-        expect { perform_job }.to change { created_transactions.length }.by(1)
+        expect { perform_shoryuken_job }.to change { created_transactions.length }.by(1)
 
         transaction = last_transaction
         expect(transaction).to be_completed
@@ -80,7 +80,7 @@ describe Appsignal::Hooks::ShoryukenMiddleware do
         end
 
         it "filters selected arguments" do
-          perform_job
+          perform_shoryuken_job
 
           transaction_hash = last_transaction.to_h
           expect(transaction_hash["sample_data"]).to include(
@@ -94,7 +94,7 @@ describe Appsignal::Hooks::ShoryukenMiddleware do
       let(:body) { "foo bar" }
 
       it "handles string arguments" do
-        perform_job
+        perform_shoryuken_job
 
         transaction_hash = last_transaction.to_h
         expect(transaction_hash["sample_data"]).to include(
@@ -107,7 +107,7 @@ describe Appsignal::Hooks::ShoryukenMiddleware do
       let(:body) { 1 }
 
       it "handles primitive types as arguments" do
-        perform_job
+        perform_shoryuken_job
 
         transaction_hash = last_transaction.to_h
         expect(transaction_hash["sample_data"]).to include(
@@ -121,7 +121,7 @@ describe Appsignal::Hooks::ShoryukenMiddleware do
     it "sets the exception on the transaction" do
       expect do
         expect do
-          perform_job { raise ExampleException, "error message" }
+          perform_shoryuken_job { raise ExampleException, "error message" }
         end.to raise_error(ExampleException)
       end.to change { created_transactions.length }.by(1)
 
@@ -167,7 +167,7 @@ describe Appsignal::Hooks::ShoryukenMiddleware do
     it "creates a transaction for the batch" do
       allow_any_instance_of(Appsignal::Transaction).to receive(:set_queue_start).and_call_original
       expect do
-        perform_job {} # rubocop:disable Lint/EmptyBlock
+        perform_shoryuken_job {} # rubocop:disable Lint/EmptyBlock
       end.to change { created_transactions.length }.by(1)
 
       transaction = last_transaction

--- a/spec/lib/appsignal/integrations/que_spec.rb
+++ b/spec/lib/appsignal/integrations/que_spec.rb
@@ -43,14 +43,14 @@ if DependencyHelper.que_present?
       end
       around { |example| keep_transactions { example.run } }
 
-      def perform_job(job)
+      def perform_que_job(job)
         job._run
       end
 
       context "success" do
         it "creates a transaction for a job" do
           expect do
-            perform_job(instance)
+            perform_que_job(instance)
           end.to change { created_transactions.length }.by(1)
 
           expect(last_transaction).to be_completed
@@ -96,7 +96,7 @@ if DependencyHelper.que_present?
 
           expect do
             expect do
-              perform_job(instance)
+              perform_que_job(instance)
             end.to raise_error(ExampleException)
           end.to change { created_transactions.length }.by(1)
 
@@ -131,7 +131,7 @@ if DependencyHelper.que_present?
         it "reports errors and not re-raise them" do
           allow(instance).to receive(:run).and_raise(error)
 
-          expect { perform_job(instance) }.to change { created_transactions.length }.by(1)
+          expect { perform_que_job(instance) }.to change { created_transactions.length }.by(1)
 
           expect(last_transaction).to be_completed
           transaction_hash = last_transaction.to_h
@@ -168,7 +168,7 @@ if DependencyHelper.que_present?
         end
 
         it "uses the custom action" do
-          perform_job(instance)
+          perform_que_job(instance)
 
           expect(last_transaction).to be_completed
           transaction_hash = last_transaction.to_h


### PR DESCRIPTION
Avoid overwriting the RSpec method with the same name.

[skip changeset]
[skip review]