### PR TITLE
Track the number of executions of Active Job jobs

### DIFF
--- a/.changesets/track-active-job-executions-per-job.md
+++ b/.changesets/track-active-job-executions-per-job.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Track Active Job executions per job. When a job is retried the "executions" metadata for Active Job jobs goes up by one for every retry. We now track this as the `executions` metadata on the job sample.

--- a/lib/appsignal/hooks/active_job.rb
+++ b/lib/appsignal/hooks/active_job.rb
@@ -162,6 +162,8 @@ module Appsignal
           tags[:queue] = queue if queue
           priority = job["priority"]
           tags[:priority] = priority if priority
+          executions = job["executions"]
+          tags[:executions] = executions.to_i + 1 if executions
           tags
         end
 

--- a/spec/lib/appsignal/hooks/activejob_spec.rb
+++ b/spec/lib/appsignal/hooks/activejob_spec.rb
@@ -129,7 +129,8 @@ if DependencyHelper.active_job_present?
           "params" => [],
           "tags" => {
             "active_job_id" => kind_of(String),
-            "queue" => queue
+            "queue" => queue,
+            "executions" => 1
           }
         )
       )
@@ -220,7 +221,8 @@ if DependencyHelper.active_job_present?
             "params" => [],
             "tags" => {
               "active_job_id" => kind_of(String),
-              "queue" => queue
+              "queue" => queue,
+              "executions" => 1
             }
           )
         )
@@ -269,7 +271,14 @@ if DependencyHelper.active_job_present?
 
             transaction = last_transaction
             transaction_hash = transaction.to_h
-            expect(transaction_hash).to include("error" => nil)
+            expect(transaction_hash).to include(
+              "error" => nil,
+              "sample_data" => hash_including(
+                "tags" => hash_including(
+                  "executions" => 1
+                )
+              )
+            )
           end
 
           it "reports error when discarding the job" do
@@ -291,7 +300,12 @@ if DependencyHelper.active_job_present?
                 "name" => "RuntimeError",
                 "message" => "uh oh",
                 "backtrace" => kind_of(String)
-              }
+              },
+              "sample_data" => hash_including(
+                "tags" => hash_including(
+                  "executions" => 2
+                )
+              )
             )
           end
         end
@@ -341,6 +355,24 @@ if DependencyHelper.active_job_present?
       end
     end
 
+    context "with retries" do
+      it "reports the number of retries as executions" do
+        with_test_adapter do
+          expect do
+            queue_job(ActiveJobErrorWithRetryTestJob)
+          end.to raise_error(RuntimeError, "uh oh")
+        end
+
+        transaction = last_transaction
+        transaction_hash = transaction.to_h
+        expect(transaction_hash).to include(
+          "sample_data" => hash_including(
+            "tags" => hash_including("executions" => 2)
+          )
+        )
+      end
+    end
+
     context "when wrapped in another transaction" do
       it "does not create a new transaction or close the currently open one" do
         current_transaction = background_job_transaction
@@ -366,7 +398,8 @@ if DependencyHelper.active_job_present?
             "params" => [],
             "tags" => {
               "active_job_id" => kind_of(String),
-              "queue" => queue
+              "queue" => queue,
+              "executions" => 1
             }
           )
         )
@@ -509,7 +542,8 @@ if DependencyHelper.active_job_present?
                            "deliver_now"] + active_job_args_wrapper,
               "tags" => {
                 "active_job_id" => kind_of(String),
-                "queue" => "mailers"
+                "queue" => "mailers",
+                "executions" => 1
               }
             )
           )
@@ -529,7 +563,8 @@ if DependencyHelper.active_job_present?
                            "deliver_now"] + active_job_args_wrapper(:args => method_expected_args),
               "tags" => {
                 "active_job_id" => kind_of(String),
-                "queue" => "mailers"
+                "queue" => "mailers",
+                "executions" => 1
               }
             )
           )
@@ -553,7 +588,8 @@ if DependencyHelper.active_job_present?
                 ] + active_job_args_wrapper(:params => parameterized_expected_args),
                 "tags" => {
                   "active_job_id" => kind_of(String),
-                  "queue" => "mailers"
+                  "queue" => "mailers",
+                  "executions" => 1
                 }
               )
             )
@@ -594,7 +630,8 @@ if DependencyHelper.active_job_present?
               ],
               "tags" => {
                 "active_job_id" => kind_of(String),
-                "queue" => "mailers"
+                "queue" => "mailers",
+                "executions" => 1
               }
             )
           )
@@ -620,7 +657,8 @@ if DependencyHelper.active_job_present?
                 ],
                 "tags" => {
                   "active_job_id" => kind_of(String),
-                  "queue" => "mailers"
+                  "queue" => "mailers",
+                  "executions" => 1
                 }
               )
             )
@@ -648,7 +686,8 @@ if DependencyHelper.active_job_present?
                 ],
                 "tags" => {
                   "active_job_id" => kind_of(String),
-                  "queue" => "mailers"
+                  "queue" => "mailers",
+                  "executions" => 1
                 }
               )
             )

--- a/spec/lib/appsignal/integrations/sidekiq_spec.rb
+++ b/spec/lib/appsignal/integrations/sidekiq_spec.rb
@@ -407,7 +407,7 @@ if DependencyHelper.active_job_present?
       end
     end
     let(:expected_tags) do
-      {}.tap do |hash|
+      { "executions" => 1 }.tap do |hash|
         hash["active_job_id"] = kind_of(String)
         if DependencyHelper.rails_version >= Gem::Version.new("5.0.0")
           hash["provider_job_id"] = kind_of(String)


### PR DESCRIPTION
When a job is retried, the execution count goes up every time. To give more insights into how many times a job has been retried, track the executions as a tag.

Executions are zero when the job is run the first time for some reason, so +1 the value so it makes more sense to a human being reading it. Calling `to_i` on the job metadata just to make sure we don't error on any weird value type.