### PR TITLE
Fix LocalJumpError for Active Job < 7.1

### DIFF
--- a/.changesets/fix-localjumperror-in-active-job-instrumentation.md
+++ b/.changesets/fix-localjumperror-in-active-job-instrumentation.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix LocalJumpError in Active Job instrumentation initialization for Active Job < 7.1.

--- a/lib/appsignal/hooks/active_job.rb
+++ b/lib/appsignal/hooks/active_job.rb
@@ -30,7 +30,7 @@ module Appsignal
           ::ActiveJob::Base
             .extend ::Appsignal::Hooks::ActiveJobHook::ActiveJobClassInstrumentation
 
-          return unless Appsignal::Hooks::ActiveJobHook.version_7_1_or_higher?
+          next unless Appsignal::Hooks::ActiveJobHook.version_7_1_or_higher?
 
           # Only works on Active Job 7.1 and newer
           ::ActiveJob::Base.after_discard do |_job, exception|


### PR DESCRIPTION
Use a `next` rather than a `return` to stop executing the block.

Fixes #1078