### PR TITLE
Use the Ruby debug gem instead of pry

### DIFF
--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |gem| # rubocop:disable Metrics/BlockLength
 
   gem.add_dependency "rack"
 
-  gem.add_development_dependency "pry"
+  gem.add_development_dependency "debug"
   gem.add_development_dependency "rake", ">= 12"
   gem.add_development_dependency "rspec", "~> 3.8"
   gem.add_development_dependency "rubocop", "1.50.0"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,7 +34,6 @@ if DependencyHelper.hanami2_present?
     require f
   end
 end
-require "pry" if DependencyHelper.dependency_present?("pry")
 require "appsignal"
 # Include patches of AppSignal modules and classes to make test helpers
 # available.


### PR DESCRIPTION
Switch to using debug instead of pry for debugging. I've found myself use debug all the, but it not being present in the development tooling of the gem is annoying.

Remove the default require for pry from the spec helper now that it's removed. I don't need the debug gem to be loaded all the time either as my snippet for it includes the require statement.

[skip changeset]