### PR TITLE
Print test names in CI

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -324,7 +324,7 @@ begin
 
   desc "Run the AppSignal gem test suite."
   RSpec::Core::RakeTask.new :test do |t|
-    t.rspec_opts = exclude_pattern
+    t.rspec_opts = "#{exclude_pattern} --format documentation"
   end
 
   namespace :test do


### PR DESCRIPTION
Print the test names in the CI so it's easier to confirm which tests are running if we're unsure and want to check manually.

[skip changeset]
[skip review]