### PR TITLE
Add ViewComponent event formatter

### DIFF
--- a/.changesets/support-viewcomponent-events.md
+++ b/.changesets/support-viewcomponent-events.md
@@ -1,0 +1,20 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Support events emitted by ViewComponent. Rendering of ViewComponent-based components will appear as events in your performance samples' event timeline.
+
+For AppSignal to instrument ViewComponent events, you must first configure ViewComponent to emit those events:
+
+```ruby
+# config/application.rb
+module MyRailsApp
+  class Application < Rails::Application
+    config.view_component.instrumentation_enabled = true
+    config.view_component.use_deprecated_instrumentation_name = false
+  end
+end
+```
+
+Thanks to Trae Robrock (@trobrock) for providing a starting point for this implementation!

--- a/gemfiles/rails-7.1.gemfile
+++ b/gemfiles/rails-7.1.gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem "rails", "~> 7.1.0"
 gem "rake", "> 12.2"
 gem "sidekiq"
+gem "view_component"
 
 # Fix install issue for jruby on gem 3.1.8.
 # No java stub is published.

--- a/lib/appsignal/event_formatter/view_component/render_formatter.rb
+++ b/lib/appsignal/event_formatter/view_component/render_formatter.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Appsignal
+  class EventFormatter
+    # @api private
+    module ViewComponent
+      class RenderFormatter
+        BLANK = ""
+
+        attr_reader :root_path
+
+        def initialize
+          @root_path = "#{Rails.root}/"
+        end
+
+        def format(payload)
+          [payload[:name], payload[:identifier].sub(@root_path, BLANK)]
+        end
+      end
+    end
+  end
+end
+
+if defined?(Rails) && defined?(ViewComponent)
+  Appsignal::EventFormatter.register(
+    "render.view_component",
+    Appsignal::EventFormatter::ViewComponent::RenderFormatter
+  )
+  Appsignal::EventFormatter.register(
+    "!render.view_component",
+    Appsignal::EventFormatter::ViewComponent::RenderFormatter
+  )
+end

--- a/spec/lib/appsignal/event_formatter/view_component/render_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/view_component/render_formatter_spec.rb
@@ -1,0 +1,43 @@
+describe Appsignal::EventFormatter::ViewComponent::RenderFormatter do
+  let(:klass) { Appsignal::EventFormatter::ViewComponent::RenderFormatter }
+
+  if DependencyHelper.rails_present? && DependencyHelper.view_component_present?
+    require "view_component"
+
+    context "when in a Rails app" do
+      let(:formatter) { klass.new }
+      before { allow(Rails.root).to receive(:to_s).and_return("/var/www/app/20130101") }
+
+      it "registers render.view_component and (deprecated) !render.view_component" do
+        expect(Appsignal::EventFormatter.registered?("render.view_component",
+          klass)).to be_truthy
+        expect(Appsignal::EventFormatter.registered?("!render.view_component",
+          klass)).to be_truthy
+      end
+
+      describe "#format" do
+        subject { formatter.format(payload) }
+
+        context "with a name and identifier" do
+          let(:payload) do
+            {
+              :name => "WhateverComponent",
+              :identifier => "/var/www/app/20130101/app/components/whatever_component.rb"
+            }
+          end
+
+          it { is_expected.to eq ["WhateverComponent", "app/components/whatever_component.rb"] }
+        end
+      end
+    end
+  else
+    context "when not in a Rails app with the ViewComponent gem" do
+      it "does not register the event formatter" do
+        expect(Appsignal::EventFormatter.registered?("render.view_component",
+          klass)).to be_falsy
+        expect(Appsignal::EventFormatter.registered?("!render.view_component",
+          klass)).to be_falsy
+      end
+    end
+  end
+end

--- a/spec/support/helpers/dependency_helper.rb
+++ b/spec/support/helpers/dependency_helper.rb
@@ -131,6 +131,10 @@ module DependencyHelper # rubocop:disable Metrics/ModuleLength
     hanami_present? && Gem.loaded_specs["hanami"].version >= Gem::Version.new("2.0")
   end
 
+  def view_component_present?
+    dependency_present? "view_component"
+  end
+
   def dependency_present?(dependency_file)
     Gem.loaded_specs.key? dependency_file
   end


### PR DESCRIPTION
Add an event formatter for the events emitted by the `view_component` gem. See [Intercom conversation](https://app.intercom.com/a/inbox/yzor8gyw/inbox/admin/5246522/conversation/16410700323455?view=List) and [test setups PR](https://github.com/appsignal/test-setups/pull/208).

<img width="821" alt="Screenshot 2024-05-10 at 16 32 22" src="https://github.com/appsignal/appsignal-ruby/assets/45180344/e594db4d-400e-4907-a300-d59075b159b0">



To do
===

- [ ] Document this (see changelog)