### PR TITLE
Do not use `trace` on internal logger

### DIFF
--- a/.changesets/fix-issue-when-sending-heartbeats.md
+++ b/.changesets/fix-issue-when-sending-heartbeats.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix an issue where an error about the AppSignal internal logger is raised when sending a heartbeat.

--- a/lib/appsignal/heartbeat.rb
+++ b/lib/appsignal/heartbeat.rb
@@ -45,7 +45,7 @@ module Appsignal
       response = self.class.transmitter.transmit(event(kind))
 
       if response.code.to_i >= 200 && response.code.to_i < 300
-        Appsignal.internal_logger.trace("Transmitted heartbeat `#{name}` (#{id}) #{kind} event")
+        Appsignal.internal_logger.debug("Transmitted heartbeat `#{name}` (#{id}) #{kind} event")
       else
         Appsignal.internal_logger.error(
           "Failed to transmit heartbeat event: status code was #{response.code}"

--- a/spec/lib/appsignal/heartbeat_spec.rb
+++ b/spec/lib/appsignal/heartbeat_spec.rb
@@ -24,7 +24,26 @@ describe Appsignal::Heartbeat do
       expect(transmitter).to receive(:transmit).with(hash_including(
         :name => "heartbeat-name",
         :kind => "start"
-      )).and_return(nil)
+      )).and_return(Net::HTTPResponse.new(nil, "200", nil))
+
+      expect(Appsignal.internal_logger).to receive(:debug).with(
+        "Transmitted heartbeat `heartbeat-name` (#{heartbeat.id}) start event"
+      )
+      expect(Appsignal.internal_logger).not_to receive(:error)
+
+      heartbeat.start
+    end
+
+    it "should log an error if it fails" do
+      expect(transmitter).to receive(:transmit).with(hash_including(
+        :name => "heartbeat-name",
+        :kind => "start"
+      )).and_return(Net::HTTPResponse.new(nil, "499", nil))
+
+      expect(Appsignal.internal_logger).not_to receive(:debug)
+      expect(Appsignal.internal_logger).to receive(:error).with(
+        "Failed to transmit heartbeat event: status code was 499"
+      )
 
       heartbeat.start
     end
@@ -35,7 +54,26 @@ describe Appsignal::Heartbeat do
       expect(transmitter).to receive(:transmit).with(hash_including(
         :name => "heartbeat-name",
         :kind => "finish"
-      )).and_return(nil)
+      )).and_return(Net::HTTPResponse.new(nil, "200", nil))
+
+      expect(Appsignal.internal_logger).to receive(:debug).with(
+        "Transmitted heartbeat `heartbeat-name` (#{heartbeat.id}) finish event"
+      )
+      expect(Appsignal.internal_logger).not_to receive(:error)
+
+      heartbeat.finish
+    end
+
+    it "should log an error if it fails" do
+      expect(transmitter).to receive(:transmit).with(hash_including(
+        :name => "heartbeat-name",
+        :kind => "finish"
+      )).and_return(Net::HTTPResponse.new(nil, "499", nil))
+
+      expect(Appsignal.internal_logger).not_to receive(:debug)
+      expect(Appsignal.internal_logger).to receive(:error).with(
+        "Failed to transmit heartbeat event: status code was 499"
+      )
 
       heartbeat.finish
     end


### PR DESCRIPTION
The internal logger does not support `trace`. Use `debug` instead.

Since the heartbeat implementation intentionally swallows all errors and logs them, issues such as this would go unnoticed by the test suite. Add assertions on the messages that are expected to be logged to ensure that the implementation is actually working as expected.

(Another "how did this ever pass the tests?" mystery, though in this case the answer is simple in retrospect)