### PR TITLE
Document the heartbeat functionality

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -6,6 +6,7 @@ require "stringio"
 
 require "appsignal/logger"
 require "appsignal/utils/stdout_and_logger_message"
+require "appsignal/helpers/heartbeats"
 require "appsignal/helpers/instrumentation"
 require "appsignal/helpers/metrics"
 
@@ -17,6 +18,7 @@ require "appsignal/helpers/metrics"
 # {Appsignal::Helpers::Metrics}) for ease of use.
 module Appsignal
   class << self
+    include Helpers::Heartbeats
     include Helpers::Instrumentation
     include Helpers::Metrics
 

--- a/lib/appsignal/heartbeat.rb
+++ b/lib/appsignal/heartbeat.rb
@@ -55,17 +55,4 @@ module Appsignal
       Appsignal.internal_logger.error("Failed to transmit heartbeat event: #{e}")
     end
   end
-
-  def self.heartbeat(name)
-    heartbeat = Appsignal::Heartbeat.new(:name => name)
-    output = nil
-
-    if block_given?
-      heartbeat.start
-      output = yield
-    end
-
-    heartbeat.finish
-    output
-  end
 end

--- a/lib/appsignal/heartbeat.rb
+++ b/lib/appsignal/heartbeat.rb
@@ -3,6 +3,7 @@
 module Appsignal
   class Heartbeat
     class << self
+      # @api private
       def transmitter
         @transmitter ||= Appsignal::Transmitter.new(
           "#{Appsignal.config[:logging_endpoint]}/heartbeats/json"

--- a/lib/appsignal/helpers/heartbeats.rb
+++ b/lib/appsignal/helpers/heartbeats.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Appsignal
+  module Helpers
+    module Heartbeats
+      def heartbeat(name)
+        heartbeat = Appsignal::Heartbeat.new(:name => name)
+        output = nil
+
+        if block_given?
+          heartbeat.start
+          output = yield
+        end
+
+        heartbeat.finish
+        output
+      end
+    end
+  end
+end

--- a/lib/appsignal/helpers/heartbeats.rb
+++ b/lib/appsignal/helpers/heartbeats.rb
@@ -3,6 +3,30 @@
 module Appsignal
   module Helpers
     module Heartbeats
+      # Track heartbeats
+      #
+      # Track the execution of certain processes by sending a hearbeat.
+      #
+      # To track the duration of a piece of code, pass a block to {.heartbeat}
+      # to report both when the process starts, and when it finishes.
+      #
+      # If an exception is raised within the block, the finish event will not
+      # be reported, triggering a notification about the missing heartbeat. The
+      # exception will bubble outside of the heartbeat block.
+      #
+      # @example Send a heartbeat
+      #   Appsignal.heartbeat("send_invoices")
+      #
+      # @example Send a heartbeat with duration
+      #   Appsignal.heartbeat("send_invoices") do
+      #     # your code
+      #   end
+      #
+      # @param name [String] name of the heartbeat to report.
+      # @yield the block to monitor.
+      # @return [void]
+      # @since 3.7.0
+      # @see https://docs.appsignal.com/heartbeats
       def heartbeat(name)
         heartbeat = Appsignal::Heartbeat.new(:name => name)
         output = nil


### PR DESCRIPTION
## Move heartbeats helper to a helper module

Prefer not to extend the Appsignal module along with another module definition. Use the existing structure of a Helper module that is included by the `Appsignal` module module. See also the Instrumentation and Metrics modules.

## Add documentation for heartbeat functionality

Add documentation to describe the heartbeat functionality in the Ruby gem's API docs.

[skip changeset]
