### PR TITLE
Improve probe specs

### DIFF
--- a/spec/lib/appsignal/probes_spec.rb
+++ b/spec/lib/appsignal/probes_spec.rb
@@ -286,7 +286,7 @@ describe Appsignal::Probes do
 
   describe ".stop" do
     before do
-      allow(Appsignal::Probes).to receive(:initial_wait_time).and_return(0.001)
+      speed_up_tests!
     end
 
     it "stops the minutely thread" do

--- a/spec/lib/appsignal/probes_spec.rb
+++ b/spec/lib/appsignal/probes_spec.rb
@@ -240,10 +240,6 @@ describe Appsignal::Probes do
     end
 
     context "with thread already started" do
-      before do
-        allow(Appsignal::Probes).to receive(:initial_wait_time).and_return(0.00001)
-      end
-
       it "auto starts probes added after the thread is started" do
         Appsignal::Probes.start
         wait_for("Probes thread to start") { Appsignal::Probes.started? }


### PR DESCRIPTION
## Remove duplicate probe wait time stub

I saw a random failure complaining about the `initial_wait_time` being stubbed twice on JRuby. This is the only one I found, so I'm removing it.

[skip changeset]

## Use speed_up_tests helper in probes spec

Instead of manually stubbing the method call, use the helper that stubs it the same way for every spec that needs it.

[skip changeset]

[skip review]