### PR TITLE
Improve AppSignal loaded log

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -95,11 +95,11 @@ module Appsignal
     # @since 0.7.0
     def start
       unless extension_loaded?
-        internal_logger.info("Not starting appsignal, extension is not loaded")
+        internal_logger.info("Not starting AppSignal, extension is not loaded")
         return
       end
 
-      internal_logger.debug("Starting appsignal")
+      internal_logger.debug("Loading AppSignal gem")
 
       @config ||= Config.new(
         Dir.pwd,


### PR DESCRIPTION
It would say AppSignal "started", even if the integration wasn't actually configured to start and be active for the app environment.

Change the phrase to say "loading" so it's clear it's being loaded / initialized, rather than AppSignal becoming active.

[skip changeset] as it's not worth mentioning this change in a debug log message.

Closes https://github.com/appsignal/support/issues/188