### PR TITLE
Log error when probes iteration takes too long

### DIFF
--- a/.changesets/log-slow-probes-error.md
+++ b/.changesets/log-slow-probes-error.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+When the minutely probes thread takes more than 60 seconds to run all the registered probes, log an error. This helps find issues with the metrics reported by the probes not being accurately reported for every minute.


### PR DESCRIPTION
Log an error when the total probes iteration takes more than a minute. It's the 'minutely' probes process, and doesn't report accurate minutely metrics if each iteration takes more than a minute.

Closes #814