### PR TITLE
Report request response status for Rails apps

### DIFF
--- a/.changesets/report-response-status-for-rails-requests.md
+++ b/.changesets/report-response-status-for-rails-requests.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+type: add
+---
+
+Report the response status for Rails requests as the `response_status` tag on samples, e.g. 200, 301, 500. This tag is visible on the sample detail page.
+
+The response status is also reported as the `response_status` metric.

--- a/spec/lib/appsignal/rack/event_handler_spec.rb
+++ b/spec/lib/appsignal/rack/event_handler_spec.rb
@@ -183,6 +183,25 @@ describe Appsignal::Rack::EventHandler do
       )
     end
 
+    it "sets the response status as a tag" do
+      on_start
+      on_finish
+
+      expect(last_transaction.to_h).to include(
+        "sample_data" => hash_including(
+          "tags" => { "response_status" => 200 }
+        )
+      )
+    end
+
+    it "increments the response status counter for response status" do
+      expect(Appsignal).to receive(:increment_counter)
+        .with(:response_status, 1, :status => 200, :namespace => :web)
+
+      on_start
+      on_finish
+    end
+
     it "logs an error in case of an error" do
       expect(Appsignal::Transaction)
         .to receive(:complete_current!).and_raise(ExampleStandardError, "oh no")


### PR DESCRIPTION
We can now report the response status as a `response_status` tag and metric. Previously, due to the position of the Rails middleware, this was unreliable and wouldn't always report the real status code if other middleware in the stack that are run after ours returned another status.

This is part of issue #183, but only implements it now for Rails apps and apps using the `Appsignal::Rack::EventHandler` manually. We'll need to update other instrumentations for Rack, Sinatra, Padrino, Grape, etc. to use this new EventHandler, so they can also benefit from this new response status tag and metric.

Based on #1089 