### PR TITLE
Notify changelog repo of new releases

### DIFF
--- a/.github/workflows/create_release_from_tag.yml
+++ b/.github/workflows/create_release_from_tag.yml
@@ -1,0 +1,59 @@
+name: "Create release from tag"
+
+on:
+  push:
+    tags:
+      - "v**"
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  release:
+    name: "Create release"
+    runs-on: ubuntu-latest
+    env:
+      PACKAGE_NAME: "Ruby gem"
+      CHANGELOG_LINK: "https://github.com/appsignal/appsignal-ruby/blob/main/CHANGELOG.md"
+    steps:
+      - name: Checkout repository at tag
+        uses: actions/checkout@v4
+        with:
+          ref: "${{ github.ref }}"
+
+      - name: Get tag name
+        run: |
+          echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Get changelog contents from tag
+        run: |
+          # Use sed to remove everything after "-----BEGIN PGP SIGNATURE-----" if it's present
+          # and also always remove the last line of the git show output
+          git show --format=oneline --no-color --no-patch "${{ env.TAG_NAME }}" \
+          | sed '1,2d' \
+          | sed '$d' \
+          | sed '/-----BEGIN PGP SIGNATURE-----/,$d' \
+          > CHANGELOG_TEXT.txt
+
+          echo "" >> CHANGELOG_TEXT.txt
+          echo "" >> CHANGELOG_TEXT.txt
+
+          TAG_NAME_FOR_LINK=$(echo "${{ env.TAG_NAME }}" | sed 's/^v//' | tr -d '.')
+          echo "View the [$PACKAGE_NAME ${{ env.TAG_NAME }} changelog]($CHANGELOG_LINK#$TAG_NAME_FOR_LINK) for more information." >> CHANGELOG_TEXT.txt
+
+      - name: Submit changelog entry
+        run: |
+          # Prepare JSON payload using jq to ensure proper escaping
+          payload=$(jq -n \
+            --arg package "Ruby gem" \
+            --arg version "${{ env.TAG_NAME }}" \
+            --arg changelog "$(cat CHANGELOG_TEXT.txt)" \
+            '{ref: "main", inputs: {package: $package, version: $version, changelog: $changelog}}')
+
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.INTEGRATIONS_CHANGELOG_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            --fail-with-body \
+            https://api.github.com/repos/appsignal/appsignal.com/actions/workflows/102125282/dispatches \
+            -d "$payload"


### PR DESCRIPTION
Automate updating our changelog on the appsignal.com/changelog website.

This workflow will notify the `workflow_dispatch` workflow in the appsignal.com repo a new changelog entry needs to be made. Related PR: https://github.com/appsignal/appsignal.com/pull/1790

This requires new releases to be made with annotated tags created with the latest version of Mono. Related PR: https://github.com/appsignal/mono/pull/75

Cross repository communication via the GitHub API is done with a Personal Access Token (PAT), that expires every year. That's the longest GitHub will allow it be active for. This token will need to updated for all repositories we add such an action to. Let's configure a reminder for that somewhere, but also GitHub will notify the token owner of this before it expires.

[skip changeset]
