### PR TITLE
Fix compatibility with Rack 3.1.0

### DIFF
--- a/gemfiles/grape.gemfile
+++ b/gemfiles/grape.gemfile
@@ -1,6 +1,5 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'grape'
-gem 'activesupport', '~> 4.2'
+gem "grape"
 
-gemspec :path => '../'
+gemspec :path => "../"

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -719,7 +719,6 @@ describe Appsignal::Transaction do
 
         sample_data = transaction.to_h["sample_data"]
         expect(sample_data["environment"]).to include(
-          "CONTENT_LENGTH" => "0",
           "REQUEST_METHOD" => "GET",
           "SERVER_NAME" => "example.org",
           "SERVER_PORT" => "80",


### PR DESCRIPTION
## Fix compatibility with Rack 3.1.0

Rack 3.1.0 broke our assertion on the default sample data. Previously a `rack.input` object was always set by the env returned by `Rack::MockRequest`. Since this commit this is no longer required: https://github.com/rack/rack/commit/54368a0981c46c2c62137e47795b38de50dabefb

I could add it back so there's an input by default again, but if we were to implement this now from scratch we wouldn't add this assertion. Instead, I'm leaving it out.

This test doesn't assert that the CONTENT_LENGTH environment is required to be set. It just asserts a couple environment values are present.

[skip changeset]

## Remove ActiveSupport lock for Grape

Make sure it tests against the latest Grape and isn't locked by another gem. ActiveSupport is a dependency of Grape.

[skip review]