### PR TITLE
Fix ArgumentError on other non-String log messages

### DIFF
--- a/.changesets/fix-argumenterror-on-rails-logger-error-call.md
+++ b/.changesets/fix-argumenterror-on-rails-logger-error-call.md
@@ -1,0 +1,12 @@
+---
+bump: patch
+type: fix
+---
+
+Fix ArgumentError being raised on Ruby logger and Rails.logger error calls. This fixes the error from being raised from within the AppSignal Ruby gem.
+Please do not use this for error reporting. We recommend using our error reporting feature instead to be notified of new errors. Read more on [exception handling in Ruby with our Ruby gem](https://docs.appsignal.com/ruby/instrumentation/exception-handling.html).
+
+```ruby
+# No longer raises an error
+Rails.logger.error StandardError.new("StandardError log message")
+```

--- a/lib/appsignal/logger.rb
+++ b/lib/appsignal/logger.rb
@@ -53,6 +53,13 @@ module Appsignal
 
       message = formatter.call(severity, Time.now, group, message) if formatter
 
+      unless message.is_a?(String)
+        Appsignal.internal_logger.warn(
+          "Logger message was ignored, because it was not a String: #{message.inspect}"
+        )
+        return
+      end
+
       Appsignal::Extension.log(
         group,
         SEVERITY_MAP.fetch(severity, 0),

--- a/lib/appsignal/logger.rb
+++ b/lib/appsignal/logger.rb
@@ -112,6 +112,8 @@ module Appsignal
       message = yield if message.nil? && block_given?
       return if message.nil?
 
+      message = "#{message.class}: #{message.message}" if message.is_a?(Exception)
+
       add_with_attributes(ERROR, message, @group, attributes)
     end
 

--- a/spec/lib/appsignal/logger_spec.rb
+++ b/spec/lib/appsignal/logger_spec.rb
@@ -162,4 +162,25 @@ describe Appsignal::Logger do
       end
     end
   end
+
+  describe "#error with exception object" do
+    it "logs the exception class and its message" do
+      error =
+        begin
+          raise ExampleStandardError, "oh no!"
+        rescue => e
+          # This makes the exception include a backtrace, so we can assert it's NOT included
+          e
+        end
+      expect(Appsignal::Extension).to receive(:log)
+        .with(
+          "group",
+          6,
+          0,
+          "ExampleStandardError: oh no!",
+          instance_of(Appsignal::Extension::Data)
+        )
+      logger.error(error)
+    end
+  end
 end


### PR DESCRIPTION
## Fix logger error call with exception object

It was reported that calling `Rails.logger.error` with an exception object raises an ArgumentError. This comes from the extension, which expects the log message to be a String, not an Exception object.

```ruby
Rails.logger.error StandardError.new("StandardError log message")
```

The log message for the exception will only be the exception class and the message. The backtrace is omitted because it would just squash the multiple lines from the backtrace on one line, making it difficult to read.

Fixes #1095

## Fix ArgumentError on other non-String log messages

When the Ruby logger receives a non-String log message, ignore it. If we would call the extension with it, it would raise an ArgumentError about the log message not being a String.

Log a message on our internal log about the ignored log message.
