### PR TITLE
Improve nested Sinatra app instrumentation

### DIFF
--- a/.changesets/improve-mounted-sinatra-apps-in-rails-apps-instrumentation.md
+++ b/.changesets/improve-mounted-sinatra-apps-in-rails-apps-instrumentation.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Improve instrumentation for mounted Sinatra apps in Rails apps. The sample reported for the Sinatra request will now include the time spent in Rails and its middleware.


### PR DESCRIPTION
Sinatra apps, mounted in Rails app, would run into the issue that the Rails middleware has already created a transaction for the request. It could "force" a new transaction to be made, which loses information from everything that happened before it.

Previously, before PR #1089, it would also leave a transaction that was not closed properly. Even with that change, for one request, now two transactions are created, one for Rails and one for the nested Sinatra app.

This change reads if there's a current transaction from the request env, and uses that instead of creating a new one. Some logic in the Transaction class would read from the request object given to it on `Transaction.create` to set metadata like parameters, so these need to be set manually now.

It will also make sure not to close the transaction if one existed already before this middleware was called.

Part of #329, the Rack middleware refactor.