### PR TITLE
Skip RubyGems and Bundler update on JRuby

### DIFF
--- a/support/install_deps
+++ b/support/install_deps
@@ -4,6 +4,12 @@ set -eu
 
 gem_args="--no-verbose --no-document"
 
+# Workaround for https://github.com/jruby/jruby/issues/7059
+if [[ "${RUBY_VERSION}" == *"jruby"* ]]; then
+  echo "Skipping rubygems and bundler update for JRuby"
+  exit 0
+fi
+
 case "${_RUBYGEMS_VERSION-"latest"}" in
   "latest")
     echo "Updating rubygems"


### PR DESCRIPTION
When running on JRuby, skip updating RubyGems and Bundler. This is a workaround for a build issue involving JRuby: https://github.com/jruby/jruby/issues/7059

[skip changeset] because it only affects CI