### PR TITLE
Supported nested Rack EventHandlers

### DIFF
--- a/.changesets/support-nested-rack-eventhandlers.md
+++ b/.changesets/support-nested-rack-eventhandlers.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Support apps that have multiple Appsignal::Rack::EventHandler-s in the middleware stack.


### PR DESCRIPTION
In the case that an app, for whatever reason, has nested Rack EventHandlers, handle this properly.

This change makes it so that the EventHandler doesn't create multiple transactions if it's nested inside another EventHandler. It does this by assigning itself an ID (UUID), and adding it to the request environment. Then, on every callback it receives, it checks if it is the first EventHandler that handled the request. Only then does it do any instrumentation.

This will help with accidental multiple registrations of the AppSignal Rack EventHandler in one app, like with nested apps. It also opens the door for automatically registering the EventHandler for other gems, like Sinatra.

Part of #329 