### PR TITLE
Fix APPSIGNAL_ACTIVEJOB_REPORT_ERRORS var naming

### DIFF
--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -67,7 +67,7 @@ module Appsignal
 
     ENV_TO_KEY_MAPPING = {
       "APPSIGNAL_ACTIVE" => :active,
-      "APPSIGNAL_ACTIVE_JOB_REPORT_ERRORS" => :activejob_report_errors,
+      "APPSIGNAL_ACTIVEJOB_REPORT_ERRORS" => :activejob_report_errors,
       "APPSIGNAL_APP_NAME" => :name,
       "APPSIGNAL_BIND_ADDRESS" => :bind_address,
       "APPSIGNAL_CA_FILE_PATH" => :ca_file_path,
@@ -117,7 +117,7 @@ module Appsignal
     }.freeze
     # @api private
     ENV_STRING_KEYS = %w[
-      APPSIGNAL_ACTIVE_JOB_REPORT_ERRORS
+      APPSIGNAL_ACTIVEJOB_REPORT_ERRORS
       APPSIGNAL_APP_NAME
       APPSIGNAL_BIND_ADDRESS
       APPSIGNAL_CA_FILE_PATH


### PR DESCRIPTION
The config option is `activejob_report_errors`, but the env var had an underscore between "ACTIVE" and "JOB".

We never documented the env var, so we can hopefully stealth fix this without requiring a backwards compatibility change.

After this name change, let's document the env var.

[skip changeset]