### PR TITLE
Report Sidekiq errors when the job is discarded

### DIFF
--- a/.changesets/report-sidekiq-exceptions-on-discard.md
+++ b/.changesets/report-sidekiq-exceptions-on-discard.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+type: add
+---
+
+Report Sidekiq errors when a job is dead/discarded. Configure the new `sidekiq_report_errors` config option to "discard" to only report errors when the job is not retried further.

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -47,6 +47,7 @@ module Appsignal
       ],
       :send_environment_metadata => true,
       :send_params => true,
+      :sidekiq_report_errors => "all",
       :transaction_debug_mode => false
     }.freeze
 
@@ -108,6 +109,7 @@ module Appsignal
       "APPSIGNAL_SEND_ENVIRONMENT_METADATA" => :send_environment_metadata,
       "APPSIGNAL_SEND_PARAMS" => :send_params,
       "APPSIGNAL_SEND_SESSION_DATA" => :send_session_data,
+      "APPSIGNAL_SIDEKIQ_REPORT_ERRORS" => :sidekiq_report_errors,
       "APPSIGNAL_SKIP_SESSION_DATA" => :skip_session_data,
       "APPSIGNAL_STATSD_PORT" => :statsd_port,
       "APPSIGNAL_TRANSACTION_DEBUG_MODE" => :transaction_debug_mode,
@@ -130,6 +132,7 @@ module Appsignal
       APPSIGNAL_LOGGING_ENDPOINT
       APPSIGNAL_PUSH_API_ENDPOINT
       APPSIGNAL_PUSH_API_KEY
+      APPSIGNAL_SIDEKIQ_REPORT_ERRORS
       APPSIGNAL_STATSD_PORT
       APPSIGNAL_WORKING_DIRECTORY_PATH
       APPSIGNAL_WORKING_DIR_PATH
@@ -561,6 +564,11 @@ module Appsignal
       if config_hash[:activejob_report_errors] == "discard" &&
           !Appsignal::Hooks::ActiveJobHook.version_7_1_or_higher?
         config[:activejob_report_errors] = "all"
+      end
+
+      if config_hash[:sidekiq_report_errors] == "discard" &&
+          !Appsignal::Hooks::SidekiqHook.version_5_1_or_higher?
+        config[:sidekiq_report_errors] = "all"
       end
 
       config


### PR DESCRIPTION
## Test Sidekiq error handler for more scenarios

Make sure to test the two different error reporting scenarios:

- a transaction is active for a job, and
- no transaction is active for an internal Sidekiq error.

## Report Sidekiq errors when the job is discarded

Add the `sidekiq_report_errors` config option. If set to `discard`, it will only report the error if the job is discarded, or "dead" in Sidekiq terminology.

This follows the same behavior as the `activejob_report_errors` config option.

To make this behavior work, it uses a Sidekiq death handler to report the error when the job is discarded. This death handler is run before the error handler, so the error handler can stay responsible for completing the transaction.

Death handlers were introduced in Sidekiq 5.1. Older versions will report all errors for jobs.

Part of #1091
