### PR TITLE
Fix Sinatra instrumentation causing boot loop

### DIFF
--- a/.changesets/don-t-start-for-sinatra-if-already-started.md
+++ b/.changesets/don-t-start-for-sinatra-if-already-started.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+type: fix
+---
+
+Fix issue with AppSignal getting stuck in a boot loop when loading the Sinatra integration with: `require "appsignal/integrations/sinatra"`
+This could happen in nested applications, like a Sinatra app in a Rails app. It will now use the first config AppSignal starts with.

--- a/lib/appsignal/integrations/sinatra.rb
+++ b/lib/appsignal/integrations/sinatra.rb
@@ -5,13 +5,15 @@ require "appsignal/rack/sinatra_instrumentation"
 
 Appsignal.internal_logger.debug("Loading Sinatra (#{Sinatra::VERSION}) integration")
 
-app_settings = ::Sinatra::Application.settings
-Appsignal.config = Appsignal::Config.new(
-  app_settings.root || Dir.pwd,
-  app_settings.environment
-)
+unless Appsignal.active?
+  app_settings = ::Sinatra::Application.settings
+  Appsignal.config = Appsignal::Config.new(
+    app_settings.root || Dir.pwd,
+    app_settings.environment
+  )
 
-Appsignal.start_logger
-Appsignal.start
+  Appsignal.start_logger
+  Appsignal.start
+end
 
 ::Sinatra::Base.use(Appsignal::Rack::SinatraBaseInstrumentation) if Appsignal.active?


### PR DESCRIPTION
I noticed in our test setup that when I added a Sinatra app to the Rails app, and loaded the Sinatra instrumentation as specified in our docs it would get stuck in a boot loop. This was caused by the two different configs overwriting each other every time.

Prevent this issue by skipping loading the AppSignal config if it's already active.