### PR TITLE
Fix parameter reporting for Rack and Sinatra app

### DIFF
--- a/.changesets/fix-parameter-reporting-for-rack-and-sinatra-apps.md
+++ b/.changesets/fix-parameter-reporting-for-rack-and-sinatra-apps.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix parameter reporting for Rack and Sinatra apps, especially POST payloads.

--- a/lib/appsignal/rack/abstract_middleware.rb
+++ b/lib/appsignal/rack/abstract_middleware.rb
@@ -91,8 +91,6 @@ module Appsignal
       # Override this method to set metadata before the app is called.
       # Call `super` to also include the default set metadata.
       def add_transaction_metadata_before(transaction, request)
-        params = params_for(request)
-        transaction.params = params if params
       end
 
       # Add metadata to the transaction based on the request environment.
@@ -104,6 +102,7 @@ module Appsignal
         transaction.set_action_if_nil(default_action)
         transaction.set_metadata("path", request.path)
         transaction.set_metadata("method", request.request_method)
+        transaction.set_params_if_nil(params_for(request))
         transaction.set_http_or_background_queue_start
       end
 

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -76,18 +76,6 @@ module Appsignal
     attr_reader :ext, :transaction_id, :action, :namespace, :request, :paused, :tags, :options,
       :discarded, :breadcrumbs
 
-    # @!attribute params
-    #   Attribute for parameters of the transaction.
-    #
-    #   When no parameters are set with {#params=} the parameters it will look
-    #   for parameters on the {#request} environment.
-    #
-    #   The parameters set using {#params=} are leading over those extracted
-    #   from a request's environment.
-    #
-    #   @return [Hash]
-    attr_writer :params
-
     def initialize(transaction_id, namespace, request, options = {})
       @transaction_id = transaction_id
       @action = nil
@@ -154,6 +142,40 @@ module Appsignal
       return @params if defined?(@params)
 
       request_params
+    end
+
+    # Set parameters on the transaction.
+    #
+    # When no parameters are set this way, the transaction will look for
+    # parameters on the {#request} environment.
+    #
+    # The parameters set using {#set_params} are leading over those extracted
+    # from a request's environment.
+    #
+    # @param given_params [Hash] The parameters to set on the transaction.
+    # @return [void]
+    def set_params(given_params)
+      @params = given_params if given_params
+    end
+
+    # @deprecated Use {#set_params} or {#set_params_if_nil} instead.
+    def params=(given_params)
+      Appsignal::Utils::StdoutAndLoggerMessage.warning(
+        "Transaction#params= is deprecated." \
+          "Use Transaction#set_params or #set_params_if_nil instead."
+      )
+      set_params(given_params)
+    end
+
+    # Set parameters on the transaction if not already set
+    #
+    # When no parameters are set this way, the transaction will look for
+    # parameters on the {#request} environment.
+    #
+    # @param given_params [Hash] The parameters to set on the transaction if none are already set.
+    # @return [void]
+    def set_params_if_nil(given_params)
+      set_params(given_params) unless @params
     end
 
     # Set tags on the transaction.

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -348,9 +348,94 @@ describe Appsignal::Transaction do
     end
 
     describe "#params=" do
+      around { |example| keep_transactions { example.run } }
+
       it "sets params on the transaction" do
-        transaction.params = { :foo => "bar" }
-        expect(transaction.params).to eq(:foo => "bar")
+        params = { "foo" => "bar" }
+        transaction.params = params
+
+        transaction.complete # Sample the data
+        expect(transaction.params).to eq(params)
+        expect(transaction.to_h.dig("sample_data", "params")).to eq(params)
+      end
+
+      it "logs a deprecation warning" do
+        transaction.params = { "foo" => "bar" }
+
+        expect(log_contents(log)).to contains_log(
+          :warn,
+          "Transaction#params= is deprecated." \
+            "Use Transaction#set_params or #set_params_if_nil instead."
+        )
+      end
+    end
+
+    describe "#set_params" do
+      around { |example| keep_transactions { example.run } }
+
+      context "when the params are set" do
+        it "updates the params on the transaction" do
+          params = { "key" => "value" }
+          transaction.set_params(params)
+
+          transaction.complete # Sample the data
+          expect(transaction.params).to eq(params)
+          expect(transaction.to_h.dig("sample_data", "params")).to eq(params)
+        end
+      end
+
+      context "when the given params is nil" do
+        it "does not update the params on the transaction" do
+          params = { "key" => "value" }
+          transaction.set_params(params)
+          transaction.set_params(nil)
+
+          transaction.complete # Sample the data
+          expect(transaction.params).to eq(params)
+          expect(transaction.to_h.dig("sample_data", "params")).to eq(params)
+        end
+      end
+    end
+
+    describe "#set_params_if_nil" do
+      around { |example| keep_transactions { example.run } }
+
+      context "when the params are not set" do
+        it "sets the params on the transaction" do
+          expect(transaction.params).to be_nil
+
+          params = { "key" => "value" }
+          transaction.set_params_if_nil(params)
+
+          transaction.complete # Sample the data
+          expect(transaction.params).to eq(params)
+          expect(transaction.to_h.dig("sample_data", "params")).to eq(params)
+        end
+
+        context "when the given params is nil" do
+          it "does not update the params on the transaction" do
+            params = { "key" => "value" }
+            transaction.set_params(params)
+            transaction.set_params_if_nil(nil)
+
+            transaction.complete # Sample the data
+            expect(transaction.params).to eq(params)
+            expect(transaction.to_h.dig("sample_data", "params")).to eq(params)
+          end
+        end
+      end
+
+      context "when the params are set" do
+        it "does not update the params on the transaction" do
+          preset_params = { "other" => "params" }
+          params = { "key" => "value" }
+          transaction.set_params(preset_params)
+          transaction.set_params_if_nil(params)
+
+          transaction.complete # Sample the data
+          expect(transaction.params).to eq(preset_params)
+          expect(transaction.to_h.dig("sample_data", "params")).to eq(preset_params)
+        end
       end
     end
 

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -402,8 +402,6 @@ describe Appsignal::Transaction do
 
       context "when the params are not set" do
         it "sets the params on the transaction" do
-          expect(transaction.params).to be_nil
-
           params = { "key" => "value" }
           transaction.set_params_if_nil(params)
 


### PR DESCRIPTION
## Add Transaction set_params(_if_nil) methods

Add methods to set the parameters on the Transaction. This replaces and deprecates the Transaction `params=` writer method that was used before this.

We need the `_if_nil` variant for the AbstractMiddleware to only write the parameters if they're not already set by the app it's instrumenting. Currently it tries to set the parameters before the app handles the request, but this is unreliable and doesn't always report the parameters of the request.

The `_if_nil` variant isn't perfect, because it doesn't consider whatever parameters could be fetched from the request object, because it now skips this. I can improve this later if necessary.

Part of #1108

## Fix parameter reporting for Rack and Sinatra apps

The AbstractMiddleware tried to set the request parameters before the app handled the request. This could cause the request object to end up in a weird state where, if some other middleware (like a JSON payload parsing middleware) hadn't parsed the request payload yet, the parameters were reported as empty.

Move setting the parameters to the "after" hook so that it doesn't try to read the parameters before they're parsed. Use the new `Transaction#set_params_if_nil` so that it doesn't overwrite any custom parameters set by the app.

Fixes #1108