### PR TITLE
Refactor Hanami specs to use Transaction#to_h

### DIFF
--- a/lib/appsignal/integrations/hanami.rb
+++ b/lib/appsignal/integrations/hanami.rb
@@ -17,7 +17,9 @@ module Appsignal
         Appsignal.start_logger
         Appsignal.start
 
-        ::Hanami::Action.prepend Appsignal::Integrations::HanamiIntegration if Appsignal.active?
+        return unless Appsignal.active?
+
+        ::Hanami::Action.prepend Appsignal::Integrations::HanamiIntegration
       end
     end
   end
@@ -41,11 +43,15 @@ module Appsignal::Integrations::HanamiIntegration
     begin
       Appsignal.instrument("process_action.hanami") do
         super.tap do |response|
+          # TODO: update to response_status or remove:
+          # https://github.com/appsignal/appsignal-ruby/issues/183
           transaction.set_metadata("status", response.status.to_s)
         end
       end
     rescue Exception => error # rubocop:disable Lint/RescueException
       transaction.set_error(error)
+      # TODO: update to response_status or remove:
+      # https://github.com/appsignal/appsignal-ruby/issues/183
       transaction.set_metadata("status", "500")
       raise error
     ensure

--- a/spec/support/hanami/hanami_app.rb
+++ b/spec/support/hanami/hanami_app.rb
@@ -21,11 +21,9 @@ module HanamiApp
 
       class Error < Hanami::Action
         def handle(_request, _response)
-          raise ExampleError
+          raise ExampleException, "exception message"
         end
       end
     end
   end
-
-  class ExampleError < StandardError; end
 end


### PR DESCRIPTION
Don't assert method calls but check what the extension receives for transaction data.

Part of #252

[skip changeset]
[skip review]