### PR TITLE
Instrument entire Sinatra request

### DIFF
--- a/.changesets/instrument-the-entire-sinatra-request.md
+++ b/.changesets/instrument-the-entire-sinatra-request.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Instrument the entire Sinatra request. Instrumenting Sinatra apps using `require "appsignal/integrations/sinatra"` will now report more of the request, if previously other middleware were not instrumented. It will also report the response status with the `response_status` tag and metric.

--- a/lib/appsignal/integrations/sinatra.rb
+++ b/lib/appsignal/integrations/sinatra.rb
@@ -16,4 +16,10 @@ unless Appsignal.active?
   Appsignal.start
 end
 
-::Sinatra::Base.use(Appsignal::Rack::SinatraBaseInstrumentation) if Appsignal.active?
+if Appsignal.active?
+  ::Sinatra::Base.use(
+    ::Rack::Events,
+    [Appsignal::Rack::EventHandler.new]
+  )
+  ::Sinatra::Base.use(Appsignal::Rack::SinatraBaseInstrumentation)
+end

--- a/spec/lib/appsignal/integrations/sinatra_spec.rb
+++ b/spec/lib/appsignal/integrations/sinatra_spec.rb
@@ -50,8 +50,12 @@ if DependencyHelper.sinatra_present?
         context "when AppSignal is not active" do
           it "does not add the instrumentation middleware to Sinatra::Base" do
             install_sinatra_integration
-            expect(Sinatra::Base.middleware.to_a).to_not include(
+            middlewares = Sinatra::Base.middleware.to_a
+            expect(middlewares).to_not include(
               [Appsignal::Rack::SinatraBaseInstrumentation, [], nil]
+            )
+            expect(middlewares).to_not include(
+              [Rack::Events, [Appsignal::Rack::EventHandler], nil]
             )
           end
         end
@@ -63,7 +67,9 @@ if DependencyHelper.sinatra_present?
             ENV["APPSIGNAL_PUSH_API_KEY"] = "my-key"
 
             install_sinatra_integration
-            expect(Sinatra::Base.middleware.to_a).to include(
+            middlewares = Sinatra::Base.middleware.to_a
+            expect(middlewares).to include(
+              [Rack::Events, [[Appsignal::Rack::EventHandler]], nil],
               [Appsignal::Rack::SinatraBaseInstrumentation, [], nil]
             )
           end


### PR DESCRIPTION
Add the EventHandler to the default Sinatra instrumentation. This will have it report more of the request runtime.

It will also report the `response_status` tag and metric, as reported by the EventHandler.

This is compatible with other instrumentations using the EventHandler or an AbstractMiddleware subclass.

Part of #329