### PR TITLE
Update Hanami to use Rack middleware

### DIFF
--- a/.changesets/report-response_status-tag-and-metric-for-hanami-requests.md
+++ b/.changesets/report-response_status-tag-and-metric-for-hanami-requests.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+type: add
+---
+
+Improve instrumentation of Hanami requests by making sure the transaction is always closed.
+It will also report a `response_status` tag and metric for Hanami requests.

--- a/lib/appsignal/rack/hanami_middleware.rb
+++ b/lib/appsignal/rack/hanami_middleware.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Appsignal
+  module Rack
+    # @api private
+    class HanamiMiddleware < AbstractMiddleware
+      def initialize(app, options = {})
+        options[:request_class] ||= ::Hanami::Action::Request
+        options[:params_method] ||= :params
+        options[:instrument_span_name] ||= "process_action.hanami"
+        super
+      end
+
+      private
+
+      def params_for(request)
+        super&.to_h
+      end
+
+      def request_for(env)
+        params = ::Hanami::Action.params_class.new(env)
+        @request_class.new(
+          :env => env,
+          :params => params,
+          :sessions_enabled => true
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/appsignal/rack/hanami_middleware_spec.rb
+++ b/spec/lib/appsignal/rack/hanami_middleware_spec.rb
@@ -1,0 +1,50 @@
+require "appsignal/rack/hanami_middleware"
+
+if DependencyHelper.hanami2_present?
+  describe Appsignal::Rack::HanamiMiddleware do
+    let(:app) { double(:call => true) }
+    let(:router_params) { { "param1" => "value1", "param2" => "value2" } }
+    let(:env) do
+      Rack::MockRequest.env_for(
+        "/some/path",
+        "router.params" => router_params
+      )
+    end
+    let(:middleware) { Appsignal::Rack::HanamiMiddleware.new(app, {}) }
+
+    before(:context) { start_agent }
+    around { |example| keep_transactions { example.run } }
+
+    def make_request(env)
+      middleware.call(env)
+    end
+
+    context "with params" do
+      it "sets request parameters on the transaction" do
+        make_request(env)
+
+        expect(last_transaction.to_h).to include(
+          "sample_data" => hash_including(
+            "params" => { "param1" => "value1", "param2" => "value2" }
+          )
+        )
+      end
+    end
+
+    it "reports a process_action.hanami event" do
+      make_request(env)
+
+      expect(last_transaction.to_h).to include(
+        "events" => [
+          hash_including(
+            "body" => "",
+            "body_format" => Appsignal::EventFormatter::DEFAULT,
+            "count" => 1,
+            "name" => "process_action.hanami",
+            "title" => ""
+          )
+        ]
+      )
+    end
+  end
+end


### PR DESCRIPTION
As part of #329, update the Hanami integration to use Rack middleware and the EventHandler to instrument requests made to Hanami apps. This standardizes the instrumentation as much as possible between Rack apps and minimizes our reliance on monkeypatches.

The only monkeypatch that remains is setting the action name to the Action class name. I have found no other way yet to fetch this metadata from the request metadata, environment or the Hanami router.

Part of #329
Mostly solves #911