### PR TITLE
Fix error in EventHandler on request with error

### DIFF
--- a/.changesets/fix-error-reporting-for-requests-with-an-error.md
+++ b/.changesets/fix-error-reporting-for-requests-with-an-error.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix error reporting for requests with an error that use the AppSignal EventHandler.


### PR DESCRIPTION
When a request has an error, it would give the `on_finish` callback a response object that is `nil`.

This would break when we called `response.status`, and it would fail to complete the transaction.

Make sure the transaction is always completed by putting the `complete_current!` call in `ensure` blocks.

Check if the `response` object is `nil` before calling other methods on it to the response status tag and metric. This way we don't raise an error.

Luckily no integrations of ours that have been published yet would run into this behavior. The Rails integrations uses the EventHandler, but has its own error reporting.

This would only be a problem for people who use the EventHandler directly, or when we move more integrations over to use AbstractMiddleware subclasses.