### PR TITLE
Move the Grape middleware to the rack directory

### DIFF
--- a/.changesets/deprecate-appsignal--grape--middleware.md
+++ b/.changesets/deprecate-appsignal--grape--middleware.md
@@ -1,0 +1,18 @@
+---
+bump: patch
+type: deprecate
+---
+
+Deprecate `Appsignal::Grape::Middleware` constant in favor of `Appsignal::Rack::GrapeMiddleware` constant.
+
+To fix this deprecation warning, update the usage of `Appsignal::Grape::Middleware` like this:
+
+```ruby
+# Grape only apps
+insert_before Grape::Middleware::Error, Appsignal::Rack::GrapeMiddleware
+# or
+use Appsignal::Rack::GrapeMiddleware
+
+# Grape on Rails app
+use Appsignal::Rack::GrapeMiddleware
+```

--- a/lib/appsignal/integrations/grape.rb
+++ b/lib/appsignal/integrations/grape.rb
@@ -1,55 +1,24 @@
 # frozen_string_literal: true
 
+require "appsignal/rack/grape_middleware"
+
 module Appsignal
-  # @todo Move to sub-namespace
   # @api private
   module Grape
-    class Middleware < ::Grape::Middleware::Base
-      def call(env)
-        if Appsignal.active?
-          call_with_appsignal_monitoring(env)
-        else
-          app.call(env)
-        end
-      end
-
-      def call_with_appsignal_monitoring(env)
-        request     = ::Rack::Request.new(env)
-        transaction = Appsignal::Transaction.create(
-          SecureRandom.uuid,
-          Appsignal::Transaction::HTTP_REQUEST,
-          request
-        )
-        begin
-          app.call(env)
-        rescue Exception => error # rubocop:disable Lint/RescueException
-          # Do not set error if "grape.skip_appsignal_error" is set to `true`.
-          transaction.set_error(error) unless env["grape.skip_appsignal_error"]
-          raise error
-        ensure
-          request_method = request.request_method.to_s.upcase
-          path = request.path # Path without namespaces
-          endpoint = env["api.endpoint"]
-
-          if endpoint&.options
-            options = endpoint.options
-            request_method = options[:method].first.to_s.upcase
-            klass = options[:for]
-            namespace = endpoint.namespace
-            namespace = "" if namespace == "/"
-
-            path = options[:path].first.to_s
-            path = "/#{path}" if path[0] != "/"
-            path = "#{namespace}#{path}"
-
-            transaction.set_action_if_nil("#{request_method}::#{klass}##{path}")
-          end
-
-          transaction.set_http_or_background_queue_start
-          transaction.set_metadata("path", path)
-          transaction.set_metadata("method", request_method)
-          Appsignal::Transaction.complete_current!
-        end
+    # Alias constants that have moved with a warning message that points to the
+    # place to update the reference.
+    def self.const_missing(name)
+      case name
+      when :Middleware
+        callers = caller
+        Appsignal::Utils::StdoutAndLoggerMessage.warning \
+          "The constant Appsignal::Grape::Middleware has been deprecated. " \
+            "Please update the constant name to " \
+            "Appsignal::Rack::GrapeMiddleware in the following file to " \
+            "remove this message.\n#{callers.first}"
+        Appsignal::Rack::GrapeMiddleware
+      else
+        super
       end
     end
   end

--- a/lib/appsignal/rack/grape_middleware.rb
+++ b/lib/appsignal/rack/grape_middleware.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Appsignal
+  module Rack
+    # @api private
+    class GrapeMiddleware < ::Grape::Middleware::Base
+      def call(env)
+        if Appsignal.active?
+          call_with_appsignal_monitoring(env)
+        else
+          app.call(env)
+        end
+      end
+
+      def call_with_appsignal_monitoring(env)
+        request     = ::Rack::Request.new(env)
+        transaction = Appsignal::Transaction.create(
+          SecureRandom.uuid,
+          Appsignal::Transaction::HTTP_REQUEST,
+          request
+        )
+        begin
+          app.call(env)
+        rescue Exception => error # rubocop:disable Lint/RescueException
+          # Do not set error if "grape.skip_appsignal_error" is set to `true`.
+          transaction.set_error(error) unless env["grape.skip_appsignal_error"]
+          raise error
+        ensure
+          request_method = request.request_method.to_s.upcase
+          path = request.path # Path without namespaces
+          endpoint = env["api.endpoint"]
+
+          if endpoint&.options
+            options = endpoint.options
+            request_method = options[:method].first.to_s.upcase
+            klass = options[:for]
+            namespace = endpoint.namespace
+            namespace = "" if namespace == "/"
+
+            path = options[:path].first.to_s
+            path = "/#{path}" if path[0] != "/"
+            path = "#{namespace}#{path}"
+
+            transaction.set_action_if_nil("#{request_method}::#{klass}##{path}")
+          end
+
+          transaction.set_http_or_background_queue_start
+          transaction.set_metadata("path", path)
+          transaction.set_metadata("method", request_method)
+          Appsignal::Transaction.complete_current!
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/appsignal/probes_spec.rb
+++ b/spec/lib/appsignal/probes_spec.rb
@@ -20,7 +20,7 @@ describe Appsignal::Probes do
         .to include("appsignal WARNING: The constant Appsignal::Minutely has been deprecated.")
     end
 
-    it "logs a warning to STDERR" do
+    it "logs a warning" do
       logs =
         capture_logs do
           silence do
@@ -28,7 +28,10 @@ describe Appsignal::Probes do
           end
         end
 
-      expect(logs).to include("The constant Appsignal::Minutely has been deprecated.")
+      expect(logs).to contains_log(
+        :warn,
+        "The constant Appsignal::Minutely has been deprecated."
+      )
     end
   end
 


### PR DESCRIPTION
## Move the Grape middleware to the rack directory

Move the Appsignal::Grape::Middleware constant to Appsignal::Rack::GrapeMiddleware so it matches the format of some of the other middleware we have.

Move it to the `rack/` directory as well so all the middleware are in one place. People can still require the `appsignal/integrations/grape` file like previously, same as we support for `appsignal/integrations/sinatra`. The integrations file can stay to automate or include any other things we need.

## Update Probes missing constant spec

Use log matcher to make sure it's logging as a warning.
