### PR TITLE
Support nested Grape apps

### DIFF
--- a/.changesets/support-nested-grape-apps.md
+++ b/.changesets/support-nested-grape-apps.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Support Grape apps that are nested in other apps like Sinatra and Rails, that also include AppSignal middleware for instrumentation.

--- a/lib/appsignal/rack/grape_middleware.rb
+++ b/lib/appsignal/rack/grape_middleware.rb
@@ -3,52 +3,37 @@
 module Appsignal
   module Rack
     # @api private
-    class GrapeMiddleware < ::Grape::Middleware::Base
-      def call(env)
-        if Appsignal.active?
-          call_with_appsignal_monitoring(env)
-        else
-          app.call(env)
-        end
+    class GrapeMiddleware < Appsignal::Rack::AbstractMiddleware
+      def initialize(app, options = {})
+        options[:instrument_span_name] = "process_request.grape"
+        options[:report_errors] = lambda { |env| !env["grape.skip_appsignal_error"] }
+        super
       end
 
-      def call_with_appsignal_monitoring(env)
-        request     = ::Rack::Request.new(env)
-        transaction = Appsignal::Transaction.create(
-          SecureRandom.uuid,
-          Appsignal::Transaction::HTTP_REQUEST,
-          request
-        )
-        begin
-          app.call(env)
-        rescue Exception => error # rubocop:disable Lint/RescueException
-          # Do not set error if "grape.skip_appsignal_error" is set to `true`.
-          transaction.set_error(error) unless env["grape.skip_appsignal_error"]
-          raise error
-        ensure
-          request_method = request.request_method.to_s.upcase
-          path = request.path # Path without namespaces
-          endpoint = env["api.endpoint"]
+      private
 
-          if endpoint&.options
-            options = endpoint.options
-            request_method = options[:method].first.to_s.upcase
-            klass = options[:for]
-            namespace = endpoint.namespace
-            namespace = "" if namespace == "/"
-
-            path = options[:path].first.to_s
-            path = "/#{path}" if path[0] != "/"
-            path = "#{namespace}#{path}"
-
-            transaction.set_action_if_nil("#{request_method}::#{klass}##{path}")
-          end
-
-          transaction.set_http_or_background_queue_start
-          transaction.set_metadata("path", path)
-          transaction.set_metadata("method", request_method)
-          Appsignal::Transaction.complete_current!
+      def add_transaction_metadata_after(transaction, request)
+        endpoint = request.env["api.endpoint"]
+        unless endpoint&.options
+          super
+          return
         end
+
+        options = endpoint.options
+        request_method = options[:method].first.to_s.upcase
+        klass = options[:for]
+        namespace = endpoint.namespace
+        namespace = "" if namespace == "/"
+
+        path = options[:path].first.to_s
+        path = "/#{path}" if path[0] != "/"
+        path = "#{namespace}#{path}"
+
+        transaction.set_action_if_nil("#{request_method}::#{klass}##{path}")
+
+        super
+
+        transaction.set_metadata("path", path)
       end
     end
   end

--- a/spec/lib/appsignal/rack/abstract_middleware_spec.rb
+++ b/spec/lib/appsignal/rack/abstract_middleware_spec.rb
@@ -90,13 +90,68 @@ describe Appsignal::Rack::AbstractMiddleware do
           expect(last_transaction.to_h).to include(
             "error" => hash_including(
               "name" => "ExampleException",
-              "message" => "error message"
+              "message" => "error message",
+              "backtrace" => kind_of(String)
             )
           )
         end
 
         it "completes the transaction" do
           expect(last_transaction).to be_completed
+        end
+
+        context "with :report_errors set to false" do
+          let(:app) { lambda { |_env| raise ExampleException, "error message" } }
+          let(:options) { { :report_errors => false } }
+
+          it "does not record the exception on the transaction" do
+            make_request_with_error(env, ExampleException, "error message")
+
+            expect(last_transaction.to_h).to include("error" => nil)
+          end
+        end
+
+        context "with :report_errors set to true" do
+          let(:app) { lambda { |_env| raise ExampleException, "error message" } }
+          let(:options) { { :report_errors => true } }
+
+          it "records the exception on the transaction" do
+            make_request_with_error(env, ExampleException, "error message")
+
+            expect(last_transaction.to_h).to include(
+              "error" => hash_including(
+                "name" => "ExampleException",
+                "message" => "error message"
+              )
+            )
+          end
+        end
+
+        context "with :report_errors set to a lambda that returns false" do
+          let(:app) { lambda { |_env| raise ExampleException, "error message" } }
+          let(:options) { { :report_errors => lambda { |_env| false } } }
+
+          it "does not record the exception on the transaction" do
+            make_request_with_error(env, ExampleException, "error message")
+
+            expect(last_transaction.to_h).to include("error" => nil)
+          end
+        end
+
+        context "with :report_errors set to a lambda that returns true" do
+          let(:app) { lambda { |_env| raise ExampleException, "error message" } }
+          let(:options) { { :report_errors => lambda { |_env| true } } }
+
+          it "records the exception on the transaction" do
+            make_request_with_error(env, ExampleException, "error message")
+
+            expect(last_transaction.to_h).to include(
+              "error" => hash_including(
+                "name" => "ExampleException",
+                "message" => "error message"
+              )
+            )
+          end
         end
       end
 
@@ -296,9 +351,47 @@ describe Appsignal::Rack::AbstractMiddleware do
           end
         end
 
+        context "with :report_errors set to false" do
+          let(:app) { lambda { |_env| raise ExampleException, "error message" } }
+          let(:options) { { :report_errors => false } }
+
+          it "does not record the exception on the transaction" do
+            make_request_with_error(env, ExampleException, "error message")
+
+            expect(last_transaction.to_h).to include("error" => nil)
+          end
+        end
+
         context "with :report_errors set to true" do
           let(:app) { lambda { |_env| raise ExampleException, "error message" } }
           let(:options) { { :report_errors => true } }
+
+          it "records the exception on the transaction" do
+            make_request_with_error(env, ExampleException, "error message")
+
+            expect(last_transaction.to_h).to include(
+              "error" => hash_including(
+                "name" => "ExampleException",
+                "message" => "error message"
+              )
+            )
+          end
+        end
+
+        context "with :report_errors set to a lambda that returns false" do
+          let(:app) { lambda { |_env| raise ExampleException, "error message" } }
+          let(:options) { { :report_errors => lambda { |_env| false } } }
+
+          it "does not record the exception on the transaction" do
+            make_request_with_error(env, ExampleException, "error message")
+
+            expect(last_transaction.to_h).to include("error" => nil)
+          end
+        end
+
+        context "with :report_errors set to a lambda that returns true" do
+          let(:app) { lambda { |_env| raise ExampleException, "error message" } }
+          let(:options) { { :report_errors => lambda { |_env| true } } }
 
           it "records the exception on the transaction" do
             make_request_with_error(env, ExampleException, "error message")

--- a/spec/lib/appsignal/rack/grape_middleware_spec.rb
+++ b/spec/lib/appsignal/rack/grape_middleware_spec.rb
@@ -51,220 +51,208 @@ if DependencyHelper.grape_present?
         :path => "/ping"
     end
     let(:middleware) { Appsignal::Rack::GrapeMiddleware.new(api_endpoint) }
+    let(:transaction) { http_request_transaction }
+    before(:context) { start_agent }
     around do |example|
       GrapeExample = Module.new
       GrapeExample.send(:const_set, :Api, app)
-      example.run
+      keep_transactions { example.run }
       Object.send(:remove_const, :GrapeExample)
     end
 
-    describe "#call" do
-      context "when AppSignal is not active" do
-        before(:context) do
-          Appsignal.config = nil
-          Appsignal::Hooks.load_hooks
-        end
+    def make_request(env)
+      middleware.call(env)
+    end
 
-        it "creates no transaction" do
-          expect(Appsignal::Transaction).to_not receive(:create)
-        end
+    def make_request_with_exception(env, exception_class, exception_message)
+      expect do
+        middleware.call(env)
+      end.to raise_error(exception_class, exception_message)
+    end
 
-        it "calls the endpoint normally" do
-          expect(api_endpoint).to receive(:call).with(env)
+    context "with error" do
+      let(:app) do
+        Class.new(::Grape::API) do
+          format :json
+          post :ping do
+            raise ExampleException, "error message"
+          end
         end
-
-        after { middleware.call(env) }
       end
 
-      context "when AppSignal is active" do
-        let(:transaction) { http_request_transaction }
-        before :context do
-          Appsignal.config = project_fixture_config
-          expect(Appsignal.active?).to be_truthy
-        end
-        before do
-          expect(Appsignal::Transaction).to receive(:create).with(
-            kind_of(String),
-            Appsignal::Transaction::HTTP_REQUEST,
-            kind_of(::Rack::Request)
-          ).and_return(transaction)
-        end
+      it "sets the error" do
+        make_request_with_exception(env, ExampleException, "error message")
 
-        context "without error" do
-          it "calls the endpoint" do
-            expect(api_endpoint).to receive(:call).with(env)
-          end
+        expect(last_transaction.to_h).to include(
+          "error" => {
+            "name" => "ExampleException",
+            "message" => "error message",
+            "backtrace" => kind_of(String)
+          }
+        )
+      end
 
-          it "sets metadata" do
-            expect(transaction).to receive(:set_http_or_background_queue_start)
-            expect(transaction).to receive(:set_action_if_nil).with("POST::GrapeExample::Api#/ping")
-            expect(transaction).to receive(:set_metadata).with("path", "/ping")
-            expect(transaction).to receive(:set_metadata).with("method", "POST")
-          end
-
-          after { middleware.call(env) }
-        end
-
-        context "with error" do
-          let(:app) do
-            Class.new(::Grape::API) do
-              format :json
-              post :ping do
-                raise ExampleException
-              end
-            end
-          end
-
-          it "sets metadata" do
-            expect(transaction).to receive(:set_http_or_background_queue_start)
-            expect(transaction).to receive(:set_action_if_nil).with("POST::GrapeExample::Api#/ping")
-            expect(transaction).to receive(:set_metadata).with("path", "/ping")
-            expect(transaction).to receive(:set_metadata).with("method", "POST")
-          end
-
-          it "sets the error" do
-            expect(transaction).to receive(:set_error).with(kind_of(ExampleException))
-          end
-
-          context "with env['grape.skip_appsignal_error'] = true" do
-            before do
+      context "with env['grape.skip_appsignal_error'] = true" do
+        let(:app) do
+          Class.new(::Grape::API) do
+            format :json
+            post :ping do
               env["grape.skip_appsignal_error"] = true
+              raise ExampleException, "error message"
             end
-
-            it "does not add the error" do
-              expect(transaction).to_not receive(:set_error)
-            end
-          end
-
-          after do
-            expect { middleware.call(env) }.to raise_error ExampleException
           end
         end
 
-        context "with route" do
-          let(:app) do
-            Class.new(::Grape::API) do
-              route([:get, :post], "hello") do
-                "Hello!"
+        it "does not add the error" do
+          make_request_with_exception(env, ExampleException, "error message")
+
+          expect(last_transaction).to include("error" => nil)
+        end
+      end
+    end
+
+    context "with route" do
+      let(:app) do
+        Class.new(::Grape::API) do
+          route([:get, :post], "hello") do
+            "Hello!"
+          end
+        end
+      end
+      let(:env) do
+        http_request_env_with_data \
+          "api.endpoint" => api_endpoint,
+          "REQUEST_METHOD" => "GET",
+          :path => ""
+      end
+
+      it "sets non-unique route path" do
+        make_request(env)
+
+        expect(last_transaction.to_h).to include(
+          "action" => "GET::GrapeExample::Api#/hello",
+          "metadata" => {
+            "path" => "/hello",
+            "method" => "GET"
+          }
+        )
+      end
+    end
+
+    context "with route_param" do
+      let(:app) do
+        Class.new(::Grape::API) do
+          format :json
+          resource :users do
+            route_param :id do
+              get do
+                { :name => "Tom" }
               end
             end
           end
-          let(:env) do
-            http_request_env_with_data \
-              "api.endpoint" => api_endpoint,
-              "REQUEST_METHOD" => "GET",
-              :path => ""
-          end
+        end
+      end
+      let(:env) do
+        http_request_env_with_data \
+          "api.endpoint" => api_endpoint,
+          "REQUEST_METHOD" => "GET",
+          :path => ""
+      end
 
-          it "sets non-unique route path" do
-            expect(transaction).to receive(:set_action).with("GET::GrapeExample::Api#/hello")
-            expect(transaction).to receive(:set_metadata).with("path", "/hello")
-            expect(transaction).to receive(:set_metadata).with("method", "GET")
-          end
+      it "sets non-unique route_param path" do
+        make_request(env)
 
-          after { middleware.call(env) }
+        expect(last_transaction.to_h).to include(
+          "action" => "GET::GrapeExample::Api#/users/:id/",
+          "metadata" => {
+            "path" => "/users/:id/",
+            "method" => "GET"
+          }
+        )
+      end
+    end
+
+    context "with namespaced path" do
+      context "with symbols" do
+        let(:app) do
+          Class.new(::Grape::API) do
+            format :json
+            namespace :v1 do
+              namespace :beta do
+                post :ping do
+                  { :message => "Hello namespaced world!" }
+                end
+              end
+            end
+          end
         end
 
-        context "with route_param" do
+        it "sets namespaced path" do
+          make_request(env)
+
+          expect(last_transaction.to_h).to include(
+            "action" => "POST::GrapeExample::Api#/v1/beta/ping",
+            "metadata" => {
+              "path" => "/v1/beta/ping",
+              "method" => "POST"
+            }
+          )
+        end
+      end
+
+      context "with strings" do
+        context "without / prefix" do
           let(:app) do
             Class.new(::Grape::API) do
               format :json
-              resource :users do
-                route_param :id do
-                  get do
-                    { :name => "Tom" }
+              namespace "v1" do
+                namespace "beta" do
+                  post "ping" do
+                    { :message => "Hello namespaced world!" }
                   end
                 end
               end
             end
           end
-          let(:env) do
-            http_request_env_with_data \
-              "api.endpoint" => api_endpoint,
-              "REQUEST_METHOD" => "GET",
-              :path => ""
-          end
 
-          it "sets non-unique route_param path" do
-            expect(transaction).to receive(:set_action_if_nil)
-              .with("GET::GrapeExample::Api#/users/:id/")
-            expect(transaction).to receive(:set_metadata).with("path", "/users/:id/")
-            expect(transaction).to receive(:set_metadata).with("method", "GET")
-          end
+          it "sets namespaced path" do
+            make_request(env)
 
-          after { middleware.call(env) }
+            expect(last_transaction.to_h).to include(
+              "action" => "POST::GrapeExample::Api#/v1/beta/ping",
+              "metadata" => {
+                "path" => "/v1/beta/ping",
+                "method" => "POST"
+              }
+            )
+          end
         end
 
-        context "with namespaced path" do
-          context "with symbols" do
-            let(:app) do
-              Class.new(::Grape::API) do
-                format :json
-                namespace :v1 do
-                  namespace :beta do
-                    post :ping do
-                      { :message => "Hello namespaced world!" }
-                    end
+        context "with / prefix" do
+          let(:app) do
+            Class.new(::Grape::API) do
+              format :json
+              namespace "/v1" do
+                namespace "/beta" do
+                  post "/ping" do
+                    { :message => "Hello namespaced world!" }
                   end
                 end
-              end
-            end
-
-            it "sets namespaced path" do
-              expect(transaction).to receive(:set_action_if_nil)
-                .with("POST::GrapeExample::Api#/v1/beta/ping")
-              expect(transaction).to receive(:set_metadata).with("path", "/v1/beta/ping")
-              expect(transaction).to receive(:set_metadata).with("method", "POST")
-            end
-          end
-
-          context "with strings" do
-            context "without / prefix" do
-              let(:app) do
-                Class.new(::Grape::API) do
-                  format :json
-                  namespace "v1" do
-                    namespace "beta" do
-                      post "ping" do
-                        { :message => "Hello namespaced world!" }
-                      end
-                    end
-                  end
-                end
-              end
-
-              it "sets namespaced path" do
-                expect(transaction).to receive(:set_action_if_nil)
-                  .with("POST::GrapeExample::Api#/v1/beta/ping")
-                expect(transaction).to receive(:set_metadata).with("path", "/v1/beta/ping")
-                expect(transaction).to receive(:set_metadata).with("method", "POST")
-              end
-            end
-
-            context "with / prefix" do
-              let(:app) do
-                Class.new(::Grape::API) do
-                  format :json
-                  namespace "/v1" do
-                    namespace "/beta" do
-                      post "/ping" do
-                        { :message => "Hello namespaced world!" }
-                      end
-                    end
-                  end
-                end
-              end
-
-              it "sets namespaced path" do
-                expect(transaction).to receive(:set_action_if_nil)
-                  .with("POST::GrapeExample::Api#/v1/beta/ping")
-                expect(transaction).to receive(:set_metadata).with("path", "/v1/beta/ping")
-                expect(transaction).to receive(:set_metadata).with("method", "POST")
               end
             end
           end
 
-          after { middleware.call(env) }
+          it "sets namespaced path" do
+            make_request(env)
+
+            expect(last_transaction.to_h).to include(
+              "action" => "POST::GrapeExample::Api#/v1/beta/ping",
+              "metadata" => {
+                "path" => "/v1/beta/ping",
+                "method" => "POST"
+              }
+            )
+          end
         end
       end
     end


### PR DESCRIPTION
~⚠️ Based on rebased PRs #1107 and #1117, as they both contain changes needed for this change. Only the last commit in this PR (as of writing) contains the reviewable change. Please also review PRs #1107 and #1117 so I can rebase this branch only to contain the relevant changes.~

## Support nested Grape apps

Refactor the Grape middleware to inherit from the AbstractMiddleware class. I've removed the inheritance on the Grape::Middleware::Base. We don't rely on the base Grape middleware.

By using an AbstractMiddleware subclass for Grape, we support Grape apps nested in Sinatra, Rails, and other apps already using AppSignal instrumentation middleware.

To keep the `grape.skip_appsignal_error` request env logic to work, I've made the `report_errors` option accept a proc and call it if it's callable to determine per request if the error should be reported.
