### PR TITLE
Deprecate Appsignal.start_logger

### DIFF
--- a/.changesets/deprecate-appsignal-start_logger.md
+++ b/.changesets/deprecate-appsignal-start_logger.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: deprecate
+---
+
+Deprecate the `Appsignal.start_logger` method. Remove this method call from apps if it is present. Calling `Appsignal.start` will now initialize the logger.

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -200,7 +200,7 @@ module Appsignal
             initial_config
           )
           Appsignal.config.write_to_environment
-          Appsignal.start_logger
+          Appsignal._start_logger
           Appsignal.internal_logger.info("Starting AppSignal diagnose")
         end
 

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -233,7 +233,7 @@ module Appsignal
     #   variables config.
     # @param logger [Logger] The logger to use for the AppSignal gem. This is
     #   used by the configuration class only. Default:
-    #   {Appsignal.internal_logger}. See also {Appsignal.start_logger}.
+    #   {Appsignal.internal_logger}. See also {Appsignal.start}.
     # @param config_file [String] Custom config file location. Default
     #   `config/appsignal.yml`.
     #

--- a/lib/appsignal/integrations/hanami.rb
+++ b/lib/appsignal/integrations/hanami.rb
@@ -16,7 +16,6 @@ module Appsignal
           hanami_app_config.env
         )
 
-        Appsignal.start_logger
         Appsignal.start
 
         return unless Appsignal.active?

--- a/lib/appsignal/integrations/padrino.rb
+++ b/lib/appsignal/integrations/padrino.rb
@@ -12,7 +12,6 @@ module Appsignal
         root = Padrino.mounted_root
         Appsignal.config = Appsignal::Config.new(root, Padrino.env)
 
-        Appsignal.start_logger
         Appsignal.start
       end
     end

--- a/lib/appsignal/integrations/railtie.rb
+++ b/lib/appsignal/integrations/railtie.rb
@@ -26,9 +26,6 @@ module Appsignal
           :log_path => Rails.root.join("log")
         )
 
-        # Start logger
-        Appsignal.start_logger
-
         app.middleware.insert(
           0,
           ::Rack::Events,

--- a/lib/appsignal/integrations/sinatra.rb
+++ b/lib/appsignal/integrations/sinatra.rb
@@ -12,7 +12,6 @@ unless Appsignal.active?
     app_settings.environment
   )
 
-  Appsignal.start_logger
   Appsignal.start
 end
 

--- a/spec/lib/appsignal/integrations/hanami_spec.rb
+++ b/spec/lib/appsignal/integrations/hanami_spec.rb
@@ -19,7 +19,6 @@ if DependencyHelper.hanami2_present?
     describe Appsignal::Integrations::HanamiPlugin do
       it "starts AppSignal on init" do
         expect(Appsignal).to receive(:start)
-        expect(Appsignal).to receive(:start_logger)
         Appsignal::Integrations::HanamiPlugin.init
       end
 

--- a/spec/lib/appsignal/integrations/padrino_spec.rb
+++ b/spec/lib/appsignal/integrations/padrino_spec.rb
@@ -5,16 +5,11 @@ if DependencyHelper.padrino_present?
     before do
       allow(Appsignal).to receive(:active?).and_return(true)
       allow(Appsignal).to receive(:start).and_return(true)
-      allow(Appsignal).to receive(:start_logger).and_return(true)
     end
 
     describe Appsignal::Integrations::PadrinoPlugin do
       it "starts AppSignal on init" do
         expect(Appsignal).to receive(:start)
-      end
-
-      it "starts the logger on init" do
-        expect(Appsignal).to receive(:start_logger)
       end
 
       context "when not active" do

--- a/spec/lib/appsignal/integrations/sinatra_spec.rb
+++ b/spec/lib/appsignal/integrations/sinatra_spec.rb
@@ -24,7 +24,6 @@ if DependencyHelper.sinatra_present?
       it "does not start AppSignal again" do
         expect(Appsignal::Config).to_not receive(:new)
         expect(Appsignal).to_not receive(:start)
-        expect(Appsignal).to_not receive(:start_logger)
         install_sinatra_integration
       end
 


### PR DESCRIPTION
We always tell people to call both `Appsignal.start` and `Appsignal.start_logger`. Let's make it easier for everyone and start the logger when AppSignal is started?

For the one scenario where the logger needs to be called separately in our gem, we can call the private `_start_logger` method.