### PR TITLE
Fix in memory logger not logging all messages

### DIFF
--- a/lib/appsignal/utils.rb
+++ b/lib/appsignal/utils.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "appsignal/utils/integration_memory_logger"
 require "appsignal/utils/stdout_and_logger_message"
 require "appsignal/utils/data"
 require "appsignal/utils/hash_sanitizer"

--- a/lib/appsignal/utils/integration_memory_logger.rb
+++ b/lib/appsignal/utils/integration_memory_logger.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "logger"
+
+module Appsignal
+  module Utils
+    # @api private
+    class IntegrationMemoryLogger
+      LEVELS = {
+        Logger::DEBUG => :DEBUG,
+        Logger::INFO => :INFO,
+        Logger::WARN => :WARN,
+        Logger::ERROR => :ERROR,
+        Logger::FATAL => :FATAL,
+        Logger::UNKNOWN => :UNKNOWN
+      }.freeze
+
+      attr_accessor :formatter, :level
+
+      def add(severity, message, _progname = nil)
+        message = formatter.call(severity, Time.now, nil, message) if formatter
+        messages[severity] << message
+      end
+      alias log add
+
+      def debug(message)
+        add(:DEBUG, message)
+      end
+
+      def info(message)
+        add(:INFO, message)
+      end
+
+      def warn(message)
+        add(:WARN, message)
+      end
+
+      def error(message)
+        add(:ERROR, message)
+      end
+
+      def fatal(message)
+        add(:FATAL, message)
+      end
+
+      def unknown(message)
+        add(:UNKNOWN, message)
+      end
+
+      def clear
+        messages.clear
+      end
+
+      def messages
+        @messages ||= Hash.new { |hash, key| hash[key] = [] }
+      end
+
+      def messages_for_level(level)
+        levels = LEVELS.select { |log_level| log_level >= level }.values
+        messages
+          .select { |log_level| levels.include?(log_level) }
+          .flat_map { |_level, message| message }
+      end
+    end
+  end
+end

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -385,6 +385,8 @@ describe Appsignal::Config do
 
     context "without the selected env" do
       let(:config) { project_fixture_config("nonsense") }
+      let(:log_stream) { std_stream }
+      let(:log) { log_contents(log_stream) }
 
       it "is not valid or active" do
         expect(config.valid?).to be_falsy
@@ -392,11 +394,11 @@ describe Appsignal::Config do
       end
 
       it "logs an error" do
-        expect_any_instance_of(Logger).to receive(:error).once
-          .with("Not loading from config file: config for 'nonsense' not found")
-        expect_any_instance_of(Logger).to receive(:error).once
-          .with("Push API key not set after loading config")
-        config
+        use_logger_with(log_stream) { config }
+        expect(log)
+          .to contains_log(:error, "Not loading from config file: config for 'nonsense' not found")
+        expect(log)
+          .to contains_log(:error, "Push API key not set after loading config")
       end
     end
   end

--- a/spec/lib/appsignal/utils/integration_memory_logger_spec.rb
+++ b/spec/lib/appsignal/utils/integration_memory_logger_spec.rb
@@ -1,0 +1,153 @@
+describe Appsignal::Utils::IntegrationLogger do
+  let(:formatter) { nil }
+  let(:logger) do
+    Appsignal::Utils::IntegrationMemoryLogger.new.tap do |l|
+      l.formatter = formatter if formatter
+    end
+  end
+
+  describe "#add" do
+    it "adds a log message with the severity" do
+      logger.add(:DEBUG, "debug message")
+      logger.add(:INFO, "info message")
+      logger.add(:WARN, "warn message")
+      logger.add(:ERROR, "error message")
+      logger.add(:FATAL, "fatal message")
+      logger.add(:UNKNOWN, "unknown message")
+
+      expect(logger.messages[:DEBUG]).to eq(["debug message"])
+      expect(logger.messages[:INFO]).to eq(["info message"])
+      expect(logger.messages[:WARN]).to eq(["warn message"])
+      expect(logger.messages[:ERROR]).to eq(["error message"])
+      expect(logger.messages[:FATAL]).to eq(["fatal message"])
+      expect(logger.messages[:UNKNOWN]).to eq(["unknown message"])
+    end
+
+    context "without formatter" do
+      it "logs in the default format" do
+        logger.add(:DEBUG, "debug message")
+        expect(logger.messages[:DEBUG]).to eq(["debug message"])
+      end
+    end
+
+    context "with formatter" do
+      let(:formatter) do
+        proc do |severity, _datetime, _progname, msg|
+          "[TIME (process) #PID][#{severity}] #{msg}\n"
+        end
+      end
+
+      it "formats the logs using the formatter" do
+        logger.add(:DEBUG, "debug message")
+        expect(logger.messages[:DEBUG]).to eq(["[TIME (process) #PID][DEBUG] debug message\n"])
+      end
+    end
+  end
+
+  describe "#debug" do
+    it "adds a log message with the debug severity" do
+      logger.debug("debug message")
+
+      expect(logger.messages[:DEBUG]).to eq(["debug message"])
+    end
+  end
+
+  describe "#info" do
+    it "adds a log message with the info severity" do
+      logger.info("info message")
+
+      expect(logger.messages[:INFO]).to eq(["info message"])
+    end
+  end
+
+  describe "#warn" do
+    it "adds a log message with the warn severity" do
+      logger.warn("warn message")
+
+      expect(logger.messages[:WARN]).to eq(["warn message"])
+    end
+  end
+
+  describe "#error" do
+    it "adds a log message with the error severity" do
+      logger.error("error message")
+
+      expect(logger.messages[:ERROR]).to eq(["error message"])
+    end
+  end
+
+  describe "#fatal" do
+    it "adds a log message with the fatal severity" do
+      logger.fatal("fatal message")
+
+      expect(logger.messages[:FATAL]).to eq(["fatal message"])
+    end
+  end
+
+  describe "#unknown" do
+    it "adds a log message with the unknown severity" do
+      logger.unknown("unknown message")
+
+      expect(logger.messages[:UNKNOWN]).to eq(["unknown message"])
+    end
+  end
+
+  describe "#clear" do
+    it "clears all log messages" do
+      logger.add(:DEBUG, "debug message")
+      logger.add(:INFO, "info message")
+      logger.add(:WARN, "warn message")
+      logger.add(:ERROR, "error message")
+      logger.add(:FATAL, "fatal message")
+      logger.add(:UNKNOWN, "unknown message")
+      logger.clear
+
+      expect(logger.messages).to be_empty
+    end
+  end
+
+  describe "#messages_for_level" do
+    it "returns only log messages for level and higher" do
+      logger.add(:DEBUG, "debug message")
+      logger.add(:INFO, "info message")
+      logger.add(:WARN, "warn message")
+      logger.add(:ERROR, "error message")
+      logger.add(:FATAL, "fatal message")
+      logger.add(:UNKNOWN, "unknown message")
+
+      expect(logger.messages_for_level(Logger::DEBUG)).to eq([
+        "debug message",
+        "info message",
+        "warn message",
+        "error message",
+        "fatal message",
+        "unknown message"
+      ])
+      expect(logger.messages_for_level(Logger::INFO)).to eq([
+        "info message",
+        "warn message",
+        "error message",
+        "fatal message",
+        "unknown message"
+      ])
+      expect(logger.messages_for_level(Logger::WARN)).to eq([
+        "warn message",
+        "error message",
+        "fatal message",
+        "unknown message"
+      ])
+      expect(logger.messages_for_level(Logger::ERROR)).to eq([
+        "error message",
+        "fatal message",
+        "unknown message"
+      ])
+      expect(logger.messages_for_level(Logger::FATAL)).to eq([
+        "fatal message",
+        "unknown message"
+      ])
+      expect(logger.messages_for_level(Logger::UNKNOWN)).to eq([
+        "unknown message"
+      ])
+    end
+  end
+end


### PR DESCRIPTION
When the in-memory logger is active (before AppSignal is started), it ignores the log level and only logs messages of level info or higher. On AppSignal start, all debug messages were lost, and we log a couple of debug messages during boot.

I first thought of setting the in-memory logger level to debug, but this results in the log file containing debug messages, even if the logger eventually wasn't set to the debug log level.

I added a new class called IntegrationMemoryLogger that keeps the log messages in a Hash so that it can figure out later what log messages it should copy to the initialized logger. Now, the debug messages are logged when the 'real' logger is initialized with the debug log level.

[skip changeset]