### PR TITLE
Require appsignal in Grape integration file

### DIFF
--- a/.changesets/require-appsignal-in-grape-integration-file.md
+++ b/.changesets/require-appsignal-in-grape-integration-file.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Require the AppSignal gem in the Grape integration file. Previously `require "appsignal"` had to be called before `require "appsignal/integrations/grape"`. This `require "appsignal"` is no longer required.

--- a/lib/appsignal/integrations/grape.rb
+++ b/lib/appsignal/integrations/grape.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
+require "appsignal"
 require "appsignal/rack/grape_middleware"
+
+Appsignal.internal_logger.debug("Loading Grape integration")
 
 module Appsignal
   # @api private


### PR DESCRIPTION
Make people's lives easier by requiring appsignal from the Grape integration file so they don't have to require two files.

Also add a log message to help debug if the Grape integration file is loaded like we do for other integrations.

[skip review]