### PR TITLE
Don't report middleware event for Rails

### DIFF
--- a/lib/appsignal/rack/abstract_middleware.rb
+++ b/lib/appsignal/rack/abstract_middleware.rb
@@ -77,7 +77,11 @@ module Appsignal
       #
       # @see {#instrument_app_call_with_exception_handling}
       def instrument_app_call(env)
-        Appsignal.instrument(@instrument_span_name) do
+        if @instrument_span_name
+          Appsignal.instrument(@instrument_span_name) do
+            @app.call(env)
+          end
+        else
           @app.call(env)
         end
       end

--- a/lib/appsignal/rack/rails_instrumentation.rb
+++ b/lib/appsignal/rack/rails_instrumentation.rb
@@ -9,7 +9,7 @@ module Appsignal
       def initialize(app, options = {})
         options[:request_class] ||= ActionDispatch::Request
         options[:params_method] ||= :filtered_parameters
-        options[:instrument_span_name] ||= "middleware.rails"
+        options[:instrument_span_name] = nil
         options[:report_errors] = true
         super
       end

--- a/spec/lib/appsignal/rack/abstract_middleware_spec.rb
+++ b/spec/lib/appsignal/rack/abstract_middleware_spec.rb
@@ -72,6 +72,18 @@ describe Appsignal::Rack::AbstractMiddleware do
           )
         end
 
+        context "when instrument_span_name option is nil" do
+          let(:options) { { :instrument_span_name => nil } }
+
+          it "does not report an event" do
+            make_request(env)
+
+            expect(last_transaction.to_h).to include(
+              "events" => []
+            )
+          end
+        end
+
         it "completes the transaction" do
           make_request(env)
           expect(last_transaction).to be_completed

--- a/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
@@ -49,6 +49,16 @@ if DependencyHelper.rails_present?
       expect { make_request(env) }.to raise_error(error_class, error_message)
     end
 
+    context "with a request without an error" do
+      it "does not report an event" do
+        make_request(env)
+
+        expect(last_transaction.to_h).to include(
+          "events" => []
+        )
+      end
+    end
+
     context "with a request that raises an error" do
       let(:app) { lambda { |_env| raise ExampleException, "error message" } }
 


### PR DESCRIPTION
As discussed in PR #1107, do not create a transaction event for a Rails apps using the RailsInstrumentation middleware. The ActiveSupport Notifications and Rack EventHandler events are enough. The `middleware.rails` event didn't add much.

Closes #1120

[skip changeset] because the related change in PR #1107 has not been released yet.