### PR TITLE
Report response status when there is no response

### DIFF
--- a/.changesets/track-error-response-status.md
+++ b/.changesets/track-error-response-status.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Track error response status for web requests. When an unhandled exception reaches the AppSignal EventHandler instrumentation, report the response status as `500` for the `response_status` tag on the transaction and on the `response_status` metric.


### PR DESCRIPTION
When there is no response object given to the EventHandler's `on_finish` callback, we can expect an unhandled error has occurred.

When have also received an exception in the `on_error` callback, report the response status as 500. This solution is not perfect. It may actually be another response status if something else above the EventHandler handles the exception. A setup we don't recommend.

Part of #329