### PR TITLE
Remove deprecated start_logger method call

### DIFF
--- a/lib/appsignal/demo.rb
+++ b/lib/appsignal/demo.rb
@@ -29,7 +29,6 @@ module Appsignal
       #   - returns `false` if Appsignal is not active.
       def transmit
         Appsignal.start
-        Appsignal.start_logger
         return false unless Appsignal.active?
 
         create_example_error_request


### PR DESCRIPTION
Remove the method call to the deprecated `Appsignal.start_logger` method from the Demo CLI class.

[skip changeset] because it's part of the unreleased PR #1119
[skip review]