### PR TITLE
Add process name and ID tags to GVL metrics

### DIFF
--- a/.changesets/report-gvl-metrics-per-process.md
+++ b/.changesets/report-gvl-metrics-per-process.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Report Global VM Lock metrics per process. In addition to the existing `hostname` tag, add `process_name` and `process_id` tags to the `gvl_global_timer` and `gvl_waiting_threads` metrics emitted by the [GVL probe](https://docs.appsignal.com/ruby/integrations/global-vm-lock.html), allowing these metrics to be tracked in a per-process basis.

--- a/spec/lib/appsignal/probes/gvl_spec.rb
+++ b/spec/lib/appsignal/probes/gvl_spec.rb
@@ -4,6 +4,13 @@ describe Appsignal::Probes::GvlProbe do
 
   let(:hostname) { "some-host" }
 
+  around do |example|
+    real_program_name = $PROGRAM_NAME
+    example.run
+  ensure
+    $PROGRAM_NAME = real_program_name
+  end
+
   def gauges_for(metric)
     gauges = appsignal_mock.gauges.select do |gauge|
       gauge[0] == metric
@@ -14,7 +21,7 @@ describe Appsignal::Probes::GvlProbe do
     end
   end
 
-  after(:each) { FakeGVLTools.reset }
+  after { FakeGVLTools.reset }
 
   it "gauges the global timer delta" do
     FakeGVLTools::GlobalTimer.monotonic_time = 100_000_000
@@ -26,6 +33,11 @@ describe Appsignal::Probes::GvlProbe do
     probe.call
 
     expect(gauges_for("gvl_global_timer")).to eq [
+      [200, {
+        :hostname => hostname,
+        :process_name => "rspec",
+        :process_id => Process.pid
+      }],
       [200, { :hostname => hostname }]
     ]
   end
@@ -58,7 +70,7 @@ describe Appsignal::Probes::GvlProbe do
   end
 
   context "when the waiting threads count is enabled" do
-    before(:each) do
+    before do
       FakeGVLTools::WaitingThreads.enabled = true
     end
 
@@ -67,13 +79,18 @@ describe Appsignal::Probes::GvlProbe do
       probe.call
 
       expect(gauges_for("gvl_waiting_threads")).to eq [
+        [3, {
+          :hostname => hostname,
+          :process_name => "rspec",
+          :process_id => Process.pid
+        }],
         [3, { :hostname => hostname }]
       ]
     end
   end
 
   context "when the waiting threads count is disabled" do
-    before(:each) do
+    before do
       FakeGVLTools::WaitingThreads.enabled = false
     end
 
@@ -82,6 +99,66 @@ describe Appsignal::Probes::GvlProbe do
       probe.call
 
       expect(gauges_for("gvl_waiting_threads")).to be_empty
+    end
+  end
+
+  context "when the process name is a custom value" do
+    before do
+      FakeGVLTools::WaitingThreads.enabled = true
+    end
+
+    it "uses only the first word as the process name" do
+      $PROGRAM_NAME = "sidekiq 7.1.6 app [0 of 5 busy]"
+      probe.call
+
+      expect(gauges_for("gvl_waiting_threads")).to eq [
+        [0, {
+          :hostname => hostname,
+          :process_name => "sidekiq",
+          :process_id => Process.pid
+        }],
+        [0, { :hostname => hostname }]
+      ]
+    end
+  end
+
+  context "when the process name is a path" do
+    before do
+      FakeGVLTools::WaitingThreads.enabled = true
+    end
+
+    it "uses only the binary name as the process name" do
+      $PROGRAM_NAME = "/foo/folder with spaces/bin/rails"
+      probe.call
+
+      expect(gauges_for("gvl_waiting_threads")).to eq [
+        [0, {
+          :hostname => hostname,
+          :process_name => "rails",
+          :process_id => Process.pid
+        }],
+        [0, { :hostname => hostname }]
+      ]
+    end
+  end
+
+  context "when the process name is an empty string" do
+    before do
+      FakeGVLTools::WaitingThreads.enabled = true
+    end
+
+    it "uses [unknown process] as the process name" do
+      $PROGRAM_NAME = ""
+      probe.call
+
+      expect(gauges_for("gvl_waiting_threads")).to eq [
+        [0, {
+          :hostname => hostname,
+          :process_name => "[unknown process]",
+          :process_id => Process.pid
+        }],
+        [0, { :hostname => hostname }]
+      ]
     end
   end
 end


### PR DESCRIPTION
When reporting the GVL metrics, which measure the time spent by the Ruby VM in its global VM lock, and as such are per-process metrics, add the process name and process ID as tags, alongside the existing hostname tag.

As the process name can change during the lifetime of the process, store it when initialising the GVL probe, to prevent potentially reporting the same metric with different tag combinations.

To attempt to account for custom process names, keep only the first word of the process name, after removing path prefixes from it.

Fixes #1106.