### PR TITLE
Fix Hanami instrumentation causing boot loop

### DIFF
--- a/.changesets/don-t-start-for-hanami-if-already-started.md
+++ b/.changesets/don-t-start-for-hanami-if-already-started.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+type: fix
+---
+
+Fix issue with AppSignal getting stuck in a boot loop when loading the Hanami integration with: `require "appsignal/integrations/hanami"`
+This could happen in nested applications, like a Hanami app in a Rails app. It will now use the first config AppSignal starts with.

--- a/lib/appsignal/integrations/hanami.rb
+++ b/lib/appsignal/integrations/hanami.rb
@@ -43,4 +43,4 @@ module Appsignal
   end
 end
 
-Appsignal::Integrations::HanamiPlugin.init
+Appsignal::Integrations::HanamiPlugin.init unless Appsignal.testing?

--- a/lib/appsignal/integrations/hanami.rb
+++ b/lib/appsignal/integrations/hanami.rb
@@ -11,12 +11,14 @@ module Appsignal
         Appsignal.internal_logger.debug("Loading Hanami integration")
 
         hanami_app_config = ::Hanami.app.config
-        Appsignal.config = Appsignal::Config.new(
-          hanami_app_config.root || Dir.pwd,
-          hanami_app_config.env
-        )
 
-        Appsignal.start
+        unless Appsignal.active?
+          Appsignal.config = Appsignal::Config.new(
+            hanami_app_config.root || Dir.pwd,
+            hanami_app_config.env
+          )
+          Appsignal.start
+        end
 
         return unless Appsignal.active?
 

--- a/spec/lib/appsignal/integrations/hanami_spec.rb
+++ b/spec/lib/appsignal/integrations/hanami_spec.rb
@@ -5,7 +5,12 @@ if DependencyHelper.hanami2_present?
     require "appsignal/integrations/hanami"
 
     before do
+      Appsignal.config = nil
+      allow(::Hanami::Action).to receive(:prepend)
       uninstall_hanami_middleware
+      ENV["APPSIGNAL_APP_NAME"] = "hanamia-test-app"
+      ENV["APPSIGNAL_APP_ENV"] = "test"
+      ENV["APPSIGNAL_PUSH_API_KEY"] = "0000"
     end
 
     def uninstall_hanami_middleware
@@ -18,19 +23,21 @@ if DependencyHelper.hanami2_present?
 
     describe Appsignal::Integrations::HanamiPlugin do
       it "starts AppSignal on init" do
-        expect(Appsignal).to receive(:start)
+        expect(Appsignal.active?).to be_falsey
+
         Appsignal::Integrations::HanamiPlugin.init
+
+        expect(Appsignal.active?).to be_truthy
       end
 
       it "prepends the integration to Hanami::Action" do
-        allow(Appsignal).to receive(:active?).and_return(true)
         Appsignal::Integrations::HanamiPlugin.init
-        expect(::Hanami::Action.included_modules)
-          .to include(Appsignal::Integrations::HanamiIntegration)
+
+        expect(::Hanami::Action)
+          .to have_received(:prepend).with(Appsignal::Integrations::HanamiIntegration)
       end
 
       it "adds middleware to the Hanami app" do
-        allow(Appsignal).to receive(:active?).and_return(true)
         Appsignal::Integrations::HanamiPlugin.init
 
         expect(::Hanami.app.config.middleware.stack[::Hanami::Router::DEFAULT_PREFIX])
@@ -41,11 +48,16 @@ if DependencyHelper.hanami2_present?
       end
 
       context "when not active" do
-        before { allow(Appsignal).to receive(:active?).and_return(false) }
+        before do
+          ENV.delete("APPSIGNAL_APP_NAME")
+          ENV.delete("APPSIGNAL_APP_ENV")
+          ENV.delete("APPSIGNAL_PUSH_API_KEY")
+        end
 
         it "does not prepend the integration to Hanami::Action" do
           Appsignal::Integrations::HanamiPlugin.init
-          expect(::Hanami::Action).to_not receive(:prepend)
+
+          expect(::Hanami::Action).to_not have_received(:prepend)
             .with(Appsignal::Integrations::HanamiIntegration)
         end
 
@@ -85,14 +97,24 @@ if DependencyHelper.hanami2_present?
 
     describe Appsignal::Integrations::HanamiIntegration do
       let(:transaction) { http_request_transaction }
+      let(:app) do
+        Class.new(HanamiApp::Actions::Books::Index) do
+          def self.name
+            "HanamiApp::Actions::Books::Index::TestClass"
+          end
+        end
+      end
       around { |example| keep_transactions { example.run } }
-      before(:context) { start_agent }
       before do
-        allow(Appsignal).to receive(:active?).and_return(true)
+        ENV["APPSIGNAL_APP_NAME"] = "hanamia-test-app"
+        ENV["APPSIGNAL_APP_ENV"] = "test"
+        ENV["APPSIGNAL_PUSH_API_KEY"] = "0000"
         Appsignal::Integrations::HanamiPlugin.init
+        allow(app).to receive(:prepend).and_call_original
+        app.prepend(Appsignal::Integrations::HanamiIntegration)
       end
 
-      def make_request(env, app: HanamiApp::Actions::Books::Index)
+      def make_request(env)
         action = app.new
         action.call(env)
       end
@@ -117,7 +139,7 @@ if DependencyHelper.hanami2_present?
             make_request(env)
 
             expect(transaction.to_h).to include(
-              "action" => "HanamiApp::Actions::Books::Index"
+              "action" => "HanamiApp::Actions::Books::Index::TestClass"
             )
           end
         end


### PR DESCRIPTION
Based on #1127 

## Improve Hanami integration testing

Improve testing for the Hanami integration by making sure the it prepends the module in every scenario. That means we're not really prepending the module to Hanami::Action in the tests, because that would make testing it multiple times impossible. It's not possible to "unprepend" a module.

I've updated the prepended module test to prepend the module to an Action class. First it subclasses the Hanami Action fixture using an anonymous class (using `Class.new`). Then it prepends the module to that anonymous class to see if the behavior works.

## Don't start again in Hanami integration

When AppSignal is already active, do not start AppSignal again. This is a good precaution as it prevents boot loops, when AppSignal is started twice with different configurations.

This will improve support for nested Hanami applications, when they're mounted in another frameworks we support, like Rails or Sinatra.

This is similar to PR #1105

Part of #329
