### PR TITLE
Refactor test suite with transaction helpers

### DIFF
--- a/spec/lib/appsignal/hooks/active_support_notifications/finish_with_state_shared_examples.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications/finish_with_state_shared_examples.rb
@@ -5,31 +5,19 @@ shared_examples "activesupport finish_with_state override" do
     listeners_state = instrumenter.start("sql.active_record", {})
     instrumenter.finish_with_state(listeners_state, "sql.active_record", :sql => "SQL")
 
-    expect(transaction.to_h["events"]).to match([
-      {
-        "allocation_count" => kind_of(Integer),
-        "body" => "SQL",
-        "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
-        "child_allocation_count" => kind_of(Integer),
-        "child_duration" => kind_of(Float),
-        "child_gc_duration" => kind_of(Float),
-        "count" => 1,
-        "duration" => kind_of(Float),
-        "gc_duration" => kind_of(Float),
-        "name" => "sql.active_record",
-        "start" => kind_of(Float),
-        "title" => ""
-      }
-    ])
+    expect(transaction).to include_event(
+      "body" => "SQL",
+      "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
+      "count" => 1,
+      "name" => "sql.active_record",
+      "title" => ""
+    )
   end
 
   it "does not instrument events whose name starts with a bang" do
-    expect(Appsignal::Transaction.current).not_to receive(:start_event)
-    expect(Appsignal::Transaction.current).not_to receive(:finish_event)
-
     listeners_state = instrumenter.start("!sql.active_record", {})
     instrumenter.finish_with_state(listeners_state, "!sql.active_record", :sql => "SQL")
 
-    expect(transaction.to_h["events"]).to be_empty
+    expect(transaction).to_not include_events
   end
 end

--- a/spec/lib/appsignal/hooks/active_support_notifications/instrument_shared_examples.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications/instrument_shared_examples.rb
@@ -5,22 +5,13 @@ shared_examples "activesupport instrument override" do
     end
 
     expect(return_value).to eq "value"
-    expect(transaction.to_h["events"]).to match([
-      {
-        "allocation_count" => kind_of(Integer),
-        "body" => "SQL",
-        "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
-        "child_allocation_count" => kind_of(Integer),
-        "child_duration" => kind_of(Float),
-        "child_gc_duration" => kind_of(Float),
-        "count" => 1,
-        "duration" => kind_of(Float),
-        "gc_duration" => kind_of(Float),
-        "name" => "sql.active_record",
-        "start" => kind_of(Float),
-        "title" => ""
-      }
-    ])
+    expect(transaction).to include_event(
+      "body" => "SQL",
+      "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
+      "count" => 1,
+      "name" => "sql.active_record",
+      "title" => ""
+    )
   end
 
   it "instruments an ActiveSupport::Notifications.instrument event with no registered formatter" do
@@ -29,53 +20,34 @@ shared_examples "activesupport instrument override" do
     end
 
     expect(return_value).to eq "value"
-    expect(transaction.to_h["events"]).to match([
-      {
-        "allocation_count" => kind_of(Integer),
-        "body" => "",
-        "body_format" => Appsignal::EventFormatter::DEFAULT,
-        "child_allocation_count" => kind_of(Integer),
-        "child_duration" => kind_of(Float),
-        "child_gc_duration" => kind_of(Float),
-        "count" => 1,
-        "duration" => kind_of(Float),
-        "gc_duration" => kind_of(Float),
-        "name" => "no-registered.formatter",
-        "start" => kind_of(Float),
-        "title" => ""
-      }
-    ])
+    expect(transaction).to include_event(
+      "body" => "",
+      "body_format" => Appsignal::EventFormatter::DEFAULT,
+      "count" => 1,
+      "name" => "no-registered.formatter",
+      "title" => ""
+    )
   end
 
   it "converts non-string names to strings" do
     as.instrument(:not_a_string) {} # rubocop:disable Lint/EmptyBlock
-    expect(transaction.to_h["events"]).to match([
-      {
-        "allocation_count" => kind_of(Integer),
-        "body" => "",
-        "body_format" => Appsignal::EventFormatter::DEFAULT,
-        "child_allocation_count" => kind_of(Integer),
-        "child_duration" => kind_of(Float),
-        "child_gc_duration" => kind_of(Float),
-        "count" => 1,
-        "duration" => kind_of(Float),
-        "gc_duration" => kind_of(Float),
-        "name" => "not_a_string",
-        "start" => kind_of(Float),
-        "title" => ""
-      }
-    ])
+    expect(transaction).to include_event(
+      "body" => "",
+      "body_format" => Appsignal::EventFormatter::DEFAULT,
+      "count" => 1,
+      "name" => "not_a_string",
+      "title" => ""
+    )
   end
 
   it "does not instrument events whose name starts with a bang" do
-    expect(Appsignal::Transaction.current).not_to receive(:start_event)
-    expect(Appsignal::Transaction.current).not_to receive(:finish_event)
-
     return_value = as.instrument("!sql.active_record", :sql => "SQL") do
       "value"
     end
 
     expect(return_value).to eq "value"
+
+    expect(transaction).to_not include_events
   end
 
   context "when an error is raised in an instrumented block" do
@@ -86,22 +58,13 @@ shared_examples "activesupport instrument override" do
         end
       end.to raise_error(ExampleException, "foo")
 
-      expect(transaction.to_h["events"]).to match([
-        {
-          "allocation_count" => kind_of(Integer),
-          "body" => "SQL",
-          "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
-          "child_allocation_count" => kind_of(Integer),
-          "child_duration" => kind_of(Float),
-          "child_gc_duration" => kind_of(Float),
-          "count" => 1,
-          "duration" => kind_of(Float),
-          "gc_duration" => kind_of(Float),
-          "name" => "sql.active_record",
-          "start" => kind_of(Float),
-          "title" => ""
-        }
-      ])
+      expect(transaction).to include_event(
+        "body" => "SQL",
+        "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
+        "count" => 1,
+        "name" => "sql.active_record",
+        "title" => ""
+      )
     end
   end
 
@@ -113,22 +76,13 @@ shared_examples "activesupport instrument override" do
         end
       end.to throw_symbol(:foo)
 
-      expect(transaction.to_h["events"]).to match([
-        {
-          "allocation_count" => kind_of(Integer),
-          "body" => "SQL",
-          "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
-          "child_allocation_count" => kind_of(Integer),
-          "child_duration" => kind_of(Float),
-          "child_gc_duration" => kind_of(Float),
-          "count" => 1,
-          "duration" => kind_of(Float),
-          "gc_duration" => kind_of(Float),
-          "name" => "sql.active_record",
-          "start" => kind_of(Float),
-          "title" => ""
-        }
-      ])
+      expect(transaction).to include_event(
+        "body" => "SQL",
+        "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
+        "count" => 1,
+        "name" => "sql.active_record",
+        "title" => ""
+      )
     end
   end
 
@@ -139,7 +93,7 @@ shared_examples "activesupport instrument override" do
         Appsignal::Transaction.complete_current!
       end
 
-      expect(transaction.to_h["events"]).to match([])
+      expect(transaction).to_not include_events
     end
   end
 end

--- a/spec/lib/appsignal/hooks/active_support_notifications/start_finish_shared_examples.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications/start_finish_shared_examples.rb
@@ -5,44 +5,26 @@ shared_examples "activesupport start finish override" do
     instrumenter.start("sql.active_record", :sql => "SQL")
     instrumenter.finish("sql.active_record", {})
 
-    expect(transaction.to_h["events"]).to match([
-      {
-        "allocation_count" => kind_of(Integer),
-        "body" => "",
-        "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
-        "child_allocation_count" => kind_of(Integer),
-        "child_duration" => kind_of(Float),
-        "child_gc_duration" => kind_of(Float),
-        "count" => 1,
-        "duration" => kind_of(Float),
-        "gc_duration" => kind_of(Float),
-        "name" => "sql.active_record",
-        "start" => kind_of(Float),
-        "title" => ""
-      }
-    ])
+    expect(transaction).to include_event(
+      "body" => "",
+      "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
+      "count" => 1,
+      "name" => "sql.active_record",
+      "title" => ""
+    )
   end
 
   it "instruments an ActiveSupport::Notifications.start/finish event with payload on finish" do
     instrumenter.start("sql.active_record", {})
     instrumenter.finish("sql.active_record", :sql => "SQL")
 
-    expect(transaction.to_h["events"]).to match([
-      {
-        "allocation_count" => kind_of(Integer),
-        "body" => "SQL",
-        "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
-        "child_allocation_count" => kind_of(Integer),
-        "child_duration" => kind_of(Float),
-        "child_gc_duration" => kind_of(Float),
-        "count" => 1,
-        "duration" => kind_of(Float),
-        "gc_duration" => kind_of(Float),
-        "name" => "sql.active_record",
-        "start" => kind_of(Float),
-        "title" => ""
-      }
-    ])
+    expect(transaction).to include_event(
+      "body" => "SQL",
+      "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
+      "count" => 1,
+      "name" => "sql.active_record",
+      "title" => ""
+    )
   end
 
   it "does not instrument events whose name starts with a bang" do
@@ -52,7 +34,7 @@ shared_examples "activesupport start finish override" do
     instrumenter.start("!sql.active_record", {})
     instrumenter.finish("!sql.active_record", {})
 
-    expect(transaction.to_h["events"]).to be_empty
+    expect(transaction).to_not include_events
   end
 
   context "when a transaction is completed in an instrumented block" do
@@ -63,7 +45,7 @@ shared_examples "activesupport start finish override" do
       Appsignal::Transaction.complete_current!
       instrumenter.finish("sql.active_record", {})
 
-      expect(transaction.to_h["events"]).to match([])
+      expect(transaction).to_not include_events
     end
   end
 end

--- a/spec/lib/appsignal/hooks/dry_monitor_spec.rb
+++ b/spec/lib/appsignal/hooks/dry_monitor_spec.rb
@@ -53,22 +53,13 @@ if DependencyHelper.dry_monitor_present?
 
       it "creates an sql event" do
         notifications.instrument(event_id, payload)
-        expect(transaction.to_h["events"]).to match([
-          {
-            "allocation_count" => kind_of(Integer),
-            "body" => "SELECT * FROM users",
-            "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
-            "child_allocation_count" => kind_of(Integer),
-            "child_duration" => kind_of(Float),
-            "child_gc_duration" => kind_of(Float),
-            "count" => 1,
-            "duration" => kind_of(Float),
-            "gc_duration" => kind_of(Float),
-            "name" => "query.postgres",
-            "start" => kind_of(Float),
-            "title" => "query.postgres"
-          }
-        ])
+        expect(transaction).to include_event(
+          "body" => "SELECT * FROM users",
+          "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
+          "count" => 1,
+          "name" => "query.postgres",
+          "title" => "query.postgres"
+        )
       end
     end
 
@@ -82,22 +73,13 @@ if DependencyHelper.dry_monitor_present?
 
       it "creates a generic event" do
         notifications.instrument(event_id, payload)
-        expect(transaction.to_h["events"]).to match([
-          {
-            "allocation_count" => kind_of(Integer),
-            "body" => "",
-            "body_format" => Appsignal::EventFormatter::DEFAULT,
-            "child_allocation_count" => kind_of(Integer),
-            "child_duration" => kind_of(Float),
-            "child_gc_duration" => kind_of(Float),
-            "count" => 1,
-            "duration" => kind_of(Float),
-            "gc_duration" => kind_of(Float),
-            "name" => "foo",
-            "start" => kind_of(Float),
-            "title" => ""
-          }
-        ])
+        expect(transaction).to include_event(
+          "body" => "",
+          "body_format" => Appsignal::EventFormatter::DEFAULT,
+          "count" => 1,
+          "name" => "foo",
+          "title" => ""
+        )
       end
     end
   end

--- a/spec/lib/appsignal/hooks/excon_spec.rb
+++ b/spec/lib/appsignal/hooks/excon_spec.rb
@@ -40,12 +40,10 @@ describe Appsignal::Hooks::ExconHook do
         }
         Excon.defaults[:instrumentor].instrument("excon.request", data) {} # rubocop:disable Lint/EmptyBlock
 
-        expect(transaction.to_h["events"]).to include(
-          hash_including(
-            "name" => "request.excon",
-            "title" => "GET http://www.google.com",
-            "body" => ""
-          )
+        expect(transaction).to include_event(
+          "name" => "request.excon",
+          "title" => "GET http://www.google.com",
+          "body" => ""
         )
       end
 
@@ -53,12 +51,10 @@ describe Appsignal::Hooks::ExconHook do
         data = { :host => "www.google.com" }
         Excon.defaults[:instrumentor].instrument("excon.response", data) {} # rubocop:disable Lint/EmptyBlock
 
-        expect(transaction.to_h["events"]).to include(
-          hash_including(
-            "name" => "response.excon",
-            "title" => "www.google.com",
-            "body" => ""
-          )
+        expect(transaction).to include_event(
+          "name" => "response.excon",
+          "title" => "www.google.com",
+          "body" => ""
         )
       end
     end

--- a/spec/lib/appsignal/hooks/redis_client_spec.rb
+++ b/spec/lib/appsignal/hooks/redis_client_spec.rb
@@ -88,13 +88,10 @@ describe Appsignal::Hooks::RedisClientHook do
                 connection = RedisClient::RubyConnection.new client_config
                 expect(connection.write([:get, "key"])).to eql("stub_write")
 
-                transaction_hash = transaction.to_h
-                expect(transaction_hash["events"]).to include(
-                  hash_including(
-                    "name" => "query.redis",
-                    "body" => "get ?",
-                    "title" => "stub_id"
-                  )
+                expect(transaction).to include_event(
+                  "name" => "query.redis",
+                  "body" => "get ?",
+                  "title" => "stub_id"
                 )
               end
 
@@ -103,16 +100,13 @@ describe Appsignal::Hooks::RedisClientHook do
                 script = "return redis.call('set',KEYS[1],ARGV[1])"
                 keys = ["foo"]
                 argv = ["bar"]
-                expect(connection.write([:eval, script, keys.size, keys,
-                                         argv])).to eql("stub_write")
+                expect(connection.write([:eval, script, keys.size, keys, argv]))
+                  .to eql("stub_write")
 
-                transaction_hash = transaction.to_h
-                expect(transaction_hash["events"]).to include(
-                  hash_including(
-                    "name" => "query.redis",
-                    "body" => "#{script} ? ?",
-                    "title" => "stub_id"
-                  )
+                expect(transaction).to include_event(
+                  "name" => "query.redis",
+                  "body" => "#{script} ? ?",
+                  "title" => "stub_id"
                 )
               end
             end
@@ -181,13 +175,10 @@ describe Appsignal::Hooks::RedisClientHook do
                   connection = RedisClient::HiredisConnection.new client_config
                   expect(connection.write([:get, "key"])).to eql("stub_write")
 
-                  transaction_hash = transaction.to_h
-                  expect(transaction_hash["events"]).to include(
-                    hash_including(
-                      "name" => "query.redis",
-                      "body" => "get ?",
-                      "title" => "stub_id"
-                    )
+                  expect(transaction).to include_event(
+                    "name" => "query.redis",
+                    "body" => "get ?",
+                    "title" => "stub_id"
                   )
                 end
 
@@ -199,13 +190,10 @@ describe Appsignal::Hooks::RedisClientHook do
                   expect(connection.write([:eval, script, keys.size, keys,
                                            argv])).to eql("stub_write")
 
-                  transaction_hash = transaction.to_h
-                  expect(transaction_hash["events"]).to include(
-                    hash_including(
-                      "name" => "query.redis",
-                      "body" => "#{script} ? ?",
-                      "title" => "stub_id"
-                    )
+                  expect(transaction).to include_event(
+                    "name" => "query.redis",
+                    "body" => "#{script} ? ?",
+                    "title" => "stub_id"
                   )
                 end
               end

--- a/spec/lib/appsignal/hooks/redis_spec.rb
+++ b/spec/lib/appsignal/hooks/redis_spec.rb
@@ -81,14 +81,11 @@ describe Appsignal::Hooks::RedisHook do
                 client = Redis::Client.new
                 expect(client.write([:get, "key"])).to eql("stub_write")
 
-                transaction_hash = transaction.to_h
-                expect(transaction_hash["events"]).to include(
-                                                        hash_including(
-                                                          "name" => "query.redis",
-                                                          "body" => "get ?",
-                                                          "title" => "stub_id"
-                                                        )
-                                                      )
+                expect(transaction).to include_event(
+                  "name" => "query.redis",
+                  "body" => "get ?",
+                  "title" => "stub_id"
+                )
               end
 
               it "instrument a redis script call" do
@@ -98,14 +95,11 @@ describe Appsignal::Hooks::RedisHook do
                 argv = ["bar"]
                 expect(client.write([:eval, script, keys.size, keys, argv])).to eql("stub_write")
 
-                transaction_hash = transaction.to_h
-                expect(transaction_hash["events"]).to include(
-                                                        hash_including(
-                                                          "name" => "query.redis",
-                                                          "body" => "#{script} ? ?",
-                                                          "title" => "stub_id"
-                                                        )
-                                                      )
+                expect(transaction).to include_event(
+                  "name" => "query.redis",
+                  "body" => "#{script} ? ?",
+                  "title" => "stub_id"
+                )
               end
             end
           end

--- a/spec/lib/appsignal/hooks/resque_spec.rb
+++ b/spec/lib/appsignal/hooks/resque_spec.rb
@@ -53,20 +53,14 @@ describe Appsignal::Hooks::ResqueHook do
         perform_rescue_job(ResqueTestJob)
 
         transaction = last_transaction
-        transaction_hash = transaction.to_h
-        expect(transaction_hash).to include(
-          "id" => kind_of(String),
-          "action" => "ResqueTestJob#perform",
-          "error" => nil,
-          "namespace" => namespace,
-          "metadata" => {},
-          "sample_data" => {
-            "breadcrumbs" => [],
-            "tags" => { "queue" => queue }
-          }
-        )
-        expect(transaction_hash["events"].map { |e| e["name"] })
-          .to eql(["perform.resque"])
+        expect(transaction).to have_id
+        expect(transaction).to have_namespace(namespace)
+        expect(transaction).to have_action("ResqueTestJob#perform")
+        expect(transaction).to_not have_error
+        expect(transaction).to_not include_metadata
+        expect(transaction).to_not include_breadcrumbs
+        expect(transaction).to include_tags("queue" => queue)
+        expect(transaction).to include_event("name" => "perform.resque")
       end
 
       context "with error" do
@@ -76,22 +70,14 @@ describe Appsignal::Hooks::ResqueHook do
           end.to raise_error(RuntimeError, "resque job error")
 
           transaction = last_transaction
-          transaction_hash = transaction.to_h
-          expect(transaction_hash).to include(
-            "id" => kind_of(String),
-            "action" => "ResqueErrorTestJob#perform",
-            "error" => {
-              "name" => "RuntimeError",
-              "message" => "resque job error",
-              "backtrace" => kind_of(String)
-            },
-            "namespace" => namespace,
-            "metadata" => {},
-            "sample_data" => {
-              "breadcrumbs" => [],
-              "tags" => { "queue" => queue }
-            }
-          )
+          expect(transaction).to have_id
+          expect(transaction).to have_namespace(namespace)
+          expect(transaction).to have_action("ResqueErrorTestJob#perform")
+          expect(transaction).to have_error("RuntimeError", "resque job error")
+          expect(transaction).to_not include_metadata
+          expect(transaction).to_not include_breadcrumbs
+          expect(transaction).to include_tags("queue" => queue)
+          expect(transaction).to include_event("name" => "perform.resque")
         end
       end
 
@@ -115,25 +101,23 @@ describe Appsignal::Hooks::ResqueHook do
           )
 
           transaction = last_transaction
-          transaction_hash = transaction.to_h
-          expect(transaction_hash).to include(
-            "id" => kind_of(String),
-            "action" => "ResqueTestJob#perform",
-            "error" => nil,
-            "namespace" => namespace,
-            "metadata" => {},
-            "sample_data" => {
-              "tags" => { "queue" => queue },
-              "breadcrumbs" => [],
-              "params" => [
-                "foo",
-                {
-                  "foo" => "[FILTERED]",
-                  "bar" => "Bar",
-                  "baz" => { "1" => "foo" }
-                }
-              ]
-            }
+          expect(transaction).to have_id
+          expect(transaction).to have_namespace(namespace)
+          expect(transaction).to have_action("ResqueTestJob#perform")
+          expect(transaction).to_not have_error
+          expect(transaction).to_not include_metadata
+          expect(transaction).to_not include_breadcrumbs
+          expect(transaction).to include_tags("queue" => queue)
+          expect(transaction).to include_event("name" => "perform.resque")
+          expect(transaction).to include_params(
+            [
+              "foo",
+              {
+                "foo" => "[FILTERED]",
+                "bar" => "Bar",
+                "baz" => { "1" => "foo" }
+              }
+            ]
           )
         end
       end
@@ -173,19 +157,15 @@ describe Appsignal::Hooks::ResqueHook do
           )
 
           transaction = last_transaction
-          transaction_hash = transaction.to_h
-          expect(transaction_hash).to include(
-            "id" => kind_of(String),
-            "action" => "ResqueTestJobByActiveJob#perform",
-            "error" => nil,
-            "namespace" => namespace,
-            "metadata" => {},
-            "sample_data" => {
-              "breadcrumbs" => [],
-              "tags" => { "queue" => queue }
-              # Params will be set by the ActiveJob integration
-            }
-          )
+          expect(transaction).to have_id
+          expect(transaction).to have_namespace(namespace)
+          expect(transaction).to have_action("ResqueTestJobByActiveJob#perform")
+          expect(transaction).to_not have_error
+          expect(transaction).to_not include_metadata
+          expect(transaction).to_not include_breadcrumbs
+          expect(transaction).to include_tags("queue" => queue)
+          expect(transaction).to include_event("name" => "perform.resque")
+          expect(transaction).to_not include_params
         end
       end
     end

--- a/spec/lib/appsignal/integrations/hanami_spec.rb
+++ b/spec/lib/appsignal/integrations/hanami_spec.rb
@@ -159,9 +159,7 @@ if DependencyHelper.hanami2_present?
           it "does not set the action name" do
             make_request(env)
 
-            expect(transaction.to_h).to include(
-              "action" => nil
-            )
+            expect(transaction).to_not have_action
           end
         end
 
@@ -171,9 +169,7 @@ if DependencyHelper.hanami2_present?
           it "sets action name on the transaction" do
             make_request(env)
 
-            expect(transaction.to_h).to include(
-              "action" => "HanamiApp::Actions::Books::Index::TestClass"
-            )
+            expect(transaction).to have_action("HanamiApp::Actions::Books::Index::TestClass")
           end
         end
       end

--- a/spec/lib/appsignal/integrations/http_spec.rb
+++ b/spec/lib/appsignal/integrations/http_spec.rb
@@ -23,9 +23,8 @@ if DependencyHelper.http_present?
 
       HTTP.get("http://www.google.com")
 
-      transaction_hash = transaction.to_h
-      expect(transaction_hash).to include("namespace" => Appsignal::Transaction::HTTP_REQUEST)
-      expect(transaction_hash["events"].first).to include(
+      expect(transaction).to have_namespace(Appsignal::Transaction::HTTP_REQUEST)
+      expect(transaction).to include_event(
         "body" => "",
         "body_format" => Appsignal::EventFormatter::DEFAULT,
         "name" => "request.http_rb",
@@ -38,9 +37,8 @@ if DependencyHelper.http_present?
 
       HTTP.get("https://www.google.com")
 
-      transaction_hash = transaction.to_h
-      expect(transaction_hash).to include("namespace" => Appsignal::Transaction::HTTP_REQUEST)
-      expect(transaction_hash["events"].first).to include(
+      expect(transaction).to have_namespace(Appsignal::Transaction::HTTP_REQUEST)
+      expect(transaction).to include_event(
         "body" => "",
         "body_format" => Appsignal::EventFormatter::DEFAULT,
         "name" => "request.http_rb",
@@ -54,7 +52,7 @@ if DependencyHelper.http_present?
 
         HTTP.get("https://www.google.com", :params => { :q => "Appsignal" })
 
-        expect(transaction.to_h["events"].first).to include(
+        expect(transaction).to include_event(
           "body" => "",
           "title" => "GET https://www.google.com"
         )
@@ -66,7 +64,7 @@ if DependencyHelper.http_present?
 
         HTTP.post("https://www.google.com", :json => { :q => "Appsignal" })
 
-        expect(transaction.to_h["events"].first).to include(
+        expect(transaction).to include_event(
           "body" => "",
           "title" => "POST https://www.google.com"
         )
@@ -83,20 +81,14 @@ if DependencyHelper.http_present?
           HTTP.get("https://www.google.com")
         end.to raise_error(ExampleException)
 
-        transaction_hash = transaction.to_h
-        expect(transaction_hash).to include("namespace" => Appsignal::Transaction::HTTP_REQUEST)
-        expect(transaction_hash["events"].first).to include(
+        expect(transaction).to have_namespace(Appsignal::Transaction::HTTP_REQUEST)
+        expect(transaction).to include_event(
           "body" => "",
           "body_format" => Appsignal::EventFormatter::DEFAULT,
           "name" => "request.http_rb",
           "title" => "GET https://www.google.com"
         )
-
-        expect(transaction_hash["error"]).to include(
-          "backtrace" => kind_of(String),
-          "name" => error.class.name,
-          "message" => error.message
-        )
+        expect(transaction).to have_error(error.class.name, error.message)
       end
     end
 
@@ -112,7 +104,7 @@ if DependencyHelper.http_present?
 
         HTTP.get(request_uri.new("http://www.google.com"))
 
-        expect(transaction.to_h["events"].first).to include(
+        expect(transaction).to include_event(
           "name" => "request.http_rb",
           "title" => "GET http://www.google.com"
         )
@@ -123,7 +115,7 @@ if DependencyHelper.http_present?
 
         HTTP.get(URI("http://www.google.com"))
 
-        expect(transaction.to_h["events"].first).to include(
+        expect(transaction).to include_event(
           "name" => "request.http_rb",
           "title" => "GET http://www.google.com"
         )
@@ -134,7 +126,7 @@ if DependencyHelper.http_present?
 
         HTTP.get("http://www.google.com")
 
-        expect(transaction.to_h["events"].first).to include(
+        expect(transaction).to include_event(
           "name" => "request.http_rb",
           "title" => "GET http://www.google.com"
         )

--- a/spec/lib/appsignal/integrations/que_spec.rb
+++ b/spec/lib/appsignal/integrations/que_spec.rb
@@ -53,38 +53,27 @@ if DependencyHelper.que_present?
             perform_que_job(instance)
           end.to change { created_transactions.length }.by(1)
 
-          expect(last_transaction).to be_completed
-          transaction_hash = last_transaction.to_h
-          expect(transaction_hash).to include(
-            "action" => "MyQueJob#run",
-            "id" => instance_of(String),
-            "namespace" => Appsignal::Transaction::BACKGROUND_JOB
-          )
-          expect(transaction_hash["error"]).to be_nil
-          expect(transaction_hash["events"].first).to include(
-            "allocation_count" => kind_of(Integer),
+          transaction = last_transaction
+          expect(transaction).to have_id
+          expect(transaction).to have_namespace(Appsignal::Transaction::BACKGROUND_JOB)
+          expect(transaction).to have_action("MyQueJob#run")
+          expect(transaction).to_not have_error
+          expect(transaction).to include_event(
             "body" => "",
             "body_format" => Appsignal::EventFormatter::DEFAULT,
-            "child_allocation_count" => kind_of(Integer),
-            "child_duration" => kind_of(Float),
-            "child_gc_duration" => kind_of(Float),
             "count" => 1,
-            "gc_duration" => kind_of(Float),
-            "start" => kind_of(Float),
-            "duration" => kind_of(Float),
             "name" => "perform_job.que",
             "title" => ""
           )
-          expect(transaction_hash["sample_data"]).to include(
-            "params" => %w[1 birds],
-            "metadata" => {
-              "attempts" => 0,
-              "id" => 123,
-              "priority" => 100,
-              "queue" => "dfl",
-              "run_at" => fixed_time.to_s
-            }
+          expect(transaction).to include_params(%w[1 birds])
+          expect(transaction).to include_sample_metadata(
+            "attempts" => 0,
+            "id" => 123,
+            "priority" => 100,
+            "queue" => "dfl",
+            "run_at" => fixed_time.to_s
           )
+          expect(transaction).to be_completed
         end
       end
 
@@ -100,28 +89,20 @@ if DependencyHelper.que_present?
             end.to raise_error(ExampleException)
           end.to change { created_transactions.length }.by(1)
 
-          expect(last_transaction).to be_completed
-          transaction_hash = last_transaction.to_h
-          expect(transaction_hash).to include(
-            "action" => "MyQueJob#run",
-            "id" => instance_of(String),
-            "namespace" => Appsignal::Transaction::BACKGROUND_JOB
+          transaction = last_transaction
+          expect(transaction).to have_id
+          expect(transaction).to have_action("MyQueJob#run")
+          expect(transaction).to have_namespace(Appsignal::Transaction::BACKGROUND_JOB)
+          expect(transaction).to have_error(error.class.name, error.message)
+          expect(transaction).to include_params(%w[1 birds])
+          expect(transaction).to include_sample_metadata(
+            "attempts" => 0,
+            "id" => 123,
+            "priority" => 100,
+            "queue" => "dfl",
+            "run_at" => fixed_time.to_s
           )
-          expect(transaction_hash["error"]).to include(
-            "backtrace" => kind_of(String),
-            "name" => error.class.name,
-            "message" => error.message
-          )
-          expect(transaction_hash["sample_data"]).to include(
-            "params" => %w[1 birds],
-            "metadata" => {
-              "attempts" => 0,
-              "id" => 123,
-              "priority" => 100,
-              "queue" => "dfl",
-              "run_at" => fixed_time.to_s
-            }
-          )
+          expect(transaction).to be_completed
         end
       end
 
@@ -133,28 +114,20 @@ if DependencyHelper.que_present?
 
           expect { perform_que_job(instance) }.to change { created_transactions.length }.by(1)
 
-          expect(last_transaction).to be_completed
-          transaction_hash = last_transaction.to_h
-          expect(transaction_hash).to include(
-            "action" => "MyQueJob#run",
-            "id" => instance_of(String),
-            "namespace" => Appsignal::Transaction::BACKGROUND_JOB
+          transaction = last_transaction
+          expect(transaction).to have_id
+          expect(transaction).to have_action("MyQueJob#run")
+          expect(transaction).to have_namespace(Appsignal::Transaction::BACKGROUND_JOB)
+          expect(transaction).to have_error(error.class.name, error.message)
+          expect(transaction).to include_params(%w[1 birds])
+          expect(transaction).to include_sample_metadata(
+            "attempts" => 0,
+            "id" => 123,
+            "priority" => 100,
+            "queue" => "dfl",
+            "run_at" => fixed_time.to_s
           )
-          expect(transaction_hash["error"]).to include(
-            "backtrace" => kind_of(String),
-            "name" => error.class.name,
-            "message" => error.message
-          )
-          expect(transaction_hash["sample_data"]).to include(
-            "params" => %w[1 birds],
-            "metadata" => {
-              "attempts" => 0,
-              "id" => 123,
-              "priority" => 100,
-              "queue" => "dfl",
-              "run_at" => fixed_time.to_s
-            }
-          )
+          expect(transaction).to be_completed
         end
       end
 
@@ -170,9 +143,9 @@ if DependencyHelper.que_present?
         it "uses the custom action" do
           perform_que_job(instance)
 
-          expect(last_transaction).to be_completed
-          transaction_hash = last_transaction.to_h
-          expect(transaction_hash).to include("action" => "MyCustomJob#perform")
+          transaction = last_transaction
+          expect(transaction).to have_action("MyCustomJob#perform")
+          expect(transaction).to be_completed
         end
       end
     end

--- a/spec/lib/appsignal/rack/abstract_middleware_spec.rb
+++ b/spec/lib/appsignal/rack/abstract_middleware_spec.rb
@@ -1,5 +1,5 @@
 describe Appsignal::Rack::AbstractMiddleware do
-  let(:app) { double(:call => true) }
+  let(:app) { DummyApp.new }
   let(:request_path) { "/some/path" }
   let(:env) do
     Rack::MockRequest.env_for(
@@ -9,224 +9,184 @@ describe Appsignal::Rack::AbstractMiddleware do
     )
   end
   let(:options) { {} }
-  let(:middleware) { Appsignal::Rack::AbstractMiddleware.new(app, options) }
+  let(:middleware) { described_class.new(app, options) }
 
   before(:context) { start_agent }
   around { |example| keep_transactions { example.run } }
 
-  def make_request(env)
+  def make_request
     middleware.call(env)
   end
 
-  def make_request_with_error(env, error_class, error_message)
-    expect { make_request(env) }.to raise_error(error_class, error_message)
+  def make_request_with_error(error_class, error_message)
+    expect { make_request }.to raise_error(error_class, error_message)
   end
 
   describe "#call" do
-    context "when appsignal is not active" do
+    context "when not active" do
       before { allow(Appsignal).to receive(:active?).and_return(false) }
 
-      it "does not instrument requests" do
-        expect { make_request(env) }.to_not(change { created_transactions.count })
+      it "does not instrument the request" do
+        expect { make_request }.to_not(change { created_transactions.count })
       end
 
       it "calls the next middleware in the stack" do
-        expect(app).to receive(:call).with(env)
-        make_request(env)
+        make_request
+        expect(app).to be_called
       end
     end
 
     context "when appsignal is active" do
       before { allow(Appsignal).to receive(:active?).and_return(true) }
 
-      it "calls the next middleware in the stack" do
-        make_request(env)
+      it "creates a transaction for the request" do
+        expect { make_request }.to(change { created_transactions.count }.by(1))
 
-        expect(app).to have_received(:call).with(env)
+        expect(last_transaction).to have_namespace(Appsignal::Transaction::HTTP_REQUEST)
       end
 
-      context "without an exception" do
-        it "create a transaction for the request" do
-          expect { make_request(env) }.to(change { created_transactions.count }.by(1))
+      context "without an error" do
+        before { make_request }
 
-          expect(last_transaction.to_h).to include(
-            "namespace" => Appsignal::Transaction::HTTP_REQUEST,
-            "action" => nil,
-            "error" => nil
-          )
+        it "calls the next middleware in the stack" do
+          expect(app).to be_called
         end
 
-        it "reports a process.abstract event" do
-          make_request(env)
+        it "does not record an error" do
+          expect(last_transaction).to_not have_error
+        end
 
-          expect(last_transaction.to_h).to include(
-            "events" => [
-              hash_including(
-                "body" => "",
-                "body_format" => Appsignal::EventFormatter::DEFAULT,
-                "count" => 1,
-                "name" => "process.abstract",
-                "title" => ""
-              )
-            ]
-          )
+        it "records an instrumentation event" do
+          expect(last_transaction).to include_event(:name => "process.abstract")
+        end
+
+        it "completes the transaction" do
+          expect(last_transaction).to be_completed
+          expect(Appsignal::Transaction.current)
+            .to be_kind_of(Appsignal::Transaction::NilTransaction)
         end
 
         context "when instrument_span_name option is nil" do
           let(:options) { { :instrument_span_name => nil } }
 
-          it "does not report an event" do
-            make_request(env)
-
-            expect(last_transaction.to_h).to include(
-              "events" => []
-            )
+          it "does not record an instrumentation event" do
+            expect(last_transaction).to_not include_events
           end
-        end
-
-        it "completes the transaction" do
-          make_request(env)
-          expect(last_transaction).to be_completed
         end
       end
 
-      context "with an exception" do
+      context "with an error" do
         let(:error) { ExampleException.new("error message") }
         let(:app) { lambda { |_env| raise ExampleException, "error message" } }
-        before do
-          expect { make_request_with_error(env, ExampleException, "error message") }
+
+        it "create a transaction for the request" do
+          expect { make_request_with_error(ExampleException, "error message") }
             .to(change { created_transactions.count }.by(1))
+
+          expect(last_transaction).to have_namespace(Appsignal::Transaction::HTTP_REQUEST)
         end
 
-        it "creates a transaction for the request and records the exception" do
-          expect(last_transaction.to_h).to include(
-            "error" => hash_including(
-              "name" => "ExampleException",
-              "message" => "error message",
-              "backtrace" => kind_of(String)
-            )
-          )
-        end
-
-        it "completes the transaction" do
-          expect(last_transaction).to be_completed
-        end
-
-        context "with :report_errors set to false" do
-          let(:app) { lambda { |_env| raise ExampleException, "error message" } }
-          let(:options) { { :report_errors => false } }
-
-          it "does not record the exception on the transaction" do
-            make_request_with_error(env, ExampleException, "error message")
-
-            expect(last_transaction.to_h).to include("error" => nil)
+        describe "error" do
+          before do
+            make_request_with_error(ExampleException, "error message")
           end
-        end
 
-        context "with :report_errors set to true" do
-          let(:app) { lambda { |_env| raise ExampleException, "error message" } }
-          let(:options) { { :report_errors => true } }
-
-          it "records the exception on the transaction" do
-            make_request_with_error(env, ExampleException, "error message")
-
-            expect(last_transaction.to_h).to include(
-              "error" => hash_including(
-                "name" => "ExampleException",
-                "message" => "error message"
-              )
-            )
+          it "records the error" do
+            expect(last_transaction).to have_error("ExampleException", "error message")
           end
-        end
 
-        context "with :report_errors set to a lambda that returns false" do
-          let(:app) { lambda { |_env| raise ExampleException, "error message" } }
-          let(:options) { { :report_errors => lambda { |_env| false } } }
-
-          it "does not record the exception on the transaction" do
-            make_request_with_error(env, ExampleException, "error message")
-
-            expect(last_transaction.to_h).to include("error" => nil)
+          it "completes the transaction" do
+            expect(last_transaction).to be_completed
+            expect(Appsignal::Transaction.current)
+              .to be_kind_of(Appsignal::Transaction::NilTransaction)
           end
-        end
 
-        context "with :report_errors set to a lambda that returns true" do
-          let(:app) { lambda { |_env| raise ExampleException, "error message" } }
-          let(:options) { { :report_errors => lambda { |_env| true } } }
+          context "with :report_errors set to false" do
+            let(:app) { lambda { |_env| raise ExampleException, "error message" } }
+            let(:options) { { :report_errors => false } }
 
-          it "records the exception on the transaction" do
-            make_request_with_error(env, ExampleException, "error message")
+            it "does not record the exception on the transaction" do
+              expect(last_transaction).to_not have_error
+            end
+          end
 
-            expect(last_transaction.to_h).to include(
-              "error" => hash_including(
-                "name" => "ExampleException",
-                "message" => "error message"
-              )
-            )
+          context "with :report_errors set to true" do
+            let(:app) { lambda { |_env| raise ExampleException, "error message" } }
+            let(:options) { { :report_errors => true } }
+
+            it "records the exception on the transaction" do
+              expect(last_transaction).to have_error("ExampleException", "error message")
+            end
+          end
+
+          context "with :report_errors set to a lambda that returns false" do
+            let(:app) { lambda { |_env| raise ExampleException, "error message" } }
+            let(:options) { { :report_errors => lambda { |_env| false } } }
+
+            it "does not record the exception on the transaction" do
+              expect(last_transaction).to_not have_error
+            end
+          end
+
+          context "with :report_errors set to a lambda that returns true" do
+            let(:app) { lambda { |_env| raise ExampleException, "error message" } }
+            let(:options) { { :report_errors => lambda { |_env| true } } }
+
+            it "records the exception on the transaction" do
+              expect(last_transaction).to have_error("ExampleException", "error message")
+            end
           end
         end
       end
 
       context "without action name metadata" do
         it "reports no action name" do
-          make_request(env)
+          make_request
 
-          expect(last_transaction.to_h).to include("action" => nil)
+          expect(last_transaction).to_not have_action
         end
       end
 
       context "with appsignal.route env" do
-        before do
-          env["appsignal.route"] = "POST /my-route"
-        end
-
         it "reports the appsignal.route value as the action name" do
-          make_request(env)
+          env["appsignal.route"] = "POST /my-route"
+          make_request
 
-          expect(last_transaction.to_h).to include("action" => "POST /my-route")
+          expect(last_transaction).to have_action("POST /my-route")
         end
       end
 
       context "with appsignal.action env" do
-        before do
-          env["appsignal.action"] = "POST /my-action"
-        end
-
         it "reports the appsignal.route value as the action name" do
-          make_request(env)
+          env["appsignal.action"] = "POST /my-action"
+          make_request
 
-          expect(last_transaction.to_h).to include("action" => "POST /my-action")
+          expect(last_transaction).to have_action("POST /my-action")
         end
       end
 
       describe "request metadata" do
-        before do
-          env.merge!("PATH_INFO" => "/some/path", "REQUEST_METHOD" => "GET")
-        end
-
         it "sets request metadata" do
-          make_request(env)
+          env.merge!("PATH_INFO" => "/some/path", "REQUEST_METHOD" => "GET")
+          make_request
 
-          expect(last_transaction.to_h).to include(
-            "metadata" => {
-              "method" => "GET",
-              "path" => "/some/path"
-            },
-            "sample_data" => hash_including(
-              "environment" => hash_including(
-                "REQUEST_METHOD" => "GET",
-                "PATH_INFO" => "/some/path"
-                # and more, but we don't need to test Rack mock defaults
-              )
-            )
+          expect(last_transaction).to include_metadata(
+            "method" => "GET",
+            "path" => "/some/path"
+          )
+          expect(last_transaction).to include_environment(
+            "REQUEST_METHOD" => "GET",
+            "PATH_INFO" => "/some/path"
+            # and more, but we don't need to test Rack mock defaults
           )
         end
 
         context "with an invalid HTTP request method" do
           it "stores the invalid HTTP request method" do
-            make_request(env.merge("REQUEST_METHOD" => "FOO"))
+            env["REQUEST_METHOD"] = "FOO"
+            make_request
 
-            expect(last_transaction.to_h["metadata"]).to include("method" => "FOO")
+            expect(last_transaction).to include_metadata("method" => "FOO")
           end
         end
 
@@ -239,54 +199,45 @@ describe Appsignal::Rack::AbstractMiddleware do
 
           let(:options) { { :request_class => BrokenRequestMethodRequest } }
           it "does not store the invalid HTTP request method" do
-            make_request(env.merge("REQUEST_METHOD" => "FOO"))
+            env["REQUEST_METHOD"] = "FOO"
+            make_request
 
-            expect(last_transaction.to_h["metadata"]).to_not have_key("method")
+            expect(last_transaction).to_not include_metadata("method" => anything)
           end
         end
 
         it "sets request parameters" do
-          make_request(env)
+          make_request
 
-          expect(last_transaction.to_h).to include(
-            "sample_data" => hash_including(
-              "params" => hash_including(
-                "page" => "2",
-                "query" => "lorem"
-              )
-            )
+          expect(last_transaction).to include_params(
+            "page" => "2",
+            "query" => "lorem"
           )
         end
 
         context "when setting custom params" do
           let(:app) do
-            lambda { |_env| Appsignal::Transaction.current.set_params("custom" => "param") }
+            DummyApp.new do |_env|
+              Appsignal::Transaction.current.set_params("custom" => "param")
+            end
           end
 
           it "allow custom request parameters to be set" do
-            make_request(env)
+            make_request
 
-            expect(last_transaction.to_h).to include(
-              "sample_data" => hash_including(
-                "params" => hash_including(
-                  "custom" => "param"
-                )
-              )
-            )
+            expect(last_transaction).to include_params("custom" => "param")
           end
         end
       end
 
       context "with queue start header" do
         let(:queue_start_time) { fixed_time * 1_000 }
-        before do
-          env["HTTP_X_REQUEST_START"] = "t=#{queue_start_time.to_i}" # in milliseconds
-        end
 
         it "sets the queue start" do
-          make_request(env)
+          env["HTTP_X_REQUEST_START"] = "t=#{queue_start_time.to_i}" # in milliseconds
+          make_request
 
-          expect(last_transaction.ext.queue_start).to eq(queue_start_time)
+          expect(last_transaction).to have_queue_start(queue_start_time)
         end
       end
 
@@ -316,13 +267,9 @@ describe Appsignal::Rack::AbstractMiddleware do
         end
 
         it "uses the overridden request class and params method to fetch params" do
-          make_request(env)
+          make_request
 
-          expect(last_transaction.to_h).to include(
-            "sample_data" => hash_including(
-              "params" => { "abc" => "123" }
-            )
-          )
+          expect(last_transaction).to include_params("abc" => "123")
         end
       end
 
@@ -332,23 +279,23 @@ describe Appsignal::Rack::AbstractMiddleware do
         end
 
         it "uses the existing transaction" do
-          make_request(env)
+          make_request
 
-          expect { make_request(env) }.to_not(change { created_transactions.count })
+          expect { make_request }.to_not(change { created_transactions.count })
         end
 
-        context "with exception" do
+        context "with error" do
           let(:app) { lambda { |_env| raise ExampleException, "error message" } }
 
-          it "doesn't record the exception on the transaction" do
-            make_request_with_error(env, ExampleException, "error message")
+          it "doesn't record the error on the transaction" do
+            make_request_with_error(ExampleException, "error message")
 
-            expect(last_transaction.to_h).to include("error" => nil)
+            expect(last_transaction).to_not have_error
           end
         end
 
         it "doesn't complete the existing transaction" do
-          make_request(env)
+          make_request
 
           expect(env[Appsignal::Rack::APPSIGNAL_TRANSACTION]).to_not be_completed
         end
@@ -357,9 +304,9 @@ describe Appsignal::Rack::AbstractMiddleware do
           it "does not overwrite the action name" do
             env[Appsignal::Rack::APPSIGNAL_TRANSACTION].set_action("My custom action")
             env["appsignal.action"] = "POST /my-action"
-            make_request(env)
+            make_request
 
-            expect(last_transaction.to_h).to include("action" => "My custom action")
+            expect(last_transaction).to have_action("My custom action")
           end
         end
 
@@ -367,10 +314,10 @@ describe Appsignal::Rack::AbstractMiddleware do
           let(:app) { lambda { |_env| raise ExampleException, "error message" } }
           let(:options) { { :report_errors => false } }
 
-          it "does not record the exception on the transaction" do
-            make_request_with_error(env, ExampleException, "error message")
+          it "does not record the error on the transaction" do
+            make_request_with_error(ExampleException, "error message")
 
-            expect(last_transaction.to_h).to include("error" => nil)
+            expect(last_transaction).to_not have_error
           end
         end
 
@@ -378,15 +325,10 @@ describe Appsignal::Rack::AbstractMiddleware do
           let(:app) { lambda { |_env| raise ExampleException, "error message" } }
           let(:options) { { :report_errors => true } }
 
-          it "records the exception on the transaction" do
-            make_request_with_error(env, ExampleException, "error message")
+          it "records the error on the transaction" do
+            make_request_with_error(ExampleException, "error message")
 
-            expect(last_transaction.to_h).to include(
-              "error" => hash_including(
-                "name" => "ExampleException",
-                "message" => "error message"
-              )
-            )
+            expect(last_transaction).to have_error("ExampleException", "error message")
           end
         end
 
@@ -395,9 +337,9 @@ describe Appsignal::Rack::AbstractMiddleware do
           let(:options) { { :report_errors => lambda { |_env| false } } }
 
           it "does not record the exception on the transaction" do
-            make_request_with_error(env, ExampleException, "error message")
+            make_request_with_error(ExampleException, "error message")
 
-            expect(last_transaction.to_h).to include("error" => nil)
+            expect(last_transaction).to_not have_error
           end
         end
 
@@ -405,15 +347,10 @@ describe Appsignal::Rack::AbstractMiddleware do
           let(:app) { lambda { |_env| raise ExampleException, "error message" } }
           let(:options) { { :report_errors => lambda { |_env| true } } }
 
-          it "records the exception on the transaction" do
-            make_request_with_error(env, ExampleException, "error message")
+          it "records the error on the transaction" do
+            make_request_with_error(ExampleException, "error message")
 
-            expect(last_transaction.to_h).to include(
-              "error" => hash_including(
-                "name" => "ExampleException",
-                "message" => "error message"
-              )
-            )
+            expect(last_transaction).to have_error("ExampleException", "error message")
           end
         end
       end

--- a/spec/lib/appsignal/rack/generic_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/generic_instrumentation_spec.rb
@@ -14,17 +14,7 @@ describe Appsignal::Rack::GenericInstrumentation do
     it "reports a process_action.generic event" do
       make_request(env)
 
-      expect(last_transaction.to_h).to include(
-        "events" => [
-          hash_including(
-            "body" => "",
-            "body_format" => Appsignal::EventFormatter::DEFAULT,
-            "count" => 1,
-            "name" => "process_action.generic",
-            "title" => ""
-          )
-        ]
-      )
+      expect(last_transaction).to include_event("name" => "process_action.generic")
     end
   end
 
@@ -32,7 +22,7 @@ describe Appsignal::Rack::GenericInstrumentation do
     it "reports 'unknown' as the action name" do
       make_request(env)
 
-      expect(last_transaction.to_h).to include("action" => "unknown")
+      expect(last_transaction).to have_action("unknown")
     end
   end
 end

--- a/spec/lib/appsignal/rack/grape_middleware_spec.rb
+++ b/spec/lib/appsignal/rack/grape_middleware_spec.rb
@@ -83,13 +83,7 @@ if DependencyHelper.grape_present?
       it "sets the error" do
         make_request_with_exception(env, ExampleException, "error message")
 
-        expect(last_transaction.to_h).to include(
-          "error" => {
-            "name" => "ExampleException",
-            "message" => "error message",
-            "backtrace" => kind_of(String)
-          }
-        )
+        expect(last_transaction).to have_error("ExampleException", "error message")
       end
 
       context "with env['grape.skip_appsignal_error'] = true" do
@@ -106,7 +100,7 @@ if DependencyHelper.grape_present?
         it "does not add the error" do
           make_request_with_exception(env, ExampleException, "error message")
 
-          expect(last_transaction).to include("error" => nil)
+          expect(last_transaction).to_not have_error
         end
       end
     end
@@ -129,13 +123,8 @@ if DependencyHelper.grape_present?
       it "sets non-unique route path" do
         make_request(env)
 
-        expect(last_transaction.to_h).to include(
-          "action" => "GET::GrapeExample::Api#/hello",
-          "metadata" => {
-            "path" => "/hello",
-            "method" => "GET"
-          }
-        )
+        expect(last_transaction).to have_action("GET::GrapeExample::Api#/hello")
+        expect(last_transaction).to include_metadata("path" => "/hello", "method" => "GET")
       end
     end
 
@@ -162,13 +151,8 @@ if DependencyHelper.grape_present?
       it "sets non-unique route_param path" do
         make_request(env)
 
-        expect(last_transaction.to_h).to include(
-          "action" => "GET::GrapeExample::Api#/users/:id/",
-          "metadata" => {
-            "path" => "/users/:id/",
-            "method" => "GET"
-          }
-        )
+        expect(last_transaction).to have_action("GET::GrapeExample::Api#/users/:id/")
+        expect(last_transaction).to include_metadata("path" => "/users/:id/", "method" => "GET")
       end
     end
 
@@ -190,13 +174,9 @@ if DependencyHelper.grape_present?
         it "sets namespaced path" do
           make_request(env)
 
-          expect(last_transaction.to_h).to include(
-            "action" => "POST::GrapeExample::Api#/v1/beta/ping",
-            "metadata" => {
-              "path" => "/v1/beta/ping",
-              "method" => "POST"
-            }
-          )
+          expect(last_transaction).to have_action("POST::GrapeExample::Api#/v1/beta/ping")
+          expect(last_transaction).to include_metadata("path" => "/v1/beta/ping",
+            "method" => "POST")
         end
       end
 
@@ -218,12 +198,10 @@ if DependencyHelper.grape_present?
           it "sets namespaced path" do
             make_request(env)
 
-            expect(last_transaction.to_h).to include(
-              "action" => "POST::GrapeExample::Api#/v1/beta/ping",
-              "metadata" => {
-                "path" => "/v1/beta/ping",
-                "method" => "POST"
-              }
+            expect(last_transaction).to have_action("POST::GrapeExample::Api#/v1/beta/ping")
+            expect(last_transaction).to include_metadata(
+              "path" => "/v1/beta/ping",
+              "method" => "POST"
             )
           end
         end
@@ -245,13 +223,9 @@ if DependencyHelper.grape_present?
           it "sets namespaced path" do
             make_request(env)
 
-            expect(last_transaction.to_h).to include(
-              "action" => "POST::GrapeExample::Api#/v1/beta/ping",
-              "metadata" => {
-                "path" => "/v1/beta/ping",
-                "method" => "POST"
-              }
-            )
+            expect(last_transaction).to have_action("POST::GrapeExample::Api#/v1/beta/ping")
+            expect(last_transaction).to include_metadata("path" => "/v1/beta/ping",
+              "method" => "POST")
           end
         end
       end

--- a/spec/lib/appsignal/rack/hanami_middleware_spec.rb
+++ b/spec/lib/appsignal/rack/hanami_middleware_spec.rb
@@ -23,28 +23,14 @@ if DependencyHelper.hanami2_present?
       it "sets request parameters on the transaction" do
         make_request(env)
 
-        expect(last_transaction.to_h).to include(
-          "sample_data" => hash_including(
-            "params" => { "param1" => "value1", "param2" => "value2" }
-          )
-        )
+        expect(last_transaction).to include_params("param1" => "value1", "param2" => "value2")
       end
     end
 
     it "reports a process_action.hanami event" do
       make_request(env)
 
-      expect(last_transaction.to_h).to include(
-        "events" => [
-          hash_including(
-            "body" => "",
-            "body_format" => Appsignal::EventFormatter::DEFAULT,
-            "count" => 1,
-            "name" => "process_action.hanami",
-            "title" => ""
-          )
-        ]
-      )
+      expect(last_transaction).to include_event("name" => "process_action.hanami")
     end
   end
 end

--- a/spec/support/helpers/std_streams_helper.rb
+++ b/spec/support/helpers/std_streams_helper.rb
@@ -89,6 +89,6 @@ module StdStreamsHelper
         end
       end
       reject
-    end.join(",")
+    end.join
   end
 end

--- a/spec/support/matchers/be_completed.rb
+++ b/spec/support/matchers/be_completed.rb
@@ -1,5 +1,0 @@
-RSpec::Matchers.define :be_completed do
-  match do |transaction|
-    values_match? transaction.ext._completed?, true
-  end
-end

--- a/spec/support/matchers/transaction.rb
+++ b/spec/support/matchers/transaction.rb
@@ -1,0 +1,185 @@
+def define_transaction_metadata_matcher_for(matcher_key, value_key = matcher_key)
+  value_key = value_key.to_s
+
+  RSpec::Matchers.define "have_#{matcher_key}" do |expected_value|
+    match(:notify_expectation_failures => true) do |transaction|
+      actual_value = transaction.to_h[value_key]
+      if expected_value
+        expect(actual_value).to eq(expected_value)
+      else
+        expect(actual_value).to_not be_nil
+      end
+    end
+
+    match_when_negated(:notify_expectation_failures => true) do |transaction|
+      actual_value = transaction.to_h[value_key]
+      if expected_value
+        expect(actual_value).to_not eq(expected_value)
+      else
+        expect(actual_value).to be_nil
+      end
+    end
+  end
+end
+
+define_transaction_metadata_matcher_for(:id)
+define_transaction_metadata_matcher_for(:namespace)
+define_transaction_metadata_matcher_for(:action)
+
+def define_transaction_sample_matcher_for(matcher_key, value_key = matcher_key)
+  value_key = value_key.to_s
+
+  RSpec::Matchers.define "include_#{matcher_key}" do |expected_value|
+    match(:notify_expectation_failures => true) do |transaction|
+      sample_data = transaction.to_h.dig("sample_data", value_key) || {}
+
+      if expected_value
+        expected_value = hash_including(expected_value) if expected_value.is_a?(Hash)
+        expect(sample_data).to match(expected_value)
+      else
+        expect(sample_data).to be_present
+      end
+    end
+
+    match_when_negated(:notify_expectation_failures => true) do |transaction|
+      sample_data = transaction.to_h.dig("sample_data", value_key) || {}
+
+      if expected_value
+        expect(sample_data).to_not include(expected_value)
+      else
+        expect(sample_data).to be_empty
+      end
+    end
+  end
+end
+
+define_transaction_sample_matcher_for(:sample_metadata, :metadata)
+define_transaction_sample_matcher_for(:params)
+define_transaction_sample_matcher_for(:environment)
+define_transaction_sample_matcher_for(:session_data)
+define_transaction_sample_matcher_for(:tags)
+define_transaction_sample_matcher_for(:custom_data)
+
+RSpec::Matchers.define :be_completed do
+  match(:notify_expectation_failures => true) do |transaction|
+    values_match? transaction.ext._completed?, true
+  end
+end
+
+RSpec::Matchers.define :have_error do |error_class, error_message|
+  match(:notify_expectation_failures => true) do |transaction|
+    transaction_error = transaction.to_h["error"]
+    if error_class && error_message
+      expect(transaction_error).to include(
+        "name" => error_class,
+        "message" => error_message,
+        "backtrace" => kind_of(String)
+      )
+    else
+      expect(transaction_error).to be_any
+    end
+  end
+
+  match_when_negated(:notify_expectation_failures => true) do |transaction|
+    transaction_error = transaction.to_h["error"]
+    if error_class && error_message
+      expect(transaction_error).to_not include(
+        "name" => error_class,
+        "message" => error_message,
+        "backtrace" => kind_of(String)
+      )
+    else
+      expect(transaction_error).to be_nil
+    end
+  end
+end
+
+RSpec::Matchers.define :include_event do |event|
+  match(:notify_expectation_failures => true) do |transaction|
+    events = transaction.to_h["events"]
+    if event
+      expect(events).to include(format_event(event))
+    else
+      expect(events).to be_any
+    end
+  end
+
+  match_when_negated(:notify_expectation_failures => true) do |transaction|
+    events = transaction.to_h["events"]
+    if event
+      expect(events).to_not include(format_event(event))
+    else
+      expect(events).to be_empty
+    end
+  end
+
+  def format_event(event)
+    hash_including({
+      "body" => "",
+      "body_format" => Appsignal::EventFormatter::DEFAULT,
+      "count" => 1,
+      "name" => kind_of(String),
+      "title" => ""
+    }.merge(event.transform_keys(&:to_s)))
+  end
+end
+RSpec::Matchers.alias_matcher :include_events, :include_event
+
+RSpec::Matchers.define :include_metadata do |metadata|
+  match(:notify_expectation_failures => true) do |transaction|
+    actual_metadata = transaction.to_h["metadata"]
+    if metadata
+      expect(actual_metadata).to include(metadata)
+    else
+      expect(actual_metadata).to be_any
+    end
+  end
+
+  match_when_negated(:notify_expectation_failures => true) do |transaction|
+    actual_metadata = transaction.to_h["metadata"]
+    if metadata
+      expect(actual_metadata).to_not include(metadata)
+    else
+      expect(actual_metadata).to be_empty
+    end
+  end
+end
+
+RSpec::Matchers.define :include_breadcrumb do |action, category, message, metadata, time|
+  match(:notify_expectation_failures => true) do |transaction|
+    breadcrumbs = transaction.to_h.dig("sample_data", "breadcrumbs")
+    if action
+      breadcrumb = format_breadcrumb(action, category, message, metadata, time)
+      expect(breadcrumbs).to include(breadcrumb)
+    else
+      expect(transaction.to_h.dig("sample_data", "breadcrumbs")).to be_any
+    end
+  end
+
+  match_when_negated(:notify_expectation_failures => true) do |transaction|
+    breadcrumbs = transaction.to_h.dig("sample_data", "breadcrumbs")
+    if action
+      breadcrumb = format_breadcrumb(action, category, message, metadata, time)
+      expect(breadcrumbs).to_not include(breadcrumb)
+    else
+      expect(breadcrumbs).to_not be_any
+    end
+  end
+
+  def format_breadcrumb(action, category, message, metadata, time)
+    {
+      "action" => action,
+      "category" => category,
+      "message" => message,
+      "metadata" => metadata,
+      "time" => time
+    }
+  end
+end
+RSpec::Matchers.alias_matcher :include_breadcrumbs, :include_breadcrumb
+
+RSpec::Matchers.define :have_queue_start do |queue_start_time|
+  match(:notify_expectation_failures => true) do |transaction|
+    expect(transaction.ext.queue_start).to eq(queue_start_time)
+  end
+end

--- a/spec/support/mocks/dummy_app.rb
+++ b/spec/support/mocks/dummy_app.rb
@@ -1,0 +1,16 @@
+class DummyApp
+  def initialize(&app)
+    @app = app
+    @called = false
+  end
+
+  def call(env)
+    @app&.call(env)
+  ensure
+    @called = true
+  end
+
+  def called?
+    @called
+  end
+end

--- a/spec/support/shared_examples/instrument.rb
+++ b/spec/support/shared_examples/instrument.rb
@@ -1,22 +1,14 @@
 RSpec.shared_examples "instrument helper" do
-  let(:stub) { double }
-  before do
-    expect(stub).to receive(:method_call).and_return("return value")
-
-    expect(transaction).to receive(:start_event)
-    expect(transaction).to receive(:finish_event).with(
-      "name",
-      "title",
-      "body",
-      0
-    )
-  end
+  around { |example| keep_transactions { example.run } }
+  let(:stub) { double(:method_call => "return value") }
 
   it "records an event around the given block" do
     return_value = instrumenter.instrument "name", "title", "body" do
       stub.method_call
     end
     expect(return_value).to eq "return value"
+
+    expect_transaction_to_have_event
   end
 
   context "with an error raised in the passed block" do
@@ -27,6 +19,8 @@ RSpec.shared_examples "instrument helper" do
           raise ExampleException, "foo"
         end
       end.to raise_error(ExampleException, "foo")
+
+      expect_transaction_to_have_event
     end
   end
 
@@ -38,6 +32,17 @@ RSpec.shared_examples "instrument helper" do
           throw :foo
         end
       end.to throw_symbol(:foo)
+
+      expect_transaction_to_have_event
     end
+  end
+
+  def expect_transaction_to_have_event
+    expect(transaction).to include_event(
+      "name" => "name",
+      "title" => "title",
+      "body" => "body",
+      "body_format" => Appsignal::EventFormatter::DEFAULT
+    )
   end
 end

--- a/spec/support/testing.rb
+++ b/spec/support/testing.rb
@@ -120,16 +120,25 @@ end
 
 module AppsignalTest
   module Transaction
-    # Override the {Appsignal::Transaction.new} method so we can track which
-    # transactions are created on the {Appsignal::Testing.transactions} list.
-    #
-    # @see TransactionHelpers#last_transaction
-    def new(*_args)
-      transaction = super
-      Appsignal::Testing.transactions << transaction
-      transaction
+    module ClassMethods
+      # Override the {Appsignal::Transaction.new} method so we can track which
+      # transactions are created on the {Appsignal::Testing.transactions} list.
+      #
+      # @see TransactionHelpers#last_transaction
+      def new(*_args)
+        transaction = super
+        Appsignal::Testing.transactions << transaction
+        transaction
+      end
+    end
+
+    module InstanceMethods
+      def _sample
+        sample_data
+      end
     end
   end
 end
 
-Appsignal::Transaction.extend(AppsignalTest::Transaction)
+Appsignal::Transaction.extend(AppsignalTest::Transaction::ClassMethods)
+Appsignal::Transaction.prepend(AppsignalTest::Transaction::InstanceMethods)


### PR DESCRIPTION
Make the assertions easier to read by describing what we want to see happen, rather than assert some Hash of internal representation of the transaction.

Part of #252
Part of #299

[skip changeset]
[skip review]