### PR TITLE
Test transaction contents through extension

### DIFF
--- a/spec/lib/appsignal/hooks/action_cable_spec.rb
+++ b/spec/lib/appsignal/hooks/action_cable_spec.rb
@@ -53,14 +53,6 @@ describe Appsignal::Hooks::ActionCableHook do
 
           set_current_transaction(transaction)
 
-          expect(Appsignal::Transaction).to receive(:create).with(
-            transaction_id,
-            Appsignal::Transaction::ACTION_CABLE,
-            kind_of(ActionDispatch::Request)
-          )
-            .and_return(transaction)
-          allow(Appsignal::Transaction).to receive(:current).and_return(transaction)
-
           # Stub transmit call for subscribe/unsubscribe tests
           allow(connection).to receive(:websocket)
             .and_return(instance_double("ActionCable::Connection::WebSocket", :transmit => nil))
@@ -122,9 +114,6 @@ describe Appsignal::Hooks::ActionCableHook do
                 kind_of(ActionDispatch::Request)
               ).and_return(action_transaction)
               allow(Appsignal::Transaction).to receive(:current).and_return(action_transaction)
-              # Stub complete call, stops it from being cleared in the extension
-              # And allows us to call `#to_h` on it after it's been completed.
-              expect(action_transaction.ext).to receive(:complete)
 
               instance.perform_action("message" => "foo", "action" => "speak")
               expect(action_transaction).to have_id(transaction_id)

--- a/spec/lib/appsignal/hooks/active_support_notifications/start_finish_shared_examples.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications/start_finish_shared_examples.rb
@@ -28,9 +28,6 @@ shared_examples "activesupport start finish override" do
   end
 
   it "does not instrument events whose name starts with a bang" do
-    expect(Appsignal::Transaction.current).not_to receive(:start_event)
-    expect(Appsignal::Transaction.current).not_to receive(:finish_event)
-
     instrumenter.start("!sql.active_record", {})
     instrumenter.finish("!sql.active_record", {})
 

--- a/spec/lib/appsignal/hooks/net_http_spec.rb
+++ b/spec/lib/appsignal/hooks/net_http_spec.rb
@@ -1,51 +1,16 @@
 describe Appsignal::Hooks::NetHttpHook do
-  before :context do
-    start_agent
-  end
+  before(:context) { start_agent }
 
-  context "with Net::HTTP instrumentation enabled" do
-    describe "#dependencies_present?" do
-      subject { described_class.new.dependencies_present? }
+  describe "#dependencies_present?" do
+    subject { described_class.new.dependencies_present? }
 
+    context "with Net::HTTP instrumentation enabled" do
       it { is_expected.to be_truthy }
     end
 
-    it "should instrument a http request" do
-      Appsignal::Transaction.create("uuid", Appsignal::Transaction::HTTP_REQUEST, "test")
-      expect(Appsignal::Transaction.current).to receive(:start_event)
-        .at_least(:once)
-      expect(Appsignal::Transaction.current).to receive(:finish_event)
-        .at_least(:once)
-        .with("request.net_http", "GET http://www.google.com", nil, 0)
-
-      stub_request(:any, "http://www.google.com/")
-
-      Net::HTTP.get_response(URI.parse("http://www.google.com"))
-    end
-
-    it "should instrument a https request" do
-      Appsignal::Transaction.create("uuid", Appsignal::Transaction::HTTP_REQUEST, "test")
-      expect(Appsignal::Transaction.current).to receive(:start_event)
-        .at_least(:once)
-      expect(Appsignal::Transaction.current).to receive(:finish_event)
-        .at_least(:once)
-        .with("request.net_http", "GET https://www.google.com", nil, 0)
-
-      stub_request(:any, "https://www.google.com/")
-
-      uri = URI.parse("https://www.google.com")
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
-      http.get(uri.request_uri)
-    end
-  end
-
-  context "with Net::HTTP instrumentation disabled" do
-    before { Appsignal.config.config_hash[:instrument_net_http] = false }
-    after { Appsignal.config.config_hash[:instrument_net_http] = true }
-
-    describe "#dependencies_present?" do
-      subject { described_class.new.dependencies_present? }
+    context "with Net::HTTP instrumentation disabled" do
+      before { Appsignal.config.config_hash[:instrument_net_http] = false }
+      after { Appsignal.config.config_hash[:instrument_net_http] = true }
 
       it { is_expected.to be_falsy }
     end

--- a/spec/lib/appsignal/integrations/net_http_spec.rb
+++ b/spec/lib/appsignal/integrations/net_http_spec.rb
@@ -1,0 +1,33 @@
+require "appsignal/integrations/net_http"
+
+describe Appsignal::Integrations::NetHttpIntegration do
+  let(:transaction) { http_request_transaction }
+  before(:context) { start_agent }
+  before { set_current_transaction transaction }
+  around { |example| keep_transactions { example.run } }
+
+  it "instruments a http request" do
+    stub_request(:any, "http://www.google.com/")
+
+    Net::HTTP.get_response(URI.parse("http://www.google.com"))
+
+    expect(transaction).to include_event(
+      "name" => "request.net_http",
+      "title" => "GET http://www.google.com"
+    )
+  end
+
+  it "instruments a https request" do
+    stub_request(:any, "https://www.google.com/")
+
+    uri = URI.parse("https://www.google.com")
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    http.get(uri.request_uri)
+
+    expect(transaction).to include_event(
+      "name" => "request.net_http",
+      "title" => "GET https://www.google.com"
+    )
+  end
+end

--- a/spec/lib/appsignal/integrations/padrino_spec.rb
+++ b/spec/lib/appsignal/integrations/padrino_spec.rb
@@ -2,11 +2,6 @@ if DependencyHelper.padrino_present?
   describe "Padrino integration" do
     require "appsignal/integrations/padrino"
 
-    before do
-      allow(Appsignal).to receive(:active?).and_return(true)
-      allow(Appsignal).to receive(:start).and_return(true)
-    end
-
     describe Appsignal::Integrations::PadrinoPlugin do
       it "starts AppSignal on init" do
         expect(Appsignal).to receive(:start)
@@ -54,20 +49,9 @@ if DependencyHelper.padrino_present?
       let(:env)      { {} }
       # TODO: use an instance double
       let(:settings) { double(:name => "TestApp") }
+      around { |example| keep_transactions { example.run } }
 
       describe "routes" do
-        let(:transaction) do
-          instance_double "Appsignal::Transaction",
-            :set_http_or_background_action => nil,
-            :set_http_or_background_queue_start => nil,
-            :set_metadata => nil,
-            :set_action => nil,
-            :set_action_if_nil => nil,
-            :set_error => nil,
-            :start_event => nil,
-            :finish_event => nil,
-            :complete => nil
-        end
         let(:request_kind) { kind_of(Sinatra::Request) }
         let(:env) do
           {
@@ -85,10 +69,6 @@ if DependencyHelper.padrino_present?
           end
         end
         let(:response) { app.call(env) }
-        before do
-          allow(Appsignal::Transaction).to receive(:create).and_return(transaction)
-          allow(Appsignal::Transaction).to receive(:current).and_return(transaction)
-        end
 
         RSpec::Matchers.define :match_response do |expected_status, expected_content|
           match do |response|
@@ -104,46 +84,41 @@ if DependencyHelper.padrino_present?
         end
 
         def expect_a_transaction_to_be_created
-          expect(Appsignal::Transaction).to receive(:create).with(
-            kind_of(String),
-            Appsignal::Transaction::HTTP_REQUEST,
-            request_kind
-          ).and_return(transaction)
-
-          expect(Appsignal).to receive(:instrument)
-            .at_least(:once)
-            .with("process_action.padrino")
-            .and_call_original
-          expect(transaction).to receive(:set_metadata).with("path", path)
-          expect(transaction).to receive(:set_metadata).with("method", "GET")
-          expect(transaction).to receive(:complete)
-        end
-
-        def expect_no_transaction_to_be_created
-          expect(Appsignal::Transaction).to_not receive(:create)
-          expect(Appsignal).to_not receive(:instrument)
+          transaction = last_transaction
+          expect(transaction).to have_id
+          expect(transaction).to have_namespace(Appsignal::Transaction::HTTP_REQUEST)
+          expect(transaction).to include_metadata(
+            "path" => path,
+            "method" => "GET"
+          )
+          expect(transaction).to include_event("name" => "process_action.padrino")
+          expect(transaction).to be_completed
         end
 
         context "when AppSignal is not active" do
           before { allow(Appsignal).to receive(:active?).and_return(false) }
           let(:path) { "/foo" }
           before { app.controllers { get(:foo) { "content" } } }
-          after { expect(response).to match_response(200, "content") }
 
           it "does not instrument the request" do
-            expect_no_transaction_to_be_created
+            expect do
+              expect(response).to match_response(200, "content")
+            end.to_not(change { created_transactions.count })
           end
         end
 
         context "when AppSignal is active" do
+          before { start_agent }
+
           context "with not existing route" do
             let(:path) { "/404" }
 
             it "instruments the request" do
+              expect(response).to match_response(404, /^GET &#x2F;404/)
+
               expect_a_transaction_to_be_created
               # Uses path for action name
-              expect(transaction).to receive(:set_action_if_nil).with("PadrinoTestApp#unknown")
-              expect(response).to match_response(404, /^GET &#x2F;404/)
+              expect(last_transaction).to have_action("PadrinoTestApp#unknown")
             end
           end
 
@@ -153,10 +128,11 @@ if DependencyHelper.padrino_present?
               env["sinatra.static_file"] = true
               app.controllers { get(:static) { "Static!" } }
             end
-            after { expect(response).to match_response(200, "Static!") }
 
             it "does not instrument the request" do
-              expect_no_transaction_to_be_created
+              expect do
+                expect(response).to match_response(200, "Static!")
+              end.to_not(change { created_transactions.count })
             end
           end
 
@@ -167,12 +143,14 @@ if DependencyHelper.padrino_present?
               allow_any_instance_of(Sinatra::Request).to receive(:action).and_return(nil)
               app.controllers { get(:my_original_path, :with => :id) { "content" } }
             end
-            after { expect(response).to match_response(200, "content") }
 
             it "falls back on Sinatra::Request#route_obj.original_path" do
+              expect do
+                expect(response).to match_response(200, "content")
+              end.to(change { created_transactions.count }.by(1))
+
               expect_a_transaction_to_be_created
-              expect(transaction)
-                .to receive(:set_action_if_nil).with("PadrinoTestApp:/my_original_path/:id")
+              expect(last_transaction).to have_action("PadrinoTestApp:/my_original_path/:id")
             end
           end
 
@@ -183,11 +161,11 @@ if DependencyHelper.padrino_present?
               allow_any_instance_of(Sinatra::Request).to receive(:route_obj).and_return(nil)
               app.controllers { get(:my_original_path) { "content" } }
             end
-            after { expect(response).to match_response(200, "content") }
 
             it "falls back on app name" do
+              expect(response).to match_response(200, "content")
               expect_a_transaction_to_be_created
-              expect(transaction).to receive(:set_action_if_nil).with("PadrinoTestApp#unknown")
+              expect(last_transaction).to have_action("PadrinoTestApp#unknown")
             end
           end
 
@@ -195,25 +173,25 @@ if DependencyHelper.padrino_present?
             context "with an exception in the controller" do
               let(:path) { "/exception" }
               before do
-                app.controllers { get(:exception) { raise ExampleException } }
+                app.controllers { get(:exception) { raise ExampleException, "error message" } }
+                expect { response }.to raise_error(ExampleException, "error message")
                 expect_a_transaction_to_be_created
-              end
-              after do
-                expect { response }.to raise_error(ExampleException)
               end
 
               it "sets the action name based on the app name and action name" do
-                expect(transaction).to receive(:set_action_if_nil).with("PadrinoTestApp:#exception")
+                expect(last_transaction).to have_action("PadrinoTestApp:#exception")
               end
 
               it "sets the error on the transaction" do
-                expect(transaction).to receive(:set_error).with(ExampleException)
+                expect(last_transaction).to have_error("ExampleException", "error message")
               end
             end
 
             context "without an exception in the controller" do
               let(:path) { "/" }
-              after { expect(response).to match_response(200, "content") }
+              def make_request
+                expect(response).to match_response(200, "content")
+              end
 
               context "with action name as symbol" do
                 context "with :index helper" do
@@ -223,8 +201,9 @@ if DependencyHelper.padrino_present?
                   end
 
                   it "sets the action with the app name and action name" do
+                    make_request
                     expect_a_transaction_to_be_created
-                    expect(transaction).to receive(:set_action_if_nil).with("PadrinoTestApp:#index")
+                    expect(last_transaction).to have_action("PadrinoTestApp:#index")
                   end
                 end
 
@@ -235,8 +214,9 @@ if DependencyHelper.padrino_present?
                   end
 
                   it "sets the action with the app name and action name" do
+                    make_request
                     expect_a_transaction_to_be_created
-                    expect(transaction).to receive(:set_action_if_nil).with("PadrinoTestApp:#foo")
+                    expect(last_transaction).to have_action("PadrinoTestApp:#foo")
                   end
                 end
               end
@@ -249,8 +229,9 @@ if DependencyHelper.padrino_present?
                   end
 
                   it "sets the action with the app name and action path" do
+                    make_request
                     expect_a_transaction_to_be_created
-                    expect(transaction).to receive(:set_action_if_nil).with("PadrinoTestApp:#/")
+                    expect(last_transaction).to have_action("PadrinoTestApp:#/")
                   end
                 end
 
@@ -261,8 +242,9 @@ if DependencyHelper.padrino_present?
                   end
 
                   it "sets the action with the app name and action path" do
+                    make_request
                     expect_a_transaction_to_be_created
-                    expect(transaction).to receive(:set_action_if_nil).with("PadrinoTestApp:#/foo")
+                    expect(last_transaction).to have_action("PadrinoTestApp:#/foo")
                   end
                 end
               end
@@ -277,9 +259,9 @@ if DependencyHelper.padrino_present?
                   end
 
                   it "sets the action with the app name, controller name and action name" do
+                    make_request
                     expect_a_transaction_to_be_created
-                    expect(transaction).to receive(:set_action_if_nil)
-                      .with("PadrinoTestApp:my_controller#index")
+                    expect(last_transaction).to have_action("PadrinoTestApp:my_controller#index")
                   end
                 end
 
@@ -290,9 +272,9 @@ if DependencyHelper.padrino_present?
                   end
 
                   it "sets the action with the app name, controller name and action path" do
+                    make_request
                     expect_a_transaction_to_be_created
-                    expect(transaction).to receive(:set_action_if_nil)
-                      .with("PadrinoTestApp:/my_controller#index")
+                    expect(last_transaction).to have_action("PadrinoTestApp:/my_controller#index")
                   end
                 end
               end

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -662,9 +662,7 @@ describe Appsignal::Transaction do
 
         expect(Appsignal.internal_logger).to receive(:warn).with("Queue start value 10 is too big")
 
-        expect do
-          transaction.set_queue_start(10)
-        end.to_not raise_error
+        transaction.set_queue_start(10)
       end
     end
 
@@ -966,7 +964,7 @@ describe Appsignal::Transaction do
         end
 
         it "should not raise an error" do
-          expect { transaction.set_error(error) }.to_not raise_error
+          transaction.set_error(error)
         end
 
         it "should set an error in the extension" do
@@ -1607,22 +1605,20 @@ describe Appsignal::Transaction do
     subject { Appsignal::Transaction::NilTransaction.new }
 
     it "should have method stubs" do
-      expect do
-        subject.complete
-        subject.pause!
-        subject.resume!
-        subject.paused?
-        subject.store(:key)
-        subject.set_tags(:tag => 1)
-        subject.set_action("action")
-        subject.set_http_or_background_action
-        subject.set_queue_start(1)
-        subject.set_http_or_background_queue_start
-        subject.set_metadata("key", "value")
-        subject.set_sample_data("key", "data")
-        subject.sample_data
-        subject.set_error("a")
-      end.to_not raise_error
+      subject.complete
+      subject.pause!
+      subject.resume!
+      subject.paused?
+      subject.store(:key)
+      subject.set_tags(:tag => 1)
+      subject.set_action("action")
+      subject.set_http_or_background_action
+      subject.set_queue_start(1)
+      subject.set_http_or_background_queue_start
+      subject.set_metadata("key", "value")
+      subject.set_sample_data("key", "data")
+      subject.sample_data
+      subject.set_error("a")
     end
   end
 end

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -83,10 +83,6 @@ describe Appsignal::Transaction do
     end
 
     describe ".current" do
-      def current_transaction
-        Appsignal::Transaction.current
-      end
-
       context "when there is a current transaction" do
         let!(:transaction) do
           Appsignal::Transaction.create(transaction_id, namespace, request, options)

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -274,45 +274,40 @@ describe Appsignal do
     end
 
     describe ".listen_for_error" do
-      it "does not record anything" do
-        error = RuntimeError.new("specific error")
+      let(:error) { ExampleException.new("specific error") }
+
+      it "reraises the error" do
         expect do
-          Appsignal.listen_for_error do
-            raise error
-          end
+          Appsignal.listen_for_error { raise error }
         end.to raise_error(error)
       end
     end
 
     describe ".send_error" do
-      it "should do nothing" do
-        expect do
-          Appsignal.send_error(RuntimeError.new)
-        end.to_not raise_error
+      let(:error) { ExampleException.new("specific error") }
+
+      it "does not raise an error" do
+        Appsignal.send_error(error)
       end
     end
 
     describe ".set_error" do
-      it "should do nothing" do
-        expect do
-          Appsignal.set_error(RuntimeError.new)
-        end.to_not raise_error
+      let(:error) { ExampleException.new("specific error") }
+
+      it "does not raise an error" do
+        Appsignal.set_error(error)
       end
     end
 
     describe ".set_namespace" do
-      it "should do nothing" do
-        expect do
-          Appsignal.set_namespace("custom")
-        end.to_not raise_error
+      it "does not raise an error" do
+        Appsignal.set_namespace("custom")
       end
     end
 
     describe ".tag_request" do
-      it "should do nothing" do
-        expect do
-          Appsignal.tag_request(:tag => "tag")
-        end.to_not raise_error
+      it "does not raise an error" do
+        Appsignal.tag_request(:tag => "tag")
       end
     end
   end
@@ -542,9 +537,8 @@ describe Appsignal do
           ).and_raise(RangeError)
           expect(Appsignal.internal_logger).to receive(:warn)
             .with("Gauge value 10 for key 'key' is too big")
-          expect do
-            Appsignal.set_gauge("key", 10)
-          end.to_not raise_error
+
+          Appsignal.set_gauge("key", 10)
         end
       end
 
@@ -622,9 +616,8 @@ describe Appsignal do
             .with("key", 10, Appsignal::Extension.data_map_new).and_raise(RangeError)
           expect(Appsignal.internal_logger).to receive(:warn)
             .with("Counter value 10 for key 'key' is too big")
-          expect do
-            Appsignal.increment_counter("key", 10)
-          end.to_not raise_error
+
+          Appsignal.increment_counter("key", 10)
         end
       end
 
@@ -652,9 +645,8 @@ describe Appsignal do
             .with("key", 10, Appsignal::Extension.data_map_new).and_raise(RangeError)
           expect(Appsignal.internal_logger).to receive(:warn)
             .with("Distribution value 10 for key 'key' is too big")
-          expect do
-            Appsignal.add_distribution_value("key", 10)
-          end.to_not raise_error
+
+          Appsignal.add_distribution_value("key", 10)
         end
       end
     end

--- a/spec/support/helpers/transaction_helpers.rb
+++ b/spec/support/helpers/transaction_helpers.rb
@@ -44,6 +44,14 @@ module TransactionHelpers
     created_transactions.last
   end
 
+  def current_transaction?
+    Appsignal::Transaction.current?
+  end
+
+  def current_transaction
+    Appsignal::Transaction.current
+  end
+
   # Set current transaction manually.
   # Cleared by {clear_current_transaction!}
   #

--- a/spec/support/mocks/dummy_app.rb
+++ b/spec/support/mocks/dummy_app.rb
@@ -5,7 +5,11 @@ class DummyApp
   end
 
   def call(env)
-    @app&.call(env)
+    if @app
+      @app&.call(env)
+    else
+      [200, {}, "body"]
+    end
   ensure
     @called = true
   end


### PR DESCRIPTION
## Remove checks for not raising errors

This check is unnecessary. If an error was raised, the spec would fail.

Part of #229

## Test transaction contents through extension

Refactor the test suite to not test if transactions are created by asserting method calls. Use the tooling to see if a transaction has been created or not and assert what's set on the transaction using the transaction matchers.

Part of #299 Closes #252

---

[skip changeset]
[skip review]