### PR TITLE
Fix internal memory logger warn_once_then_debug

### DIFF
--- a/lib/appsignal/utils/integration_memory_logger.rb
+++ b/lib/appsignal/utils/integration_memory_logger.rb
@@ -35,6 +35,18 @@ module Appsignal
         add(:WARN, message)
       end
 
+      def seen_keys
+        @seen_keys ||= Set.new
+      end
+
+      def warn_once_then_debug(key, message)
+        if seen_keys.add?(key).nil?
+          debug message
+        else
+          warn message
+        end
+      end
+
       def error(message)
         add(:ERROR, message)
       end

--- a/spec/lib/appsignal/utils/integration_memory_logger_spec.rb
+++ b/spec/lib/appsignal/utils/integration_memory_logger_spec.rb
@@ -68,6 +68,16 @@ describe Appsignal::Utils::IntegrationLogger do
     end
   end
 
+  describe "#warn_once_then_debug" do
+    it "only warns once, then uses debug" do
+      message = "This is a log line"
+      3.times { logger.warn_once_then_debug(:key, message) }
+
+      expect(logger.messages[:WARN]).to eq([message])
+      expect(logger.messages[:DEBUG]).to eq([message, message])
+    end
+  end
+
   describe "#error" do
     it "adds a log message with the error severity" do
       logger.error("error message")


### PR DESCRIPTION
The `warn_once_then_debug` method is missing for the IntegrationMemoryLogger. I ran into this issue when refactoring another test, but somehow it wasn't failing in tests itself before and after the refactor. Still needs to be fixed.

[skip changeset] because the original change in #1121 has not yet been released.
[skip review]