### PR TITLE
Remove default abstract instrumentation event

### DIFF
--- a/lib/appsignal/rack/abstract_middleware.rb
+++ b/lib/appsignal/rack/abstract_middleware.rb
@@ -14,7 +14,7 @@ module Appsignal
         @options = options
         @request_class = options.fetch(:request_class, ::Rack::Request)
         @params_method = options.fetch(:params_method, :params)
-        @instrument_span_name = options.fetch(:instrument_span_name, "process.abstract")
+        @instrument_span_name = options.fetch(:instrument_span_name, nil)
         @report_errors = options.fetch(:report_errors, DEFAULT_ERROR_REPORTING)
       end
 

--- a/spec/lib/appsignal/rack/abstract_middleware_spec.rb
+++ b/spec/lib/appsignal/rack/abstract_middleware_spec.rb
@@ -56,8 +56,20 @@ describe Appsignal::Rack::AbstractMiddleware do
           expect(last_transaction).to_not have_error
         end
 
-        it "records an instrumentation event" do
-          expect(last_transaction).to include_event(:name => "process.abstract")
+        context "without :instrument_span_name option set" do
+          let(:options) { {} }
+
+          it "does not record an instrumentation event" do
+            expect(last_transaction).to_not include_event
+          end
+        end
+
+        context "with :instrument_span_name option set" do
+          let(:options) { { :instrument_span_name => "span_name.category" } }
+
+          it "records an instrumentation event" do
+            expect(last_transaction).to include_event(:name => "span_name.category")
+          end
         end
 
         it "completes the transaction" do


### PR DESCRIPTION
In PR #1124, I added functionality to not report an instrumentation event for the Rails instrumentation middleware.

The AbstractMiddleware shouldn't be used on its own, but it did have a default for reporting instrumentation events. Remove that default so it doesn't report an event by default.

[skip changeset] It's an internal change to the AbstractMiddleware and no one should be using that directly.