### PR TITLE
Support nested webmachine apps

### DIFF
--- a/.changesets/support-nested-webmachine-apps.md
+++ b/.changesets/support-nested-webmachine-apps.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Support nested webmachine apps. If webmachine apps are nested in other AppSignal instrumentation it will now report the webmachine instrumentation as part of the parent transaction, reporting more runtime of the request.

--- a/gemfiles/webmachine1.gemfile
+++ b/gemfiles/webmachine1.gemfile
@@ -1,6 +1,7 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'webmachine', '~> 1.6'
-gem 'webrick'
+gem "i18n", "~> 0.0" # Lock to pre 1.x version as it's not compatible
+gem "webmachine", "~> 1.6"
+gem "webrick"
 
-gemspec :path => '../'
+gemspec :path => "../"

--- a/spec/lib/appsignal/integrations/webmachine_spec.rb
+++ b/spec/lib/appsignal/integrations/webmachine_spec.rb
@@ -86,6 +86,26 @@ if DependencyHelper.webmachine_present?
         expect(last_transaction).to be_completed
         expect(current_transaction?).to be_falsy
       end
+
+      context "with parent transaction" do
+        let(:transaction) { http_request_transaction }
+        before { set_current_transaction(transaction) }
+
+        it "sets the action" do
+          fsm.run
+          expect(last_transaction).to have_action("MyResource#GET")
+        end
+
+        it "sets the params" do
+          fsm.run
+          last_transaction._sample
+          expect(last_transaction).to include_params("param1" => "value1", "param2" => "value2")
+        end
+
+        it "does not close the transaction" do
+          expect(last_transaction).to_not be_completed
+        end
+      end
     end
 
     describe "#handle_exceptions" do


### PR DESCRIPTION
## Test webmachine instrumentation to set params

I noticed the webmachine tests don't test if it sets the params, now it does.

Also clean up some other spec stuff that's not needed.

## Test webmachine custom action names

Use a Webmachine resource to test the instrumentation. Use that to set a custom action name and test that it doesn't get overwritten by the instrumentation.

## Support nested webmachine apps

Apply the same logic as we have in the AbstractMiddleware for webmachine apps. When a parent transaction is active, use that and don't create a new one. More importantly, don't close the active transaction.

The webmachine instrumentation can't use the AbstractMiddleware, or any middleware, as this discouraged by the webmachine project. In practice I don't see this happening, but if someone happens to add an AppSignal EventHandler to the middleware stack in `config.ru`, we now support it.

Part of #329
