### PR TITLE
Use Rack middleware for Padrino instrumentation

### DIFF
--- a/.changesets/report-response-status-for-padrino-apps.md
+++ b/.changesets/report-response-status-for-padrino-apps.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+type: add
+---
+
+Report the response status for Padrino requests as the `response_status` tag on samples, e.g. 200, 301, 500. This tag is visible on the sample detail page.
+Report the response status for Padrino requests as the `response_status` metric.

--- a/.changesets/support-nested-padrino-apps.md
+++ b/.changesets/support-nested-padrino-apps.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Add support for nested Padrino apps. When a Padrino app is nested in another Padrino app, or another framework like Sinatra or Rails, it will now report the entire request.

--- a/spec/lib/appsignal/integrations/sinatra_spec.rb
+++ b/spec/lib/appsignal/integrations/sinatra_spec.rb
@@ -7,8 +7,12 @@ if DependencyHelper.sinatra_present?
 
   # "Uninstall" the AppSignal integration
   def uninstall_sinatra_integration
+    expected_middleware = [
+      Rack::Events,
+      Appsignal::Rack::SinatraBaseInstrumentation
+    ]
     Sinatra::Base.instance_variable_get(:@middleware).delete_if do |middleware|
-      middleware.first == Appsignal::Rack::SinatraBaseInstrumentation
+      expected_middleware.include?(middleware.first)
     end
   end
 
@@ -29,7 +33,11 @@ if DependencyHelper.sinatra_present?
 
       it "adds the instrumentation middleware to Sinatra::Base" do
         install_sinatra_integration
-        expect(Sinatra::Base.middleware.to_a).to include(
+        middlewares = Sinatra::Base.middleware.to_a
+        expect(middlewares).to include(
+          [Rack::Events, [[instance_of(Appsignal::Rack::EventHandler)]], nil]
+        )
+        expect(middlewares).to include(
           [Appsignal::Rack::SinatraBaseInstrumentation, [], nil]
         )
       end


### PR DESCRIPTION
## Update Sinatra test to assert EventHandler

I noticed this one scenario doesn't test if the EventHandler is present. Now it does check it.

## Use Rack middleware for Padrino instrumentation

Refactor the Padrino instrumentation to use as much existing Rack middleware for instrumentation as possible.

Padrino is a framework built on Sinatra. We can reuse the Sinatra instrumentation middleware to instrument Padrino apps. In combination with the EventHandler we have 99% of the instrumentation done. To differentiate between Padrino and Sinatra events I've configured the Sinatra middleware to report the instrumentation event as a Padrino event.

The only thing we do need a monkeypatch for is the action name for Padrino. Everything else can be removed from the monkeypatch. The request metadata and exceptions are reported by the Sinatra middleware.

I've moved all the plugin initialization to the `Padrino.before_load` callback. It seems to initialize all the things we need before this time: app path and environment.
