### PR TITLE
Fix Padrino instrumentation causing boot loop

### DIFF
--- a/.changesets/padrino-boot-loop.md
+++ b/.changesets/padrino-boot-loop.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+type: fix
+---
+
+Fix issue with AppSignal getting stuck in a boot loop when loading the Padrino integration with: `require "appsignal/integrations/padrino"`
+This could happen in nested applications, like a Padrino app in a Rails app. AppSignal will now use the first config AppSignal starts with.

--- a/lib/appsignal/integrations/padrino.rb
+++ b/lib/appsignal/integrations/padrino.rb
@@ -13,9 +13,11 @@ module Appsignal
         Padrino.before_load do
           Appsignal.internal_logger.debug("Loading Padrino (#{Padrino::VERSION}) integration")
 
-          root = Padrino.mounted_root
-          Appsignal.config = Appsignal::Config.new(root, Padrino.env)
-          Appsignal.start
+          unless Appsignal.active?
+            root = Padrino.mounted_root
+            Appsignal.config = Appsignal::Config.new(root, Padrino.env)
+            Appsignal.start
+          end
 
           next unless Appsignal.active?
 


### PR DESCRIPTION
Apply the same boot loop fix as for Sinatra for Padrino from PR #1105.

For Sinatra apps noticed in our test setup that when I added a Sinatra app to the Rails app, and loaded the Sinatra instrumentation as specified in our docs it would get stuck in a boot loop. This was caused by the two different configs overwriting each other every time.

Apply the same fix for Padrino by checking first if AppSignal has already started and skipping the auto start.

Part of #329 
Based on #1142