### PR TITLE
Add Appsignal.report_error helper

### DIFF
--- a/.changesets/add-report_error-helper.md
+++ b/.changesets/add-report_error-helper.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+type: add
+---
+
+Add the `Appsignal.report_error` helper to report errors. If you were ever unsure whether to use `Appsignal.set_error` or `Appsignal.send_error`, use `Appsignal.report_error` from now to always report the error.


### PR DESCRIPTION
To help alleviate issues with confusion around when to use `Appsignal.set_error` and `Appsignal.send_error`, introduce the `Appsignal.report_error` helper.

This helper will always report the error. If a transaction is active, it reports the error on the current transaction. If no transaction is active, it will create a new transaction and report the error this way.

It should allow apps to call this helper method in all contexts: with and without an active transaction.

Closes #176
Related to https://github.com/appsignal/integration-guide/issues/167