### PR TITLE
Add set_custom_data instrumentation helper

### DIFF
--- a/.changesets/add-set_custom_data-helper.md
+++ b/.changesets/add-set_custom_data-helper.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Add `Appsignal.set_custom_data` helper to set custom data on the transaction. Previously, this could only be set with `Appsignal::Transaction.current.set_custom_data("custom_data", ...)`. This helper makes setting the custom data more convenient.

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -474,6 +474,35 @@ module Appsignal
         Appsignal::Transaction.current.set_namespace(namespace)
       end
 
+      # Set custom data on the current transaction.
+      #
+      # Add extra information about the request or background that cannot be
+      # expressed in tags, like nested data structures.
+      #
+      # When this method is called multiple times, it will overwrite the
+      # previously set value.
+      #
+      # @example
+      #   Appsignal.set_custom_data(:user => { :locale => "en" })
+      #   Appsignal.set_custom_data([
+      #     "array with data",
+      #     :options => { :verbose => true }
+      #   ])
+      #
+      # @since 3.10.0
+      # @see Transaction#set_custom_data
+      # @see https://docs.appsignal.com/guides/custom-data/sample-data.html
+      #   Sample data guide
+      # @param data [Hash/Array]
+      # @return [void]
+      def set_custom_data(data)
+        return unless active?
+        return unless Appsignal::Transaction.current?
+
+        transaction = Appsignal::Transaction.current
+        transaction.set_custom_data(data)
+      end
+
       # Set tags on the current transaction.
       #
       # Tags are extra bits of information that are added to transaction and


### PR DESCRIPTION
I saw we tell people in our docs to use the
`Appsignal::Transaction#set_sample_data` method. Let's not do that.

Here's a helper to hide all those internals away and make it less likely to break when setting custom data as sample data.

I considered adding logic to merge the custom data, but merging these values is quite tricky because it can be both a Hash and an Array as the root object. It's not something I want to think about right now. If we want to add this in the future, we can also name that helper `add_custom_data` to differentiate between setting and merging the custom data.

Closes #1147