### PR TITLE
Add Appsignal.set_tags alias

### DIFF
--- a/.changesets/add-appsignal-set_tags-helper.md
+++ b/.changesets/add-appsignal-set_tags-helper.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Add `Appsignal.set_tags` helper as an alias for `Appsignal.tag_request`. This is a context independent named alias which we use on the Transaction class as well.

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -517,6 +517,7 @@ module Appsignal
         transaction.set_tags(tags)
       end
       alias :tag_job :tag_request
+      alias :set_tags :tag_request
 
       # Add breadcrumbs to the transaction.
       #

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -508,7 +508,11 @@ describe Appsignal do
       end
 
       it "also listens to tag_job" do
-        expect(Appsignal).to respond_to(:tag_job)
+        expect(Appsignal.method(:tag_job)).to eq(Appsignal.method(:tag_request))
+      end
+
+      it "also listens to set_tags" do
+        expect(Appsignal.method(:set_tags)).to eq(Appsignal.method(:tag_request))
       end
     end
 


### PR DESCRIPTION
Alias `set_tags` to `Appsignal.tag_request`. We have and document `set_tags` in the context of a `set_error` callback, like:

```ruby
Appsignal.set_error(error) do |transaction|
  transaction.set_tags(:key => "value")
end
```

Now apps can use one consistent naming for the way to set tags independent of the context.

Closes #1151