### PR TITLE
Add Appsignal.set_params helper

### DIFF
--- a/.changesets/add-appsignal-set_params-helper.md
+++ b/.changesets/add-appsignal-set_params-helper.md
@@ -1,0 +1,10 @@
+---
+bump: patch
+type: add
+---
+
+Add `Appsignal.set_params` helper. Set custom parameters on the current transaction with the `Appsignal.set_params` helper. Note that this will overwrite any request parameters that would be set automatically on the transaction. When this method is called multiple times, it will overwrite the previously set value.
+
+```ruby
+Appsignal.set_params("param1" => "value1", "param2" => "value2")
+```

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -518,6 +518,43 @@ module Appsignal
       end
       alias :tag_job :tag_request
 
+      # Set parameters on the current transaction.
+      #
+      # Parameters are automatically set by most of our integrations. It should
+      # not be necessary to call this method unless you want to report
+      # different parameters.
+      #
+      # To filter parameters, see our parameter filtering guide.
+      #
+      # When this method is called multiple times, it will overwrite the
+      # previously set value.
+      #
+      # When no parameters are set this way, the transaction will look for
+      # parameters in its request environment.
+      #
+      # @example
+      #   Appsignal.set_params("param1" => "value1")
+      #
+      # @example
+      #   Appsignal.set_params("param1" => "value1")
+      #   Appsignal.set_params("param2" => "value2")
+      #   # Parameters are: { "param2" => "value2" }
+      #
+      # @since 3.10.0
+      # @param given_params [Hash] The parameters to set on the transaction.
+      # @see https://docs.appsignal.com/guides/custom-data/sample-data.html
+      #   Sample data guide
+      # @see https://docs.appsignal.com/guides/filter-data/filter-parameters.html
+      #   Parameter filtering guide
+      # @return [void]
+      def set_params(params)
+        return unless active?
+        return unless Appsignal::Transaction.current?
+
+        transaction = Appsignal::Transaction.current
+        transaction.set_params(params)
+      end
+
       # Add breadcrumbs to the transaction.
       #
       # Breadcrumbs can be used to trace what path a user has taken

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -152,6 +152,7 @@ module Appsignal
     # The parameters set using {#set_params} are leading over those extracted
     # from a request's environment.
     #
+    # @since 3.9.1
     # @param given_params [Hash] The parameters to set on the transaction.
     # @return [void]
     def set_params(given_params)
@@ -172,6 +173,7 @@ module Appsignal
     # When no parameters are set this way, the transaction will look for
     # parameters on the {#request} environment.
     #
+    # @since 3.9.1
     # @param given_params [Hash] The parameters to set on the transaction if none are already set.
     # @return [void]
     def set_params_if_nil(given_params)

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -512,6 +512,40 @@ describe Appsignal do
       end
     end
 
+    describe ".set_params" do
+      before do
+        start_agent
+      end
+
+      context "with transaction" do
+        let(:transaction) { http_request_transaction }
+        before { set_current_transaction(transaction) }
+
+        it "sets parameters on the transaction" do
+          Appsignal.set_params("param1" => "value1")
+
+          transaction._sample
+          expect(transaction).to include_params("param1" => "value1")
+        end
+
+        it "overwrites the params if called multiple times" do
+          Appsignal.set_params("param1" => "value1")
+          Appsignal.set_params("param2" => "value2")
+
+          transaction._sample
+          expect(transaction).to include_params("param2" => "value2")
+        end
+      end
+
+      context "without transaction" do
+        it "does not set tags on the transaction" do
+          Appsignal.set_params("a" => "b")
+
+          expect_any_instance_of(Appsignal::Transaction).to_not receive(:set_params)
+        end
+      end
+    end
+
     describe ".add_breadcrumb" do
       around do |example|
         start_agent


### PR DESCRIPTION
We didn't have an `Appsignal.set_params` helper yet. It was only available on the Transaction class. Make the two APIs consistent by adding one to be called on the `Appsignal` module like the other instrumentation helpers.

Closes #1150