### PR TITLE
Remove duplicate parameter filtering

### DIFF
--- a/lib/appsignal/hooks/active_job.rb
+++ b/lib/appsignal/hooks/active_job.rb
@@ -62,12 +62,7 @@ module Appsignal
             end
 
           if transaction
-            transaction.set_params_if_nil(
-              Appsignal::Utils::HashSanitizer.sanitize(
-                job["arguments"],
-                Appsignal.config[:filter_parameters]
-              )
-            )
+            transaction.set_params_if_nil(job["arguments"])
 
             transaction_tags = ActiveJobHelpers.transaction_tags_for(job)
             transaction_tags["active_job_id"] = job["job_id"]

--- a/lib/appsignal/integrations/sidekiq.rb
+++ b/lib/appsignal/integrations/sidekiq.rb
@@ -83,7 +83,7 @@ module Appsignal
         raise exception
       ensure
         if transaction
-          transaction.set_params_if_nil(filtered_arguments(item))
+          transaction.set_params_if_nil(parse_arguments(item))
           transaction.set_http_or_background_queue_start
           Appsignal::Transaction.complete_current! unless exception
 
@@ -113,16 +113,6 @@ module Appsignal
         return sidekiq_action_name if complete_action
 
         "#{sidekiq_action_name}#perform"
-      end
-
-      def filtered_arguments(job)
-        arguments = parse_arguments(job)
-        return unless arguments
-
-        Appsignal::Utils::HashSanitizer.sanitize(
-          arguments,
-          Appsignal.config[:filter_parameters]
-        )
       end
 
       def formatted_metadata(item)


### PR DESCRIPTION
The Active Job and Sidekiq instrumentations called out to our parameter filtering. It doesn't need to do this. Our Transaction class runs it through the parameter filtering when it calls `sanitized_params` when sampling the transaction.

No test updates needed. There were already tests present it filtered out parameters. It still does that.

[skip changeset] No behavior change, only an optimization.