### PR TITLE
Optimize setting parameters for transactions

### DIFF
--- a/.changesets/add-block-argument-to-set_params.md
+++ b/.changesets/add-block-argument-to-set_params.md
@@ -1,0 +1,13 @@
+---
+bump: patch
+type: add
+---
+
+Add a block argument to the `Appsignal.set_params` and `Appsignal::Transaction#set_params` helpers. When `set_params` is called with a block argument, the block is executed when the parameters are stored on the Transaction. This block is only called when the Transaction is sampled. Use this block argument to avoid having to parse parameters for every transaction, even when it's not sampled.
+
+```ruby
+Appsignal.set_params do
+  # Some slow code to parse parameters
+  JSON.parse('{"param1": "value1"}')
+end
+```

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -532,27 +532,50 @@ module Appsignal
       # When no parameters are set this way, the transaction will look for
       # parameters in its request environment.
       #
-      # @example
+      # A block can be given to this method to defer the fetching and parsing
+      # of the parameters until and only when the transaction is sampled.
+      #
+      # When both the `given_params` and a block is given to this method, the
+      # `given_params` argument is leading and the block will _not_ be called.
+      #
+      # @example Set parameters
       #   Appsignal.set_params("param1" => "value1")
       #
-      # @example
+      # @example Calling `set_params` multiple times will only keep the last call
       #   Appsignal.set_params("param1" => "value1")
       #   Appsignal.set_params("param2" => "value2")
-      #   # Parameters are: { "param2" => "value2" }
+      #   # The parameters are: { "param2" => "value2" }
+      #
+      # @example Calling `set_params` with a block
+      #   Appsignal.set_params do
+      #     # Some slow code to parse parameters
+      #     JSON.parse('{"param1": "value1"}')
+      #   end
+      #   # The parameters are: { "param1" => "value1" }
+      #
+      # @example Calling `set_params` with a parameter and a block
+      #   Appsignal.set_params("argument" => "argument value") do
+      #     # Some slow code to parse parameters
+      #     JSON.parse('{"param1": "value1"}')
+      #   end
+      #   # The parameters are: { "argument" => "argument value" }
       #
       # @since 3.10.0
       # @param given_params [Hash] The parameters to set on the transaction.
+      # @yield This block is called when the transaction is sampled. The block's
+      #   return value will become the new parameters.
       # @see https://docs.appsignal.com/guides/custom-data/sample-data.html
       #   Sample data guide
       # @see https://docs.appsignal.com/guides/filter-data/filter-parameters.html
       #   Parameter filtering guide
+      # @see Transaction#set_params
       # @return [void]
-      def set_params(params)
+      def set_params(params = nil, &block)
         return unless active?
         return unless Appsignal::Transaction.current?
 
         transaction = Appsignal::Transaction.current
-        transaction.set_params(params)
+        transaction.set_params(params, &block)
       end
 
       # Add breadcrumbs to the transaction.

--- a/lib/appsignal/rack/abstract_middleware.rb
+++ b/lib/appsignal/rack/abstract_middleware.rb
@@ -129,7 +129,7 @@ module Appsignal
         request_method = request_method_for(request)
         transaction.set_metadata("method", request_method) if request_method
 
-        transaction.set_params_if_nil(params_for(request))
+        transaction.set_params_if_nil { params_for(request) }
         transaction.set_http_or_background_queue_start
       end
 

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -326,6 +326,16 @@ describe Appsignal::Transaction do
         it "returns custom parameters" do
           expect(subject).to eq(:foo => "bar")
         end
+
+        context "when params is a callable object" do
+          it "calls the params object and sets the return value as parametesr" do
+            transaction.set_params { { "param1" => "value1" } }
+
+            expect(transaction.params).to eq(
+              "param1" => "value1"
+            )
+          end
+        end
       end
 
       context "without custom params set on transaction" do
@@ -374,6 +384,25 @@ describe Appsignal::Transaction do
           expect(transaction.params).to eq(params)
           expect(transaction).to include_params(params)
         end
+
+        it "updates the params on the transaction with a block" do
+          params = { "key" => "value" }
+          transaction.set_params { params }
+
+          transaction._sample
+          expect(transaction.params).to eq(params)
+          expect(transaction).to include_params(params)
+        end
+
+        it "updates with the params argument when both an argument and block are given" do
+          arg_params = { "argument" => "value" }
+          block_params = { "block" => "value" }
+          transaction.set_params(arg_params) { block_params }
+
+          transaction._sample
+          expect(transaction.params).to eq(arg_params)
+          expect(transaction).to include_params(arg_params)
+        end
       end
 
       context "when the given params is nil" do
@@ -402,6 +431,25 @@ describe Appsignal::Transaction do
           expect(transaction).to include_params(params)
         end
 
+        it "updates the params on the transaction with a block" do
+          params = { "key" => "value" }
+          transaction.set_params_if_nil { params }
+
+          transaction._sample
+          expect(transaction.params).to eq(params)
+          expect(transaction).to include_params(params)
+        end
+
+        it "updates with the params argument when both an argument and block are given" do
+          arg_params = { "argument" => "value" }
+          block_params = { "block" => "value" }
+          transaction.set_params_if_nil(arg_params) { block_params }
+
+          transaction._sample
+          expect(transaction.params).to eq(arg_params)
+          expect(transaction).to include_params(arg_params)
+        end
+
         context "when the given params is nil" do
           it "does not update the params on the transaction" do
             params = { "key" => "value" }
@@ -421,6 +469,17 @@ describe Appsignal::Transaction do
           params = { "key" => "value" }
           transaction.set_params(preset_params)
           transaction.set_params_if_nil(params)
+
+          transaction._sample
+          expect(transaction.params).to eq(preset_params)
+          expect(transaction).to include_params(preset_params)
+        end
+
+        it "does not update the params with a block on the transaction" do
+          preset_params = { "other" => "params" }
+          params = { "key" => "value" }
+          transaction.set_params(preset_params)
+          transaction.set_params_if_nil { params }
 
           transaction._sample
           expect(transaction.params).to eq(preset_params)
@@ -820,6 +879,17 @@ describe Appsignal::Transaction do
           { "key" => "value" },
           kind_of(Integer)
         )
+      end
+
+      context "when params is a callable object" do
+        it "calls the params object and sets the return value as parametesr" do
+          transaction.set_params { { "param1" => "value1" } }
+
+          transaction.sample_data
+          expect(transaction).to include_params(
+            "param1" => "value1"
+          )
+        end
       end
     end
 

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -535,6 +535,13 @@ describe Appsignal do
           transaction._sample
           expect(transaction).to include_params("param2" => "value2")
         end
+
+        it "sets parameters with a block on the transaction" do
+          Appsignal.set_params { { "param1" => "value1" } }
+
+          transaction._sample
+          expect(transaction).to include_params("param1" => "value1")
+        end
       end
 
       context "without transaction" do


### PR DESCRIPTION
With the recent refactoring of the Rack middleware, I changed how we set the request parameters on the transaction. Previously, we read the parameters from the request object in the transaction when we sampled it. Not always.

Now that we use the currently active transaction when a transaction is already active, I needed to update how we set parameters using the `set_params`/`set_params_if_nil` helpers. These helper methods require us to pass in the parsed parameters, potentially making every request slower because it has to fetch and parse the request parameters.

Add a block argument to the `set_params`/`set_params_if_nil` helpers to fetch and parse the parameters only when we sample the transaction. This change should reduce the AppSignal overhead for non-sampled transactions.

I have no specific preference if the argument or block is leading. I chose the argument to be leading.

Based on #1154 

## To do

- [ ] Use this method to set sidekiq and active job parameters when #1157 is also merged