### PR TITLE
Fix all_specs deprecation of bundler

### DIFF
--- a/.changesets/fix-deprecation-of-bundler-rubygems-all_specs.md
+++ b/.changesets/fix-deprecation-of-bundler-rubygems-all_specs.md
@@ -3,4 +3,4 @@ bump: "patch"
 type: "fix"
 ---
 
-Fix deprecation of Bundler.rubygems.all_specs
+Fix deprecation warning of Bundler.rubygems.all_specs usage.

--- a/.changesets/fix-deprecation-of-bundler-rubygems-all_specs.md
+++ b/.changesets/fix-deprecation-of-bundler-rubygems-all_specs.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix deprecation of Bundler.rubygems.all_specs

--- a/lib/appsignal/environment.rb
+++ b/lib/appsignal/environment.rb
@@ -121,11 +121,12 @@ module Appsignal
     def self.report_supported_gems
       return unless defined?(Bundler) # Do nothing if Bundler is not present
 
-      bundle_gem_specs = if ::Bundler.rubygems.respond_to?(:installed_specs)
-        ::Bundler.rubygems.installed_specs
-      else
-        ::Bundler.rubygems.all_specs
-      end
+      bundle_gem_specs =
+        if ::Bundler.rubygems.respond_to?(:installed_specs)
+          ::Bundler.rubygems.installed_specs
+        else
+          ::Bundler.rubygems.all_specs
+        end
       SUPPORTED_GEMS.each do |gem_name|
         gem_spec = bundle_gem_specs.find { |spec| spec.name == gem_name }
         next unless gem_spec

--- a/lib/appsignal/environment.rb
+++ b/lib/appsignal/environment.rb
@@ -121,7 +121,11 @@ module Appsignal
     def self.report_supported_gems
       return unless defined?(Bundler) # Do nothing if Bundler is not present
 
-      bundle_gem_specs = ::Bundler.rubygems.all_specs
+      bundle_gem_specs = if ::Bundler.rubygems.respond_to?(:installed_specs)
+        ::Bundler.rubygems.installed_specs
+      else
+        ::Bundler.rubygems.all_specs
+      end
       SUPPORTED_GEMS.each do |gem_name|
         gem_spec = bundle_gem_specs.find { |spec| spec.name == gem_name }
         next unless gem_spec


### PR DESCRIPTION
bundler deprecated the usage of `Bundler.rubygems.all_specs` with version 2.5.12 (June 13, 2024), in order to better support default gems.
This version is the new default version with ruby 3.3.3 and thus the warning pops up:

Bundler.rubygems.all_specs has been removed in favor of Bundler.rubygems.installed_specs