### PR TITLE
Update GitHub actions to run builds for forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,15 @@
 ---
 name: Ruby gem CI
 'on':
-  push: {}
+  push:
+    branches:
+    - main
+    - develop
+  pull_request:
+    types:
+    - opened
+    - reopened
+    - synchronize
   schedule:
   - cron: 0 0 * * 1-5
 concurrency:

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -1,7 +1,10 @@
 github:
   name: Ruby gem CI
   "on":
-    push: {}
+    push:
+      branches: ["main", "develop"]
+    pull_request:
+      types: [opened, reopened, synchronize]
     schedule:
       - cron: "0 0 * * 1-5"
 


### PR DESCRIPTION
Apparently it only builds builds for forks on the `pull_request` events.

> Workflows triggered by pull_request_target events are run in the
> context of the base branch.

https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks

[skip changeset]
[skip review]