### PR TITLE
Add monitor instrumentation helpers

### DIFF
--- a/.changesets/add-monitor-helper.md
+++ b/.changesets/add-monitor-helper.md
@@ -1,0 +1,32 @@
+---
+bump: minor
+type: add
+---
+
+Add `Appsignal.monitor` and `Appsignal.monitor_and_stop` instrumentation helpers. These helpers are a replacement for the `Appsignal.monitor_transaction` and `Appsignal.monitor_single_transaction` helpers.
+
+Use these new helpers to create an AppSignal transaction and track any exceptions that occur within the instrumented block. This new helper supports custom namespaces and has a simpler way to set an action name. Use this helper in combination with our other `Appsignal.set_*` helpers to add more metadata to the transaction.
+
+```ruby
+# New helper
+Appsignal.monitor(
+  :namespace => "my_namespace",
+  :action => "MyClass#my_method"
+) do
+  # Track an instrumentation event
+  Appsignal.instrument("my_event.my_group") do
+    # Some code
+  end
+end
+
+# Old helper
+Appsignal.monitor_transaction(
+  "process_action.my_group",
+  :class_name => "MyClass",
+  :action_name => "my_method"
+) do
+  # Some code
+end
+```
+
+The `Appsignal.monitor_and_stop` helper can be used in the same scenarios as the `Appsignal.monitor_single_transaction` helper is used. One-off Ruby scripts that are not part of a long running process.

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -37,6 +37,15 @@ module Appsignal
       #     end
       #   end
       #
+      # @example Set the action name in the monitor block
+      #   Appsignal.monitor(
+      #     :namespace => "my_namespace",
+      #   ) do
+      #     # Some code
+      #
+      #     Appsignal.set_action("GET /resource/:id")
+      #   end
+      #
       # @example Set custom metadata on the transaction
       #   Appsignal.monitor(
       #     :namespace => "my_namespace",
@@ -68,10 +77,14 @@ module Appsignal
       # @param namespace [String/Symbol] The namespace to set on the new
       #   transaction.
       #   Defaults to the 'web' namespace.
-      #   This will update the already active transaction's namespace if
+      #   This will not update the active transaction's namespace if
       #   {.monitor} is called when another transaction is already active.
       # @param action [String/Symbol] The action name for the transaction.
-      #   This will update the already active transaction's action if
+      #   The action name is required to be set for the transaction to be
+      #   reported.
+      #   The argument can be omitted only if the action is set within the
+      #   block with {#set_action}.
+      #   This will not update the active transaction's action if
       #   {.monitor} is called when another transaction is already active.
       # @yield The block to monitor.
       # @raise [Exception] Any exception that occurs within the given block is

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -5,6 +5,140 @@ module Appsignal
     module Instrumentation
       include Appsignal::Utils::StdoutAndLoggerMessage
 
+      # Monitor a block of code with AppSignal.
+      #
+      # This is a helper to create an AppSignal transaction, track any errors
+      # that may occur and complete the transaction.
+      #
+      # This helper is recommended to be used in Ruby scripts and parts of an
+      # app not already instrumented by AppSignal's automatic instrumentations.
+      #
+      # Use this helper in combination with our {.instrument} helper to track
+      # instrumentation events.
+      #
+      # If AppSignal is not active ({Appsignal.active?}) it will still execute
+      # the block, but not create a transaction for it.
+      #
+      # @example Instrument a block of code
+      #   Appsignal.monitor(
+      #     :namespace => "my_namespace",
+      #     :action => "MyClass#my_method"
+      #   ) do
+      #     # Some code
+      #   end
+      #
+      # @example Instrument a block of code with an instrumentation event
+      #   Appsignal.monitor(
+      #     :namespace => "my_namespace",
+      #     :action => "MyClass#my_method"
+      #   ) do
+      #     Appsignal.instrument("some_event.some_group") do
+      #       # Some code
+      #     end
+      #   end
+      #
+      # @example Set custom metadata on the transaction
+      #   Appsignal.monitor(
+      #     :namespace => "my_namespace",
+      #     :action => "MyClass#my_method"
+      #   ) do
+      #     # Some code
+      #
+      #     Appsignal.set_tags(:tag1 => "value1", :tag2 => "value2")
+      #     Appsignal.set_params(:param1 => "value1", :param2 => "value2")
+      #   end
+      #
+      # @example Call monitor within monitor (not recommended)
+      #   Appsignal.monitor(
+      #     :namespace => "my_namespace",
+      #     :action => "MyClass#my_method"
+      #   ) do
+      #     # This will _not_ update the namespace and action name
+      #     Appsignal.monitor(
+      #       :namespace => "my_other_namespace",
+      #       :action => "MyOtherClass#my_other_method"
+      #     ) do
+      #       # Some code
+      #
+      #       # The reported namespace will be "my_namespace"
+      #       # The reported action will be "MyClass#my_method"
+      #     end
+      #   end
+      #
+      # @param namespace [String/Symbol] The namespace to set on the new
+      #   transaction.
+      #   Defaults to the 'web' namespace.
+      #   This will update the already active transaction's namespace if
+      #   {.monitor} is called when another transaction is already active.
+      # @param action [String/Symbol] The action name for the transaction.
+      #   This will update the already active transaction's action if
+      #   {.monitor} is called when another transaction is already active.
+      # @yield The block to monitor.
+      # @raise [Exception] Any exception that occurs within the given block is
+      #   re-raised by this method.
+      # @return [Object] The value of the given block is returned.
+      # @since 3.11.0
+      def monitor(
+        namespace: nil,
+        action: nil
+      )
+        return yield unless active?
+
+        has_parent_transaction = Appsignal::Transaction.current?
+        transaction =
+          if has_parent_transaction
+            Appsignal::Transaction.current
+          else
+            Appsignal::Transaction.create(namespace || Appsignal::Transaction::HTTP_REQUEST)
+          end
+
+        begin
+          yield if block_given?
+        rescue Exception => error # rubocop:disable Lint/RescueException
+          transaction.set_error(error)
+          raise error
+        ensure
+          if has_parent_transaction
+            if namespace
+              callers = caller
+              Appsignal::Utils::StdoutAndLoggerMessage.warning \
+                "A parent transaction is active around this 'Appsignal.monitor' call. " \
+                  "The namespace is not updated for the parent transaction." \
+                  "If you want to update the namespace for this parent transaction, " \
+                  "call 'Appsignal.set_namespace' from within the 'Appsignal.monitor' block. " \
+                  "Update the 'Appsignal.monitor' call in: #{callers.first}"
+            end
+            if action
+              callers = caller
+              Appsignal::Utils::StdoutAndLoggerMessage.warning \
+                "A parent transaction is active around this 'Appsignal.monitor' call. " \
+                  "The action is not updated for the parent transaction." \
+                  "If you want to update the action for this parent transaction, " \
+                  "call 'Appsignal.set_action' from within the 'Appsignal.monitor' block. " \
+                  "Update the 'Appsignal.monitor' call in: #{callers.first}"
+            end
+          else
+            transaction.set_action_if_nil(action)
+            Appsignal::Transaction.complete_current!
+          end
+        end
+      end
+
+      # Instrument a block of code and stop AppSignal.
+      #
+      # Useful for cases such as one-off scripts where there is no long running
+      # process active and the data needs to be sent after the process exists.
+      #
+      # Acts the same way as {.monitor}. See that method for more
+      # documentation.
+      #
+      # @see monitor
+      def monitor_and_stop(namespace: nil, action: nil)
+        monitor(:namespace => namespace, :action => action)
+      ensure
+        Appsignal.stop("monitor_and_stop")
+      end
+
       # Creates an AppSignal transaction for the given block.
       #
       # If AppSignal is not {Appsignal.active?} it will still execute the
@@ -818,14 +952,11 @@ module Appsignal
         name,
         title = nil,
         body = nil,
-        body_format = Appsignal::EventFormatter::DEFAULT
+        body_format = Appsignal::EventFormatter::DEFAULT,
+        &block
       )
-        Appsignal::Transaction.current.start_event
-        yield if block_given?
-      ensure
-        Appsignal::Transaction
-          .current
-          .finish_event(name, title, body, body_format)
+        Appsignal::Transaction.current
+          .instrument(name, title, body, body_format, &block)
       end
 
       # Instrumentation helper for SQL queries.

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -358,6 +358,132 @@ describe Appsignal do
     before { start_agent }
     around { |example| keep_transactions { example.run } }
 
+    describe ".monitor" do
+      it "creates a transaction" do
+        expect do
+          Appsignal.monitor
+        end.to(change { created_transactions.count }.by(1))
+
+        transaction = last_transaction
+        expect(transaction).to have_namespace(Appsignal::Transaction::HTTP_REQUEST)
+        expect(transaction).to_not have_action
+        expect(transaction).to_not have_error
+        expect(transaction).to_not include_events
+        expect(transaction).to_not have_queue_start
+        expect(transaction).to be_completed
+      end
+
+      it "returns the block's return value" do
+        expect(Appsignal.monitor { :return_value }).to eq(:return_value)
+      end
+
+      it "sets a custom namespace via the namespace argument" do
+        Appsignal.monitor(:namespace => "custom")
+
+        expect(last_transaction).to have_namespace("custom")
+      end
+
+      it "doesn't overwrite custom namespace set in the block" do
+        Appsignal.monitor(:namespace => "custom") do
+          Appsignal.set_namespace("more custom")
+        end
+
+        expect(last_transaction).to have_namespace("more custom")
+      end
+
+      it "sets a custom action via the action argument" do
+        Appsignal.monitor(:action => "custom")
+
+        expect(last_transaction).to have_action("custom")
+      end
+
+      it "doesn't overwrite custom action set in the block" do
+        Appsignal.monitor(:action => "custom") do
+          Appsignal.set_action("more custom")
+        end
+
+        expect(last_transaction).to have_action("more custom")
+      end
+
+      it "reports exceptions that occur in the block" do
+        expect do
+          Appsignal.monitor do
+            raise ExampleException, "error message"
+          end
+        end.to raise_error(ExampleException, "error message")
+
+        expect(last_transaction).to have_error("ExampleException", "error message")
+      end
+
+      context "with already active transction" do
+        let(:err_stream) { std_stream }
+        let(:stderr) { err_stream.read }
+        let(:transaction) { http_request_transaction }
+        before do
+          set_current_transaction(transaction)
+          transaction.set_action("My action")
+        end
+
+        it "doesn't create a new transaction" do
+          expect do
+            Appsignal.monitor
+          end.to_not(change { created_transactions.count })
+        end
+
+        it "does not overwrite the parent transaction's namespace" do
+          logs =
+            capture_logs do
+              capture_std_streams(std_stream, err_stream) do
+                Appsignal.monitor(:namespace => "custom")
+              end
+            end
+
+          expect(transaction).to have_namespace(Appsignal::Transaction::HTTP_REQUEST)
+          warning =
+            "A parent transaction is active around this 'Appsignal.monitor' call. " \
+              "The namespace is not updated"
+          expect(logs).to contains_log(:warn, warning)
+          expect(stderr).to include("appsignal WARNING: #{warning}")
+        end
+
+        it "does not overwrite the parent transaction's action" do
+          logs =
+            capture_logs do
+              capture_std_streams(std_stream, err_stream) do
+                Appsignal.monitor(:action => "custom")
+              end
+            end
+
+          expect(transaction).to have_action("My action")
+          warning =
+            "A parent transaction is active around this 'Appsignal.monitor' call. " \
+              "The action is not updated"
+          expect(logs).to contains_log(:warn, warning)
+          expect(stderr).to include("appsignal WARNING: #{warning}")
+        end
+
+        it "doesn't complete the parent transaction" do
+          Appsignal.monitor
+
+          expect(transaction).to_not be_completed
+        end
+      end
+    end
+
+    describe ".monitor_and_stop" do
+      it "calls Appsignal.stop after the block" do
+        allow(Appsignal).to receive(:stop)
+        Appsignal.monitor_and_stop(:namespace => "custom", :action => "My Action")
+
+        transaction = last_transaction
+        expect(transaction).to have_namespace("custom")
+        expect(transaction).to have_action("My Action")
+        expect(transaction).to be_completed
+
+        expect(Appsignal).to have_received(:stop).with("monitor_and_stop")
+      end
+    end
+
     describe ".monitor_transaction" do
       context "with a successful call" do
         it "instruments and completes for a background job" do

--- a/spec/support/matchers/transaction.rb
+++ b/spec/support/matchers/transaction.rb
@@ -180,18 +180,20 @@ RSpec::Matchers.alias_matcher :include_breadcrumbs, :include_breadcrumb
 
 RSpec::Matchers.define :have_queue_start do |queue_start_time|
   match(:notify_expectation_failures => true) do |transaction|
+    actual_start = transaction.ext.queue_start
     if queue_start_time
-      expect(transaction.ext.queue_start).to eq(queue_start_time)
+      expect(actual_start).to eq(queue_start_time)
     else
-      expect(transaction.ext.queue_start).to_not be_nil
+      expect(actual_start).to_not be_nil
     end
   end
 
   match_when_negated(:notify_expectation_failures => true) do |transaction|
+    actual_start = transaction.ext.queue_start
     if queue_start_time
-      expect(transaction.ext.queue_start).to_not eq(queue_start_time)
+      expect(actual_start).to_not eq(queue_start_time)
     else
-      expect(transaction.ext.queue_start).to be_nil
+      expect(actual_start).to be_nil
     end
   end
 end


### PR DESCRIPTION
Add new "create a transaction" helpers to replace the `monitor_transaction` and `monitor_single_transaction` helpers. These helpers do too much and are confusing to use. We didn't end up using them ourselves anymore in our integrations.

These new helpers are based on what we most commonly do in the Ruby gem to instrument blocks of code.

These helpers don't accept adding metadata to the transaction using an `env` argument. This can now be set using the instrumentation helpers like `set_action`, `set_params`, `set_custom_data`, etc.

If an app wants to track blocks of code with an instrumentation event, `Appsignal.instrument` needs to be called in the `Appsignal.monitor` block.

If this helper were to both create a transaction and an instrumentation event the arguments would get complicated and it becomes unclear what it's meant to be used for.

These helpers support nested transaction in such a way that it won't break anything, but the namespace and action arguments are ignored when a parent transaction is active.


## To do

- [x] Decide if we want to add this
- [ ] Deprecate the `monitor_transaction` and `monitor_single_transaction` helpers