### PR TITLE
Optimize setting Sidekiq job arguments

### DIFF
--- a/.changesets/optimize-sidekiq-argumetns.md
+++ b/.changesets/optimize-sidekiq-argumetns.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Optimize Sidekiq job arguments being recorded. Job arguments are only fetched and set when we sample the job transaction, which should decrease our overhead for all jobs we don't sample.

--- a/lib/appsignal/integrations/sidekiq.rb
+++ b/lib/appsignal/integrations/sidekiq.rb
@@ -83,7 +83,7 @@ module Appsignal
         raise exception
       ensure
         if transaction
-          transaction.set_params_if_nil(parse_arguments(item))
+          transaction.set_params_if_nil { parse_arguments(item) }
           transaction.set_http_or_background_queue_start
           Appsignal::Transaction.complete_current! unless exception
 


### PR DESCRIPTION
Use the improvements from PR #1158 to fetch and set parameters with a block, only when the transaction is sampled.