### PR TITLE
Specify visibility in API docs

### DIFF
--- a/lib/appsignal/cli/demo.rb
+++ b/lib/appsignal/cli/demo.rb
@@ -39,7 +39,6 @@ module Appsignal
     #   AppSignal demo documentation
     # @see https://docs.appsignal.com/support/debugging.html
     #   Debugging AppSignal guide
-    # @api private
     class Demo
       class << self
         # @param options [Hash]

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -10,6 +10,7 @@ module Appsignal
   class Config
     include Appsignal::Utils::StdoutAndLoggerMessage
 
+    # @api private
     DEFAULT_CONFIG = {
       :activejob_report_errors => "all",
       :ca_file_path => File.expand_path(File.join("../../../resources/cacert.pem"), __FILE__),
@@ -67,6 +68,7 @@ module Appsignal
       "trace" => ::Logger::DEBUG
     }.freeze
 
+    # @api private
     ENV_TO_KEY_MAPPING = {
       "APPSIGNAL_ACTIVE" => :active,
       "APPSIGNAL_ACTIVEJOB_REPORT_ERRORS" => :activejob_report_errors,
@@ -178,6 +180,7 @@ module Appsignal
       APPSIGNAL_IGNORE_NAMESPACES
       APPSIGNAL_REQUEST_HEADERS
     ].freeze
+    # @api private
     ENV_FLOAT_KEYS = %w[
       APPSIGNAL_CPU_COUNT
     ].freeze
@@ -211,8 +214,10 @@ module Appsignal
     #   @api private
     #   @return [Hash]
 
+    # @api private
     attr_reader :root_path, :env, :config_hash, :system_config,
       :initial_config, :file_config, :env_config, :override_config
+    # @api private
     attr_accessor :logger
 
     # Initialize a new configuration object for AppSignal.
@@ -316,6 +321,7 @@ module Appsignal
       config_hash[key] = value
     end
 
+    # @api private
     def log_level
       level = ::Logger::DEBUG if config_hash[:debug] || config_hash[:transaction_debug_mode]
       option = config_hash[:log_level]
@@ -326,6 +332,7 @@ module Appsignal
       level.nil? ? Appsignal::Config::DEFAULT_LOG_LEVEL : level
     end
 
+    # @api private
     def log_file_path
       return @log_file_path if defined? @log_file_path
 
@@ -360,6 +367,7 @@ module Appsignal
       @valid && config_hash[:active]
     end
 
+    # @api private
     def write_to_environment # rubocop:disable Metrics/AbcSize
       ENV["_APPSIGNAL_ACTIVE"]                       = active?.to_s
       ENV["_APPSIGNAL_AGENT_PATH"]                   = File.expand_path("../../ext", __dir__).to_s
@@ -405,6 +413,7 @@ module Appsignal
       ENV["_APP_REVISION"] = config_hash[:revision].to_s
     end
 
+    # @api private
     def validate
       # Strip path from endpoint so we're backwards compatible with
       # earlier versions of the gem.

--- a/lib/appsignal/event_formatter.rb
+++ b/lib/appsignal/event_formatter.rb
@@ -10,14 +10,14 @@ module Appsignal
   # event, the same object will be called intermittently in a threaded environment.
   # So only keep global configuration as state and pass the payload around as an
   # argument if you need to use helper methods.
-  #
-  # @api private
   class EventFormatter
     class << self
+      # @api private
       def formatters
         @formatters ||= {}
       end
 
+      # @api private
       def formatter_classes
         @formatter_classes ||= {}
       end
@@ -49,6 +49,7 @@ module Appsignal
         end
       end
 
+      # @api private
       def format(name, payload)
         formatter = formatters[name]
         formatter&.format(payload)

--- a/lib/appsignal/event_formatter/rom/sql_formatter.rb
+++ b/lib/appsignal/event_formatter/rom/sql_formatter.rb
@@ -2,6 +2,7 @@
 
 module Appsignal
   class EventFormatter
+    # @api private
     module Rom
       class SqlFormatter
         def format(payload)

--- a/lib/appsignal/integrations/action_cable.rb
+++ b/lib/appsignal/integrations/action_cable.rb
@@ -2,6 +2,7 @@
 
 module Appsignal
   module Integrations
+    # @api private
     module ActionCableIntegration
       def perform_action(*args, &block)
         # The request is only the original websocket request

--- a/lib/appsignal/integrations/active_support_notifications.rb
+++ b/lib/appsignal/integrations/active_support_notifications.rb
@@ -2,6 +2,7 @@
 
 module Appsignal
   module Integrations
+    # @api private
     module ActiveSupportNotificationsIntegration
       BANG = "!"
 

--- a/lib/appsignal/integrations/data_mapper.rb
+++ b/lib/appsignal/integrations/data_mapper.rb
@@ -2,6 +2,7 @@
 
 module Appsignal
   class Hooks
+    # @api private
     module DataMapperLogListener
       SQL_CLASSES = [
         "DataObjects::SqlServer::Connection",

--- a/lib/appsignal/integrations/dry_monitor.rb
+++ b/lib/appsignal/integrations/dry_monitor.rb
@@ -2,6 +2,7 @@
 
 module Appsignal
   module Integrations
+    # @api private
     module DryMonitorIntegration
       def instrument(event_id, payload = {}, &block)
         Appsignal::Transaction.current.start_event

--- a/lib/appsignal/integrations/excon.rb
+++ b/lib/appsignal/integrations/excon.rb
@@ -2,6 +2,7 @@
 
 module Appsignal
   module Integrations
+    # @api private
     module ExconIntegration
       def self.instrument(name, data, &block)
         namespace, *event = name.split(".")

--- a/lib/appsignal/integrations/http.rb
+++ b/lib/appsignal/integrations/http.rb
@@ -2,6 +2,7 @@
 
 module Appsignal
   module Integrations
+    # @api private
     module HttpIntegration
       def request(verb, uri, opts = {})
         parsed_request_uri = uri.is_a?(URI) ? uri : URI.parse(uri.to_s)

--- a/lib/appsignal/integrations/net_http.rb
+++ b/lib/appsignal/integrations/net_http.rb
@@ -2,6 +2,7 @@
 
 module Appsignal
   module Integrations
+    # @api private
     module NetHttpIntegration
       def request(request, body = nil, &block)
         Appsignal.instrument(

--- a/lib/appsignal/integrations/object.rb
+++ b/lib/appsignal/integrations/object.rb
@@ -3,6 +3,8 @@
 Appsignal::Environment.report_enabled("object_instrumentation") if defined?(Appsignal)
 
 class Object
+  # @see https://docs.appsignal.com/ruby/instrumentation/method-instrumentation.html
+  #   Method instrumentation documentation.
   def self.appsignal_instrument_class_method(method_name, options = {})
     singleton_class.send \
       :alias_method, "appsignal_uninstrumented_#{method_name}", method_name
@@ -20,6 +22,8 @@ class Object
     end
   end
 
+  # @see https://docs.appsignal.com/ruby/instrumentation/method-instrumentation.html
+  #   Method instrumentation documentation.
   def self.appsignal_instrument_method(method_name, options = {})
     alias_method "appsignal_uninstrumented_#{method_name}", method_name
     define_method method_name do |*args, &block|
@@ -33,12 +37,14 @@ class Object
     ruby2_keywords method_name if respond_to?(:ruby2_keywords, true)
   end
 
+  # @api private
   def self.appsignal_reverse_class_name
     return "AnonymousClass" unless name
 
     name.split("::").reverse.join(".")
   end
 
+  # @api private
   def appsignal_reverse_class_name
     self.class.appsignal_reverse_class_name
   end

--- a/lib/appsignal/integrations/que.rb
+++ b/lib/appsignal/integrations/que.rb
@@ -2,6 +2,7 @@
 
 module Appsignal
   module Integrations
+    # @api private
     module QuePlugin
       def _run(*)
         local_attrs = respond_to?(:que_attrs) ? que_attrs : attrs

--- a/lib/appsignal/integrations/redis.rb
+++ b/lib/appsignal/integrations/redis.rb
@@ -2,6 +2,7 @@
 
 module Appsignal
   module Integrations
+    # @api private
     module RedisIntegration
       def write(command)
         sanitized_command =

--- a/lib/appsignal/integrations/redis_client.rb
+++ b/lib/appsignal/integrations/redis_client.rb
@@ -2,6 +2,7 @@
 
 module Appsignal
   module Integrations
+    # @api private
     module RedisClientIntegration
       def write(command)
         sanitized_command =

--- a/lib/appsignal/integrations/resque.rb
+++ b/lib/appsignal/integrations/resque.rb
@@ -34,6 +34,7 @@ module Appsignal
       end
     end
 
+    # @api private
     class ResqueHelpers
       def self.arguments(payload)
         case payload["class"]

--- a/lib/appsignal/integrations/sidekiq.rb
+++ b/lib/appsignal/integrations/sidekiq.rb
@@ -11,6 +11,7 @@ module Appsignal
     # about completing the transaction.
     #
     # Introduced in Sidekiq 5.1.
+    # @api private
     class SidekiqDeathHandler
       def call(_job_context, exception)
         return unless Appsignal.config[:sidekiq_report_errors] == "discard"

--- a/lib/appsignal/integrations/unicorn.rb
+++ b/lib/appsignal/integrations/unicorn.rb
@@ -2,6 +2,7 @@
 
 module Appsignal
   module Integrations
+    # @api private
     module UnicornIntegration
       # Make sure that appsignal is started and the last transaction
       # in a worker gets flushed.

--- a/lib/appsignal/logger.rb
+++ b/lib/appsignal/logger.rb
@@ -4,7 +4,10 @@ require "logger"
 require "set"
 
 module Appsignal
-  # Logger that flushes logs to the AppSignal logging service
+  # Logger that flushes logs to the AppSignal logging service.
+  #
+  # @see https://docs.appsignal.com/logging/platforms/integrations/ruby.html
+  #   AppSignal Ruby logging documentation.
   class Logger < ::Logger
     PLAINTEXT = 0
     LOGFMT = 1
@@ -144,8 +147,9 @@ module Appsignal
     # as our logger directly inherits from Ruby base logger.
     #
     # Links:
-    # https://github.com/rails/rails/blob/e11ebc04cfbe41c06cdfb70ee5a9fdbbd98bb263/activesupport/lib/active_support/logger.rb#L60-L76
-    # https://github.com/rails/rails/blob/main/activesupport/e11ebc04cfbe41c06cdfb70ee5a9fdbbd98bb263/active_support/logger_silence.rb
+    #
+    # - https://github.com/rails/rails/blob/e11ebc04cfbe41c06cdfb70ee5a9fdbbd98bb263/activesupport/lib/active_support/logger.rb#L60-L76
+    # - https://github.com/rails/rails/blob/main/activesupport/e11ebc04cfbe41c06cdfb70ee5a9fdbbd98bb263/active_support/logger_silence.rb
     def silence(_severity = ERROR, &block)
       block.call
     end

--- a/lib/appsignal/probes.rb
+++ b/lib/appsignal/probes.rb
@@ -2,8 +2,10 @@
 
 module Appsignal
   module Probes
+    # @api private
     ITERATION_IN_SECONDS = 60
 
+    # @api private
     class ProbeCollection
       def initialize
         @probes = {}
@@ -72,6 +74,7 @@ module Appsignal
 
       # @see ProbeCollection
       # @return [ProbeCollection] Returns list of probes.
+      # @api private
       def probes
         @probes ||= ProbeCollection.new
       end

--- a/lib/appsignal/probes/helpers.rb
+++ b/lib/appsignal/probes/helpers.rb
@@ -2,6 +2,7 @@
 
 module Appsignal
   module Probes
+    # @api private
     module Helpers
       private
 

--- a/lib/appsignal/probes/mri.rb
+++ b/lib/appsignal/probes/mri.rb
@@ -2,6 +2,7 @@
 
 module Appsignal
   module Probes
+    # @api private
     class MriProbe
       include Helpers
 

--- a/lib/appsignal/probes/sidekiq.rb
+++ b/lib/appsignal/probes/sidekiq.rb
@@ -2,6 +2,7 @@
 
 module Appsignal
   module Probes
+    # @api private
     class SidekiqProbe
       include Helpers
 

--- a/lib/appsignal/rack/abstract_middleware.rb
+++ b/lib/appsignal/rack/abstract_middleware.rb
@@ -9,6 +9,7 @@ module Appsignal
     # Do not use this middleware directly. Instead use
     # {InstrumentationMiddleware}.
     #
+    # @abstract
     # @api private
     class AbstractMiddleware
       DEFAULT_ERROR_REPORTING = :default

--- a/lib/appsignal/rack/abstract_middleware.rb
+++ b/lib/appsignal/rack/abstract_middleware.rb
@@ -80,7 +80,7 @@ module Appsignal
       # Either another {AbstractMiddleware} or {EventHandler} is higher in the
       # stack and will report the exception and complete the transaction.
       #
-      # @see {#instrument_app_call_with_exception_handling}
+      # @see #instrument_app_call_with_exception_handling
       def instrument_app_call(env, transaction)
         if @instrument_event_name
           Appsignal.instrument(@instrument_event_name) do
@@ -108,7 +108,7 @@ module Appsignal
       # {#instrument_app_call} this will report any exceptions being
       # raised.
       #
-      # @see {#instrument_app_call}
+      # @see #instrument_app_call
       def instrument_app_call_with_exception_handling(env, transaction, wrapped_instrumentation)
         instrument_app_call(env, transaction)
       rescue Exception => error # rubocop:disable Lint/RescueException

--- a/lib/appsignal/rack/generic_instrumentation.rb
+++ b/lib/appsignal/rack/generic_instrumentation.rb
@@ -2,6 +2,7 @@
 
 module Appsignal
   module Rack
+    # @deprecated Use {InstrumentationMiddleware} instead.
     # @api private
     class GenericInstrumentation < AbstractMiddleware
       def initialize(app, options = {})

--- a/lib/appsignal/rack/grape_middleware.rb
+++ b/lib/appsignal/rack/grape_middleware.rb
@@ -2,8 +2,9 @@
 
 module Appsignal
   module Rack
-    # @api private
+    # @api public
     class GrapeMiddleware < Appsignal::Rack::AbstractMiddleware
+      # @api private
       def initialize(app, options = {})
         options[:instrument_event_name] = "process_request.grape"
         options[:report_errors] = lambda { |env| !env["grape.skip_appsignal_error"] }

--- a/lib/appsignal/rack/streaming_listener.rb
+++ b/lib/appsignal/rack/streaming_listener.rb
@@ -10,6 +10,7 @@ module Appsignal
     # Instrumentation middleware that tracks exceptions in streaming Rack
     # responses.
     #
+    # @deprecated Use {InstrumentationMiddleware} instead.
     # @api private
     class StreamingListener < AbstractMiddleware
       def initialize(app, options = {})

--- a/lib/appsignal/span.rb
+++ b/lib/appsignal/span.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Appsignal
+  # @api private
   class Span
     def initialize(namespace = nil, ext = nil)
       @ext = ext || Appsignal::Extension::Span.root(namespace || "")

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -6,15 +6,24 @@ module Appsignal
   class Transaction
     HTTP_REQUEST   = "http_request"
     BACKGROUND_JOB = "background_job"
+    # @api private
     ACTION_CABLE   = "action_cable"
+    # @api private
     FRONTEND       = "frontend"
+    # @api private
     BLANK          = ""
+    # @api private
     ALLOWED_TAG_KEY_TYPES = [Symbol, String].freeze
+    # @api private
     ALLOWED_TAG_VALUE_TYPES = [Symbol, String, Integer].freeze
+    # @api private
     BREADCRUMB_LIMIT = 20
+    # @api private
     ERROR_CAUSES_LIMIT = 10
 
     class << self
+      # Create a new transaction and set it as the currently active
+      # transaction.
       def create(id, namespace, request, options = {})
         # Allow middleware to force a new transaction
         Thread.current[:appsignal_transaction] = nil if options.include?(:force) && options[:force]
@@ -56,6 +65,8 @@ module Appsignal
         current && !current.nil_transaction?
       end
 
+      # Complete the currently active transaction and unset it as the active
+      # transaction.
       def complete_current!
         current.complete
       rescue => e
@@ -73,8 +84,9 @@ module Appsignal
       end
     end
 
+    # @api private
     attr_reader :ext, :transaction_id, :action, :namespace, :request, :paused, :tags, :options,
-      :discarded, :breadcrumbs, :custom_data
+      :breadcrumbs, :custom_data
 
     def initialize(transaction_id, namespace, request, options = {})
       @transaction_id = transaction_id
@@ -124,18 +136,22 @@ module Appsignal
       @paused == true
     end
 
+    # @api private
     def discard!
       @discarded = true
     end
 
+    # @api private
     def restore!
       @discarded = false
     end
 
+    # @api private
     def discarded?
       @discarded == true
     end
 
+    # @api private
     def store(key)
       @store[key]
     end
@@ -325,6 +341,7 @@ module Appsignal
       @ext.set_namespace(namespace)
     end
 
+    # @api private
     def set_http_or_background_action(from = request.params)
       return unless from
 
@@ -383,6 +400,7 @@ module Appsignal
       @ext.set_metadata(key, value)
     end
 
+    # @api private
     def set_sample_data(key, data)
       return unless key && data
 
@@ -410,6 +428,7 @@ module Appsignal
       end
     end
 
+    # @api private
     def sample_data
       {
         :params => sanitized_params,
@@ -424,6 +443,7 @@ module Appsignal
       end
     end
 
+    # @see Appsignal::Helpers::Instrumentation#set_error
     def set_error(error)
       unless error.is_a?(Exception)
         Appsignal.internal_logger.error "Appsignal::Transaction#set_error: Cannot set error. " \
@@ -521,6 +541,7 @@ module Appsignal
     end
     alias_method :to_hash, :to_h
 
+    # @api private
     class GenericRequest
       attr_reader :env
 

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -166,7 +166,7 @@ module Appsignal
     # @yield This block is called when the transaction is sampled. The block's
     #   return value will become the new parameters.
     # @return [void]
-    # @see {Helpers::Instrumentation#set_params}
+    # @see Helpers::Instrumentation#set_params
     def set_params(given_params = nil, &block)
       @params = block if block
       @params = given_params if given_params
@@ -191,7 +191,7 @@ module Appsignal
     # @yield This block is called when the transaction is sampled. The block's
     #   return value will become the new parameters.
     # @return [void]
-    # @see {Helpers::Instrumentation#set_params_if_nil}
+    # @see Helpers::Instrumentation#set_params_if_nil
     def set_params_if_nil(given_params = nil, &block)
       set_params(given_params, &block) unless @params
     end

--- a/lib/appsignal/utils.rb
+++ b/lib/appsignal/utils.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+module Appsignal
+  # @api private
+  module Utils
+  end
+end
+
 require "appsignal/utils/integration_memory_logger"
 require "appsignal/utils/stdout_and_logger_message"
 require "appsignal/utils/data"

--- a/lib/appsignal/utils/data.rb
+++ b/lib/appsignal/utils/data.rb
@@ -2,7 +2,6 @@
 
 module Appsignal
   module Utils
-    # @api private
     class Data
       class << self
         def generate(body)

--- a/lib/appsignal/utils/hash_sanitizer.rb
+++ b/lib/appsignal/utils/hash_sanitizer.rb
@@ -2,7 +2,6 @@
 
 module Appsignal
   module Utils
-    # @api private
     class HashSanitizer
       FILTERED = "[FILTERED]"
       RECURSIVE = "[RECURSIVE VALUE]"

--- a/lib/appsignal/utils/integration_memory_logger.rb
+++ b/lib/appsignal/utils/integration_memory_logger.rb
@@ -4,7 +4,6 @@ require "logger"
 
 module Appsignal
   module Utils
-    # @api private
     class IntegrationMemoryLogger
       LEVELS = {
         Logger::DEBUG => :DEBUG,

--- a/lib/appsignal/utils/json.rb
+++ b/lib/appsignal/utils/json.rb
@@ -2,7 +2,6 @@
 
 module Appsignal
   module Utils
-    # @api private
     class JSON
       class << self
         def generate(body)

--- a/lib/appsignal/utils/query_params_sanitizer.rb
+++ b/lib/appsignal/utils/query_params_sanitizer.rb
@@ -2,7 +2,6 @@
 
 module Appsignal
   module Utils
-    # @api private
     class QueryParamsSanitizer
       REPLACEMENT_KEY = "?"
 

--- a/lib/appsignal/utils/stdout_and_logger_message.rb
+++ b/lib/appsignal/utils/stdout_and_logger_message.rb
@@ -2,7 +2,6 @@
 
 module Appsignal
   module Utils
-    # @api private
     module StdoutAndLoggerMessage
       def self.warning(message, logger = Appsignal.internal_logger)
         Kernel.warn "appsignal WARNING: #{message}"


### PR DESCRIPTION
## Fix YARD warnings for some new documentation

Fix the issues YARD prints when generating the documentation.

## Specify visibility in API docs

I've gone through the entire Ruby gem and added API visibility doc comments. This makes it clear to our users reading our API docs what parts can and can't be interacted with.

Also documented a couple things I came across and linked to our docs website.

[skip changeset] [skip review]
