### PR TITLE
Move Capistrano integration class to namespace

### DIFF
--- a/lib/appsignal/integrations/capistrano/capistrano_2_tasks.rb
+++ b/lib/appsignal/integrations/capistrano/capistrano_2_tasks.rb
@@ -1,47 +1,48 @@
 # frozen_string_literal: true
 
 module Appsignal
-  # @todo Move to sub-namespace
-  # @api private
-  class Capistrano
-    def self.tasks(config)
-      config.load do # rubocop:disable Metrics/BlockLength
-        after "deploy", "appsignal:deploy"
-        after "deploy:migrations", "appsignal:deploy"
+  module Integrations
+    # @api private
+    class Capistrano
+      def self.tasks(config)
+        config.load do # rubocop:disable Metrics/BlockLength
+          after "deploy", "appsignal:deploy"
+          after "deploy:migrations", "appsignal:deploy"
 
-        namespace :appsignal do
-          task :deploy do
-            env = fetch(:appsignal_env,
-              fetch(:stage, fetch(:rails_env, fetch(:rack_env, "production"))))
-            user = fetch(:appsignal_user, ENV["USER"] || ENV.fetch("USERNAME", nil))
-            revision = fetch(:appsignal_revision, fetch(:current_revision))
+          namespace :appsignal do
+            task :deploy do
+              env = fetch(:appsignal_env,
+                fetch(:stage, fetch(:rails_env, fetch(:rack_env, "production"))))
+              user = fetch(:appsignal_user, ENV["USER"] || ENV.fetch("USERNAME", nil))
+              revision = fetch(:appsignal_revision, fetch(:current_revision))
 
-            appsignal_config = Appsignal::Config.new(
-              ENV.fetch("PWD", nil),
-              env,
-              {},
-              Appsignal::Utils::IntegrationLogger.new(StringIO.new)
-            ).tap do |c|
-              fetch(:appsignal_config, {}).each do |key, value|
-                c[key] = value
+              appsignal_config = Appsignal::Config.new(
+                ENV.fetch("PWD", nil),
+                env,
+                {},
+                Appsignal::Utils::IntegrationLogger.new(StringIO.new)
+              ).tap do |c|
+                fetch(:appsignal_config, {}).each do |key, value|
+                  c[key] = value
+                end
+                c.validate
               end
-              c.validate
-            end
 
-            if appsignal_config&.active?
-              marker_data = {
-                :revision => revision,
-                :user => user
-              }
+              if appsignal_config&.active?
+                marker_data = {
+                  :revision => revision,
+                  :user => user
+                }
 
-              marker = Marker.new(marker_data, appsignal_config)
-              if config.dry_run
-                puts "Dry run: AppSignal deploy marker not actually sent."
+                marker = Marker.new(marker_data, appsignal_config)
+                if config.dry_run
+                  puts "Dry run: AppSignal deploy marker not actually sent."
+                else
+                  marker.transmit
+                end
               else
-                marker.transmit
+                puts "Not notifying of deploy, config is not active for environment: #{env}"
               end
-            else
-              puts "Not notifying of deploy, config is not active for environment: #{env}"
             end
           end
         end
@@ -51,5 +52,5 @@ module Appsignal
 end
 
 if ::Capistrano::Configuration.instance
-  Appsignal::Capistrano.tasks(::Capistrano::Configuration.instance)
+  Appsignal::Integrations::Capistrano.tasks(::Capistrano::Configuration.instance)
 end

--- a/spec/lib/appsignal/capistrano2_spec.rb
+++ b/spec/lib/appsignal/capistrano2_spec.rb
@@ -17,7 +17,7 @@ if DependencyHelper.capistrano2_present?
         c.dry_run = false
       end
     end
-    before { Appsignal::Capistrano.tasks(capistrano_config) }
+    before { Appsignal::Integrations::Capistrano.tasks(capistrano_config) }
 
     def run
       capture_stdout(out_stream) do


### PR DESCRIPTION
Fix the to do item to move the capistrano 2 class the integrations namespace.

This is a move without aliasing the old namespace location as no one should be calling the `Appsignal::Capistrano` class directly.

[skip changeset]
[skip review]