### PR TITLE
Add sample data helpers

### DIFF
--- a/.changesets/add-appsignal-set_headers-helper.md
+++ b/.changesets/add-appsignal-set_headers-helper.md
@@ -1,0 +1,10 @@
+---
+bump: patch
+type: add
+---
+
+Add `Appsignal.set_headers` helper. Set custom request headers on the current transaction with the `Appsignal.set_headers` helper. Note that this will overwrite any request headers that would be set automatically on the transaction. When this method is called multiple times, it will overwrite the previously set value.
+
+```ruby
+Appsignal.set_headers("PATH_INFO" => "/some-path", "HTTP_USER_AGENT" => "Firefox")
+```

--- a/.changesets/add-appsignal-set_session_data-helper.md
+++ b/.changesets/add-appsignal-set_session_data-helper.md
@@ -1,0 +1,10 @@
+---
+bump: patch
+type: add
+---
+
+Add `Appsignal.set_session_data` helper. Set custom session data on the current transaction with the `Appsignal.set_session_data` helper. Note that this will overwrite any request session data that would be set automatically on the transaction. When this method is called multiple times, it will overwrite the previously set value.
+
+```ruby
+Appsignal.set_session_data("data1" => "value1", "data2" => "value2")
+```

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -666,6 +666,67 @@ module Appsignal
         transaction.set_session_data(session_data, &block)
       end
 
+      # Set request headers on the current transaction.
+      #
+      # Request headers are automatically set by most of our integrations. It
+      # should not be necessary to call this method unless you want to report
+      # different request headers.
+      #
+      # To filter request headers, see our session data filtering guide.
+      #
+      # When this method is called multiple times, it will overwrite the
+      # previously set value.
+      #
+      # A block can be given to this method to defer the fetching and parsing
+      # of the request headers until and only when the transaction is sampled.
+      #
+      # When both the `request_headers` argument and a block is given to this
+      # method, the `request_headers` argument is leading and the block will
+      # _not_ be called.
+      #
+      # @example Set request headers
+      #   Appsignal.set_headers(
+      #     "PATH_INFO" => "/some-path",
+      #     "HTTP_USER_AGENT" => "Firefox"
+      #   )
+      #
+      # @example Calling `set_headers` multiple times will only keep the last call
+      #   Appsignal.set_headers("PATH_INFO" => "/some-path")
+      #   Appsignal.set_headers("HTTP_USER_AGENT" => "Firefox")
+      #   # The request headers are: { "HTTP_USER_AGENT" => "Firefox" }
+      #
+      # @example Calling `set_headers` with a block
+      #   Appsignal.set_headers do
+      #     # Some slow code to parse request headers
+      #     JSON.parse('{"PATH_INFO": "/some-path"}')
+      #   end
+      #   # The session data is: { "PATH_INFO" => "/some-path" }
+      #
+      # @example Calling `set_headers` with a headers argument and a block
+      #   Appsignal.set_headers("PATH_INFO" => "/some-path") do
+      #     # Some slow code to parse session data
+      #     JSON.parse('{"PATH_INFO": "/block-path"}')
+      #   end
+      #   # The session data is: { "PATH_INFO" => "/some-path" }
+      #
+      # @since 3.11.0
+      # @param headers [Hash] The request headers to set on the transaction.
+      # @yield This block is called when the transaction is sampled. The block's
+      #   return value will become the new request headers.
+      # @see https://docs.appsignal.com/guides/custom-data/sample-data.html
+      #   Sample data guide
+      # @see https://docs.appsignal.com/guides/filter-data/filter-headers.html
+      #   Request headers filtering guide
+      # @see Transaction#set_headers
+      # @return [void]
+      def set_headers(headers = nil, &block)
+        return unless active?
+        return unless Appsignal::Transaction.current?
+
+        transaction = Appsignal::Transaction.current
+        transaction.set_headers(headers, &block)
+      end
+
       # Add breadcrumbs to the transaction.
       #
       # Breadcrumbs can be used to trace what path a user has taken

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -565,8 +565,8 @@ module Appsignal
       # A block can be given to this method to defer the fetching and parsing
       # of the parameters until and only when the transaction is sampled.
       #
-      # When both the `params` and a block is given to this method, the
-      # `params` argument is leading and the block will _not_ be called.
+      # When both the `params` argument and a block is given to this method,
+      # the `params` argument is leading and the block will _not_ be called.
       #
       # @example Set parameters
       #   Appsignal.set_params("param1" => "value1")
@@ -606,6 +606,64 @@ module Appsignal
 
         transaction = Appsignal::Transaction.current
         transaction.set_params(params, &block)
+      end
+
+      # Set session data on the current transaction.
+      #
+      # Session data is automatically set by most of our integrations. It
+      # should not be necessary to call this method unless you want to report
+      # different session data.
+      #
+      # To filter session data, see our session data filtering guide.
+      #
+      # When this method is called multiple times, it will overwrite the
+      # previously set value.
+      #
+      # A block can be given to this method to defer the fetching and parsing
+      # of the session data until and only when the transaction is sampled.
+      #
+      # When both the `session_data` argument and a block is given to this
+      # method, the `session_data` argument is leading and the block will _not_
+      # be called.
+      #
+      # @example Set session data
+      #   Appsignal.set_session_data("data" => "value")
+      #
+      # @example Calling `set_session_data` multiple times will only keep the last call
+      #   Appsignal.set_session_data("data1" => "value1")
+      #   Appsignal.set_session_data("data2" => "value2")
+      #   # The session data is: { "data2" => "value2" }
+      #
+      # @example Calling `set_session_data` with a block
+      #   Appsignal.set_session_data do
+      #     # Some slow code to parse session data
+      #     JSON.parse('{"data": "value"}')
+      #   end
+      #   # The session data is: { "data" => "value" }
+      #
+      # @example Calling `set_session_data` with a session_data argument and a block
+      #   Appsignal.set_session_data("argument" => "argument value") do
+      #     # Some slow code to parse session data
+      #     JSON.parse('{"data": "value"}')
+      #   end
+      #   # The session data is: { "argument" => "argument value" }
+      #
+      # @since 3.11.0
+      # @param session_data [Hash] The session data to set on the transaction.
+      # @yield This block is called when the transaction is sampled. The block's
+      #   return value will become the new session data.
+      # @see https://docs.appsignal.com/guides/custom-data/sample-data.html
+      #   Sample data guide
+      # @see https://docs.appsignal.com/guides/filter-data/filter-session-data.html
+      #   Session data filtering guide
+      # @see Transaction#set_session_data
+      # @return [void]
+      def set_session_data(session_data = nil, &block)
+        return unless active?
+        return unless Appsignal::Transaction.current?
+
+        transaction = Appsignal::Transaction.current
+        transaction.set_session_data(session_data, &block)
       end
 
       # Add breadcrumbs to the transaction.

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -1,8 +1,4 @@
 describe Appsignal::Transaction do
-  before :context do
-    start_agent
-  end
-
   let(:transaction_id) { "1" }
   let(:time)           { Time.at(fixed_time) }
   let(:namespace)      { Appsignal::Transaction::HTTP_REQUEST }
@@ -16,6 +12,7 @@ describe Appsignal::Transaction do
   before { Timecop.freeze(time) }
   after { Timecop.return }
   around do |example|
+    start_agent
     use_logger_with log do
       example.run
     end
@@ -484,6 +481,120 @@ describe Appsignal::Transaction do
           transaction._sample
           expect(transaction.params).to eq(preset_params)
           expect(transaction).to include_params(preset_params)
+        end
+      end
+    end
+
+    describe "#set_session_data" do
+      around { |example| keep_transactions { example.run } }
+
+      context "when the session data is set" do
+        it "updates the session data on the transaction" do
+          data = { "key" => "value" }
+          transaction.set_session_data(data)
+
+          transaction._sample
+          expect(transaction).to include_session_data(data)
+        end
+
+        it "updates the session data on the transaction with a block" do
+          data = { "key" => "value" }
+          transaction.set_session_data { data }
+
+          transaction._sample
+          expect(transaction).to include_session_data(data)
+        end
+
+        it "updates with the session data argument when both an argument and block are given" do
+          arg_data = { "argument" => "value" }
+          block_data = { "block" => "value" }
+          transaction.set_session_data(arg_data) { block_data }
+
+          transaction._sample
+          expect(transaction).to include_session_data(arg_data)
+        end
+
+        it "does not include filtered out session data" do
+          Appsignal.config[:filter_session_data] = ["filtered_key"]
+          transaction.set_session_data("data" => "value1", "filtered_key" => "filtered_value")
+
+          transaction._sample
+          expect(transaction).to include_session_data("data" => "value1")
+        end
+      end
+
+      context "when the given session data is nil" do
+        it "does not update the session data on the transaction" do
+          data = { "key" => "value" }
+          transaction.set_session_data(data)
+          transaction.set_session_data(nil)
+
+          transaction._sample
+          expect(transaction).to include_session_data(data)
+        end
+      end
+    end
+
+    describe "#set_session_data_if_nil" do
+      around { |example| keep_transactions { example.run } }
+
+      context "when the params are not set" do
+        it "sets the params on the transaction" do
+          data = { "key" => "value" }
+          transaction.set_session_data_if_nil(data)
+
+          transaction._sample
+          expect(transaction).to include_session_data(data)
+        end
+
+        it "updates the params on the transaction with a block" do
+          data = { "key" => "value" }
+          transaction.set_session_data_if_nil { data }
+
+          transaction._sample
+          expect(transaction).to include_session_data(data)
+        end
+
+        it "updates with the params argument when both an argument and block are given" do
+          arg_data = { "argument" => "value" }
+          block_data = { "block" => "value" }
+          transaction.set_session_data_if_nil(arg_data) { block_data }
+
+          transaction._sample
+          expect(transaction).to include_session_data(arg_data)
+        end
+
+        context "when the given params is nil" do
+          it "does not update the params on the transaction" do
+            data = { "key" => "value" }
+            transaction.set_session_data(data)
+            transaction.set_session_data_if_nil(nil)
+
+            transaction._sample
+            expect(transaction).to include_session_data(data)
+          end
+        end
+      end
+
+      context "when the params are set" do
+        it "does not update the params on the transaction" do
+          preset_data = { "other" => "data" }
+          data = { "key" => "value" }
+          transaction.set_session_data(preset_data)
+          transaction.set_session_data_if_nil(data)
+
+          transaction._sample
+          expect(transaction).to include_session_data(preset_data)
+        end
+
+        it "does not update the params with a block on the transaction" do
+          preset_data = { "other" => "data" }
+          data = { "key" => "value" }
+          transaction.set_session_data(preset_data)
+          transaction.set_session_data_if_nil { data }
+
+          transaction._sample
+          expect(transaction).to include_session_data(preset_data)
         end
       end
     end

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -521,9 +521,7 @@ describe Appsignal do
     end
 
     describe ".set_params" do
-      before do
-        start_agent
-      end
+      before { start_agent }
 
       context "with transaction" do
         let(:transaction) { http_request_transaction }
@@ -557,6 +555,45 @@ describe Appsignal do
           Appsignal.set_params("a" => "b")
 
           expect_any_instance_of(Appsignal::Transaction).to_not receive(:set_params)
+        end
+      end
+    end
+
+    describe ".set_session_data" do
+      before { start_agent }
+
+      context "with transaction" do
+        let(:transaction) { http_request_transaction }
+        before { set_current_transaction(transaction) }
+
+        it "sets session data on the transaction" do
+          Appsignal.set_session_data("data" => "value1")
+
+          transaction._sample
+          expect(transaction).to include_session_data("data" => "value1")
+        end
+
+        it "overwrites the session data if called multiple times" do
+          Appsignal.set_session_data("data" => "value1")
+          Appsignal.set_session_data("data" => "value2")
+
+          transaction._sample
+          expect(transaction).to include_session_data("data" => "value2")
+        end
+
+        it "sets session data with a block on the transaction" do
+          Appsignal.set_session_data { { "data" => "value1" } }
+
+          transaction._sample
+          expect(transaction).to include_session_data("data" => "value1")
+        end
+      end
+
+      context "without transaction" do
+        it "does not set session data on the transaction" do
+          Appsignal.set_session_data("a" => "b")
+
+          expect_any_instance_of(Appsignal::Transaction).to_not receive(:set_session_data)
         end
       end
     end

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -598,6 +598,45 @@ describe Appsignal do
       end
     end
 
+    describe ".set_headers" do
+      before { start_agent }
+
+      context "with transaction" do
+        let(:transaction) { http_request_transaction }
+        before { set_current_transaction(transaction) }
+
+        it "sets request headers on the transaction" do
+          Appsignal.set_headers("PATH_INFO" => "/some-path")
+
+          transaction._sample
+          expect(transaction).to include_environment("PATH_INFO" => "/some-path")
+        end
+
+        it "overwrites the request headers if called multiple times" do
+          Appsignal.set_headers("PATH_INFO" => "/some-path1")
+          Appsignal.set_headers("PATH_INFO" => "/some-path2")
+
+          transaction._sample
+          expect(transaction).to include_environment("PATH_INFO" => "/some-path2")
+        end
+
+        it "sets request headers with a block on the transaction" do
+          Appsignal.set_headers { { "PATH_INFO" => "/some-path" } }
+
+          transaction._sample
+          expect(transaction).to include_environment("PATH_INFO" => "/some-path")
+        end
+      end
+
+      context "without transaction" do
+        it "does not set request headers on the transaction" do
+          Appsignal.set_headers("PATH_INFO" => "/some-path")
+
+          expect_any_instance_of(Appsignal::Transaction).to_not receive(:set_headers)
+        end
+      end
+    end
+
     describe ".set_custom_data" do
       before { start_agent }
 


### PR DESCRIPTION
## Add Appsignal.set_session_data helper method

I want to deprecate and remove the `Transaction#set_session_data` method. To be able to remove it without breaking things for applications calling it directly, add helpers for all types of sample data, starting with session data. This is similar to our Node.js sample data helpers.

## Add Appsignal.set_headers helper method

I want to deprecate and remove the `Transaction#set_session_data` method. To be able to remove it without breaking things for applications calling it directly, add helpers for all types of sample data. This commit adds request headers helpers. This is similar to our Node.js sample data helpers.
