### PR TITLE
Allow tags to contain boolean values

### DIFF
--- a/.changesets/allow-booleans-in-tags.md
+++ b/.changesets/allow-booleans-in-tags.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+type: change
+---
+
+Allow tags to have boolean (true/false) values.
+
+```ruby
+Appsignal.set_tags("my_tag_is_amazing" => true)
+Appsignal.set_tags("my_tag_is_false" => false)
+```

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -15,7 +15,7 @@ module Appsignal
     # @api private
     ALLOWED_TAG_KEY_TYPES = [Symbol, String].freeze
     # @api private
-    ALLOWED_TAG_VALUE_TYPES = [Symbol, String, Integer].freeze
+    ALLOWED_TAG_VALUE_TYPES = [Symbol, String, Integer, TrueClass, FalseClass].freeze
     # @api private
     BREADCRUMB_LIMIT = 20
     # @api private

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -501,7 +501,9 @@ describe Appsignal::Transaction do
           :array_value => %w[invalid array],
           :object => Object.new,
           :too_long_value => long_string,
-          long_string => "too_long_key"
+          long_string => "too_long_key",
+          :true_tag => true,
+          :false_tag => false
         )
         transaction._sample
 
@@ -511,7 +513,9 @@ describe Appsignal::Transaction do
           "both_symbols" => "valid_value",
           "integer_value" => 1,
           "too_long_value" => "#{"a" * 10_000}...",
-          long_string => "too_long_key"
+          long_string => "too_long_key",
+          "true_tag" => true,
+          "false_tag" => false
         )
       end
 


### PR DESCRIPTION
Our pipeline support boolean values in tags. Let's accept those values.

## To do

- [ ] Update docs to match: https://docs.appsignal.com/guides/custom-data/tagging-request.html#ruby-limitations

## Screenshots

```ruby
Appsignal.set_tags("true_value" => true, "false_value" => false)
```

![image](https://github.com/appsignal/appsignal-ruby/assets/282402/6b7f300e-6372-4e23-b152-d6eeed2dfff3)
