### PR TITLE
Fix typo in start_logger deprecation message

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -195,7 +195,7 @@ module Appsignal
     def start_logger
       callers = caller
       Appsignal::Utils::StdoutAndLoggerMessage.warning \
-        "Callng 'Appsignal.start_logger' is deprecated. " \
+        "Calling 'Appsignal.start_logger' is deprecated. " \
           "The logger will be started when calling 'Appsignal.start'. " \
           "Remove the 'Appsignal.start_logger' call in the following file to " \
           "remove this message.\n#{callers.first}"

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -1312,8 +1312,9 @@ describe Appsignal do
           Appsignal.start_logger
         end
       end
-      expect(stderr).to include("appsignal WARNING: Callng 'Appsignal.start_logger' is deprecated.")
-      expect(log).to contains_log(:warn, "Callng 'Appsignal.start_logger' is deprecated.")
+      expect(stderr)
+        .to include("appsignal WARNING: Calling 'Appsignal.start_logger' is deprecated.")
+      expect(log).to contains_log(:warn, "Calling 'Appsignal.start_logger' is deprecated.")
     end
   end
 


### PR DESCRIPTION
Fix the typo in the warning.

[skip changeset]
[skip review]