### PR TITLE
Update benchmark task

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
   Include:
     - "**/*.rb"
     - "**/*.cap"
+    - "**/*.rake"
     - "**/Gemfile"
     - "**/Rakefile"
     - "appsignal.gemspec"
@@ -13,7 +14,6 @@ AllCops:
     - "pkg/**/*"
     - "tmp/**/*"
     - "vendor/**/*"
-    - "benchmark.rake"
     - "spec/integration/diagnose/**/*"
   DisplayCopNames: true
   UseCache: true

--- a/benchmark.rake
+++ b/benchmark.rake
@@ -1,3 +1,5 @@
+$LOAD_PATH << File.expand_path(File.join(File.dirname(__FILE__), "lib"))
+
 require 'appsignal'
 require 'benchmark'
 

--- a/benchmark.rake
+++ b/benchmark.rake
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 $LOAD_PATH << File.expand_path(File.join(File.dirname(__FILE__), "lib"))
 
-require 'appsignal'
-require 'benchmark'
+require "appsignal"
+require "benchmark"
 
 def process_rss
   `ps -o rss= -p #{Process.pid}`.to_i
@@ -9,60 +11,79 @@ end
 
 GC.disable
 
-task :default => :'benchmark:all'
+task :default => :"benchmark:all"
 
 namespace :benchmark do
   task :all => [:run_inactive, :run_active]
 
   task :run_inactive do
-    puts 'Running with appsignal off'
-    ENV['APPSIGNAL_PUSH_API_KEY'] = nil
+    puts "Running with appsignal off"
+    ENV["APPSIGNAL_PUSH_API_KEY"] = nil
     run_benchmark
   end
 
   task :run_active do
-    puts 'Running with appsignal on'
-    ENV['APPSIGNAL_PUSH_API_KEY'] = 'something'
+    puts "Running with appsignal on"
+    ENV["APPSIGNAL_PUSH_API_KEY"] = "something"
     run_benchmark
   end
 end
 
-def run_benchmark
-  no_transactions = (ENV['NO_TRANSACTIONS'] || 100_000).to_i
-  no_threads = (ENV['NO_THREADS'] || 1).to_i
+def run_benchmark # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  no_transactions = (ENV["NO_TRANSACTIONS"] || 100_000).to_i
+  no_threads = (ENV["NO_THREADS"] || 1).to_i
 
   total_objects = ObjectSpace.count_objects[:TOTAL]
   puts "Initializing, currently #{total_objects} objects"
   puts "RSS: #{process_rss}"
 
-  Appsignal.config = Appsignal::Config.new(Dir.pwd, 'production', :endpoint => 'http://localhost:8080')
+  Appsignal.config = Appsignal::Config.new(Dir.pwd, "production", :endpoint => "http://localhost:8080")
   Appsignal.start
-  puts "Appsignal #{Appsignal.active? ? 'active' : 'not active'}"
+  puts "Appsignal #{Appsignal.active? ? "active" : "not active"}"
 
   threads = []
   puts "Running #{no_transactions} normal transactions in #{no_threads} threads"
+  # rubocop:disable Metrics/BlockLength
   puts(Benchmark.measure do
     no_threads.times do
       thread = Thread.new do
         no_transactions.times do |i|
           request = Appsignal::Transaction::GenericRequest.new(
-            :controller => 'HomeController',
-            :action     => 'show',
-            :params     => {:id => 1}
+            :controller => "HomeController",
+            :action     => "show",
+            :params     => { :id => 1 }
           )
-          Appsignal::Transaction.create("transaction_#{i}", Appsignal::Transaction::HTTP_REQUEST, request)
+          Appsignal::Transaction.create(
+            "transaction_#{i}",
+            Appsignal::Transaction::HTTP_REQUEST,
+            request
+          )
 
-          Appsignal.instrument('process_action.action_controller') do
-            Appsignal.instrument_sql('sql.active_record', nil, 'SELECT `users`.* FROM `users` WHERE `users`.`id` = ?')
+          Appsignal.instrument("process_action.action_controller") do
+            Appsignal.instrument_sql(
+              "sql.active_record",
+              nil,
+              "SELECT `users`.* FROM `users` WHERE `users`.`id` = ?"
+            )
             10.times do
-              Appsignal.instrument_sql('sql.active_record', nil, 'SELECT `todos`.* FROM `todos` WHERE `todos`.`id` = ?')
+              Appsignal.instrument_sql(
+                "sql.active_record",
+                nil,
+                "SELECT `todos`.* FROM `todos` WHERE `todos`.`id` = ?"
+              )
             end
 
-            Appsignal.instrument('render_template.action_view', 'app/views/home/show.html.erb') do
+            Appsignal.instrument(
+              "render_template.action_view",
+              "app/views/home/show.html.erb"
+            ) do
               5.times do
-                Appsignal.instrument('render_partial.action_view', 'app/views/home/_piece.html.erb') do
+                Appsignal.instrument(
+                  "render_partial.action_view",
+                  "app/views/home/_piece.html.erb"
+                ) do
                   3.times do
-                    Appsignal.instrument('cache.read')
+                    Appsignal.instrument("cache.read")
                   end
                 end
               end
@@ -75,9 +96,10 @@ def run_benchmark
       thread.abort_on_exception = true
       threads << thread
     end
+    # rubocop:enable Metrics/BlockLength
 
     threads.each(&:join)
-    puts 'Finished'
+    puts "Finished"
   end)
 
   puts "Done, currently #{ObjectSpace.count_objects[:TOTAL] - total_objects} objects created"

--- a/benchmark.rake
+++ b/benchmark.rake
@@ -53,11 +53,12 @@ def run_benchmark # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
             :action     => "show",
             :params     => { :id => 1 }
           )
-          Appsignal::Transaction.create(
+          transaction = Appsignal::Transaction.create(
             "transaction_#{i}",
             Appsignal::Transaction::HTTP_REQUEST,
             request
           )
+          transaction.set_http_or_background_action
 
           Appsignal.instrument("process_action.action_controller") do
             Appsignal.instrument_sql(


### PR DESCRIPTION
## Load local Ruby gem in benchmark task

The benchmark task should load the project's Ruby gem, not whatever version is installed on the system.

Add the project path to the LOAD_PATH so it uses the local project.

## Include benchmark Rake task in RuboCop rules

Don't exclude it, but include it in the files checked by RuboCop. Fix the issues that were reported.

[skip changeset]

## Set transaction action name in benchmark script

The benchmark is not complete without setting the minimal required transaction data. Without this all samples are discarded in this benchmark.

[skip review]
