### PR TITLE
Deprecate `set_http_or_background_queue_start`

### DIFF
--- a/.changesets/deprecate--appsignal--transaction-set_http_or_background_queue_start-.md
+++ b/.changesets/deprecate--appsignal--transaction-set_http_or_background_queue_start-.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: deprecate
+---
+
+Deprecate the `Appsignal::Transaction#set_http_or_background_queue_start` method. Use the `Appsignal::Transaction#set_queue_start` instead.

--- a/lib/appsignal/demo.rb
+++ b/lib/appsignal/demo.rb
@@ -50,7 +50,6 @@ module Appsignal
         rescue => error
           Appsignal.set_error(error)
         end
-        transaction.set_http_or_background_queue_start
         transaction.set_metadata("path", "/hello")
         transaction.set_metadata("method", "GET")
         transaction.set_action("DemoController#hello")
@@ -68,7 +67,6 @@ module Appsignal
           "<h1>Hello world!</h1>" do
           sleep 2
         end
-        transaction.set_http_or_background_queue_start
         transaction.set_metadata("path", "/hello")
         transaction.set_metadata("method", "GET")
         transaction.set_action("DemoController#hello")

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -88,7 +88,9 @@ module Appsignal
           raise error
         ensure
           transaction.set_http_or_background_action(request.env)
-          transaction.set_http_or_background_queue_start
+          queue_start = Appsignal::Rack::Utils.queue_start_from(request.env) ||
+            (env[:queue_start]&.to_i&.* 1_000)
+          transaction.set_queue_start(queue_start) if queue_start
           Appsignal::Transaction.complete_current!
         end
       end

--- a/lib/appsignal/integrations/sidekiq.rb
+++ b/lib/appsignal/integrations/sidekiq.rb
@@ -68,9 +68,7 @@ module Appsignal
         transaction = Appsignal::Transaction.create(
           item["jid"],
           Appsignal::Transaction::BACKGROUND_JOB,
-          Appsignal::Transaction::GenericRequest.new(
-            :queue_start => item["enqueued_at"]
-          )
+          Appsignal::Transaction::GenericRequest.new({})
         )
         transaction.set_action_if_nil(formatted_action_name(item))
 
@@ -85,7 +83,8 @@ module Appsignal
       ensure
         if transaction
           transaction.set_params_if_nil { parse_arguments(item) }
-          transaction.set_http_or_background_queue_start
+          queue_start = (item["enqueued_at"].to_f * 1000.0).to_i # Convert seconds to milliseconds
+          transaction.set_queue_start(queue_start)
           Appsignal::Transaction.complete_current! unless exception
 
           queue = item["queue"] || "unknown"

--- a/lib/appsignal/rack.rb
+++ b/lib/appsignal/rack.rb
@@ -3,6 +3,35 @@
 module Appsignal
   # @api private
   module Rack
+    class Utils
+      # Fetch the queue start time from the request environment.
+      #
+      # @since 3.11.0
+      # @param env [Hash] Request environment hash.
+      # @return [Integer, NilClass]
+      def self.queue_start_from(env)
+        return unless env
+
+        env_var = env["HTTP_X_QUEUE_START"] || env["HTTP_X_REQUEST_START"]
+        return unless env_var
+
+        cleaned_value = env_var.tr("^0-9", "")
+        return if cleaned_value.empty?
+
+        value = cleaned_value.to_i
+        if value > 4_102_441_200_000
+          # Value is in microseconds. Transform to milliseconds.
+          value / 1_000
+        elsif value < 946_681_200_000
+          # Value is too low to be plausible
+          nil
+        else
+          # Value is in milliseconds
+          value
+        end
+      end
+    end
+
     # Alias constants that have moved with a warning message that points to the
     # place to update the reference.
     def self.const_missing(name)

--- a/lib/appsignal/rack/abstract_middleware.rb
+++ b/lib/appsignal/rack/abstract_middleware.rb
@@ -148,7 +148,8 @@ module Appsignal
         transaction.set_metadata("method", request_method) if request_method
 
         transaction.set_params_if_nil { params_for(request) }
-        transaction.set_http_or_background_queue_start
+        queue_start = Appsignal::Rack::Utils.queue_start_from(request.env)
+        transaction.set_queue_start(queue_start) if queue_start
       end
 
       def params_for(request)

--- a/lib/appsignal/rack/event_handler.rb
+++ b/lib/appsignal/rack/event_handler.rb
@@ -75,7 +75,8 @@ module Appsignal
             Appsignal::Rack::EventHandler
               .safe_execution("Appsignal::Rack::EventHandler's after_reply") do
               transaction.finish_event("process_request.rack", "", "")
-              transaction.set_http_or_background_queue_start
+              queue_start = Appsignal::Rack::Utils.queue_start_from(request.env)
+              transaction.set_queue_start(queue_start) if queue_start
             end
 
             # Make sure the current transaction is always closed when the request
@@ -113,7 +114,8 @@ module Appsignal
 
         self.class.safe_execution("Appsignal::Rack::EventHandler#on_finish") do
           transaction.finish_event("process_request.rack", "", "")
-          transaction.set_http_or_background_queue_start
+          queue_start = Appsignal::Rack::Utils.queue_start_from(request.env)
+          transaction.set_queue_start(queue_start) if queue_start
           response_status =
             if response
               response.status

--- a/spec/lib/appsignal/rack_spec.rb
+++ b/spec/lib/appsignal/rack_spec.rb
@@ -1,0 +1,63 @@
+describe Appsignal::Rack::Utils do
+  describe ".queue_start_from" do
+    let(:header_time) { fixed_time - 0.4 }
+    let(:header_time_value) { (header_time * factor).to_i }
+    subject { described_class.queue_start_from(env) }
+
+    shared_examples "HTTP queue start" do
+      context "when env is nil" do
+        let(:env) { nil }
+
+        it { is_expected.to be_nil }
+      end
+
+      context "with no relevant header set" do
+        let(:env) { {} }
+
+        it { is_expected.to be_nil }
+      end
+
+      context "with the HTTP_X_REQUEST_START header set" do
+        let(:env) { { "HTTP_X_REQUEST_START" => "t=#{header_time_value}" } }
+
+        it { is_expected.to eq 1_389_783_599_600 }
+
+        context "with unparsable content" do
+          let(:env) { { "HTTP_X_REQUEST_START" => "something" } }
+
+          it { is_expected.to be_nil }
+        end
+
+        context "with unparsable content at the end" do
+          let(:env) { { "HTTP_X_REQUEST_START" => "t=#{header_time_value}aaaa" } }
+
+          it { is_expected.to eq 1_389_783_599_600 }
+        end
+
+        context "with a really low number" do
+          let(:env) { { "HTTP_X_REQUEST_START" => "t=100" } }
+
+          it { is_expected.to be_nil }
+        end
+
+        context "with the alternate HTTP_X_QUEUE_START header set" do
+          let(:env) { { "HTTP_X_QUEUE_START" => "t=#{header_time_value}" } }
+
+          it { is_expected.to eq 1_389_783_599_600 }
+        end
+      end
+    end
+
+    context "time in milliseconds" do
+      let(:factor) { 1_000 }
+
+      it_should_behave_like "HTTP queue start"
+    end
+
+    context "time in microseconds" do
+      let(:factor) { 1_000_000 }
+
+      it_should_behave_like "HTTP queue start"
+    end
+  end
+end

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -368,7 +368,8 @@ describe Appsignal do
                 "perform_job.something",
                 {
                   :class => "BackgroundJob",
-                  :method => "perform"
+                  :method => "perform",
+                  :queue_start => fixed_time.to_i
                 }
               ) do
                 :return_value
@@ -380,6 +381,7 @@ describe Appsignal do
           expect(transaction).to have_namespace(Appsignal::Transaction::BACKGROUND_JOB)
           expect(transaction).to have_action("BackgroundJob#perform")
           expect(transaction).to include_event("name" => "perform_job.something")
+          expect(transaction).to have_queue_start(1_389_783_600_000)
           expect(transaction).to be_completed
         end
 
@@ -391,7 +393,8 @@ describe Appsignal do
                 "process_action.something",
                 {
                   :controller => "BlogPostsController",
-                  :action => "show"
+                  :action => "show",
+                  "HTTP_X_REQUEST_START" => "t=#{fixed_time.to_i * 1000}"
                 }
               ) do
                 :return_value
@@ -403,6 +406,7 @@ describe Appsignal do
           expect(transaction).to have_namespace(Appsignal::Transaction::HTTP_REQUEST)
           expect(transaction).to have_action("BlogPostsController#show")
           expect(transaction).to include_event("name" => "process_action.something")
+          expect(transaction).to have_queue_start(1_389_783_600_000)
           expect(transaction).to be_completed
         end
       end

--- a/spec/support/matchers/transaction.rb
+++ b/spec/support/matchers/transaction.rb
@@ -180,6 +180,18 @@ RSpec::Matchers.alias_matcher :include_breadcrumbs, :include_breadcrumb
 
 RSpec::Matchers.define :have_queue_start do |queue_start_time|
   match(:notify_expectation_failures => true) do |transaction|
-    expect(transaction.ext.queue_start).to eq(queue_start_time)
+    if queue_start_time
+      expect(transaction.ext.queue_start).to eq(queue_start_time)
+    else
+      expect(transaction.ext.queue_start).to_not be_nil
+    end
+  end
+
+  match_when_negated(:notify_expectation_failures => true) do |transaction|
+    if queue_start_time
+      expect(transaction.ext.queue_start).to_not eq(queue_start_time)
+    else
+      expect(transaction.ext.queue_start).to be_nil
+    end
   end
 end


### PR DESCRIPTION
Deprecate the `Transaction#set_http_or_background_queue_start` method so that the transaction doesn't need to know about any 'request' set on the transaction. The instrumentations themselves can set the queue start using the `Transaction#set_queue_start` method.

Move the logic for conversion of the queue start time from request headers to a utils class so it can be accessed by the instrumentations.