### PR TITLE
Report request headers for webmachine apps

### DIFF
--- a/.changesets/report-request-headers-for-webmachine-apps.md
+++ b/.changesets/report-request-headers-for-webmachine-apps.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Report request headers for webmachine apps.

--- a/lib/appsignal/integrations/webmachine.rb
+++ b/lib/appsignal/integrations/webmachine.rb
@@ -23,6 +23,7 @@ module Appsignal
       ensure
         transaction.set_action_if_nil("#{resource.class.name}##{request.method}")
         transaction.set_params_if_nil(request.query)
+        transaction.set_headers_if_nil { request.headers if request.respond_to?(:headers) }
 
         Appsignal::Transaction.complete_current! unless has_parent_transaction
       end

--- a/spec/lib/appsignal/integrations/webmachine_spec.rb
+++ b/spec/lib/appsignal/integrations/webmachine_spec.rb
@@ -18,7 +18,11 @@ if DependencyHelper.webmachine_present?
       Webmachine::Request.new(
         "GET",
         "http://google.com:80/foo?param1=value1&param2=value2",
-        {},
+        {
+          "REQUEST_METHOD" => "GET",
+          "PATH_INFO" => "/some/path",
+          "ignored_header" => "something"
+        },
         nil
       )
     end
@@ -79,6 +83,14 @@ if DependencyHelper.webmachine_present?
       it "sets the params" do
         fsm.run
         expect(last_transaction).to include_params("param1" => "value1", "param2" => "value2")
+      end
+
+      it "sets the headers" do
+        fsm.run
+        expect(last_transaction).to include_environment(
+          "REQUEST_METHOD" => "GET",
+          "PATH_INFO" => "/some/path"
+        )
       end
 
       it "closes the transaction" do


### PR DESCRIPTION
I noticed we don't store the request headers for webmachine apps. Track these on the transaction with our new `set_headers_if_nil` helper.