### PR TITLE
Refactor integrations to user transaction metadata helpers

### DIFF
--- a/lib/appsignal/integrations/webmachine.rb
+++ b/lib/appsignal/integrations/webmachine.rb
@@ -13,7 +13,7 @@ module Appsignal
             Appsignal::Transaction.create(
               SecureRandom.uuid,
               Appsignal::Transaction::HTTP_REQUEST,
-              request
+              Appsignal::Transaction::GenericRequest.new({})
             )
           end
 

--- a/lib/appsignal/rack/abstract_middleware.rb
+++ b/lib/appsignal/rack/abstract_middleware.rb
@@ -37,7 +37,7 @@ module Appsignal
               Appsignal::Transaction.create(
                 SecureRandom.uuid,
                 Appsignal::Transaction::HTTP_REQUEST,
-                request
+                Appsignal::Transaction::GenericRequest.new({})
               )
             end
 
@@ -148,6 +148,12 @@ module Appsignal
         transaction.set_metadata("method", request_method) if request_method
 
         transaction.set_params_if_nil { params_for(request) }
+        transaction.set_session_data_if_nil do
+          request.session if request.respond_to?(:session)
+        end
+        transaction.set_headers_if_nil do
+          request.env if request.respond_to?(:env)
+        end
         queue_start = Appsignal::Rack::Utils.queue_start_from(request.env)
         transaction.set_queue_start(queue_start) if queue_start
       end

--- a/spec/lib/appsignal/integrations/que_spec.rb
+++ b/spec/lib/appsignal/integrations/que_spec.rb
@@ -39,7 +39,6 @@ if DependencyHelper.que_present?
         allow(Que).to receive(:execute)
 
         start_agent
-        expect(Appsignal.active?).to be_truthy
       end
       around { |example| keep_transactions { example.run } }
 
@@ -66,7 +65,7 @@ if DependencyHelper.que_present?
             "title" => ""
           )
           expect(transaction).to include_params(%w[1 birds])
-          expect(transaction).to include_sample_metadata(
+          expect(transaction).to include_tags(
             "attempts" => 0,
             "id" => 123,
             "priority" => 100,
@@ -95,7 +94,7 @@ if DependencyHelper.que_present?
           expect(transaction).to have_namespace(Appsignal::Transaction::BACKGROUND_JOB)
           expect(transaction).to have_error(error.class.name, error.message)
           expect(transaction).to include_params(%w[1 birds])
-          expect(transaction).to include_sample_metadata(
+          expect(transaction).to include_tags(
             "attempts" => 0,
             "id" => 123,
             "priority" => 100,
@@ -120,7 +119,7 @@ if DependencyHelper.que_present?
           expect(transaction).to have_namespace(Appsignal::Transaction::BACKGROUND_JOB)
           expect(transaction).to have_error(error.class.name, error.message)
           expect(transaction).to include_params(%w[1 birds])
-          expect(transaction).to include_sample_metadata(
+          expect(transaction).to include_tags(
             "attempts" => 0,
             "id" => 123,
             "priority" => 100,


### PR DESCRIPTION
## Refactor que instrumentation

Use our new `set_*` helpers to set the transaction data, rather than rely on the transaction to fetch it from the request object.

Set tags, not metadata, in the que instrumentation. Move away from using sample data metadata to set these kinds of values. Use tags instead. Update the integrations to follow this new pattern.

## Refactor Demo CLI class

Use our new `set_*` helpers on the transaction to set parameters and headers. Do not use the request object for this.

## Do not use request in webmachine transaction

We set the request params and headers through the `set_*` helpers now. No need to pass in an actual request object.

## Set request metadata in middleware via helpers

Do not rely on the transaction's request object handling, but set the request metadata using our helpers.

This follows our new pattern of how our instrumentation sets data on transactions.

## Set request metadata in EventHandler via helpers

Do not rely on the transaction's request object handling, but set the request metadata using our helpers.

This follows our new pattern of how our instrumentation sets data on transactions.

[skip changeset]
[skip review]