### PR TITLE
Log errors when fetching sample data

### DIFF
--- a/lib/appsignal/rack/abstract_middleware.rb
+++ b/lib/appsignal/rack/abstract_middleware.rb
@@ -163,9 +163,9 @@ module Appsignal
 
         request.send(@params_method)
       rescue => error
-        # Getting params from the request has been know to fail.
-        Appsignal.internal_logger.debug(
-          "Exception while getting params in #{self.class} from '#{@params_method}': #{error}"
+        Appsignal.internal_logger.error(
+          "Exception while fetching params from '#{@request_class}##{@params_method}': " \
+            "#{error.class} #{error}"
         )
         nil
       end
@@ -173,7 +173,9 @@ module Appsignal
       def request_method_for(request)
         request.request_method
       rescue => error
-        Appsignal.internal_logger.error("Unable to report HTTP request method: '#{error}'")
+        Appsignal.internal_logger.error(
+          "Exception while fetching the HTTP request method: #{error.class}: #{error}"
+        )
         nil
       end
 

--- a/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
@@ -114,8 +114,10 @@ if DependencyHelper.rails_present?
         make_request
 
         expect(last_transaction).to_not include_metadata("method" => anything)
-        expect(log_contents(log))
-          .to contains_log(:error, "Unable to report HTTP request method: '")
+        expect(log_contents(log)).to contains_log(
+          :error,
+          "Exception while fetching the HTTP request method: "
+        )
       end
     end
 


### PR DESCRIPTION
When we fetch sample data, from the data set on the request (via a block) or fetch the data from the request object, log an error if something went wrong while fetching the request.

[skip changeset]
[skip review]