### PR TITLE
Set Action Cable request metadata using helpers

### DIFF
--- a/spec/lib/appsignal/hooks/action_cable_spec.rb
+++ b/spec/lib/appsignal/hooks/action_cable_spec.rb
@@ -14,13 +14,6 @@ describe Appsignal::Hooks::ActionCableHook do
       end
 
       describe ActionCable::Channel::Base do
-        let(:transaction) do
-          Appsignal::Transaction.new(
-            transaction_id,
-            Appsignal::Transaction::ACTION_CABLE,
-            ActionDispatch::Request.new(env)
-          )
-        end
         let(:channel) do
           Class.new(ActionCable::Channel::Base) do
             def speak(_data)
@@ -37,21 +30,17 @@ describe Appsignal::Hooks::ActionCableHook do
             s.config.logger = ActiveSupport::Logger.new(log)
           end
         end
+        let(:env) do
+          http_request_env_with_data("action_dispatch.request_id" => request_id, :params => params)
+        end
         let(:connection) { ActionCable::Connection::Base.new(server, env) }
         let(:identifier) { { :channel => "MyChannel" }.to_json }
         let(:params) { {} }
         let(:request_id) { SecureRandom.uuid }
         let(:transaction_id) { request_id }
-        let(:env) do
-          http_request_env_with_data("action_dispatch.request_id" => request_id, :params => params)
-        end
         let(:instance) { channel.new(connection, identifier, params) }
         before do
           start_agent
-          expect(Appsignal.active?).to be_truthy
-          transaction
-
-          set_current_transaction(transaction)
 
           # Stub transmit call for subscribe/unsubscribe tests
           allow(connection).to receive(:websocket)
@@ -103,7 +92,7 @@ describe Appsignal::Hooks::ActionCableHook do
             it "uses its own internal request_id set by the subscribed callback" do
               # Subscribe action, sets the request_id
               instance.subscribe_to_channel
-              expect(transaction).to have_id(transaction_id)
+              expect(last_transaction).to have_id(transaction_id)
 
               # Expect another transaction for the action.
               # This transaction will use the same request_id as the
@@ -245,7 +234,7 @@ describe Appsignal::Hooks::ActionCableHook do
                   "method" => "websocket",
                   "path" => "" # No path as the ConnectionStub doesn't have the real request env
                 )
-                expect(transaction).to include_params("internal" => "true")
+                expect(transaction).to_not include_params
                 expect(transaction).to include_event(
                   "body" => "",
                   "body_format" => Appsignal::EventFormatter::DEFAULT,
@@ -292,7 +281,7 @@ describe Appsignal::Hooks::ActionCableHook do
             end
 
             it "uses its own internal request_id" do
-              expect(transaction).to have_id(transaction_id)
+              expect(last_transaction).to have_id(transaction_id)
             end
           end
 
@@ -348,7 +337,7 @@ describe Appsignal::Hooks::ActionCableHook do
                   "method" => "websocket",
                   "path" => "" # No path as the ConnectionStub doesn't have the real request env
                 )
-                expect(transaction).to include_params("internal" => "true")
+                expect(transaction).to_not include_params
                 expect(transaction).to include_event(
                   "body" => "",
                   "body_format" => Appsignal::EventFormatter::DEFAULT,


### PR DESCRIPTION
Update the Action Cable instrumentation to not rely on the request object but set the request metadata using the `set_*` helpers.

This uncovered a wrong assertion in the test suite when an active transaction was already set for the subscribe and unsubscribe callbacks. This setup made the spec not use the request object created in the instrumentation but in the spec setup.

As a result, looks like these scenarios (for Rails' test suite) doesn't actually report any request params.

[skip changeset]
[skip review]