### PR TITLE
Set job ID as request_id tag

### DIFF
--- a/lib/appsignal/integrations/sidekiq.rb
+++ b/lib/appsignal/integrations/sidekiq.rb
@@ -66,7 +66,7 @@ module Appsignal
       def call(_worker, item, _queue, &block)
         job_status = nil
         transaction = Appsignal::Transaction.create(
-          item["jid"],
+          SecureRandom.uuid,
           Appsignal::Transaction::BACKGROUND_JOB,
           Appsignal::Transaction::GenericRequest.new({})
         )
@@ -85,6 +85,7 @@ module Appsignal
           transaction.set_params_if_nil { parse_arguments(item) }
           queue_start = (item["enqueued_at"].to_f * 1000.0).to_i # Convert seconds to milliseconds
           transaction.set_queue_start(queue_start)
+          transaction.set_tags(:request_id => item["jid"])
           Appsignal::Transaction.complete_current! unless exception
 
           queue = item["queue"] || "unknown"

--- a/spec/lib/appsignal/hooks/activejob_spec.rb
+++ b/spec/lib/appsignal/hooks/activejob_spec.rb
@@ -126,6 +126,7 @@ if DependencyHelper.active_job_present?
       expect(transaction).to include_params([])
       expect(transaction).to include_tags(
         "active_job_id" => kind_of(String),
+        "request_id" => kind_of(String),
         "queue" => queue,
         "executions" => 1
       )
@@ -196,6 +197,7 @@ if DependencyHelper.active_job_present?
         expect(transaction).to include_params([])
         expect(transaction).to include_tags(
           "active_job_id" => kind_of(String),
+          "request_id" => kind_of(String),
           "queue" => queue,
           "executions" => 1
         )
@@ -335,6 +337,7 @@ if DependencyHelper.active_job_present?
         expect(transaction).to include_params([])
         expect(transaction).to include_tags(
           "active_job_id" => kind_of(String),
+          "request_id" => kind_of(String),
           "queue" => queue,
           "executions" => 1
         )
@@ -470,6 +473,7 @@ if DependencyHelper.active_job_present?
           )
           expect(transaction).to include_tags(
             "active_job_id" => kind_of(String),
+            "request_id" => kind_of(String),
             "queue" => "mailers",
             "executions" => 1
           )
@@ -488,6 +492,7 @@ if DependencyHelper.active_job_present?
           )
           expect(transaction).to include_tags(
             "active_job_id" => kind_of(String),
+            "request_id" => kind_of(String),
             "queue" => "mailers",
             "executions" => 1
           )
@@ -510,6 +515,7 @@ if DependencyHelper.active_job_present?
             )
             expect(transaction).to include_tags(
               "active_job_id" => kind_of(String),
+              "request_id" => kind_of(String),
               "queue" => "mailers",
               "executions" => 1
             )
@@ -549,6 +555,7 @@ if DependencyHelper.active_job_present?
           )
           expect(transaction).to include_tags(
             "active_job_id" => kind_of(String),
+            "request_id" => kind_of(String),
             "queue" => "mailers",
             "executions" => 1
           )
@@ -573,6 +580,7 @@ if DependencyHelper.active_job_present?
             )
             expect(transaction).to include_tags(
               "active_job_id" => kind_of(String),
+              "request_id" => kind_of(String),
               "queue" => "mailers",
               "executions" => 1
             )
@@ -599,6 +607,7 @@ if DependencyHelper.active_job_present?
               )
             expect(transaction).to include_tags(
               "active_job_id" => kind_of(String),
+              "request_id" => kind_of(String),
               "queue" => "mailers",
               "executions" => 1
             )

--- a/spec/lib/appsignal/integrations/sidekiq_spec.rb
+++ b/spec/lib/appsignal/integrations/sidekiq_spec.rb
@@ -362,7 +362,7 @@ describe Appsignal::Integrations::SidekiqMiddleware, :with_yaml_parse_error => f
         perform_sidekiq_job { raise error, "uh oh" }
       end.to raise_error(error)
 
-      expect(transaction).to have_id(jid)
+      expect(transaction).to have_id
       expect(transaction).to have_namespace(namespace)
       expect(transaction).to have_action("TestClass#perform")
       expect(transaction).to have_error("ExampleException", "uh oh")
@@ -373,7 +373,7 @@ describe Appsignal::Integrations::SidekiqMiddleware, :with_yaml_parse_error => f
       )
       expect(transaction).to_not include_environment
       expect(transaction).to include_params(expected_args)
-      expect(transaction).to_not include_tags
+      expect(transaction).to include_tags("request_id" => jid)
       expect(transaction).to_not include_breadcrumbs
       expect_transaction_to_have_sidekiq_event(transaction)
     end
@@ -418,11 +418,11 @@ describe Appsignal::Integrations::SidekiqMiddleware, :with_yaml_parse_error => f
         .with("sidekiq_queue_job_count", 1, { :queue => "default", :status => :processed })
       perform_sidekiq_job
 
-      expect(transaction).to have_id(jid)
+      expect(transaction).to have_id
       expect(transaction).to have_namespace(namespace)
       expect(transaction).to have_action("TestClass#perform")
       expect(transaction).to_not have_error
-      expect(transaction).to_not include_tags
+      expect(transaction).to include_tags("request_id" => jid)
       expect(transaction).to_not include_environment
       expect(transaction).to_not include_breadcrumbs
       expect(transaction).to_not include_params(expected_args)


### PR DESCRIPTION
## Set Sidekiq job ID as a tag

Do not set the job ID as the transaction ID. Let's use generated transaction IDs for that. If the "magic" tag `request_id` is set, it has the same behavior as the legacy behavior of using the transaction ID for this. This implementation is more explicit.

The naming of the `request_id` tag doesn't fit well in the context, but that's the only tag our frontend listens too right now to connect to our logging feature.

[skip changeset] [skip review]

## Set Active Job job ID as a tag

Do not set the job ID as the transaction ID. Let's use generated transaction IDs for that. If the "magic" tag `request_id` is set, it has the same behavior as the legacy behavior of using the transaction ID for this. This implementation is more explicit.

The naming of the `request_id` tag doesn't fit well in the context, but that's the only tag our frontend listens too right now to connect to our logging feature.

[skip changeset] [skip review]
