### PR TITLE
Remove the warn_once_then_debug from the logger

### DIFF
--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -35,8 +35,7 @@ module Appsignal
             Appsignal::Transaction.new(id, namespace, request, options)
         else
           # Otherwise, log the issue about trying to start another transaction
-          Appsignal.internal_logger.warn_once_then_debug(
-            :transaction_id,
+          Appsignal.internal_logger.warn(
             "Trying to start new transaction with id " \
               "'#{id}', but a transaction with id '#{current.transaction_id}' " \
               "is already running. Using transaction '#{current.transaction_id}'."

--- a/lib/appsignal/utils/integration_logger.rb
+++ b/lib/appsignal/utils/integration_logger.rb
@@ -2,20 +2,7 @@
 
 module Appsignal
   module Utils
-    # Subclass of logger with method to only log a warning once
-    # prevents the local log from filling up with repeated messages.
     class IntegrationLogger < ::Logger
-      def seen_keys
-        @seen_keys ||= Set.new
-      end
-
-      def warn_once_then_debug(key, message)
-        if seen_keys.add?(key).nil?
-          debug message
-        else
-          warn message
-        end
-      end
     end
   end
 end

--- a/lib/appsignal/utils/integration_memory_logger.rb
+++ b/lib/appsignal/utils/integration_memory_logger.rb
@@ -34,18 +34,6 @@ module Appsignal
         add(:WARN, message)
       end
 
-      def seen_keys
-        @seen_keys ||= Set.new
-      end
-
-      def warn_once_then_debug(key, message)
-        if seen_keys.add?(key).nil?
-          debug message
-        else
-          warn message
-        end
-      end
-
       def error(message)
         add(:ERROR, message)
       end

--- a/spec/lib/appsignal/utils/integration_logger_spec.rb
+++ b/spec/lib/appsignal/utils/integration_logger_spec.rb
@@ -1,25 +1,21 @@
 describe Appsignal::Utils::IntegrationLogger do
-  let(:log) { std_stream }
+  let(:log_stream) { std_stream }
+  let(:logs) { log_contents(log_stream) }
   let(:logger) do
-    Appsignal::Utils::IntegrationLogger.new(log).tap do |l|
+    Appsignal::Utils::IntegrationLogger.new(log_stream).tap do |l|
       l.formatter = logger_formatter
     end
   end
 
-  describe "#seen_keys" do
-    it "returns a Set" do
-      expect(logger.seen_keys).to be_a(Set)
-    end
-  end
+  it "logs messages" do
+    logger.debug("debug message")
+    logger.info("info message")
+    logger.warn("warning message")
+    logger.error("error message")
 
-  describe "#warn_once_then_debug" do
-    it "only warns once, then uses debug" do
-      message = "This is a log line"
-      3.times { logger.warn_once_then_debug(:key, message) }
-
-      logs = log_contents(log)
-      expect(logs.scan(/#{Regexp.escape(log_line(:WARN, message))}/).count).to eql(1)
-      expect(logs.scan(/#{Regexp.escape(log_line(:DEBUG, message))}/).count).to eql(2)
-    end
+    expect(logs).to contains_log(:debug, "debug message")
+    expect(logs).to contains_log(:info, "info message")
+    expect(logs).to contains_log(:warn, "warning message")
+    expect(logs).to contains_log(:error, "error message")
   end
 end

--- a/spec/lib/appsignal/utils/integration_memory_logger_spec.rb
+++ b/spec/lib/appsignal/utils/integration_memory_logger_spec.rb
@@ -68,16 +68,6 @@ describe Appsignal::Utils::IntegrationLogger do
     end
   end
 
-  describe "#warn_once_then_debug" do
-    it "only warns once, then uses debug" do
-      message = "This is a log line"
-      3.times { logger.warn_once_then_debug(:key, message) }
-
-      expect(logger.messages[:WARN]).to eq([message])
-      expect(logger.messages[:DEBUG]).to eq([message, message])
-    end
-  end
-
   describe "#error" do
     it "adds a log message with the error severity" do
       logger.error("error message")


### PR DESCRIPTION
This method was originally added to stop logging many messages in Grape apps nested in Rails apps. That instrumentation didn't work well in older versions of the Ruby gem. That's been fixed with the recent Rack middleware refactors.

Let's not treat this warning as an annoyance anymore and instead treat it as a symptom of an issue we should fix. It should be happening anymore in nested apps and is probably an indication of incorrectly setup instrumentation.

See issue #584

[skip changeset] because it's an internal refactor
[skip review]