### PR TITLE
Small improvements for next release

### DIFF
--- a/.changesets/add-monitor-helper.md
+++ b/.changesets/add-monitor-helper.md
@@ -30,3 +30,5 @@ end
 ```
 
 The `Appsignal.monitor_and_stop` helper can be used in the same scenarios as the `Appsignal.monitor_single_transaction` helper is used. One-off Ruby scripts that are not part of a long running process.
+
+Read our [instrumentation documentation](https://docs.appsignal.com/ruby/instrumentation/background-jobs.html) for more information about using the`Appsignal.monitor` helper.

--- a/.changesets/deprecate--appsignal--transaction-set_http_or_background_queue_start-.md
+++ b/.changesets/deprecate--appsignal--transaction-set_http_or_background_queue_start-.md
@@ -3,4 +3,4 @@ bump: patch
 type: deprecate
 ---
 
-Deprecate the `Appsignal::Transaction#set_http_or_background_queue_start` method. Use the `Appsignal::Transaction#set_queue_start` instead.
+Deprecate the `Appsignal::Transaction#set_http_or_background_queue_start` method. Use the `Appsignal::Transaction#set_queue_start` helper instead.

--- a/.changesets/deprecate-appsignal-monitor_transaction-helper.md
+++ b/.changesets/deprecate-appsignal-monitor_transaction-helper.md
@@ -3,4 +3,4 @@ bump: patch
 type: deprecate
 ---
 
-Deprecate the `Appsignal.monitor_transaction` and `Appsignal.monitor_single_transaction` helpers. See entry about the replacement helpers `Appsignal.monitor` and `Appsignal.monitor_and_stop`.
+Deprecate the `Appsignal.monitor_transaction` and `Appsignal.monitor_single_transaction` helpers. See the entry about the replacement helpers `Appsignal.monitor` and `Appsignal.monitor_and_stop`.

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -29,14 +29,14 @@ module Appsignal
       # @return [Transaction]
       def create(id_or_namespace, arg_namespace = nil, request = nil, options = {})
         if id_or_namespace && arg_namespace
-          Appsignal.internal_logger.warn(
+          Appsignal::Utils::StdoutAndLoggerMessage.warning(
             "Appsignal::Transaction.create: " \
               "A new Transaction is created using the transaction ID argument. " \
               "This argument is deprecated without replacement."
           )
         end
         if arg_namespace
-          Appsignal.internal_logger.warn(
+          Appsignal::Utils::StdoutAndLoggerMessage.warning(
             "Appsignal::Transaction.create: " \
               "A Transaction is created using the namespace argument. " \
               "Specify the namespace as the first argument to the 'create' " \
@@ -44,7 +44,7 @@ module Appsignal
           )
         end
         if request
-          Appsignal.internal_logger.warn(
+          Appsignal::Utils::StdoutAndLoggerMessage.warning(
             "Appsignal::Transaction.create: " \
               "A Transaction is created using the request argument. " \
               "This argument is deprecated. Please use the `Appsignal.set_*` helpers instead."
@@ -52,7 +52,7 @@ module Appsignal
         end
         # Allow middleware to force a new transaction
         if options[:force]
-          Appsignal.internal_logger.warn(
+          Appsignal::Utils::StdoutAndLoggerMessage.warning(
             "Appsignal::Transaction.create: " \
               "A Transaction is created using the `:force => true` option argument. " \
               "The options argument is deprecated without replacement."

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -28,15 +28,7 @@ module Appsignal
       # @param id_or_namespace [String] Namespace of the to be created transaction.
       # @return [Transaction]
       def create(id_or_namespace, arg_namespace = nil, request = nil, options = {})
-        if arg_namespace
-          id = id_or_namespace
-          namespace = arg_namespace
-        else
-          id = SecureRandom.uuid
-          namespace = id_or_namespace
-        end
-
-        if id
+        if id_or_namespace && arg_namespace
           Appsignal.internal_logger.warn(
             "Appsignal::Transaction.create: " \
               "A new Transaction is created using the transaction ID argument. " \
@@ -66,6 +58,13 @@ module Appsignal
               "The options argument is deprecated without replacement."
           )
           Thread.current[:appsignal_transaction] = nil
+        end
+        if arg_namespace
+          id = id_or_namespace
+          namespace = arg_namespace
+        else
+          id = SecureRandom.uuid
+          namespace = id_or_namespace
         end
 
         # Check if we already have a running transaction

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -80,6 +80,36 @@ describe Appsignal::Transaction do
               "A Transaction is created using the `:force => true` option argument. "
           )
         end
+
+        it "prints deprecation warnings" do
+          err_stream = std_stream
+          capture_std_streams(std_stream, err_stream) do
+            legacy_create_transaction(
+              :id => "mock-id",
+              :namespace => "my_namespace",
+              :request => Appsignal::Transaction::InternalGenericRequest.new({}),
+              :options => { :force => true }
+            )
+          end
+
+          stderr = err_stream.read
+          expect(stderr).to include(
+            "appsignal WARNING: Appsignal::Transaction.create: " \
+              "A new Transaction is created using the transaction ID argument."
+          )
+          expect(stderr).to include(
+            "appsignal WARNING: Appsignal::Transaction.create: " \
+              "A Transaction is created using the namespace argument."
+          )
+          expect(stderr).to include(
+            "appsignal WARNING: Appsignal::Transaction.create: " \
+              "A Transaction is created using the request argument."
+          )
+          expect(stderr).to include(
+            "appsignal WARNING: Appsignal::Transaction.create: " \
+              "A Transaction is created using the `:force => true` option argument. "
+          )
+        end
       end
     end
 


### PR DESCRIPTION
## Fix deprecation warning always being printed

Check if the Appsignal::Transaction.create's arguments are all set or not. The `id_or_namespace` can also be set if only the namespace is given.

## Print Transaction deprecation warnings to STDERR

Make them more visible by also printing them in the application output.

[skip changeset]

## Improve changeset text

[skip mono]

[skip review]
