### PR TITLE
Rails apps can configure AppSignal in initializers

### DIFF
--- a/.changesets/start-appsignal-after-rails-is-initialized.md
+++ b/.changesets/start-appsignal-after-rails-is-initialized.md
@@ -1,0 +1,37 @@
+---
+bump: minor
+type: add
+---
+
+Add a Rails configuration option to start AppSignal after Rails is initialized. By default, AppSignal will start before the Rails initializers are run. It is not possible to configure AppSignal in a Rails initializer using Ruby. To configure AppSignal in a Rails initializer, configure Rails to start AppSignal after it is initialized.
+
+```ruby
+# config/application.rb
+
+# ...
+
+module MyApp
+  class Application < Rails::Application
+    # Add this line
+    config.appsignal.start_at = :after_initialize
+
+    # Other config
+  end
+end
+```
+
+Then, in the initializer:
+
+```ruby
+# config/initializers/appsignal.rb
+
+Appsignal.config = Appsignal::Config.new(
+  Rails.root,
+  Rails.env,
+  :ignore_actions => ["My action"]
+)
+```
+
+Be aware that with `start_at` set to `after_initialize` AppSignal will not track any errors that occur when the initializers are run and the app fails to start.
+
+See [our Rails documentation](https://docs.appsignal.com/ruby/integrations/rails.html) for more information.

--- a/spec/support/helpers/config_helpers.rb
+++ b/spec/support/helpers/config_helpers.rb
@@ -4,6 +4,7 @@ module ConfigHelpers
       File.join(File.dirname(__FILE__), "../fixtures/projects/valid")
     )
   end
+  module_function :project_fixture_path
 
   def project_fixture_config( # rubocop:disable Metrics/ParameterLists
     env = "production",


### PR DESCRIPTION
Add a Rails config option `appsignal.start_at` to specify when AppSignal is started and loaded.

This allows apps to configure AppSignal using Ruby code, rather than the YAML file or environment variables.