### PR TITLE
Bunch of tiny improvements

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -147,9 +147,9 @@ module Appsignal
     # @since 1.0.0
     def stop(called_by = nil)
       if called_by
-        internal_logger.debug("Stopping appsignal (#{called_by})")
+        internal_logger.debug("Stopping AppSignal (#{called_by})")
       else
-        internal_logger.debug("Stopping appsignal")
+        internal_logger.debug("Stopping AppSignal")
       end
       Appsignal::Extension.stop
       Appsignal::Probes.stop

--- a/spec/lib/appsignal/integrations/grape_spec.rb
+++ b/spec/lib/appsignal/integrations/grape_spec.rb
@@ -1,0 +1,36 @@
+if DependencyHelper.grape_present?
+  require "appsignal/integrations/grape"
+
+  context "Appsignal::Grape::Middleware constant" do
+    let(:err_stream) { std_stream }
+    let(:stderr) { err_stream.read }
+
+    it "returns the Rack::GrapeMiddleware constant calling the Grape::Middleware constant" do
+      silence { expect(Appsignal::Grape::Middleware).to be(Appsignal::Rack::GrapeMiddleware) }
+    end
+
+    it "prints a deprecation warning to STDERR" do
+      capture_std_streams(std_stream, err_stream) do
+        expect(Appsignal::Grape::Middleware).to be(Appsignal::Rack::GrapeMiddleware)
+      end
+
+      expect(stderr).to include(
+        "appsignal WARNING: The constant Appsignal::Grape::Middleware has been deprecated."
+      )
+    end
+
+    it "logs a warning" do
+      logs =
+        capture_logs do
+          silence do
+            expect(Appsignal::Grape::Middleware).to be(Appsignal::Rack::GrapeMiddleware)
+          end
+        end
+
+      expect(logs).to contains_log(
+        :warn,
+        "The constant Appsignal::Grape::Middleware has been deprecated."
+      )
+    end
+  end
+end

--- a/spec/lib/appsignal/rack/grape_middleware_spec.rb
+++ b/spec/lib/appsignal/rack/grape_middleware_spec.rb
@@ -1,38 +1,5 @@
 if DependencyHelper.grape_present?
-  require "appsignal/integrations/grape"
-
-  context "Appsignal::Grape::Middleware constant" do
-    let(:err_stream) { std_stream }
-    let(:stderr) { err_stream.read }
-
-    it "returns the Rack::GrapeMiddleware constant calling the Grape::Middleware constant" do
-      silence { expect(Appsignal::Grape::Middleware).to be(Appsignal::Rack::GrapeMiddleware) }
-    end
-
-    it "prints a deprecation warning to STDERR" do
-      capture_std_streams(std_stream, err_stream) do
-        expect(Appsignal::Grape::Middleware).to be(Appsignal::Rack::GrapeMiddleware)
-      end
-
-      expect(stderr).to include(
-        "appsignal WARNING: The constant Appsignal::Grape::Middleware has been deprecated."
-      )
-    end
-
-    it "logs a warning" do
-      logs =
-        capture_logs do
-          silence do
-            expect(Appsignal::Grape::Middleware).to be(Appsignal::Rack::GrapeMiddleware)
-          end
-        end
-
-      expect(logs).to contains_log(
-        :warn,
-        "The constant Appsignal::Grape::Middleware has been deprecated."
-      )
-    end
-  end
+  require "appsignal/rack/grape_middleware"
 
   describe Appsignal::Rack::GrapeMiddleware do
     let(:app) do

--- a/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
@@ -1,5 +1,5 @@
 if DependencyHelper.sinatra_present?
-  require "appsignal/integrations/sinatra"
+  require "appsignal/rack/sinatra_instrumentation"
 
   module SinatraRequestHelpers
     def make_request

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -162,7 +162,7 @@ describe Appsignal do
 
   describe ".stop" do
     it "calls stop on the extension" do
-      expect(Appsignal.internal_logger).to receive(:debug).with("Stopping appsignal")
+      expect(Appsignal.internal_logger).to receive(:debug).with("Stopping AppSignal")
       expect(Appsignal::Extension).to receive(:stop)
       Appsignal.stop
       expect(Appsignal.active?).to be_falsy
@@ -177,7 +177,7 @@ describe Appsignal do
 
     context "with context specified" do
       it "should log the context" do
-        expect(Appsignal.internal_logger).to receive(:debug).with("Stopping appsignal (something)")
+        expect(Appsignal.internal_logger).to receive(:debug).with("Stopping AppSignal (something)")
         expect(Appsignal::Extension).to receive(:stop)
         Appsignal.stop("something")
         expect(Appsignal.active?).to be_falsy


### PR DESCRIPTION
## Fix capitalization of AppSignal in stop command

Let's use the AppSignal version of the gem name when stopping.

## Split Grape specs

Move specs to spec files related to the files they are testing. This way I have less searching to do where something is tested.

## Only require the Sinatra middleware in the tests

Don't require the entire integration file. We only need the middleware classes for these tests.

[skip changeset]
[skip review]