### PR TITLE
Disable EventHandler when AppSignal is not active

### DIFF
--- a/.changesets/disable-eventhandler-when-appsignal-is-not-active-.md
+++ b/.changesets/disable-eventhandler-when-appsignal-is-not-active-.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Disable the AppSignal Rack EventHandler when AppSignal is not active. It would still trigger our instrumentation when AppSignal is not active. This reduces the instrumentation overhead when AppSignal is not active.

--- a/lib/appsignal/rack/event_handler.rb
+++ b/lib/appsignal/rack/event_handler.rb
@@ -56,6 +56,8 @@ module Appsignal
 
       # @api private
       def on_start(request, _response)
+        return unless Appsignal.active?
+
         event_handler = self
         self.class.safe_execution("Appsignal::Rack::EventHandler#on_start") do
           request.env[APPSIGNAL_EVENT_HANDLER_ID] ||= id
@@ -90,6 +92,8 @@ module Appsignal
 
       # @api private
       def on_error(request, _response, error)
+        return unless Appsignal.active?
+
         self.class.safe_execution("Appsignal::Rack::EventHandler#on_error") do
           return unless request_handler?(request.env[APPSIGNAL_EVENT_HANDLER_ID])
 
@@ -103,6 +107,7 @@ module Appsignal
 
       # @api private
       def on_finish(request, response)
+        return unless Appsignal.active?
         return unless request_handler?(request.env[APPSIGNAL_EVENT_HANDLER_ID])
 
         transaction = request.env[APPSIGNAL_TRANSACTION]


### PR DESCRIPTION
Reduce the instrumentation overhead when AppSignal is not active. Already the EventHandler wouldn't really do anything, as it would interact with `NilTransaction` instances, but this reduces the overhead even more.

[skip review]