### PR TITLE
Update specs to not use deprecated methods

### DIFF
--- a/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
@@ -4,13 +4,10 @@ describe Appsignal::Hooks::ActiveSupportNotificationsHook do
   if active_support_present?
     let(:notifier) { ActiveSupport::Notifications::Fanout.new }
     let(:as) { ActiveSupport::Notifications }
-    let!(:transaction) do
-      Appsignal::Transaction.create("uuid", Appsignal::Transaction::HTTP_REQUEST, "test")
-    end
-    before :context do
-      start_agent
-    end
+    let(:transaction) { http_request_transaction }
     before do
+      start_agent
+      set_current_transaction(transaction)
       as.notifier = notifier
     end
 

--- a/spec/lib/appsignal/hooks/dry_monitor_spec.rb
+++ b/spec/lib/appsignal/hooks/dry_monitor_spec.rb
@@ -32,15 +32,12 @@ if DependencyHelper.dry_monitor_present?
   end
 
   describe "Dry Monitor Integration" do
-    before :context do
-      start_agent
-    end
-
-    let!(:transaction) do
-      Appsignal::Transaction.create("uuid", Appsignal::Transaction::HTTP_REQUEST, "test")
-    end
-
     let(:notifications) { Dry::Monitor::Notifications.new(:test) }
+    let(:transaction) { http_request_transaction }
+    before do
+      start_agent
+      set_current_transaction(transaction)
+    end
 
     context "when is a dry-sql event" do
       let(:event_id) { :sql }

--- a/spec/lib/appsignal/hooks/excon_spec.rb
+++ b/spec/lib/appsignal/hooks/excon_spec.rb
@@ -27,9 +27,8 @@ describe Appsignal::Hooks::ExconHook do
     end
 
     describe "instrumentation" do
-      let!(:transaction) do
-        Appsignal::Transaction.create("uuid", Appsignal::Transaction::HTTP_REQUEST, "test")
-      end
+      let(:transaction) { http_request_transaction }
+      before { set_current_transaction(transaction) }
       around { |example| keep_transactions { example.run } }
 
       it "instruments a http request" do

--- a/spec/lib/appsignal/hooks/redis_client_spec.rb
+++ b/spec/lib/appsignal/hooks/redis_client_spec.rb
@@ -78,10 +78,9 @@ describe Appsignal::Hooks::RedisClientHook do
                 # track if it was installed already or not.
                 Appsignal::Hooks::RedisClientHook.new.install
               end
-              let!(:transaction) do
-                Appsignal::Transaction.create("uuid", Appsignal::Transaction::HTTP_REQUEST, "test")
-              end
+              let(:transaction) { http_request_transaction }
               let!(:client_config) { RedisClient::Config.new(:id => "stub_id") }
+              before { set_current_transaction(transaction) }
               around { |example| keep_transactions { example.run } }
 
               it "instrument a redis call" do
@@ -164,11 +163,9 @@ describe Appsignal::Hooks::RedisClientHook do
                   # track if it was installed already or not.
                   Appsignal::Hooks::RedisClientHook.new.install
                 end
-                let!(:transaction) do
-                  Appsignal::Transaction.create("uuid", Appsignal::Transaction::HTTP_REQUEST,
-                    "test")
-                end
+                let(:transaction) { http_request_transaction }
                 let!(:client_config) { RedisClient::Config.new(:id => "stub_id") }
+                before { set_current_transaction(transaction) }
                 around { |example| keep_transactions { example.run } }
 
                 it "instrument a redis call" do

--- a/spec/lib/appsignal/hooks/redis_spec.rb
+++ b/spec/lib/appsignal/hooks/redis_spec.rb
@@ -72,9 +72,8 @@ describe Appsignal::Hooks::RedisHook do
                 # track if it was installed already or not.
                 Appsignal::Hooks::RedisHook.new.install
               end
-              let!(:transaction) do
-                Appsignal::Transaction.create("uuid", Appsignal::Transaction::HTTP_REQUEST, "test")
-              end
+              let(:transaction) { http_request_transaction }
+              before { set_current_transaction(transaction) }
               around { |example| keep_transactions { example.run } }
 
               it "instrument a redis call" do

--- a/spec/lib/appsignal/hooks/sequel_spec.rb
+++ b/spec/lib/appsignal/hooks/sequel_spec.rb
@@ -19,9 +19,9 @@ describe Appsignal::Hooks::SequelHook do
     end
 
     context "with a transaction" do
-      let(:transaction) { Appsignal::Transaction.current }
+      let(:transaction) { http_request_transaction }
       before do
-        Appsignal::Transaction.create("uuid", Appsignal::Transaction::HTTP_REQUEST, "test")
+        set_current_transaction(transaction)
         db.logger = Logger.new($stdout) # To test #log_duration call
       end
 

--- a/spec/lib/appsignal/integrations/mongo_ruby_driver_spec.rb
+++ b/spec/lib/appsignal/integrations/mongo_ruby_driver_spec.rb
@@ -3,8 +3,10 @@ describe Appsignal::Hooks::MongoMonitorSubscriber do
   let(:subscriber) { Appsignal::Hooks::MongoMonitorSubscriber.new }
 
   context "with transaction" do
-    let!(:transaction) do
-      Appsignal::Transaction.create("1", "http_request", {}, {})
+    let(:transaction) { http_request_transaction }
+    before do
+      start_agent
+      set_current_transaction(transaction)
     end
 
     describe "#started" do


### PR DESCRIPTION
Don't create a transaction by specifying the ID and request object. Use the helpers for creating transactions instead.

This reduces the noise being printed in the test suite.

[skip changeset]
[skip review]