### PR TITLE
Add Appsignal.configure helper

### DIFF
--- a/.changesets/add-appsignal-configure.md
+++ b/.changesets/add-appsignal-configure.md
@@ -1,0 +1,27 @@
+---
+bump: minor
+type: add
+---
+
+Add `Appsignal.configure` method of configuring AppSignal. This new method allows apps to configure AppSignal in Ruby.
+
+```ruby
+# The environment will be auto detected
+Appsignal.configure do |config|
+  config.activejob_report_errors = "discard"
+  config.sidekiq_report_errors = :discard
+  config.ignore_actions = ["My ignored action", "My other ignored action"]
+  config.request_headers << "MY_HTTP_HEADER"
+  config.send_params = true
+  config.enable_host_metrics = false
+end
+
+# Explicitly define which environment to start
+Appsignal.configure(:production) do |config|
+  # Some config
+end
+```
+
+If apps use the `Appsignal.config = Appsignal::Config.new(...)` way of configuring AppSignal, they should be updated to use the new `Appsignal.configure` method. The `Appsignal::Config.new` method would overwrite the given "initial config" with the config file's config and config read from environment variables. The `Appsignal.configure` method is leading. The config file, environment variables and `Appsignal.configure` methods can all be mixed.
+
+See [our configuration guide](https://docs.appsignal.com/ruby/configuration.html) for more information.

--- a/.changesets/deprecate-appsignal-config---.md
+++ b/.changesets/deprecate-appsignal-config---.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+type: deprecate
+---
+
+Deprecate the `Appsignal.config = Appsignal::Config.new(...)` method of configuring AppSignal. See the changelog entry about `Appsignal.configure { ... }` for the new way to configure AppSignal in Ruby.

--- a/Rakefile
+++ b/Rakefile
@@ -295,7 +295,7 @@ task :console do
   require "irb/completion"
   require "appsignal"
 
-  Appsignal.config = Appsignal::Config.new(".", :console)
+  Appsignal.configure(:console)
 
   ARGV.clear
   IRB.start

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -37,6 +37,7 @@ module Appsignal
     # @return [Config, nil]
     # @see Config
     attr_accessor :config
+
     # Accessor for toggle if the AppSignal C-extension is loaded.
     #
     # Can be `nil` if extension has not been loaded yet. See

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -22,8 +22,8 @@ module Appsignal
     include Helpers::Instrumentation
     include Helpers::Metrics
 
-    # Accessor for the AppSignal configuration.
-    # Return the current AppSignal configuration.
+    # The loaded AppSignal configuration.
+    # Returns the current AppSignal configuration.
     #
     # Can return `nil` if no configuration has been set or automatically loaded
     # by an automatic integration or by calling {.start}.
@@ -31,12 +31,30 @@ module Appsignal
     # @example
     #   Appsignal.config
     #
-    # @example Setting the configuration
-    #   Appsignal.config = Appsignal::Config.new(Dir.pwd, "production")
-    #
     # @return [Config, nil]
+    # @see configure
     # @see Config
-    attr_accessor :config
+    attr_reader :config
+
+    # Set the AppSignal config.
+    #
+    # @deprecated Use {Appsignal.configure} instead.
+    # @param conf [Appsignal::Config]
+    # @return [void]
+    # @see Config
+    def config=(conf)
+      Appsignal::Utils::StdoutAndLoggerMessage.warning \
+        "Configuring AppSignal with `Appsignal.config=` is deprecated. " \
+          "Use `Appsignal.configure { |config| ... }` to configure AppSignal. " \
+          "https://docs.appsignal.com/ruby/configuration.html\n" \
+          "#{caller.first}"
+      @config = conf
+    end
+
+    # @api private
+    def _config=(conf)
+      @config = conf
+    end
 
     # Accessor for toggle if the AppSignal C-extension is loaded.
     #
@@ -88,7 +106,9 @@ module Appsignal
     #   Appsignal.start
     #
     # @example with custom loaded configuration
-    #   Appsignal.config = Appsignal::Config.new(Dir.pwd, "production")
+    #   Appsignal.configure(:production) do |config|
+    #     config.ignore_actions = ["My action"]
+    #   end
     #   Appsignal.start
     #
     # @return [void]
@@ -155,6 +175,94 @@ module Appsignal
       end
       Appsignal::Extension.stop
       Appsignal::Probes.stop
+    end
+
+    # Configure the AppSignal Ruby gem using a DSL.
+    #
+    # Pass a block to the configure method to configure the Ruby gem.
+    #
+    # Each config option defined in our docs can be fetched, set and modified
+    # via a helper method in the given block.
+    #
+    # After AppSignal has started using {start}, the configuration can not be
+    # modified. Any calls to this helper will be ignored.
+    #
+    # This helper should not be used to configure multiple environments, like
+    # done in the YAML file. Configure the environment you want active when the
+    # application starts.
+    #
+    # @example Configure AppSignal for the application
+    #   Appsignal.configure do |config|
+    #     config.path = "/the/app/path"
+    #     config.active = ENV["APP_ACTIVE"] == "true"
+    #     config.push_api_key = File.read("appsignal_key.txt").chomp
+    #     config.ignore_actions = ENDPOINTS.select { |e| e.public? }.map(&:name)
+    #     config.request_headers << "MY_CUSTOM_HEADER"
+    #   end
+    #
+    # @example Configure AppSignal for the application and select the environment
+    #   Appsignal.configure(:production) do |config|
+    #     config.active = true
+    #   end
+    #
+    # @example Automatically detects the app environment
+    #   # Tries to determine the app environment automatically from the
+    #   # environment and the libraries it integrates with.
+    #   ENV["RACK_ENV"] = "production"
+    #
+    #   Appsignal.configure do |config|
+    #     config.env # => "production"
+    #   end
+    #
+    # @example Calling configure multiple times for different environments resets the configuration
+    #   Appsignal.configure(:development) do |config|
+    #     config.ignore_actions = ["My action"]
+    #   end
+    #
+    #   Appsignal.configure(:production) do |config|
+    #     config.ignore_actions # => []
+    #   end
+    #
+    # @example Load config without a block
+    #   # This will require either ENV vars being set
+    #   # or the config/appsignal.yml being present
+    #   Appsignal.configure
+    #   # Or for the environment given as an argument
+    #   Appsignal.configure(:production)
+    #
+    # @yield [Config] Gives the {Config} instance to the block.
+    # @return [void]
+    # @see config
+    # @see Config
+    # @see https://docs.appsignal.com/ruby/configuration.html Configuration guide
+    # @see https://docs.appsignal.com/ruby/configuration/options.html Configuration options
+    def configure(env = nil)
+      if Appsignal.active?
+        Appsignal.internal_logger
+          .warn("AppSignal is already active. Ignoring `Appsignal.configure` call.")
+        return
+      end
+
+      if config && config.env == env.to_s
+        config
+      else
+        self._config = Appsignal::Config.new(
+          Dir.pwd,
+          env || ENV["APPSIGNAL_APP_ENV"] || ENV["RAILS_ENV"] || ENV.fetch("RACK_ENV", nil),
+          {},
+          Appsignal.internal_logger,
+          nil,
+          false
+        )
+        config.load_config
+      end
+
+      config_dsl = Appsignal::Config::ConfigDSL.new(config)
+      if block_given?
+        yield config_dsl
+        config.merge_dsl_options(config_dsl.dsl_options)
+      end
+      config.validate
     end
 
     def forked

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -194,7 +194,7 @@ module Appsignal
             initial_config[:log_path] = current_path.join("log")
           end
 
-          Appsignal.config = Appsignal::Config.new(
+          Appsignal._config = Appsignal::Config.new(
             current_path,
             options.fetch(:environment, ENV.fetch("RACK_ENV", ENV.fetch("RAILS_ENV", nil))),
             initial_config

--- a/lib/appsignal/demo.rb
+++ b/lib/appsignal/demo.rb
@@ -6,12 +6,7 @@ module Appsignal
   # {Appsignal::Demo} is a way to send demonstration / test samples for a
   # exception and a performance issue.
   #
-  # @example Loading config automatically
-  #   Appsignal::Demo.transmit
-  #
-  # @example With custom config
-  #   # If another configuration should be used, set it beforehand.
-  #   Appsignal.config = Appsignal::Config.new(Dir.pwd, "production")
+  # @example Send example transactions
   #   Appsignal::Demo.transmit
   #
   # @since 2.0.0

--- a/lib/appsignal/integrations/railtie.rb
+++ b/lib/appsignal/integrations/railtie.rb
@@ -40,7 +40,7 @@ module Appsignal
 
       def self.start
         unless Appsignal.config
-          Appsignal.config = Appsignal::Config.new(
+          Appsignal._config = Appsignal::Config.new(
             Rails.root,
             Rails.env,
             :name => Appsignal::Utils::RailsHelper.detected_rails_app_name,

--- a/spec/lib/appsignal/cli/demo_spec.rb
+++ b/spec/lib/appsignal/cli/demo_spec.rb
@@ -13,7 +13,7 @@ describe Appsignal::CLI::Demo do
     ENV.delete("RACK_ENV")
     stub_api_request config, "auth"
   end
-  after { Appsignal.config = nil }
+  after { Appsignal.clear_config! }
 
   def run
     run_within_dir project_fixture_path

--- a/spec/lib/appsignal/cli/diagnose/paths_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose/paths_spec.rb
@@ -4,7 +4,7 @@ require "appsignal/cli/diagnose/paths"
 
 describe Appsignal::CLI::Diagnose::Paths do
   describe "#paths" do
-    before { Appsignal.config = project_fixture_config }
+    before { start_agent }
 
     it "returns gem installation path as package_install_path" do
       expect(described_class.new.paths[:package_install_path]).to eq(

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -67,7 +67,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
       capture_diagnatics_report_request
     end
     before(:send_report => :no_cli_option) { options["no-send-report"] = nil }
-    after { Appsignal.config = nil }
+    after { Appsignal.clear_config! }
 
     def capture_diagnatics_report_request
       stub_diagnostics_report_request.to_rack(DiagnosticsReportEndpoint)

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -33,6 +33,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
     let(:process_group) { Etc.getgrgid(Process.gid).name }
     before(:context) { Appsignal.stop }
     before do
+      Appsignal.clear_config!
       # Clear previous reports
       DiagnosticsReportEndpoint.clear_report!
       if cli_class.instance_variable_defined? :@data
@@ -67,7 +68,6 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
       capture_diagnatics_report_request
     end
     before(:send_report => :no_cli_option) { options["no-send-report"] = nil }
-    after { Appsignal.clear_config! }
 
     def capture_diagnatics_report_request
       stub_diagnostics_report_request.to_rack(DiagnosticsReportEndpoint)

--- a/spec/lib/appsignal/demo_spec.rb
+++ b/spec/lib/appsignal/demo_spec.rb
@@ -16,8 +16,7 @@ describe Appsignal::Demo do
     end
 
     context "with config" do
-      let(:config) { project_fixture_config("production") }
-      before { Appsignal.config = config }
+      before { start_agent }
 
       it "returns true" do
         expect(subject).to eq(true)

--- a/spec/lib/appsignal/hooks/activejob_spec.rb
+++ b/spec/lib/appsignal/hooks/activejob_spec.rb
@@ -210,7 +210,7 @@ if DependencyHelper.active_job_present?
 
       context "with activejob_report_errors set to none" do
         it "does not report the error" do
-          Appsignal.config = project_fixture_config("production")
+          start_agent("production")
           Appsignal.config[:activejob_report_errors] = "none"
 
           allow(Appsignal).to receive(:increment_counter)
@@ -229,7 +229,7 @@ if DependencyHelper.active_job_present?
       if DependencyHelper.rails_version >= Gem::Version.new("7.1.0")
         context "with activejob_report_errors set to discard" do
           before do
-            Appsignal.config = project_fixture_config("production")
+            start_agent("production")
             Appsignal.config[:activejob_report_errors] = "discard"
           end
 
@@ -352,7 +352,7 @@ if DependencyHelper.active_job_present?
 
     context "with params" do
       it "filters the configured params" do
-        Appsignal.config = project_fixture_config("production")
+        start_agent("production")
         Appsignal.config[:filter_parameters] = ["foo"]
         queue_job(ActiveJobTestJob, method_given_args)
 

--- a/spec/lib/appsignal/hooks/gvl_spec.rb
+++ b/spec/lib/appsignal/hooks/gvl_spec.rb
@@ -7,8 +7,8 @@ describe Appsignal::Hooks::GvlHook do
       end
     end
   else
-    before(:context) do
-      Appsignal.config = project_fixture_config
+    before do
+      start_agent
     end
 
     def expect_gvltools_require

--- a/spec/lib/appsignal/hooks/redis_client_spec.rb
+++ b/spec/lib/appsignal/hooks/redis_client_spec.rb
@@ -1,6 +1,6 @@
 describe Appsignal::Hooks::RedisClientHook do
   before do
-    Appsignal.config = project_fixture_config
+    start_agent
   end
 
   if DependencyHelper.redis_client_present?

--- a/spec/lib/appsignal/hooks/redis_spec.rb
+++ b/spec/lib/appsignal/hooks/redis_spec.rb
@@ -1,6 +1,6 @@
 describe Appsignal::Hooks::RedisHook do
   before do
-    Appsignal.config = project_fixture_config
+    start_agent
   end
 
   if DependencyHelper.redis_present?

--- a/spec/lib/appsignal/hooks/resque_spec.rb
+++ b/spec/lib/appsignal/hooks/resque_spec.rb
@@ -83,7 +83,7 @@ describe Appsignal::Hooks::ResqueHook do
 
       context "with arguments" do
         before do
-          Appsignal.config = project_fixture_config("production")
+          start_agent("production")
           Appsignal.config[:filter_parameters] = ["foo"]
         end
 

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -65,7 +65,7 @@ describe Appsignal::Hooks::SidekiqHook do
     end
 
     before do
-      Appsignal.config = project_fixture_config
+      start_agent
       stub_const "Sidekiq", SidekiqMock
     end
 

--- a/spec/lib/appsignal/integrations/delayed_job_plugin_spec.rb
+++ b/spec/lib/appsignal/integrations/delayed_job_plugin_spec.rb
@@ -83,7 +83,7 @@ describe "Appsignal::Integrations::DelayedJobHook" do
 
         context "with parameter filtering" do
           before do
-            Appsignal.config = project_fixture_config("production")
+            start_agent("production")
             Appsignal.config[:filter_parameters] = ["foo"]
           end
 
@@ -272,7 +272,7 @@ describe "Appsignal::Integrations::DelayedJobHook" do
 
             context "with parameter filtering" do
               before do
-                Appsignal.config = project_fixture_config("production")
+                start_agent("production")
                 Appsignal.config[:filter_parameters] = ["foo"]
               end
 

--- a/spec/lib/appsignal/integrations/object_spec.rb
+++ b/spec/lib/appsignal/integrations/object_spec.rb
@@ -29,7 +29,7 @@ describe Object do
           start_agent
           set_current_transaction(transaction)
         end
-        after { Appsignal.config = nil }
+        after { Appsignal.clear_config! }
 
         context "with different kind of arguments" do
           let(:klass) do
@@ -198,7 +198,7 @@ describe Object do
           Appsignal.config = project_fixture_config
           set_current_transaction(transaction)
         end
-        after { Appsignal.config = nil }
+        after { Appsignal.clear_config! }
 
         context "with different kind of arguments" do
           let(:klass) do

--- a/spec/lib/appsignal/integrations/object_spec.rb
+++ b/spec/lib/appsignal/integrations/object_spec.rb
@@ -195,7 +195,7 @@ describe Object do
       context "when active" do
         let(:transaction) { http_request_transaction }
         before do
-          Appsignal.config = project_fixture_config
+          start_agent
           set_current_transaction(transaction)
         end
         after { Appsignal.clear_config! }

--- a/spec/lib/appsignal/integrations/shoryuken_spec.rb
+++ b/spec/lib/appsignal/integrations/shoryuken_spec.rb
@@ -61,7 +61,7 @@ describe Appsignal::Integrations::ShoryukenMiddleware do
 
       context "with parameter filtering" do
         before do
-          Appsignal.config = project_fixture_config("production")
+          start_agent("production")
           Appsignal.config[:filter_parameters] = ["foo"]
         end
 

--- a/spec/lib/appsignal/integrations/sidekiq_spec.rb
+++ b/spec/lib/appsignal/integrations/sidekiq_spec.rb
@@ -243,7 +243,7 @@ describe Appsignal::Integrations::SidekiqMiddleware, :with_yaml_parse_error => f
 
   context "with parameter filtering" do
     before do
-      Appsignal.config = project_fixture_config("production")
+      start_agent("production")
       Appsignal.config[:filter_parameters] = ["foo"]
     end
 
@@ -384,7 +384,7 @@ describe Appsignal::Integrations::SidekiqMiddleware, :with_yaml_parse_error => f
       include RailsHelper
 
       it "reports the worker name as the action, copies the namespace and tags" do
-        Appsignal.config = project_fixture_config("production")
+        start_agent("production")
         with_rails_error_reporter do
           perform_sidekiq_job do
             Appsignal.tag_job("test_tag" => "value")

--- a/spec/lib/appsignal/probes/sidekiq_spec.rb
+++ b/spec/lib/appsignal/probes/sidekiq_spec.rb
@@ -6,7 +6,7 @@ describe Appsignal::Probes::SidekiqProbe do
     let(:redis_hostname) { "localhost" }
     let(:expected_default_tags) { { :hostname => "localhost" } }
     before do
-      Appsignal.config = project_fixture_config
+      start_agent
 
       class SidekiqStats
         class << self

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -166,7 +166,7 @@ RSpec.configure do |config|
 
   config.after :context do
     FileUtils.rm_f(File.join(project_fixture_path, "log/appsignal.log"))
-    Appsignal.config = nil
+    Appsignal.clear_config!
     Appsignal.internal_logger = nil
   end
 

--- a/spec/support/helpers/config_helpers.rb
+++ b/spec/support/helpers/config_helpers.rb
@@ -23,7 +23,7 @@ module ConfigHelpers
   module_function :project_fixture_config, :project_fixture_path
 
   def start_agent(env = "production")
-    Appsignal.config = project_fixture_config(env)
+    Appsignal._config = project_fixture_config(env)
     Appsignal.start
   end
 end

--- a/spec/support/testing.rb
+++ b/spec/support/testing.rb
@@ -9,6 +9,11 @@ module Appsignal
       @testing = true unless defined?(@testing)
       @testing
     end
+
+    # @api private
+    def clear_config!
+      @config = nil
+    end
   end
 
   class Config


### PR DESCRIPTION
## Add dedicated clear_config! helper

Instead of writing `nil` to the `Appsignal.config` accessor, add a helper for this. This makes it more explicit what's happening when it's set to `nil`.

I also want to remove the `Appsignal.config=` writer and this provides another way to unset the config.

It's private because no one other than us should call it.

## Add Appsignal.configure helper

Create a new interface to configure AppSignal.

The `Appsignal.config = Appsignal::Config.new` method has some problems with it.

- Apps can overwrite the config at any time, which causes problems like
  AppSignal boot loops.
- The environment and root path need to be specified all the time,
  overwriting any previously set value.
- The config given to the helper is overwritten by the file config and
  environment variables config. Which goes against what we decided in:
  https://github.com/appsignal/integration-guide/issues/73

This new `configure` helper will allow apps to merge config with the already loaded config from the file config and environment. The config set with the `configure` helper is leading, as it can access the already loaded file and environment config, and modify it.

I had to change how to config is loaded. I moved it to a new `load_config` method that's called if apps use the old `Appsignal.config = Appsignal::Config.new(...)` way of configuring AppSignal. If apps use the new `Appsignal.configure { ... }` way, this is called by that helper method at the right time.
