### PR TITLE
Refactor config in specs

### DIFF
--- a/spec/lib/appsignal/cli/demo_spec.rb
+++ b/spec/lib/appsignal/cli/demo_spec.rb
@@ -13,7 +13,6 @@ describe Appsignal::CLI::Demo do
     ENV.delete("RACK_ENV")
     stub_api_request config, "auth"
   end
-  after { Appsignal.clear_config! }
 
   def run
     run_within_dir project_fixture_path

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -33,7 +33,6 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
     let(:process_group) { Etc.getgrgid(Process.gid).name }
     before(:context) { Appsignal.stop }
     before do
-      Appsignal.clear_config!
       # Clear previous reports
       DiagnosticsReportEndpoint.clear_report!
       if cli_class.instance_variable_defined? :@data

--- a/spec/lib/appsignal/environment_spec.rb
+++ b/spec/lib/appsignal/environment_spec.rb
@@ -1,8 +1,10 @@
 describe Appsignal::Environment do
   include EnvironmentMetadataHelper
 
-  before(:context) { start_agent }
-  before { capture_environment_metadata_report_calls }
+  before do
+    start_agent
+    capture_environment_metadata_report_calls
+  end
 
   def report(key, &value_block)
     described_class.report(key, &value_block)

--- a/spec/lib/appsignal/hooks/excon_spec.rb
+++ b/spec/lib/appsignal/hooks/excon_spec.rb
@@ -1,7 +1,5 @@
 describe Appsignal::Hooks::ExconHook do
-  before :context do
-    start_agent
-  end
+  before { start_agent }
 
   context "with Excon" do
     before(:context) do

--- a/spec/lib/appsignal/hooks/http_spec.rb
+++ b/spec/lib/appsignal/hooks/http_spec.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 describe Appsignal::Hooks::HttpHook do
-  before :context do
-    start_agent
-  end
+  before { start_agent }
 
   if DependencyHelper.http_present?
     context "with instrument_http_rb set to true" do

--- a/spec/lib/appsignal/hooks/net_http_spec.rb
+++ b/spec/lib/appsignal/hooks/net_http_spec.rb
@@ -1,5 +1,5 @@
 describe Appsignal::Hooks::NetHttpHook do
-  before(:context) { start_agent }
+  before { start_agent }
 
   describe "#dependencies_present?" do
     subject { described_class.new.dependencies_present? }

--- a/spec/lib/appsignal/hooks/redis_spec.rb
+++ b/spec/lib/appsignal/hooks/redis_spec.rb
@@ -1,7 +1,5 @@
 describe Appsignal::Hooks::RedisHook do
-  before do
-    start_agent
-  end
+  before { start_agent }
 
   if DependencyHelper.redis_present?
     context "with redis" do

--- a/spec/lib/appsignal/hooks/sequel_spec.rb
+++ b/spec/lib/appsignal/hooks/sequel_spec.rb
@@ -8,9 +8,7 @@ describe Appsignal::Hooks::SequelHook do
       end
     end
 
-    before :context do
-      start_agent
-    end
+    before { start_agent }
 
     describe "#dependencies_present?" do
       subject { described_class.new.dependencies_present? }

--- a/spec/lib/appsignal/hooks/webmachine_spec.rb
+++ b/spec/lib/appsignal/hooks/webmachine_spec.rb
@@ -2,7 +2,7 @@ describe Appsignal::Hooks::WebmachineHook do
   if DependencyHelper.webmachine_present?
     context "with webmachine" do
       let(:fsm) { Webmachine::Decision::FSM.new(double(:trace? => false), double, double) }
-      before(:context) { start_agent }
+      before { start_agent }
 
       describe "#dependencies_present?" do
         subject { described_class.new.dependencies_present? }

--- a/spec/lib/appsignal/integrations/http_spec.rb
+++ b/spec/lib/appsignal/integrations/http_spec.rb
@@ -9,12 +9,8 @@ if DependencyHelper.http_present?
     around do |example|
       keep_transactions { example.run }
     end
-
-    before :context do
-      start_agent
-    end
-
     before do
+      start_agent
       set_current_transaction(transaction)
     end
 

--- a/spec/lib/appsignal/integrations/net_http_spec.rb
+++ b/spec/lib/appsignal/integrations/net_http_spec.rb
@@ -2,7 +2,7 @@ require "appsignal/integrations/net_http"
 
 describe Appsignal::Integrations::NetHttpIntegration do
   let(:transaction) { http_request_transaction }
-  before(:context) { start_agent }
+  before { start_agent }
   before { set_current_transaction transaction }
   around { |example| keep_transactions { example.run } }
 

--- a/spec/lib/appsignal/integrations/object_spec.rb
+++ b/spec/lib/appsignal/integrations/object_spec.rb
@@ -29,7 +29,6 @@ describe Object do
           start_agent
           set_current_transaction(transaction)
         end
-        after { Appsignal.clear_config! }
 
         context "with different kind of arguments" do
           let(:klass) do
@@ -198,7 +197,6 @@ describe Object do
           start_agent
           set_current_transaction(transaction)
         end
-        after { Appsignal.clear_config! }
 
         context "with different kind of arguments" do
           let(:klass) do

--- a/spec/lib/appsignal/probes_spec.rb
+++ b/spec/lib/appsignal/probes_spec.rb
@@ -408,13 +408,14 @@ describe Appsignal::Probes do
       end
 
       context "logger" do
-        let(:log_stream) { std_stream }
-        let(:log) { log_contents(log_stream) }
+        before { start_agent }
 
-        around { |example| use_logger_with(log_stream) { example.run } }
         it "logs a deprecation message" do
-          silence { collection.register :my_probe, lambda {} }
-          expect(log).to contains_log :warn,
+          logs =
+            capture_logs do
+              silence { collection.register :my_probe, lambda {} }
+            end
+          expect(logs).to contains_log :warn,
             "The method 'Appsignal::Probes.probes.register' is deprecated. " \
               "Use 'Appsignal::Probes.register' instead."
         end

--- a/spec/lib/appsignal/rack/abstract_middleware_spec.rb
+++ b/spec/lib/appsignal/rack/abstract_middleware_spec.rb
@@ -12,7 +12,7 @@ describe Appsignal::Rack::AbstractMiddleware do
   let(:options) { {} }
   let(:middleware) { described_class.new(app, options) }
 
-  before(:context) { start_agent }
+  before { start_agent }
   around { |example| keep_transactions { example.run } }
 
   def make_request

--- a/spec/lib/appsignal/rack/generic_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/generic_instrumentation_spec.rb
@@ -46,7 +46,7 @@ describe "Appsignal::Rack::GenericInstrumentation" do
     let(:env) { Rack::MockRequest.env_for("/some/path") }
     let(:middleware) { Appsignal::Rack::GenericInstrumentation.new(app, {}) }
 
-    before(:context) { start_agent }
+    before { start_agent }
     around { |example| keep_transactions { example.run } }
 
     def make_request(env)

--- a/spec/lib/appsignal/rack/grape_middleware_spec.rb
+++ b/spec/lib/appsignal/rack/grape_middleware_spec.rb
@@ -19,7 +19,7 @@ if DependencyHelper.grape_present?
     end
     let(:middleware) { Appsignal::Rack::GrapeMiddleware.new(api_endpoint) }
     let(:transaction) { http_request_transaction }
-    before(:context) { start_agent }
+    before { start_agent }
     around do |example|
       GrapeExample = Module.new
       GrapeExample.send(:const_set, :Api, app)

--- a/spec/lib/appsignal/rack/hanami_middleware_spec.rb
+++ b/spec/lib/appsignal/rack/hanami_middleware_spec.rb
@@ -12,7 +12,7 @@ if DependencyHelper.hanami2_present?
     end
     let(:middleware) { Appsignal::Rack::HanamiMiddleware.new(app, {}) }
 
-    before(:context) { start_agent }
+    before { start_agent }
     around { |example| keep_transactions { example.run } }
 
     def make_request(env)

--- a/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
@@ -21,7 +21,7 @@ if DependencyHelper.sinatra_present?
     end
     let(:middleware) { Appsignal::Rack::SinatraInstrumentation.new(app) }
 
-    before(:context) { start_agent }
+    before { start_agent }
     around do |example|
       keep_transactions { example.run }
     end
@@ -54,7 +54,7 @@ if DependencyHelper.sinatra_present?
     let(:options) { {} }
     let(:middleware) { Appsignal::Rack::SinatraBaseInstrumentation.new(app, options) }
 
-    before(:context) { start_agent }
+    before { start_agent }
     around do |example|
       keep_transactions { example.run }
     end

--- a/spec/lib/appsignal/span_spec.rb
+++ b/spec/lib/appsignal/span_spec.rb
@@ -1,9 +1,7 @@
 require "appsignal/span"
 
 describe Appsignal::Span do
-  before :context do
-    start_agent
-  end
+  before { start_agent }
 
   let(:namespace) { "web" }
   let(:root) { Appsignal::Span.new(namespace) }

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -1,10 +1,12 @@
 describe Appsignal::Transaction do
   let(:time) { Time.at(fixed_time) }
 
-  before { Timecop.freeze(time) }
+  before do
+    start_agent
+    Timecop.freeze(time)
+  end
   after { Timecop.return }
   around do |example|
-    start_agent
     keep_transactions do
       example.run
     end

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -2,12 +2,6 @@ describe Appsignal do
   include EnvironmentMetadataHelper
   around { |example| keep_transactions { example.run } }
 
-  before do
-    # Make sure we have a clean state because we want to test
-    # initialization here.
-    Appsignal.clear_config!
-  end
-
   let(:transaction) { http_request_transaction }
 
   describe ".config=" do
@@ -39,10 +33,6 @@ describe Appsignal do
   end
 
   describe ".configure" do
-    before do
-      Appsignal.clear_config!
-    end
-
     context "when active" do
       it "doesn't update the config" do
         start_agent
@@ -1113,13 +1103,11 @@ describe Appsignal do
     end
 
     describe ".add_breadcrumb" do
-      around do |example|
-        start_agent
-        with_current_transaction(transaction) { example.run }
-      end
+      before { start_agent }
 
       context "with transaction" do
         let(:transaction) { http_request_transaction }
+        before { set_current_transaction(transaction) }
 
         it "adds the breadcrumb to the transaction" do
           Appsignal.add_breadcrumb(
@@ -2025,7 +2013,6 @@ describe Appsignal do
 
       context "when there is no config" do
         before do
-          Appsignal.clear_config!
           capture_stdout(out_stream) do
             Appsignal._start_logger
           end

--- a/spec/lib/puma/appsignal_spec.rb
+++ b/spec/lib/puma/appsignal_spec.rb
@@ -76,9 +76,6 @@ RSpec.describe "Puma plugin" do
   let(:hostname) { Socket.gethostname }
   let(:expected_default_tags) { { "hostname" => hostname } }
   let(:stats_data) { { :backlog => 1 } }
-  before :context do
-    Appsignal.stop
-  end
   before do
     module Puma
       def self.stats

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,6 +93,10 @@ RSpec.configure do |config|
   end
 
   config.before do
+    Appsignal.clear!
+    Appsignal::Testing.clear!
+    Appsignal::Loaders.clear!
+    clear_current_transaction!
     stop_minutely_probes
     ENV["RAILS_ENV"] ||= "test"
     ENV["RACK_ENV"] ||= "test"
@@ -158,16 +162,11 @@ RSpec.configure do |config|
   end
 
   config.after do
-    Appsignal::Testing.clear!
-    Appsignal::Loaders.clear!
-    clear_current_transaction!
     stop_minutely_probes
   end
 
   config.after :context do
     FileUtils.rm_f(File.join(project_fixture_path, "log/appsignal.log"))
-    Appsignal.clear_config!
-    Appsignal.internal_logger = nil
   end
 
   def stop_minutely_probes

--- a/spec/support/testing.rb
+++ b/spec/support/testing.rb
@@ -14,6 +14,13 @@ module Appsignal
     def clear_config!
       @config = nil
     end
+
+    # @api private
+    def clear!
+      Appsignal.internal_logger = nil
+
+      clear_config!
+    end
   end
 
   class Config


### PR DESCRIPTION
Globally clear the config before each spec. It was previously done after. If a spec didn't clean up after itself it would depend on that other spec to be run first. Fix that implicit dependency by making sure the states are cleared before each spec is run.

[skip changeset]
[skip review]