### PR TITLE
Allow configure to be called when not started yet

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -130,6 +130,7 @@ module Appsignal
 
       if config.valid?
         if config.active?
+          @started = true
           internal_logger.info "Starting AppSignal #{Appsignal::VERSION} " \
             "(#{$PROGRAM_NAME}, Ruby #{RUBY_VERSION}, #{RUBY_PLATFORM})"
           config.write_to_environment
@@ -237,9 +238,9 @@ module Appsignal
     # @see https://docs.appsignal.com/ruby/configuration.html Configuration guide
     # @see https://docs.appsignal.com/ruby/configuration/options.html Configuration options
     def configure(env = nil)
-      if Appsignal.active?
+      if Appsignal.started?
         Appsignal.internal_logger
-          .warn("AppSignal is already active. Ignoring `Appsignal.configure` call.")
+          .warn("AppSignal is already started. Ignoring `Appsignal.configure` call.")
         return
       end
 
@@ -378,6 +379,16 @@ module Appsignal
     # @since 1.0.0
     def extension_loaded?
       !!extension_loaded
+    end
+
+    # Returns if {.start} has been called before with a valid config to start
+    # AppSignal.
+    #
+    # @return [Boolean]
+    # @see Extension
+    # @since 3.12.0
+    def started?
+      defined?(@started) ? @started : false
     end
 
     # Returns the active state of the AppSignal integration.

--- a/spec/support/testing.rb
+++ b/spec/support/testing.rb
@@ -11,6 +11,13 @@ module Appsignal
     end
 
     # @api private
+    def clear_started!
+      return unless instance_variable_defined?(:@started)
+
+      remove_instance_variable(:@started)
+    end
+
+    # @api private
     def clear_config!
       @config = nil
     end
@@ -19,6 +26,7 @@ module Appsignal
     def clear!
       Appsignal.internal_logger = nil
 
+      clear_started!
       clear_config!
     end
   end


### PR DESCRIPTION
Support the config being modifiable until the Ruby gem has started. You can now call `configure` as many times as you want before `Appsignal.start` is called, after which changing the config should no longer be possible.

I don't want to unset `@started` on `stop` because that allows for apps to call stop and then start again every time they want to change some config, which I don't think we should cater do. It is better to get the config right the first time before it has started.

[skip changeset] because this fixes unpublished changes.
[skip review]