### PR TITLE
Do not start when file source raises an error

### DIFF
--- a/.changesets/do-not-start-on-config-file-error.md
+++ b/.changesets/do-not-start-on-config-file-error.md
@@ -1,0 +1,6 @@
+---
+bump: major
+type: change
+---
+
+Do not start AppSignal when the config file raises an error. Previously, the file source would be ignored.

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -440,20 +440,9 @@ module Appsignal
         nil
       end
     rescue => e
-      # TODO: Remove in the next major version
       @config_file_error = true
-      extra_message =
-        if inactive_on_config_file_error?
-          "Not starting AppSignal because " \
-            "APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR is set."
-        else
-          "Skipping file config. In future versions AppSignal will not start " \
-            "on a config file error. To opt-in to this new behavior set " \
-            "'APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR=1' in your system " \
-            "environment."
-        end
       message = "An error occurred while loading the AppSignal config file. " \
-        "#{extra_message}\n" \
+        "Not starting AppSignal.\n" \
         "File: #{config_file.inspect}\n" \
         "#{e.class.name}: #{e}"
       Kernel.warn "appsignal: #{message}"
@@ -506,9 +495,7 @@ module Appsignal
       # If an error was detected during config file reading/parsing and the new
       # behavior is enabled to not start AppSignal on incomplete config, do not
       # start AppSignal.
-      # TODO: Make default behavior in next major version. Remove
-      # `inactive_on_config_file_error?` call.
-      config[:active] = false if @config_file_error && inactive_on_config_file_error?
+      config[:active] = false if @config_file_error
 
       if config_hash[:activejob_report_errors] == "discard" &&
           !Appsignal::Hooks::ActiveJobHook.version_7_1_or_higher?
@@ -528,12 +515,6 @@ module Appsignal
         @logger.debug("Config key '#{key}' is being overwritten") unless config_hash[key].nil?
         config_hash[key] = value
       end
-    end
-
-    # Does it use the new behavior?
-    def inactive_on_config_file_error?
-      value = ENV.fetch("APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR", false)
-      ["1", "true"].include?(value)
     end
 
     # @api private

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -354,48 +354,24 @@ describe Appsignal::Config do
       end
       let(:config) { Appsignal::Config.new(config_path, "foo") }
 
-      context "when APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR is not set" do
-        it "logs & prints an error, skipping the file source" do
-          stdout = std_stream
-          stderr = std_stream
-          log = capture_logs { capture_std_streams(stdout, stderr) { config } }
-          message = "An error occurred while loading the AppSignal config file. " \
-            "Skipping file config. " \
-            "In future versions AppSignal will not start on a config file " \
-            "error. To opt-in to this new behavior set " \
-            "'APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR=1' in your system " \
-            "environment.\n" \
-            "File: #{File.join(config_path, "config", "appsignal.yml").inspect}\n" \
-            "KeyError: key not found"
-          expect(log).to contains_log :error, message
-          expect(log).to include("/appsignal/config.rb:") # Backtrace
-          expect(stdout.read).to_not include("appsignal:")
-          expect(stderr.read).to include "appsignal: #{message}"
-          expect(config.file_config).to eql({})
-        end
-      end
-
-      context "when APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR=1 is set" do
-        it "does not start AppSignal, logs & prints an error" do
-          stdout = std_stream
-          stderr = std_stream
-          ENV["APPSIGNAL_ACTIVE"] = "true"
-          ENV["APPSIGNAL_APP_NAME"] = "My app"
-          ENV["APPSIGNAL_APP_ENV"] = "dev"
-          ENV["APPSIGNAL_PUSH_API_KEY"] = "something valid"
-          ENV["APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR"] = "1"
-          log = capture_logs { capture_std_streams(stdout, stderr) { config } }
-          message = "An error occurred while loading the AppSignal config file. " \
-            "Not starting AppSignal because APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR is set.\n" \
-            "File: #{File.join(config_path, "config", "appsignal.yml").inspect}\n" \
-            "KeyError: key not found"
-          expect(log).to contains_log :error, message
-          expect(log).to include("/appsignal/config.rb:") # Backtrace
-          expect(stdout.read).to_not include("appsignal:")
-          expect(stderr.read).to include "appsignal: #{message}"
-          expect(config.file_config).to eql({})
-          expect(config.active?).to be(false)
-        end
+      it "does not start AppSignal, logs & prints an error" do
+        stdout = std_stream
+        stderr = std_stream
+        ENV["APPSIGNAL_ACTIVE"] = "true"
+        ENV["APPSIGNAL_APP_NAME"] = "My app"
+        ENV["APPSIGNAL_APP_ENV"] = "dev"
+        ENV["APPSIGNAL_PUSH_API_KEY"] = "something valid"
+        log = capture_logs { capture_std_streams(stdout, stderr) { config } }
+        message = "An error occurred while loading the AppSignal config file. " \
+          "Not starting AppSignal.\n" \
+          "File: #{File.join(config_path, "config", "appsignal.yml").inspect}\n" \
+          "KeyError: key not found"
+        expect(log).to contains_log :error, message
+        expect(log).to include("/appsignal/config.rb:") # Backtrace
+        expect(stdout.read).to_not include("appsignal:")
+        expect(stderr.read).to include "appsignal: #{message}"
+        expect(config.file_config).to eql({})
+        expect(config.active?).to be(false)
       end
     end
 


### PR DESCRIPTION
We added the behavior to not start AppSignal when the file source raises an error. Make this the new default as we prepare for a new major version in which we can change this behavior.

Related PR #991