### PR TITLE
Change default Rake task namespace to rake

### DIFF
--- a/.changesets/rake-task-namespace.md
+++ b/.changesets/rake-task-namespace.md
@@ -1,0 +1,6 @@
+---
+bump: major
+type: change
+---
+
+Change the default Rake task namespace to "rake". Previously, Rake tasks were reported in the "background" namespace.

--- a/lib/appsignal/integrations/rake.rb
+++ b/lib/appsignal/integrations/rake.rb
@@ -25,6 +25,7 @@ module Appsignal
           params, _ = args
           params = params.to_hash if params.respond_to?(:to_hash)
           transaction.set_params_if_nil(params)
+          transaction.set_params_if_nil(params)
           transaction.set_action(name)
           transaction.complete
         end
@@ -33,7 +34,7 @@ module Appsignal
       private
 
       def _appsignal_create_transaction
-        Appsignal::Transaction.create(Appsignal::Transaction::BACKGROUND_JOB)
+        Appsignal::Transaction.create("rake")
       end
     end
 

--- a/spec/lib/appsignal/hooks/rake_spec.rb
+++ b/spec/lib/appsignal/hooks/rake_spec.rb
@@ -58,7 +58,7 @@ describe Appsignal::Hooks::RakeHook do
 
           transaction = last_transaction
           expect(transaction).to have_id
-          expect(transaction).to have_namespace(Appsignal::Transaction::BACKGROUND_JOB)
+          expect(transaction).to have_namespace("rake")
           expect(transaction).to have_action("task:name")
           expect(transaction).to_not have_error
           expect(transaction).to include_params("foo" => "bar")
@@ -91,7 +91,7 @@ describe Appsignal::Hooks::RakeHook do
 
         transaction = last_transaction
         expect(transaction).to have_id
-        expect(transaction).to have_namespace(Appsignal::Transaction::BACKGROUND_JOB)
+        expect(transaction).to have_namespace("rake")
         expect(transaction).to have_action("task:name")
         expect(transaction).to have_error("ExampleException", "error message")
         expect(transaction).to include_params("foo" => "bar")


### PR DESCRIPTION
Make  more use of our namespace system by grouping rake tasks in their own namespace. Helps with grouping the type of actions per namespace so background jobs and tasks aren't grouped together.