### PR TITLE
Freeze config on AppSignal start

### DIFF
--- a/.changesets/freeze-config-after-appsignal-has-started.md
+++ b/.changesets/freeze-config-after-appsignal-has-started.md
@@ -1,0 +1,6 @@
+---
+bump: major
+type: change
+---
+
+Freeze the config after AppSignal has started. Prevent the config from being modified after AppSignal has started to avoid the expectation that modifying the config after starting AppSignal has any effect.

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -131,6 +131,7 @@ module Appsignal
           Appsignal::Probes.start if config[:enable_minutely_probes]
 
           collect_environment_metadata
+          @config.freeze
         else
           internal_logger.info("Not starting, not active for #{config.env}")
         end

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -409,6 +409,17 @@ module Appsignal
       end
     end
 
+    # Deep freeze the config object so it cannot be modified during the runtime
+    # of the Ruby app.
+    #
+    # @api private
+    # @since 4.0.0
+    def freeze
+      super
+      config_hash.freeze
+      config_hash.transform_values(&:freeze)
+    end
+
     private
 
     def config_file

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -248,6 +248,27 @@ describe Appsignal do
         Appsignal.start
       end
 
+      it "freezes the config" do
+        Appsignal.start
+
+        expect_frozen_error do
+          Appsignal.config[:ignore_actions] << "my action"
+        end
+        expect_frozen_error do
+          Appsignal.config.config_hash[:ignore_actions] << "my action"
+        end
+        expect_frozen_error do
+          Appsignal.config.config_hash.merge!(:option => :value)
+        end
+        expect_frozen_error do
+          Appsignal.config[:ignore_actions] = "my action"
+        end
+      end
+
+      def expect_frozen_error(&block)
+        expect(&block).to raise_error(FrozenError)
+      end
+
       context "when allocation tracking has been enabled" do
         before do
           Appsignal.config.config_hash[:enable_allocation_tracking] = true


### PR DESCRIPTION

Prevent applications from modifying the config hash. We've seen people modify the config hash with the expectation that it would affect how AppSignal operates. It doesn't.

Freeze the config object and the config hash so it will raise a FrozenError when applications try to modify it.
