### PR TITLE
Refactor config options set in specs

### DIFF
--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -405,7 +405,6 @@ describe Appsignal::Config do
         :active => true,
         :push_api_key => "abc",
         :name => "TestApp",
-        :request_headers => kind_of(Array),
         :enable_minutely_probes => false
       )
     end

--- a/spec/lib/appsignal/hooks/activejob_spec.rb
+++ b/spec/lib/appsignal/hooks/activejob_spec.rb
@@ -72,10 +72,11 @@ if DependencyHelper.active_job_present?
         ["perform_start.active_job", "perform.active_job"]
       end
     end
+    let(:options) { {} }
     before do
       ActiveJob::Base.queue_adapter = :inline
 
-      start_agent
+      start_agent(:options => options)
       Appsignal.internal_logger = test_logger(log)
       class ActiveJobTestJob < ActiveJob::Base
         def perform(*_args)
@@ -209,10 +210,9 @@ if DependencyHelper.active_job_present?
       end
 
       context "with activejob_report_errors set to none" do
-        it "does not report the error" do
-          start_agent("production")
-          Appsignal.config[:activejob_report_errors] = "none"
+        let(:options) { { :activejob_report_errors => "none" } }
 
+        it "does not report the error" do
           allow(Appsignal).to receive(:increment_counter)
           tags = { :queue => queue }
           expect(Appsignal).to receive(:increment_counter)
@@ -228,10 +228,7 @@ if DependencyHelper.active_job_present?
 
       if DependencyHelper.rails_version >= Gem::Version.new("7.1.0")
         context "with activejob_report_errors set to discard" do
-          before do
-            start_agent("production")
-            Appsignal.config[:activejob_report_errors] = "discard"
-          end
+          let(:options) { { :activejob_report_errors => "discard" } }
 
           it "does not report error on first failure" do
             with_test_adapter do
@@ -351,9 +348,9 @@ if DependencyHelper.active_job_present?
     end
 
     context "with params" do
+      let(:options) { { :filter_parameters => ["foo"] } }
+
       it "filters the configured params" do
-        start_agent("production")
-        Appsignal.config[:filter_parameters] = ["foo"]
         queue_job(ActiveJobTestJob, method_given_args)
 
         transaction = last_transaction

--- a/spec/lib/appsignal/hooks/gvl_spec.rb
+++ b/spec/lib/appsignal/hooks/gvl_spec.rb
@@ -7,8 +7,9 @@ describe Appsignal::Hooks::GvlHook do
       end
     end
   else
+    let(:options) { {} }
     before do
-      start_agent
+      start_agent(:options => options)
     end
 
     def expect_gvltools_require
@@ -100,8 +101,9 @@ describe Appsignal::Hooks::GvlHook do
 
       describe "#install" do
         context "with enable_gvl_global_timer" do
+          let(:options) { { :enable_gvl_global_timer => true } }
+
           it "enables the GVL global timer" do
-            Appsignal.config[:enable_gvl_global_timer] = true
             expect(::GVLTools::GlobalTimer).to receive(:enable)
 
             described_class.new.install
@@ -109,8 +111,9 @@ describe Appsignal::Hooks::GvlHook do
         end
 
         context "without enable_gvl_global_timer" do
+          let(:options) { { :enable_gvl_global_timer => false } }
+
           it "does not enable the GVL global timer" do
-            Appsignal.config[:enable_gvl_global_timer] = false
             expect(::GVLTools::GlobalTimer).not_to receive(:enable)
 
             described_class.new.install
@@ -118,8 +121,9 @@ describe Appsignal::Hooks::GvlHook do
         end
 
         context "with enable_gvl_waiting_threads" do
+          let(:options) { { :enable_gvl_waiting_threads => true } }
+
           it "enables the GVL waiting threads" do
-            Appsignal.config[:enable_gvl_global_timer] = true
             expect(::GVLTools::WaitingThreads).to receive(:enable)
 
             described_class.new.install
@@ -127,8 +131,9 @@ describe Appsignal::Hooks::GvlHook do
         end
 
         context "without enable_gvl_waiting_threads" do
+          let(:options) { { :enable_gvl_waiting_threads => false } }
+
           it "does not enable the GVL waiting threads" do
-            Appsignal.config[:enable_gvl_waiting_threads] = false
             expect(::GVLTools::WaitingThreads).not_to receive(:enable)
 
             described_class.new.install

--- a/spec/lib/appsignal/hooks/http_spec.rb
+++ b/spec/lib/appsignal/hooks/http_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 describe Appsignal::Hooks::HttpHook do
-  before { start_agent }
+  let(:options) { {} }
+  before { start_agent(:options => options) }
 
   if DependencyHelper.http_present?
     context "with instrument_http_rb set to true" do
@@ -18,8 +19,7 @@ describe Appsignal::Hooks::HttpHook do
     end
 
     context "with instrument_http_rb set to false" do
-      before { Appsignal.config.config_hash[:instrument_http_rb] = false }
-      after { Appsignal.config.config_hash[:instrument_http_rb] = true }
+      let(:options) { { :instrument_http_rb => false } }
 
       describe "#dependencies_present?" do
         subject { described_class.new.dependencies_present? }

--- a/spec/lib/appsignal/hooks/net_http_spec.rb
+++ b/spec/lib/appsignal/hooks/net_http_spec.rb
@@ -1,5 +1,6 @@
 describe Appsignal::Hooks::NetHttpHook do
-  before { start_agent }
+  let(:options) { {} }
+  before { start_agent(:options => options) }
 
   describe "#dependencies_present?" do
     subject { described_class.new.dependencies_present? }
@@ -9,8 +10,7 @@ describe Appsignal::Hooks::NetHttpHook do
     end
 
     context "with Net::HTTP instrumentation disabled" do
-      before { Appsignal.config.config_hash[:instrument_net_http] = false }
-      after { Appsignal.config.config_hash[:instrument_net_http] = true }
+      let(:options) { { :instrument_net_http => false } }
 
       it { is_expected.to be_falsy }
     end

--- a/spec/lib/appsignal/hooks/rake_spec.rb
+++ b/spec/lib/appsignal/hooks/rake_spec.rb
@@ -4,8 +4,9 @@ describe Appsignal::Hooks::RakeHook do
   let(:helper) { Appsignal::Integrations::RakeIntegrationHelper }
   let(:task) { Rake::Task.new("task:name", Rake::Application.new) }
   let(:arguments) { Rake::TaskArguments.new(["foo"], ["bar"]) }
+  let(:options) { {} }
   before do
-    start_agent
+    start_agent(:options => options)
     allow(Kernel).to receive(:at_exit)
   end
   around { |example| keep_transactions { example.run } }
@@ -30,9 +31,7 @@ describe Appsignal::Hooks::RakeHook do
       end
 
       context "with :enable_rake_performance_instrumentation == false" do
-        before do
-          Appsignal.config[:enable_rake_performance_instrumentation] = false
-        end
+        let(:options) { { :enable_rake_performance_instrumentation => false } }
 
         it "creates no transaction" do
           expect { perform }.to_not(change { created_transactions.count })
@@ -49,9 +48,7 @@ describe Appsignal::Hooks::RakeHook do
       end
 
       context "with :enable_rake_performance_instrumentation == true" do
-        before do
-          Appsignal.config[:enable_rake_performance_instrumentation] = true
-        end
+        let(:options) { { :enable_rake_performance_instrumentation => true } }
 
         it "creates a transaction" do
           expect { perform }.to(change { created_transactions.count }.by(1))

--- a/spec/lib/appsignal/hooks/redis_client_spec.rb
+++ b/spec/lib/appsignal/hooks/redis_client_spec.rb
@@ -1,6 +1,7 @@
 describe Appsignal::Hooks::RedisClientHook do
+  let(:options) { {} }
   before do
-    start_agent
+    start_agent(:options => options)
   end
 
   if DependencyHelper.redis_client_present?
@@ -30,9 +31,7 @@ describe Appsignal::Hooks::RedisClientHook do
 
         context "with rest-client gem" do
           describe "integration" do
-            before do
-              Appsignal.config.config_hash[:instrument_redis] = true
-            end
+            let(:options) { { :instrument_redis => true } }
 
             context "install" do
               before do
@@ -115,9 +114,7 @@ describe Appsignal::Hooks::RedisClientHook do
         if DependencyHelper.hiredis_client_present?
           context "with hiredis driver" do
             describe "integration" do
-              before do
-                Appsignal.config.config_hash[:instrument_redis] = true
-              end
+              let(:options) { { :instrument_redis => true } }
 
               context "install" do
                 before do
@@ -200,9 +197,7 @@ describe Appsignal::Hooks::RedisClientHook do
       end
 
       context "with instrumentation disabled" do
-        before do
-          Appsignal.config.config_hash[:instrument_redis] = false
-        end
+        let(:options) { { :instrument_redis => false } }
 
         describe "#dependencies_present?" do
           subject { described_class.new.dependencies_present? }

--- a/spec/lib/appsignal/hooks/redis_spec.rb
+++ b/spec/lib/appsignal/hooks/redis_spec.rb
@@ -1,5 +1,6 @@
 describe Appsignal::Hooks::RedisHook do
-  before { start_agent }
+  let(:options) { {} }
+  before { start_agent(:options => options) }
 
   if DependencyHelper.redis_present?
     context "with redis" do
@@ -22,9 +23,7 @@ describe Appsignal::Hooks::RedisHook do
           end
 
           describe "integration" do
-            before do
-              Appsignal.config.config_hash[:instrument_redis] = true
-            end
+            let(:options) { { :instrument_redis => true } }
 
             context "install" do
               before do
@@ -103,9 +102,7 @@ describe Appsignal::Hooks::RedisHook do
         end
 
         context "with instrumentation disabled" do
-          before do
-            Appsignal.config.config_hash[:instrument_redis] = false
-          end
+          let(:options) { { :instrument_redis => false } }
 
           describe "#dependencies_present?" do
             subject { described_class.new.dependencies_present? }

--- a/spec/lib/appsignal/hooks/resque_spec.rb
+++ b/spec/lib/appsignal/hooks/resque_spec.rb
@@ -25,8 +25,9 @@ describe Appsignal::Hooks::ResqueHook do
 
       let(:queue) { "default" }
       let(:namespace) { Appsignal::Transaction::BACKGROUND_JOB }
+      let(:options) { {} }
       before do
-        start_agent
+        start_agent(:options => options)
 
         class ResqueTestJob
           def self.perform(*_args)
@@ -82,10 +83,7 @@ describe Appsignal::Hooks::ResqueHook do
       end
 
       context "with arguments" do
-        before do
-          start_agent("production")
-          Appsignal.config[:filter_parameters] = ["foo"]
-        end
+        let(:options) { { :filter_parameters => ["foo"] } }
 
         it "filters out configured arguments" do
           perform_rescue_job(

--- a/spec/lib/appsignal/integrations/delayed_job_plugin_spec.rb
+++ b/spec/lib/appsignal/integrations/delayed_job_plugin_spec.rb
@@ -15,7 +15,8 @@ describe "Appsignal::Integrations::DelayedJobHook" do
     require "appsignal/integrations/delayed_job_plugin"
   end
   after(:context) { Object.send(:remove_const, :Delayed) }
-  before { start_agent }
+  let(:options) { {} }
+  before { start_agent(:options => options) }
 
   # We haven't found a way to test the hooks, we'll have to do that manually
 
@@ -82,10 +83,7 @@ describe "Appsignal::Integrations::DelayedJobHook" do
         end
 
         context "with parameter filtering" do
-          before do
-            start_agent("production")
-            Appsignal.config[:filter_parameters] = ["foo"]
-          end
+          let(:options) { { :filter_parameters => ["foo"] } }
 
           it "filters selected arguments" do
             perform
@@ -271,10 +269,7 @@ describe "Appsignal::Integrations::DelayedJobHook" do
             end
 
             context "with parameter filtering" do
-              before do
-                start_agent("production")
-                Appsignal.config[:filter_parameters] = ["foo"]
-              end
+              let(:options) { { :filter_parameters => ["foo"] } }
 
               it "filters selected arguments" do
                 perform

--- a/spec/lib/appsignal/integrations/shoryuken_spec.rb
+++ b/spec/lib/appsignal/integrations/shoryuken_spec.rb
@@ -9,7 +9,8 @@ describe Appsignal::Integrations::ShoryukenMiddleware do
   let(:queue) { "some-funky-queue-name" }
   let(:sqs_msg) { double(:message_id => "msg1", :attributes => {}) }
   let(:body) { {} }
-  before { start_agent }
+  let(:options) { {} }
+  before { start_agent(:options => options) }
   around { |example| keep_transactions { example.run } }
 
   def perform_shoryuken_job(&block)
@@ -60,10 +61,7 @@ describe Appsignal::Integrations::ShoryukenMiddleware do
       end
 
       context "with parameter filtering" do
-        before do
-          start_agent("production")
-          Appsignal.config[:filter_parameters] = ["foo"]
-        end
+        let(:options) { { :filter_parameters => ["foo"] } }
 
         it "filters selected arguments" do
           perform_shoryuken_job

--- a/spec/support/fixtures/projects/valid/config/appsignal.yml
+++ b/spec/support/fixtures/projects/valid/config/appsignal.yml
@@ -1,13 +1,6 @@
 default: &defaults
   push_api_key: "abc"
   name: "TestApp"
-  request_headers: [
-    "HTTP_ACCEPT", "HTTP_ACCEPT_CHARSET", "HTTP_ACCEPT_ENCODING",
-    "HTTP_ACCEPT_LANGUAGE", "HTTP_CACHE_CONTROL", "HTTP_CONNECTION",
-    "CONTENT_LENGTH", "PATH_INFO", "HTTP_RANGE", "HTTP_REFERER",
-    "REQUEST_METHOD", "REQUEST_PATH", "SERVER_NAME", "SERVER_PORT",
-    "SERVER_PROTOCOL", "HTTP_USER_AGENT"
-  ]
   enable_minutely_probes: false
 
 production:

--- a/spec/support/helpers/config_helpers.rb
+++ b/spec/support/helpers/config_helpers.rb
@@ -1,4 +1,8 @@
 module ConfigHelpers
+  def with_config(_options)
+    A
+  end
+
   def project_fixture_path
     File.expand_path(
       File.join(File.dirname(__FILE__), "../fixtures/projects/valid")
@@ -22,8 +26,8 @@ module ConfigHelpers
   end
   module_function :project_fixture_config, :project_fixture_path
 
-  def start_agent(env = "production")
-    Appsignal._config = project_fixture_config(env)
+  def start_agent(env: "production", options: {})
+    Appsignal._config = project_fixture_config(env, options)
     Appsignal.start
   end
 end


### PR DESCRIPTION
Set the config options in the `start_agent` helper so we don't modify the config hash directly midway through specs.

[skip changeset]
[skip review]