### PR TITLE
Report Rails runner errors

### DIFF
--- a/.changesets/report-errors-from-rails-runners.md
+++ b/.changesets/report-errors-from-rails-runners.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+type: add
+---
+
+Report errors from Rails runners. When a Rails runner reports an unhandled error, it will now report the error in the "runner" namespace.

--- a/spec/support/helpers/dependency_helper.rb
+++ b/spec/support/helpers/dependency_helper.rb
@@ -37,6 +37,10 @@ module DependencyHelper
     rails_present? && rails_version >= Gem::Version.new("7.0.0")
   end
 
+  def rails7_1_present?
+    rails_present? && rails_version >= Gem::Version.new("7.1.0")
+  end
+
   def active_job_wraps_args?
     rails7_present? || (ruby_3_1_or_newer? && rails6_1_present? && !rails6_1_5_present?)
   end


### PR DESCRIPTION
Rails runners are a way to run arbitrary code. This CLI can trigger an error that we do not report at the moment.

Add default behavior to report errors from Rails runners by checking the source and reporting it even if the error is unhandled (and will bubble up).

Part of #641