### PR TITLE
Small spec refactor

### DIFF
--- a/spec/lib/appsignal/hooks/active_support_notifications/instrument_shared_examples.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications/instrument_shared_examples.rb
@@ -88,12 +88,12 @@ shared_examples "activesupport instrument override" do
 
   context "when a transaction is completed in an instrumented block" do
     it "does not complete the ActiveSupport::Notifications.instrument event" do
-      expect(transaction).to receive(:complete)
       as.instrument("sql.active_record", :sql => "SQL") do
         Appsignal::Transaction.complete_current!
       end
 
       expect(transaction).to_not include_events
+      expect(transaction).to be_completed
     end
   end
 end

--- a/spec/lib/appsignal/hooks/active_support_notifications/start_finish_shared_examples.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications/start_finish_shared_examples.rb
@@ -36,13 +36,12 @@ shared_examples "activesupport start finish override" do
 
   context "when a transaction is completed in an instrumented block" do
     it "does not complete the ActiveSupport::Notifications.instrument event" do
-      expect(transaction).to receive(:complete)
-
       instrumenter.start("sql.active_record", {})
       Appsignal::Transaction.complete_current!
       instrumenter.finish("sql.active_record", {})
 
       expect(transaction).to_not include_events
+      expect(transaction).to be_completed
     end
   end
 end

--- a/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
@@ -10,6 +10,7 @@ describe Appsignal::Hooks::ActiveSupportNotificationsHook do
       set_current_transaction(transaction)
       as.notifier = notifier
     end
+    around { |example| keep_transactions { example.run } }
 
     describe "#dependencies_present?" do
       subject { described_class.new.dependencies_present? }

--- a/spec/lib/appsignal/probes_spec.rb
+++ b/spec/lib/appsignal/probes_spec.rb
@@ -96,12 +96,10 @@ describe Appsignal::Probes do
     context "with probe class" do
       it "creates an instance of the class and call that every <wait time>" do
         probe = MockProbe
-        probe_instance = MockProbe.new
-        expect(probe).to receive(:new).and_return(probe_instance)
         Appsignal::Probes.register :my_probe, probe
         Appsignal::Probes.start
 
-        wait_for("enough probe calls") { probe_instance.calls >= 2 }
+        wait_for("enough probe calls") { Appsignal::Testing.store[:mock_probe_call] >= 2 }
         expect(log).to contains_log(:debug, "Gathering minutely metrics with 1 probe")
         expect(log).to contains_log(:debug, "Gathering minutely metrics with 'my_probe' probe")
       end
@@ -110,15 +108,13 @@ describe Appsignal::Probes do
         it "does not initialize the probe" do
           # Working probe which we can use to wait for X ticks
           working_probe = ProbeWithoutDependency
-          working_probe_instance = working_probe.new
-          expect(working_probe).to receive(:new).and_return(working_probe_instance)
           Appsignal::Probes.register :probe_without_dep, working_probe
 
           probe = ProbeWithMissingDependency
           Appsignal::Probes.register :probe_with_missing_dep, probe
           Appsignal::Probes.start
 
-          wait_for("enough probe calls") { working_probe_instance.calls >= 2 }
+          wait_for("enough probe calls") { Appsignal::Testing.store[:mock_probe_call] >= 2 }
           # Only counts initialized probes
           expect(log).to contains_log(:debug, "Gathering minutely metrics with 1 probe")
           expect(log).to contains_log :debug, "Skipping 'probe_with_missing_dep' probe, " \
@@ -130,15 +126,13 @@ describe Appsignal::Probes do
         it "logs an error" do
           # Working probe which we can use to wait for X ticks
           working_probe = ProbeWithoutDependency
-          working_probe_instance = working_probe.new
-          expect(working_probe).to receive(:new).and_return(working_probe_instance)
           Appsignal::Probes.register :probe_without_dep, working_probe
 
           probe = BrokenProbeOnInitialize
           Appsignal::Probes.register :broken_probe_on_initialize, probe
           Appsignal::Probes.start
 
-          wait_for("enough probe calls") { working_probe_instance.calls >= 2 }
+          wait_for("enough probe calls") { Appsignal::Testing.store[:mock_probe_call] >= 2 }
           # Only counts initialized probes
           expect(log).to contains_log(:debug, "Gathering minutely metrics with 1 probe")
           # Logs error

--- a/spec/lib/appsignal/rack/abstract_middleware_spec.rb
+++ b/spec/lib/appsignal/rack/abstract_middleware_spec.rb
@@ -9,10 +9,11 @@ describe Appsignal::Rack::AbstractMiddleware do
       "rack.session" => { "session" => "data", "user_id" => 123 }
     )
   end
-  let(:options) { {} }
   let(:middleware) { described_class.new(app, options) }
 
-  before { start_agent }
+  let(:appsignal_env) { :default }
+  let(:options) { {} }
+  before { start_agent(:env => appsignal_env) }
   around { |example| keep_transactions { example.run } }
 
   def make_request
@@ -25,7 +26,7 @@ describe Appsignal::Rack::AbstractMiddleware do
 
   describe "#call" do
     context "when not active" do
-      before { allow(Appsignal).to receive(:active?).and_return(false) }
+      let(:appsignal_env) { :inactive_env }
 
       it "does not instrument the request" do
         expect { make_request }.to_not(change { created_transactions.count })
@@ -38,8 +39,6 @@ describe Appsignal::Rack::AbstractMiddleware do
     end
 
     context "when appsignal is active" do
-      before { allow(Appsignal).to receive(:active?).and_return(true) }
-
       it "creates a transaction for the request" do
         expect { make_request }.to(change { created_transactions.count }.by(1))
 

--- a/spec/lib/appsignal/rack/event_handler_spec.rb
+++ b/spec/lib/appsignal/rack/event_handler_spec.rb
@@ -15,8 +15,9 @@ describe Appsignal::Rack::EventHandler do
   let(:log_stream) { StringIO.new }
   let(:log) { log_contents(log_stream) }
   let(:event_handler_instance) { described_class.new }
+  let(:appsignal_env) { :default }
   before do
-    start_agent
+    start_agent(:env => appsignal_env)
     Appsignal.internal_logger = test_logger(log_stream)
   end
   around { |example| keep_transactions { example.run } }
@@ -41,9 +42,9 @@ describe Appsignal::Rack::EventHandler do
     end
 
     context "when not active" do
-      it "does not create a new transaction" do
-        allow(Appsignal).to receive(:active?).and_return(false)
+      let(:appsignal_env) { :inactive_env }
 
+      it "does not create a new transaction" do
         expect { on_start }.to_not(change { created_transactions.length })
       end
     end
@@ -140,9 +141,9 @@ describe Appsignal::Rack::EventHandler do
     end
 
     context "when not active" do
-      it "does not report the transaction" do
-        allow(Appsignal).to receive(:active?).and_return(false)
+      let(:appsignal_env) { :inactive_env }
 
+      it "does not report the transaction" do
         on_start
         on_error(ExampleStandardError.new("the error"))
 
@@ -195,9 +196,9 @@ describe Appsignal::Rack::EventHandler do
     end
 
     context "when not active" do
-      it "doesn't do anything" do
-        allow(Appsignal).to receive(:active?).and_return(false)
+      let(:appsignal_env) { :inactive_env }
 
+      it "doesn't do anything" do
         request.env[Appsignal::Rack::APPSIGNAL_TRANSACTION] = http_request_transaction
         on_finish
 

--- a/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/sinatra_instrumentation_spec.rb
@@ -51,13 +51,12 @@ if DependencyHelper.sinatra_present?
     let(:env) do
       Rack::MockRequest.env_for("/path", "sinatra.route" => "GET /path", "REQUEST_METHOD" => "GET")
     end
+    let(:appsignal_env) { :default }
     let(:options) { {} }
     let(:middleware) { Appsignal::Rack::SinatraBaseInstrumentation.new(app, options) }
 
-    before { start_agent }
-    around do |example|
-      keep_transactions { example.run }
-    end
+    before { start_agent(:env => appsignal_env) }
+    around { |example| keep_transactions { example.run } }
 
     describe "#initialize" do
       context "with no settings method in the Sinatra app" do
@@ -97,7 +96,7 @@ if DependencyHelper.sinatra_present?
       before { allow(middleware).to receive(:raw_payload).and_return({}) }
 
       context "when appsignal is not active" do
-        before { allow(Appsignal).to receive(:active?).and_return(false) }
+        let(:appsignal_env) { :inactive_env }
 
         it "does not instrument requests" do
           expect { make_request }.to_not(change { created_transactions.count })

--- a/spec/support/fixtures/projects/valid/config/appsignal.yml
+++ b/spec/support/fixtures/projects/valid/config/appsignal.yml
@@ -51,3 +51,7 @@ rack_env:
 
 rails_env:
   <<: *defaults
+
+inactive_env:
+  <<: *defaults
+  active: false

--- a/spec/support/helpers/config_helpers.rb
+++ b/spec/support/helpers/config_helpers.rb
@@ -1,8 +1,4 @@
 module ConfigHelpers
-  def with_config(_options)
-    A
-  end
-
   def project_fixture_path
     File.expand_path(
       File.join(File.dirname(__FILE__), "../fixtures/projects/valid")

--- a/spec/support/helpers/config_helpers.rb
+++ b/spec/support/helpers/config_helpers.rb
@@ -23,6 +23,8 @@ module ConfigHelpers
   module_function :project_fixture_config, :project_fixture_path
 
   def start_agent(env: "production", options: {})
+    env = "production" if env == :default
+    env ||= "production"
     Appsignal._config = project_fixture_config(env, options)
     Appsignal.start
   end

--- a/spec/support/mocks/mock_probe.rb
+++ b/spec/support/mocks/mock_probe.rb
@@ -2,10 +2,12 @@ class MockProbe
   attr_reader :calls
 
   def initialize
+    Appsignal::Testing.store[:mock_probe_call] = 0
     @calls = 0
   end
 
   def call
+    Appsignal::Testing.store[:mock_probe_call] += 1
     @calls += 1
   end
 end


### PR DESCRIPTION
## Remove stubbing from ActiveSupport specs

Do not test if a method is called, but check the state on the transaction object after the spec is done. This matches the way we assert this in every other spec.

## Remove unused test code

I left this code in another PR. Remove it.

## Rewrite excessive stubbing

Don't stub how objects are created but assert the probe call count from the testing store.

## Do not stub Appsignal.active? but change env

Don't stub the `Apsignal.active?` call all the time, but change to an inactive env so it's more predicable what state the integration is in during the entire spec lifetime.


---

[skip changeset]
[skip review]