### PR TITLE
Allow merging of sample data

### DIFF
--- a/.changesets/merge-sample-data.md
+++ b/.changesets/merge-sample-data.md
@@ -1,0 +1,31 @@
+---
+bump: major
+type: change
+---
+
+The transaction sample data is now merged by default. Previously, the sample data (except for tags) would be overwritten when an `Appsignal.set_*` helper was called.
+
+```ruby
+# Old behavior
+Appsignal.set_params("param1" => "value")
+Appsignal.set_params("param2" => "value")
+# The parameters are:
+# { "param2" => "value" }
+
+
+# New behavior
+Appsignal.add_params("param1" => "value")
+Appsignal.add_params("param2" => "value")
+# The parameters are:
+# {  "param1" => "value", "param2" => "value" }
+```
+
+New helpers have been added:
+
+- `Appsignal.add_tags`
+- `Appsignal.add_params`
+- `Appsignal.add_session_data`
+- `Appsignal.add_headers`
+- `Appsignal.add_custom_data`
+
+The old named helpers that start with `set_` will still work. They will also use the new merging behavior.

--- a/benchmark.rake
+++ b/benchmark.rake
@@ -70,7 +70,7 @@ def monitor_transaction(transaction_id)
     Appsignal::Transaction::HTTP_REQUEST
   )
   transaction.set_action("HomeController#show")
-  transaction.set_params(:id => 1)
+  transaction.add_params(:id => 1)
 
   Appsignal.instrument("process_action.action_controller") do
     Appsignal.instrument_sql(

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -437,6 +437,7 @@ module Appsignal
 end
 
 require "appsignal/loaders"
+require "appsignal/sample_data"
 require "appsignal/environment"
 require "appsignal/system"
 require "appsignal/utils"

--- a/lib/appsignal/demo.rb
+++ b/lib/appsignal/demo.rb
@@ -70,14 +70,14 @@ module Appsignal
       end
 
       def add_params_to(transaction)
-        transaction.set_params(
+        transaction.add_params(
           "controller" => "demo",
           "action" => "hello"
         )
       end
 
       def add_headers_to(transaction)
-        transaction.set_headers(
+        transaction.add_headers(
           "REMOTE_ADDR" => "127.0.0.1",
           "REQUEST_METHOD" => "GET",
           "SERVER_NAME" => "localhost",

--- a/lib/appsignal/hooks/action_cable.rb
+++ b/lib/appsignal/hooks/action_cable.rb
@@ -50,10 +50,10 @@ module Appsignal
             transaction.set_action_if_nil("#{channel.class}#subscribed")
             transaction.set_metadata("path", request.path)
             transaction.set_metadata("method", "websocket")
-            transaction.set_params_if_nil { request.params }
-            transaction.set_headers_if_nil { request.env }
-            transaction.set_session_data { request.session if request.respond_to? :session }
-            transaction.set_tags(:request_id => request_id) if request_id
+            transaction.add_params_if_nil { request.params }
+            transaction.add_headers_if_nil { request.env }
+            transaction.add_session_data { request.session if request.respond_to? :session }
+            transaction.add_tags(:request_id => request_id) if request_id
             Appsignal::Transaction.complete_current!
           end
         end
@@ -86,10 +86,10 @@ module Appsignal
             transaction.set_action_if_nil("#{channel.class}#unsubscribed")
             transaction.set_metadata("path", request.path)
             transaction.set_metadata("method", "websocket")
-            transaction.set_params_if_nil { request.params }
-            transaction.set_headers_if_nil { request.env }
-            transaction.set_session_data { request.session if request.respond_to? :session }
-            transaction.set_tags(:request_id => request_id) if request_id
+            transaction.add_params_if_nil { request.params }
+            transaction.add_headers_if_nil { request.env }
+            transaction.add_session_data { request.session if request.respond_to? :session }
+            transaction.add_tags(:request_id => request_id) if request_id
             Appsignal::Transaction.complete_current!
           end
         end

--- a/lib/appsignal/hooks/active_job.rb
+++ b/lib/appsignal/hooks/active_job.rb
@@ -58,10 +58,10 @@ module Appsignal
             end
 
           if transaction
-            transaction.set_params_if_nil(job["arguments"])
+            transaction.add_params_if_nil(job["arguments"])
 
             transaction_tags = ActiveJobHelpers.transaction_tags_for(job)
-            transaction.set_tags(transaction_tags)
+            transaction.add_tags(transaction_tags)
 
             transaction.set_action(ActiveJobHelpers.action_name(job))
           end

--- a/lib/appsignal/integrations/action_cable.rb
+++ b/lib/appsignal/integrations/action_cable.rb
@@ -19,11 +19,11 @@ module Appsignal
           transaction.set_error(exception)
           raise exception
         ensure
-          transaction.set_params_if_nil(args.first)
           transaction.set_action_if_nil("#{self.class}##{args.first["action"]}")
+          transaction.add_params_if_nil(args.first)
           transaction.set_metadata("path", request.path)
           transaction.set_metadata("method", "websocket")
-          transaction.set_tags(:request_id => request_id) if request_id
+          transaction.add_tags(:request_id => request_id) if request_id
           Appsignal::Transaction.complete_current!
         end
       end

--- a/lib/appsignal/integrations/delayed_job_plugin.rb
+++ b/lib/appsignal/integrations/delayed_job_plugin.rb
@@ -32,14 +32,14 @@ module Appsignal
           # ActiveJob
           job_data = payload.job_data
           transaction.set_action_if_nil("#{job_data["job_class"]}#perform")
-          transaction.set_params_if_nil(job_data.fetch("arguments", {}))
+          transaction.add_params_if_nil(job_data.fetch("arguments", {}))
         else
           # Delayed Job
           transaction.set_action_if_nil(action_name_from_payload(payload, job.name))
-          transaction.set_params_if_nil(extract_value(payload, :args, {}))
+          transaction.add_params_if_nil(extract_value(payload, :args, {}))
         end
 
-        transaction.set_tags(
+        transaction.add_tags(
           :id => extract_value(job, :id, nil, true),
           :queue => extract_value(job, :queue),
           :priority => extract_value(job, :priority, 0),

--- a/lib/appsignal/integrations/que.rb
+++ b/lib/appsignal/integrations/que.rb
@@ -16,8 +16,8 @@ module Appsignal
         ensure
           local_attrs = respond_to?(:que_attrs) ? que_attrs : attrs
           transaction.set_action_if_nil("#{local_attrs[:job_class]}#run")
-          transaction.set_params_if_nil(local_attrs[:args])
-          transaction.set_tags(
+          transaction.add_params_if_nil(local_attrs[:args])
+          transaction.add_tags(
             "id" => local_attrs[:job_id] || local_attrs[:id],
             "queue" => local_attrs[:queue],
             "run_at" => local_attrs[:run_at].to_s,

--- a/lib/appsignal/integrations/railtie.rb
+++ b/lib/appsignal/integrations/railtie.rb
@@ -95,12 +95,12 @@ module Appsignal
             transaction.set_action(action_name) if action_name
             transaction.set_metadata("path", path)
             transaction.set_metadata("method", method)
-            transaction.set_params_if_nil(params)
-            transaction.set_custom_data(custom_data) if custom_data
+            transaction.add_params_if_nil(params)
+            transaction.add_custom_data(custom_data) if custom_data
 
             tags[:severity] = severity
             tags[:source] = source.to_s if source
-            transaction.set_tags(tags)
+            transaction.add_tags(tags)
           end
         end
 

--- a/lib/appsignal/integrations/rake.rb
+++ b/lib/appsignal/integrations/rake.rb
@@ -24,9 +24,8 @@ module Appsignal
           # Format given arguments and cast to hash if possible
           params, _ = args
           params = params.to_hash if params.respond_to?(:to_hash)
-          transaction.set_params_if_nil(params)
-          transaction.set_params_if_nil(params)
           transaction.set_action(name)
+          transaction.add_params_if_nil(params)
           transaction.complete
         end
       end

--- a/lib/appsignal/integrations/resque.rb
+++ b/lib/appsignal/integrations/resque.rb
@@ -21,8 +21,8 @@ module Appsignal
               ResqueHelpers.arguments(payload),
               Appsignal.config[:filter_parameters]
             )
-          transaction.set_params_if_nil(args)
-          transaction.set_tags("queue" => queue)
+          transaction.add_params_if_nil(args)
+          transaction.add_tags("queue" => queue)
 
           Appsignal::Transaction.complete_current!
         end

--- a/lib/appsignal/integrations/shoryuken.rb
+++ b/lib/appsignal/integrations/shoryuken.rb
@@ -15,10 +15,10 @@ module Appsignal
         batch = sqs_msg.is_a?(Array)
         attributes = fetch_attributes(batch, sqs_msg)
         transaction.set_action_if_nil("#{worker_instance.class.name}#perform")
-        transaction.set_params_if_nil { fetch_args(batch, sqs_msg, body) }
-        transaction.set_tags(attributes)
-        transaction.set_tags("queue" => queue)
-        transaction.set_tags("batch" => true) if batch
+        transaction.add_params_if_nil { fetch_args(batch, sqs_msg, body) }
+        transaction.add_tags(attributes)
+        transaction.add_tags("queue" => queue)
+        transaction.add_tags("batch" => true) if batch
 
         if attributes.key?("SentTimestamp")
           transaction.set_queue_start(Time.at(attributes["SentTimestamp"].to_i).to_i)

--- a/lib/appsignal/integrations/sidekiq.rb
+++ b/lib/appsignal/integrations/sidekiq.rb
@@ -41,7 +41,7 @@ module Appsignal
           transaction = Appsignal::Transaction.create(Appsignal::Transaction::BACKGROUND_JOB)
           transaction.set_action_if_nil("SidekiqInternal")
           transaction.set_metadata("sidekiq_error", sidekiq_context[:context])
-          transaction.set_params_if_nil(:jobstr => sidekiq_context[:jobstr])
+          transaction.add_params_if_nil(:jobstr => sidekiq_context[:jobstr])
           transaction.set_error(exception)
         end
 
@@ -73,10 +73,10 @@ module Appsignal
         raise exception
       ensure
         if transaction
-          transaction.set_params_if_nil { parse_arguments(item) }
+          transaction.add_params_if_nil { parse_arguments(item) }
           queue_start = (item["enqueued_at"].to_f * 1000.0).to_i # Convert seconds to milliseconds
           transaction.set_queue_start(queue_start)
-          transaction.set_tags(:request_id => item["jid"])
+          transaction.add_tags(:request_id => item["jid"])
           Appsignal::Transaction.complete_current! unless exception
 
           queue = item["queue"] || "unknown"

--- a/lib/appsignal/integrations/webmachine.rb
+++ b/lib/appsignal/integrations/webmachine.rb
@@ -12,14 +12,14 @@ module Appsignal
           else
             Appsignal::Transaction.create(Appsignal::Transaction::HTTP_REQUEST)
           end
+        transaction.add_params_if_nil { request.query }
+        transaction.add_headers_if_nil { request.headers if request.respond_to?(:headers) }
 
         Appsignal.instrument("process_action.webmachine") do
           super
         end
       ensure
         transaction.set_action_if_nil("#{resource.class.name}##{request.method}")
-        transaction.set_params_if_nil(request.query)
-        transaction.set_headers_if_nil { request.headers if request.respond_to?(:headers) }
 
         Appsignal::Transaction.complete_current! unless has_parent_transaction
       end

--- a/lib/appsignal/rack/abstract_middleware.rb
+++ b/lib/appsignal/rack/abstract_middleware.rb
@@ -141,13 +141,14 @@ module Appsignal
         request_method = request_method_for(request)
         transaction.set_metadata("method", request_method) if request_method
 
-        transaction.set_params_if_nil { params_for(request) }
-        transaction.set_session_data_if_nil do
+        transaction.add_params { params_for(request) }
+        transaction.add_session_data do
           request.session if request.respond_to?(:session)
         end
-        transaction.set_headers_if_nil do
+        transaction.add_headers do
           request.env if request.respond_to?(:env)
         end
+
         queue_start = Appsignal::Rack::Utils.queue_start_from(request.env)
         transaction.set_queue_start(queue_start) if queue_start
       end

--- a/lib/appsignal/rack/event_handler.rb
+++ b/lib/appsignal/rack/event_handler.rb
@@ -110,9 +110,9 @@ module Appsignal
 
         self.class.safe_execution("Appsignal::Rack::EventHandler#on_finish") do
           transaction.finish_event("process_request.rack", "", "")
-          transaction.set_params_if_nil { request.params }
-          transaction.set_headers_if_nil { request.env }
-          transaction.set_session_data_if_nil do
+          transaction.add_params_if_nil { request.params }
+          transaction.add_headers_if_nil { request.env }
+          transaction.add_session_data_if_nil do
             request.session if request.respond_to?(:session)
           end
           queue_start = Appsignal::Rack::Utils.queue_start_from(request.env)
@@ -124,7 +124,7 @@ module Appsignal
               500
             end
           if response_status
-            transaction.set_tags(:response_status => response_status)
+            transaction.add_tags(:response_status => response_status)
             Appsignal.increment_counter(
               :response_status,
               1,

--- a/lib/appsignal/rack/rails_instrumentation.rb
+++ b/lib/appsignal/rack/rails_instrumentation.rb
@@ -19,7 +19,7 @@ module Appsignal
         transaction.set_action_if_nil("#{controller.class}##{controller.action_name}") if controller
 
         request_id = request.env["action_dispatch.request_id"]
-        transaction.set_tags(:request_id => request_id) if request_id
+        transaction.add_tags(:request_id => request_id) if request_id
 
         super
       end

--- a/lib/appsignal/sample_data.rb
+++ b/lib/appsignal/sample_data.rb
@@ -21,12 +21,10 @@ module Appsignal
 
     def value
       value = nil
-      @blocks.each_with_index do |block_or_value, index|
+      @blocks.map! do |block_or_value|
         new_value =
           if block_or_value.respond_to?(:call)
-            v = block_or_value.call
-            @blocks[index] = v
-            v
+            block_or_value.call
           else
             block_or_value
           end
@@ -36,6 +34,7 @@ module Appsignal
         end
 
         value = merge_values(value, new_value)
+        new_value
       end
 
       value

--- a/lib/appsignal/sample_data.rb
+++ b/lib/appsignal/sample_data.rb
@@ -68,8 +68,11 @@ module Appsignal
 
     def merge_values(value_original, value_new)
       unless value_new.instance_of?(value_original.class)
-        # TODO: add log warning
-        # Value types don't match. The block is leading so overwrite the value
+        Appsignal.internal_logger.warn(
+          "The sample data '#{@key}' changed type from " \
+            "'#{value_original.class}' to '#{value_new.class}'. " \
+            "These types can not be merged. Using new '#{value_new.class}' type."
+        )
         return value_new
       end
 

--- a/lib/appsignal/sample_data.rb
+++ b/lib/appsignal/sample_data.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Appsignal
+  # @api private
+  class SampleData
+    def initialize(key, accepted_type = nil)
+      @key = key
+      @accepted_type = accepted_type
+      @blocks = []
+    end
+
+    def add(data = nil, &block)
+      if block_given?
+        @blocks << block
+      elsif accepted_type?(data)
+        @blocks << data
+      else
+        log_unsupported_data_type(data)
+      end
+    end
+
+    def value
+      value = nil
+      @blocks.each_with_index do |block_or_value, index|
+        new_value =
+          if block_or_value.respond_to?(:call)
+            v = block_or_value.call
+            @blocks[index] = v
+            v
+          else
+            block_or_value
+          end
+        unless accepted_type?(new_value)
+          log_unsupported_data_type(new_value)
+          next
+        end
+
+        value = merge_values(value, new_value)
+      end
+
+      value
+    end
+
+    def value?
+      @blocks.any?
+    end
+
+    private
+
+    def accepted_type?(value)
+      if @accepted_type
+        value.is_a?(@accepted_type)
+      else
+        value.is_a?(Hash) || value.is_a?(Array)
+      end
+    end
+
+    def merge_values(value_original, value_new)
+      unless value_new.instance_of?(value_original.class)
+        # TODO: add log warning
+        # Value types don't match. The block is leading so overwrite the value
+        return value_new
+      end
+
+      case value_original
+      when Hash
+        value_original.merge(value_new)
+      when Array
+        value_original + value_new
+      else
+        value_new
+      end
+    end
+
+    def log_unsupported_data_type(value)
+      Appsignal.internal_logger.error(
+        "Sample data '#{@key}': Unsupported data type '#{value.class}' received: #{value.inspect}"
+      )
+    end
+  end
+end

--- a/lib/appsignal/sample_data.rb
+++ b/lib/appsignal/sample_data.rb
@@ -45,7 +45,19 @@ module Appsignal
       @blocks.any?
     end
 
+    protected
+
+    attr_reader :blocks
+
     private
+
+    # Method called by `dup` and `clone` to create a duplicate instance.
+    # Make sure the `@blocks` variable is also properly duplicated.
+    def initialize_copy(original)
+      super
+
+      @blocks = original.blocks.dup
+    end
 
     def accepted_type?(value)
       if @accepted_type

--- a/spec/lib/appsignal/integrations/railtie_spec.rb
+++ b/spec/lib/appsignal/integrations/railtie_spec.rb
@@ -253,7 +253,7 @@ if DependencyHelper.rails_present?
               current_transaction = http_request_transaction
               current_transaction.set_namespace "custom"
               current_transaction.set_action "CustomAction"
-              current_transaction.set_tags(
+              current_transaction.add_tags(
                 :duplicated_tag => "duplicated value"
               )
 
@@ -275,7 +275,7 @@ if DependencyHelper.rails_present?
 
             it "overwrites duplicated tags with tags from context" do
               current_transaction = http_request_transaction
-              current_transaction.set_tags(:tag1 => "duplicated value")
+              current_transaction.add_tags(:tag1 => "duplicated value")
 
               with_rails_error_reporter do
                 with_current_transaction current_transaction do

--- a/spec/lib/appsignal/sample_data_spec.rb
+++ b/spec/lib/appsignal/sample_data_spec.rb
@@ -50,6 +50,12 @@ describe Appsignal::SampleData do
 
       data.add(["abc"])
       expect(data.value).to eq(["abc"])
+
+      logs = capture_logs { data.value }
+      expect(logs).to contains_log(
+        :warn,
+        "The sample data 'data_key' changed type from 'Hash' to 'Array'."
+      )
     end
 
     it "ignores invalid values" do

--- a/spec/lib/appsignal/sample_data_spec.rb
+++ b/spec/lib/appsignal/sample_data_spec.rb
@@ -105,6 +105,21 @@ describe Appsignal::SampleData do
     end
   end
 
+  describe "#value" do
+    it "caches the block value after calling it once" do
+      Appsignal::Testing.store[:block_call] = 0
+      data.add do
+        Appsignal::Testing.store[:block_call] += 1
+        { :key => "value" }
+      end
+
+      expect(data.value).to eq(:key => "value")
+      data.value
+
+      expect(Appsignal::Testing.store[:block_call]).to eq(1)
+    end
+  end
+
   describe "#value?" do
     it "returns true when value is set" do
       data.add(["abc"])

--- a/spec/lib/appsignal/sample_data_spec.rb
+++ b/spec/lib/appsignal/sample_data_spec.rb
@@ -1,0 +1,123 @@
+describe Appsignal::SampleData do
+  let(:data) { described_class.new(:data_key) }
+
+  describe "#add" do
+    it "sets the given value" do
+      data.add(:key1 => "value 1")
+
+      expect(data.value).to eq(:key1 => "value 1")
+    end
+
+    it "adds the given value with the block being leading" do
+      data.add(:key1 => "value 1") { { :key2 => "value 2" } }
+
+      expect(data.value).to eq(:key2 => "value 2")
+    end
+
+    it "merges multiple values" do
+      data.add(:key1 => "value 1")
+      data.add(:key2 => "value 2")
+
+      expect(data.value).to eq(:key1 => "value 1", :key2 => "value 2")
+    end
+
+    it "merges only root level Hash keys" do
+      data.add(:key => { :abc => "value" })
+      data.add(:key => { :def => "value" })
+
+      expect(data.value).to eq(:key => { :def => "value" })
+    end
+
+    it "merges values from arguments and blocks" do
+      data.add(:key1 => "value 1")
+      data.add { { :key2 => "value 2" } }
+      data.add(:key3 => "value 3")
+
+      expect(data.value).to eq(:key1 => "value 1", :key2 => "value 2", :key3 => "value 3")
+    end
+
+    it "merges array values" do
+      data.add([:first_arg])
+      data.add { [:from_block] }
+      data.add([:second_arg])
+
+      expect(data.value).to eq([:first_arg, :from_block, :second_arg])
+    end
+
+    it "overwrites the value if the new value is of a different type" do
+      data.add(:key1 => "value 1")
+      expect(data.value).to eq(:key1 => "value 1")
+
+      data.add(["abc"])
+      expect(data.value).to eq(["abc"])
+    end
+
+    it "ignores invalid values" do
+      logs = capture_logs { data.add("string") }
+      expect(data.value).to be_nil
+      expect(logs).to contains_log(
+        :error,
+        "Sample data 'data_key': Unsupported data type 'String' received: \"string\""
+      )
+
+      set = Set.new
+      set.add("abc")
+      logs = capture_logs { data.add(set) }
+      expect(data.value).to be_nil
+      expect(logs).to contains_log(
+        :error,
+        "Sample data 'data_key': Unsupported data type 'Set' received: #<Set: {\"abc\"}>"
+      )
+
+      instance = Class.new
+      logs = capture_logs { data.add(instance) }
+      expect(data.value).to be_nil
+      expect(logs).to contains_log(
+        :error,
+        "Sample data 'data_key': Unsupported data type 'Class' received: #<Class:"
+      )
+    end
+
+    context "with a type specified" do
+      it "only accepts values of Hash type" do
+        data = described_class.new(:data_key, Hash)
+
+        data.add(:key1 => "value 1")
+        data.add(["abc"])
+        data.add { { :key2 => "value 2" } }
+        data.add { ["def"] }
+        data.add(:key3 => "value 3")
+
+        expect(data.value).to eq(:key1 => "value 1", :key2 => "value 2", :key3 => "value 3")
+      end
+
+      it "only accepts values of Array type" do
+        data = described_class.new(:data_key, Array)
+
+        data.add(:key1 => "value 1")
+        data.add(["abc"])
+        data.add { { :key2 => "value 2" } }
+        data.add { ["def"] }
+        data.add(:key3 => "value 3")
+
+        expect(data.value).to eq(["abc", "def"])
+      end
+    end
+  end
+
+  describe "#value?" do
+    it "returns true when value is set" do
+      data.add(["abc"])
+      expect(data.value?).to be_truthy
+    end
+
+    it "returns true when value is set with a block" do
+      data.add { ["abc"] }
+      expect(data.value?).to be_truthy
+    end
+
+    it "returns false when the value is not set" do
+      expect(data.value?).to be_falsey
+    end
+  end
+end

--- a/spec/lib/appsignal/sample_data_spec.rb
+++ b/spec/lib/appsignal/sample_data_spec.rb
@@ -120,4 +120,34 @@ describe Appsignal::SampleData do
       expect(data.value?).to be_falsey
     end
   end
+
+  describe "#duplicate" do
+    it "duplicates the internal Hash state without modifying the original" do
+      data = described_class.new(:my_key, Hash)
+      data.add(:abc => :value)
+
+      duplicate = data.dup
+      duplicate.add(:def => :value)
+
+      expect(data.value).to eq(:abc => :value)
+      expect(duplicate.value).to eq(:abc => :value, :def => :value)
+
+      expect(duplicate.instance_variable_get(:@key)).to eq(:my_key)
+      expect(duplicate.instance_variable_get(:@accepted_type)).to eq(Hash)
+    end
+
+    it "duplicates the internal Array state without modifying the original" do
+      data = described_class.new(:my_key, Array)
+      data.add([:abc])
+
+      duplicate = data.dup
+      duplicate.add([:def])
+
+      expect(data.value).to eq([:abc])
+      expect(duplicate.value).to eq([:abc, :def])
+
+      expect(duplicate.instance_variable_get(:@key)).to eq(:my_key)
+      expect(duplicate.instance_variable_get(:@accepted_type)).to eq(Array)
+    end
+  end
 end

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -161,7 +161,7 @@ describe Appsignal::Transaction do
 
     context "when transaction is being sampled" do
       it "samples data" do
-        transaction.set_tags(:foo => "bar")
+        transaction.add_tags(:foo => "bar")
         keep_transactions { transaction.complete }
         expect(transaction).to include_tags("foo" => "bar")
       end
@@ -295,7 +295,7 @@ describe Appsignal::Transaction do
           transaction.set_action("My action")
           transaction.set_metadata("path", "/some/path")
           transaction.set_metadata("method", "GET")
-          transaction.set_tags(tags)
+          transaction.add_tags(tags)
           transaction.set_params(params)
           transaction.set_headers(headers)
           transaction.set_session_data(session_data)
@@ -430,107 +430,122 @@ describe Appsignal::Transaction do
     end
   end
 
-  describe "#set_params" do
+  describe "#add_params" do
     let(:transaction) { new_transaction }
 
-    context "when the params are set" do
-      it "updates the params on the transaction" do
-        params = { "key" => "value" }
-        transaction.set_params(params)
-
-        transaction._sample
-        expect(transaction).to include_params(params)
-      end
-
-      it "updates the params on the transaction with a block" do
-        params = { "key" => "value" }
-        transaction.set_params { params }
-
-        transaction._sample
-        expect(transaction).to include_params(params)
-      end
-
-      it "updates with the params argument when both an argument and block are given" do
-        arg_params = { "argument" => "value" }
-        block_params = { "block" => "value" }
-        transaction.set_params(arg_params) { block_params }
-
-        transaction._sample
-        expect(transaction).to include_params(arg_params)
-      end
-
-      it "logs an error if an error occurred storing the params" do
-        transaction.set_params { raise "uh oh" }
-
-        logs = capture_logs { transaction._sample }
-        expect(logs).to contains_log(
-          :error,
-          "Exception while fetching params: RuntimeError: uh oh"
-        )
-      end
-
-      context "with AppSignal filtering" do
-        let(:options) { { :filter_parameters => %w[foo] } }
-
-        it "returns sanitized custom params" do
-          transaction.set_params("foo" => "value", "baz" => "bat")
-
-          transaction._sample
-          expect(transaction).to include_params("foo" => "[FILTERED]", "baz" => "bat")
-        end
-      end
+    it "has a #set_params alias" do
+      expect(transaction.method(:add_params)).to eq(transaction.method(:set_params))
     end
 
-    context "when the given params is nil" do
-      it "does not update the params on the transaction" do
-        params = { "key" => "value" }
-        transaction.set_params(params)
-        transaction.set_params(nil)
+    it "adds the params to the transaction" do
+      params = { "key" => "value" }
+      transaction.add_params(params)
+
+      transaction._sample
+      expect(transaction).to include_params(params)
+    end
+
+    it "merges the params on the transaction" do
+      transaction.add_params("abc" => "value")
+      transaction.add_params("def" => "value")
+      transaction.add_params { { "xyz" => "value" } }
+
+      transaction._sample
+      expect(transaction).to include_params(
+        "abc" => "value",
+        "def" => "value",
+        "xyz" => "value"
+      )
+    end
+
+    it "adds the params to the transaction with a block" do
+      params = { "key" => "value" }
+      transaction.add_params { params }
+
+      transaction._sample
+      expect(transaction).to include_params(params)
+    end
+
+    it "adds the params block value when both an argument and block are given" do
+      arg_params = { "argument" => "value" }
+      block_params = { "block" => "value" }
+      transaction.add_params(arg_params) { block_params }
+
+      transaction._sample
+      expect(transaction).to include_params(block_params)
+    end
+
+    it "logs an error if an error occurred storing the params" do
+      transaction.add_params { raise "uh oh" }
+
+      logs = capture_logs { transaction._sample }
+      expect(logs).to contains_log(
+        :error,
+        "Exception while fetching params: RuntimeError: uh oh"
+      )
+    end
+
+    it "does not update the params on the transaction if the given value is nil" do
+      params = { "key" => "value" }
+      transaction.add_params(params)
+      transaction.add_params(nil)
+
+      transaction._sample
+      expect(transaction).to include_params(params)
+    end
+
+    context "with AppSignal filtering" do
+      let(:options) { { :filter_parameters => %w[foo] } }
+
+      it "returns sanitized custom params" do
+        transaction.add_params("foo" => "value", "baz" => "bat")
 
         transaction._sample
-        expect(transaction).to include_params(params)
+        expect(transaction).to include_params("foo" => "[FILTERED]", "baz" => "bat")
       end
     end
   end
 
-  describe "#set_params_if_nil" do
+  describe "#add_params_if_nil" do
     let(:transaction) { new_transaction }
 
+    it "has a #set_params_if_nil alias" do
+      expect(transaction.method(:add_params_if_nil)).to eq(transaction.method(:set_params_if_nil))
+    end
+
     context "when the params are not set" do
-      it "sets the params on the transaction" do
+      it "adds the params to the transaction" do
         params = { "key" => "value" }
-        transaction.set_params_if_nil(params)
+        transaction.add_params_if_nil(params)
 
         transaction._sample
         expect(transaction).to include_params(params)
       end
 
-      it "updates the params on the transaction with a block" do
+      it "adds the params to the transaction with a block" do
         params = { "key" => "value" }
-        transaction.set_params_if_nil { params }
+        transaction.add_params_if_nil { params }
 
         transaction._sample
         expect(transaction).to include_params(params)
       end
 
-      it "updates with the params argument when both an argument and block are given" do
+      it "adds the params block value when both an argument and block are given" do
         arg_params = { "argument" => "value" }
         block_params = { "block" => "value" }
-        transaction.set_params_if_nil(arg_params) { block_params }
+        transaction.add_params_if_nil(arg_params) { block_params }
 
         transaction._sample
-        expect(transaction).to include_params(arg_params)
+        expect(transaction).to include_params(block_params)
       end
 
-      context "when the given params is nil" do
-        it "does not update the params on the transaction" do
-          params = { "key" => "value" }
-          transaction.set_params(params)
-          transaction.set_params_if_nil(nil)
+      it "does not update the params on the transaction if the given value is nil" do
+        params = { "key" => "value" }
+        transaction.add_params(params)
+        transaction.add_params_if_nil(nil)
 
-          transaction._sample
-          expect(transaction).to include_params(params)
-        end
+        transaction._sample
+        expect(transaction).to include_params(params)
       end
     end
 
@@ -538,8 +553,8 @@ describe Appsignal::Transaction do
       it "does not update the params on the transaction" do
         preset_params = { "other" => "params" }
         params = { "key" => "value" }
-        transaction.set_params(preset_params)
-        transaction.set_params_if_nil(params)
+        transaction.add_params(preset_params)
+        transaction.add_params_if_nil(params)
 
         transaction._sample
         expect(transaction).to include_params(preset_params)
@@ -548,8 +563,8 @@ describe Appsignal::Transaction do
       it "does not update the params with a block on the transaction" do
         preset_params = { "other" => "params" }
         params = { "key" => "value" }
-        transaction.set_params(preset_params)
-        transaction.set_params_if_nil { params }
+        transaction.add_params(preset_params)
+        transaction.add_params_if_nil { params }
 
         transaction._sample
         expect(transaction).to include_params(preset_params)
@@ -557,13 +572,89 @@ describe Appsignal::Transaction do
     end
   end
 
-  describe "#set_session_data" do
+  describe "#add_session_data" do
     let(:transaction) { new_transaction }
 
-    context "when the session data is set" do
-      it "updates the session data on the transaction" do
+    it "has a #set_session_data alias" do
+      expect(transaction.method(:add_session_data)).to eq(transaction.method(:set_session_data))
+    end
+
+    it "adds the session data to the transaction" do
+      data = { "key" => "value" }
+      transaction.add_session_data(data)
+
+      transaction._sample
+      expect(transaction).to include_session_data(data)
+    end
+
+    it "merges the session data on the transaction" do
+      transaction.add_session_data("abc" => "value")
+      transaction.add_session_data("def" => "value")
+      transaction.add_session_data { { "xyz" => "value" } }
+
+      transaction._sample
+      expect(transaction).to include_session_data(
+        "abc" => "value",
+        "def" => "value",
+        "xyz" => "value"
+      )
+    end
+
+    it "adds the session data to the transaction with a block" do
+      data = { "key" => "value" }
+      transaction.add_session_data { data }
+
+      transaction._sample
+      expect(transaction).to include_session_data(data)
+    end
+
+    it "adds the session data block value when both an argument and block are given" do
+      arg_data = { "argument" => "value" }
+      block_data = { "block" => "value" }
+      transaction.add_session_data(arg_data) { block_data }
+
+      transaction._sample
+      expect(transaction).to include_session_data(block_data)
+    end
+
+    it "logs an error if an error occurred storing the session data" do
+      transaction.add_session_data { raise "uh oh" }
+
+      logs = capture_logs { transaction._sample }
+      expect(logs).to contains_log(
+        :error,
+        "Exception while fetching session data: RuntimeError: uh oh"
+      )
+    end
+
+    it "does not update the session data on the transaction if the given value is nil" do
+      data = { "key" => "value" }
+      transaction.add_session_data(data)
+      transaction.add_session_data(nil)
+
+      transaction._sample
+      expect(transaction).to include_session_data(data)
+    end
+
+    context "with filter_session_data" do
+      let(:options) { { :filter_session_data => ["filtered_key"] } }
+
+      it "does not include filtered out session data" do
+        transaction.add_session_data("data" => "value1", "filtered_key" => "filtered_value")
+
+        transaction._sample
+        expect(transaction).to include_session_data("data" => "value1")
+      end
+    end
+  end
+
+  describe "#add_session_data_if_nil" do
+    let(:transaction) { new_transaction }
+
+    context "when the session data is not set" do
+      it "sets the session data on the transaction" do
         data = { "key" => "value" }
-        transaction.set_session_data(data)
+        transaction.add_session_data_if_nil(data)
 
         transaction._sample
         expect(transaction).to include_session_data(data)
@@ -571,112 +662,47 @@ describe Appsignal::Transaction do
 
       it "updates the session data on the transaction with a block" do
         data = { "key" => "value" }
-        transaction.set_session_data { data }
+        transaction.add_session_data_if_nil { data }
 
         transaction._sample
         expect(transaction).to include_session_data(data)
       end
 
-      it "updates with the session data argument when both an argument and block are given" do
+      it "updates with the session data block when both an argument and block are given" do
         arg_data = { "argument" => "value" }
         block_data = { "block" => "value" }
-        transaction.set_session_data(arg_data) { block_data }
+        transaction.add_session_data_if_nil(arg_data) { block_data }
 
         transaction._sample
-        expect(transaction).to include_session_data(arg_data)
+        expect(transaction).to include_session_data(block_data)
       end
 
-      context "with filter_session_data" do
-        let(:options) { { :filter_session_data => ["filtered_key"] } }
+      it "does not update the session data on the transaction if the given value is nil" do
+        data = { "key" => "value" }
+        transaction.add_session_data(data)
+        transaction.add_session_data_if_nil(nil)
 
-        it "does not include filtered out session data" do
-          transaction.set_session_data("data" => "value1", "filtered_key" => "filtered_value")
-
-          transaction._sample
-          expect(transaction).to include_session_data("data" => "value1")
-        end
-      end
-
-      it "logs an error if an error occurred storing the session data" do
-        transaction.set_session_data { raise "uh oh" }
-
-        logs = capture_logs { transaction._sample }
-        expect(logs).to contains_log(
-          :error,
-          "Exception while fetching session data: RuntimeError: uh oh"
-        )
+        transaction._sample
+        expect(transaction).to include_session_data(data)
       end
     end
 
-    context "when the given session data is nil" do
+    context "when the session data are set" do
       it "does not update the session data on the transaction" do
-        data = { "key" => "value" }
-        transaction.set_session_data(data)
-        transaction.set_session_data(nil)
-
-        transaction._sample
-        expect(transaction).to include_session_data(data)
-      end
-    end
-  end
-
-  describe "#set_session_data_if_nil" do
-    let(:transaction) { new_transaction }
-
-    context "when the params are not set" do
-      it "sets the params on the transaction" do
-        data = { "key" => "value" }
-        transaction.set_session_data_if_nil(data)
-
-        transaction._sample
-        expect(transaction).to include_session_data(data)
-      end
-
-      it "updates the params on the transaction with a block" do
-        data = { "key" => "value" }
-        transaction.set_session_data_if_nil { data }
-
-        transaction._sample
-        expect(transaction).to include_session_data(data)
-      end
-
-      it "updates with the params argument when both an argument and block are given" do
-        arg_data = { "argument" => "value" }
-        block_data = { "block" => "value" }
-        transaction.set_session_data_if_nil(arg_data) { block_data }
-
-        transaction._sample
-        expect(transaction).to include_session_data(arg_data)
-      end
-
-      context "when the given params is nil" do
-        it "does not update the params on the transaction" do
-          data = { "key" => "value" }
-          transaction.set_session_data(data)
-          transaction.set_session_data_if_nil(nil)
-
-          transaction._sample
-          expect(transaction).to include_session_data(data)
-        end
-      end
-    end
-
-    context "when the params are set" do
-      it "does not update the params on the transaction" do
         preset_data = { "other" => "data" }
         data = { "key" => "value" }
-        transaction.set_session_data(preset_data)
-        transaction.set_session_data_if_nil(data)
+        transaction.add_session_data(preset_data)
+        transaction.add_session_data_if_nil(data)
 
         transaction._sample
         expect(transaction).to include_session_data(preset_data)
       end
 
-      it "does not update the params with a block on the transaction" do
+      it "does not update the session data with a block on the transaction" do
         preset_data = { "other" => "data" }
         data = { "key" => "value" }
-        transaction.set_session_data(preset_data)
-        transaction.set_session_data_if_nil { data }
+        transaction.add_session_data(preset_data)
+        transaction.add_session_data_if_nil { data }
 
         transaction._sample
         expect(transaction).to include_session_data(preset_data)
@@ -684,126 +710,141 @@ describe Appsignal::Transaction do
     end
   end
 
-  describe "#set_headers" do
+  describe "#add_headers" do
     let(:transaction) { new_transaction }
+
+    it "has a #set_headers alias" do
+      expect(transaction.method(:add_headers)).to eq(transaction.method(:set_headers))
+    end
+
+    it "adds the headers to the transaction" do
+      headers = { "PATH_INFO" => "value" }
+      transaction.add_headers(headers)
+
+      transaction._sample
+      expect(transaction).to include_environment(headers)
+    end
+
+    it "merges the headers on the transaction" do
+      transaction.add_headers("PATH_INFO" => "value")
+      transaction.add_headers("REQUEST_METHOD" => "value")
+      transaction.add_headers { { "HTTP_ACCEPT" => "value" } }
+
+      transaction._sample
+      expect(transaction).to include_environment(
+        "PATH_INFO" => "value",
+        "REQUEST_METHOD" => "value",
+        "HTTP_ACCEPT" => "value"
+      )
+    end
+
+    it "adds the headers to the transaction with a block" do
+      headers = { "PATH_INFO" => "value" }
+      transaction.add_headers { headers }
+
+      transaction._sample
+      expect(transaction).to include_environment(headers)
+    end
+
+    it "adds the headers block value when both an argument and block are given" do
+      arg_data = { "PATH_INFO" => "/arg-path" }
+      block_data = { "PATH_INFO" => "/block-path" }
+      transaction.add_headers(arg_data) { block_data }
+
+      transaction._sample
+      expect(transaction).to include_environment(block_data)
+    end
+
+    it "logs an error if an error occurred storing the headers" do
+      transaction.add_headers { raise "uh oh" }
+
+      logs = capture_logs { transaction._sample }
+      expect(logs).to contains_log(
+        :error,
+        "Exception while fetching headers: RuntimeError: uh oh"
+      )
+    end
+
+    it "does not update the headers on the transaction if the given value is nil" do
+      headers = { "PATH_INFO" => "value" }
+      transaction.add_headers(headers)
+      transaction.add_headers(nil)
+
+      transaction._sample
+      expect(transaction).to include_environment(headers)
+    end
+
+    context "with request_headers options" do
+      let(:options) { { :request_headers => ["MY_HEADER"] } }
+
+      it "does not include filtered out headers" do
+        transaction.add_headers("MY_HEADER" => "value1", "filtered_key" => "filtered_value")
+
+        transaction._sample
+        expect(transaction).to include_environment("MY_HEADER" => "value1")
+      end
+    end
+  end
+
+  describe "#add_headers_if_nil" do
+    let(:transaction) { new_transaction }
+
+    it "has a #set_headers_if_nil alias" do
+      expect(transaction.method(:add_headers_if_nil)).to eq(transaction.method(:set_headers_if_nil))
+    end
+
+    context "when the headers are not set" do
+      it "adds the headers to the transaction" do
+        headers = { "PATH_INFO" => "value" }
+        transaction.add_headers_if_nil(headers)
+
+        transaction._sample
+        expect(transaction).to include_environment(headers)
+      end
+
+      it "adds the headers to the transaction with a block" do
+        headers = { "PATH_INFO" => "value" }
+        transaction.add_headers_if_nil { headers }
+
+        transaction._sample
+        expect(transaction).to include_environment(headers)
+      end
+
+      it "adds the headers block value when both an argument and block are given" do
+        arg_data = { "PATH_INFO" => "/arg-path" }
+        block_data = { "PATH_INFO" => "/block-path" }
+        transaction.add_headers_if_nil(arg_data) { block_data }
+
+        transaction._sample
+        expect(transaction).to include_environment(block_data)
+      end
+
+      it "does not update the headers on the transaction if the given value is nil" do
+        headers = { "PATH_INFO" => "value" }
+        transaction.add_headers(headers)
+        transaction.add_headers_if_nil(nil)
+
+        transaction._sample
+        expect(transaction).to include_environment(headers)
+      end
+    end
 
     context "when the headers are set" do
-      it "updates the headers on the transaction" do
-        headers = { "PATH_INFO" => "value" }
-        transaction.set_headers(headers)
-
-        transaction._sample
-        expect(transaction).to include_environment(headers)
-      end
-
-      it "updates the headers on the transaction with a block" do
-        headers = { "PATH_INFO" => "value" }
-        transaction.set_headers { headers }
-
-        transaction._sample
-        expect(transaction).to include_environment(headers)
-      end
-
-      it "updates with the headers argument when both an argument and block are given" do
-        arg_data = { "PATH_INFO" => "/arg-path" }
-        block_data = { "PATH_INFO" => "/block-path" }
-        transaction.set_headers(arg_data) { block_data }
-
-        transaction._sample
-        expect(transaction).to include_environment(arg_data)
-      end
-
-      context "with request_headers options" do
-        let(:options) { { :request_headers => ["MY_HEADER"] } }
-
-        it "does not include filtered out headers" do
-          transaction.set_headers("MY_HEADER" => "value1", "filtered_key" => "filtered_value")
-
-          transaction._sample
-          expect(transaction).to include_environment("MY_HEADER" => "value1")
-        end
-      end
-
-      it "logs an error if an error occurred storing the headers" do
-        transaction.set_headers { raise "uh oh" }
-
-        logs = capture_logs { transaction._sample }
-        expect(logs).to contains_log(
-          :error,
-          "Exception while fetching headers: RuntimeError: uh oh"
-        )
-      end
-    end
-
-    context "when the given headers is nil" do
       it "does not update the headers on the transaction" do
-        headers = { "PATH_INFO" => "value" }
-        transaction.set_headers(headers)
-        transaction.set_headers(nil)
-
-        transaction._sample
-        expect(transaction).to include_environment(headers)
-      end
-    end
-  end
-
-  describe "#set_headers_if_nil" do
-    let(:transaction) { new_transaction }
-
-    context "when the params are not set" do
-      it "sets the params on the transaction" do
-        headers = { "PATH_INFO" => "value" }
-        transaction.set_headers_if_nil(headers)
-
-        transaction._sample
-        expect(transaction).to include_environment(headers)
-      end
-
-      it "updates the params on the transaction with a block" do
-        headers = { "PATH_INFO" => "value" }
-        transaction.set_headers_if_nil { headers }
-
-        transaction._sample
-        expect(transaction).to include_environment(headers)
-      end
-
-      it "updates with the params argument when both an argument and block are given" do
-        arg_data = { "PATH_INFO" => "/arg-path" }
-        block_data = { "PATH_INFO" => "/block-path" }
-        transaction.set_headers_if_nil(arg_data) { block_data }
-
-        transaction._sample
-        expect(transaction).to include_environment(arg_data)
-      end
-
-      context "when the given params is nil" do
-        it "does not update the params on the transaction" do
-          headers = { "PATH_INFO" => "value" }
-          transaction.set_headers(headers)
-          transaction.set_headers_if_nil(nil)
-
-          transaction._sample
-          expect(transaction).to include_environment(headers)
-        end
-      end
-    end
-
-    context "when the params are set" do
-      it "does not update the params on the transaction" do
         preset_headers = { "PATH_INFO" => "/first-path" }
         headers = { "PATH_INFO" => "/other-path" }
-        transaction.set_headers(preset_headers)
-        transaction.set_headers_if_nil(headers)
+        transaction.add_headers(preset_headers)
+        transaction.add_headers_if_nil(headers)
 
         transaction._sample
         expect(transaction).to include_environment(preset_headers)
       end
 
-      it "does not update the params with a block on the transaction" do
+      it "does not update the headers with a block on the transaction" do
         preset_headers = { "PATH_INFO" => "/first-path" }
         headers = { "PATH_INFO" => "/other-path" }
-        transaction.set_headers(preset_headers)
-        transaction.set_headers_if_nil { headers }
+        transaction.add_headers(preset_headers)
+        transaction.add_headers_if_nil { headers }
 
         transaction._sample
         expect(transaction).to include_environment(preset_headers)
@@ -811,12 +852,12 @@ describe Appsignal::Transaction do
     end
   end
 
-  describe "#set_tags" do
+  describe "#add_tags" do
     let(:transaction) { new_transaction }
     let(:long_string) { "a" * 10_001 }
 
     it "stores tags on the transaction" do
-      transaction.set_tags(
+      transaction.add_tags(
         :valid_key => "valid_value",
         "valid_string_key" => "valid_value",
         :both_symbols => :valid_value,
@@ -844,8 +885,8 @@ describe Appsignal::Transaction do
     end
 
     it "merges the tags when called multiple times" do
-      transaction.set_tags(:key1 => "value1")
-      transaction.set_tags(:key2 => "value2")
+      transaction.add_tags(:key1 => "value1")
+      transaction.add_tags(:key2 => "value2")
       transaction._sample
 
       expect(transaction).to include_tags(
@@ -855,11 +896,15 @@ describe Appsignal::Transaction do
     end
   end
 
-  describe "#set_custom_data" do
+  describe "#add_custom_data" do
     let(:transaction) { new_transaction }
 
-    it "stores custom Hash data on the transaction" do
-      transaction.set_custom_data(
+    it "has a #add_custom_data alias" do
+      expect(transaction.method(:add_custom_data)).to eq(transaction.method(:set_custom_data))
+    end
+
+    it "adds a custom Hash data to the transaction" do
+      transaction.add_custom_data(
         :user => {
           :id => 123,
           :locale => "abc"
@@ -883,8 +928,8 @@ describe Appsignal::Transaction do
       )
     end
 
-    it "stores custom Array data on the transaction" do
-      transaction.set_custom_data([
+    it "adds a custom Array data to the transaction" do
+      transaction.add_custom_data([
         [123, "abc"],
         ["appsignal", "enterprise"]
       ])
@@ -899,39 +944,42 @@ describe Appsignal::Transaction do
     it "does not store non Hash or Array custom data" do
       logs =
         capture_logs do
-          transaction.set_custom_data("abc")
+          transaction.add_custom_data("abc")
           transaction._sample
           expect(transaction).to_not include_custom_data
 
-          transaction.set_custom_data(123)
+          transaction.add_custom_data(123)
           transaction._sample
           expect(transaction).to_not include_custom_data
 
-          transaction.set_custom_data(Object.new)
+          transaction.add_custom_data(Object.new)
           transaction._sample
           expect(transaction).to_not include_custom_data
         end
 
       expect(logs).to contains_log(
         :error,
-        "set_custom_data: Unsupported data type String received."
+        %(Sample data 'custom_data': Unsupported data type 'String' received: "abc")
       )
       expect(logs).to contains_log(
         :error,
-        "set_custom_data: Unsupported data type Integer received."
+        %(Sample data 'custom_data': Unsupported data type 'Integer' received: 123)
       )
       expect(logs).to contains_log(
         :error,
-        "set_custom_data: Unsupported data type String received."
+        %(Sample data 'custom_data': Unsupported data type 'Object' received: #<Object:)
       )
     end
 
-    it "overwrites the custom data if called multiple times" do
-      transaction.set_custom_data("user" => { "id" => 123 })
-      transaction.set_custom_data("user" => { "id" => 456 })
+    it "merges the custom data if called multiple times" do
+      transaction.add_custom_data("abc" => "value")
+      transaction.add_custom_data("def" => "value")
 
       transaction._sample
-      expect(transaction).to include_custom_data("user" => { "id" => 456 })
+      expect(transaction).to include_custom_data(
+        "abc" => "value",
+        "def" => "value"
+      )
     end
   end
 
@@ -1201,14 +1249,22 @@ describe Appsignal::Transaction do
           expect(transaction).to_not include_params
         end
 
-      expect(logs).to contains_log :error,
-        %(Invalid sample data for 'params'. Value is not an Array or Hash: '"some string"')
-      expect(logs).to contains_log :error,
-        %(Invalid sample data for 'params'. Value is not an Array or Hash: '123')
-      expect(logs).to contains_log :error,
-        %(Invalid sample data for 'params'. Value is not an Array or Hash: '"#<Class>"')
-      expect(logs).to contains_log :error,
-        %(Invalid sample data for 'params'. Value is not an Array or Hash: '"#<Set>"')
+      expect(logs).to contains_log(
+        :error,
+        %(Sample data 'params': Unsupported data type 'String' received: "some string")
+      )
+      expect(logs).to contains_log(
+        :error,
+        %(Sample data 'params': Unsupported data type 'Integer' received: 123)
+      )
+      expect(logs).to contains_log(
+        :error,
+        %(Sample data 'params': Unsupported data type 'Class' received: #<Class)
+      )
+      expect(logs).to contains_log(
+        :error,
+        %(Sample data 'params': Unsupported data type 'Set' received: #<Set: {"some value"}>)
+      )
     end
 
     it "does not store data that can't be converted to JSON" do
@@ -1861,7 +1917,7 @@ describe Appsignal::Transaction do
       subject.resume!
       subject.paused?
       subject.store(:key)
-      subject.set_tags(:tag => 1)
+      subject.add_tags(:tag => 1)
       subject.set_action("action")
       subject.set_http_or_background_action
       subject.set_queue_start(1)

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -918,30 +918,37 @@ describe Appsignal do
       end
     end
 
-    describe ".set_params" do
+    describe ".add_params" do
       before { start_agent }
+
+      it "has a .set_params alias" do
+        expect(Appsignal.method(:add_params)).to eq(Appsignal.method(:set_params))
+      end
 
       context "with transaction" do
         let(:transaction) { http_request_transaction }
         before { set_current_transaction(transaction) }
 
-        it "sets parameters on the transaction" do
-          Appsignal.set_params("param1" => "value1")
+        it "adds parameters to the transaction" do
+          Appsignal.add_params("param1" => "value1")
 
           transaction._sample
           expect(transaction).to include_params("param1" => "value1")
         end
 
-        it "overwrites the params if called multiple times" do
-          Appsignal.set_params("param1" => "value1")
-          Appsignal.set_params("param2" => "value2")
+        it "merges the params if called multiple times" do
+          Appsignal.add_params("param1" => "value1")
+          Appsignal.add_params("param2" => "value2")
 
           transaction._sample
-          expect(transaction).to include_params("param2" => "value2")
+          expect(transaction).to include_params(
+            "param1" => "value1",
+            "param2" => "value2"
+          )
         end
 
-        it "sets parameters with a block on the transaction" do
-          Appsignal.set_params { { "param1" => "value1" } }
+        it "adds parameters with a block to the transaction" do
+          Appsignal.add_params { { "param1" => "value1" } }
 
           transaction._sample
           expect(transaction).to include_params("param1" => "value1")
@@ -949,37 +956,44 @@ describe Appsignal do
       end
 
       context "without transaction" do
-        it "does not set tags on the transaction" do
-          Appsignal.set_params("a" => "b")
+        it "does not add tags to any transaction" do
+          Appsignal.add_params("a" => "b")
 
-          expect_any_instance_of(Appsignal::Transaction).to_not receive(:set_params)
+          expect_any_instance_of(Appsignal::Transaction).to_not receive(:add_params)
         end
       end
     end
 
-    describe ".set_session_data" do
+    describe ".add_session_data" do
       before { start_agent }
+
+      it "has a .set_session_data alias" do
+        expect(Appsignal.method(:add_session_data)).to eq(Appsignal.method(:set_session_data))
+      end
 
       context "with transaction" do
         let(:transaction) { http_request_transaction }
         before { set_current_transaction(transaction) }
 
-        it "sets session data on the transaction" do
-          Appsignal.set_session_data("data" => "value1")
+        it "adds session data to the transaction" do
+          Appsignal.add_session_data("data" => "value1")
 
           transaction._sample
           expect(transaction).to include_session_data("data" => "value1")
         end
 
-        it "overwrites the session data if called multiple times" do
-          Appsignal.set_session_data("data" => "value1")
-          Appsignal.set_session_data("data" => "value2")
+        it "merges the session data if called multiple times" do
+          Appsignal.set_session_data("data1" => "value1")
+          Appsignal.set_session_data("data2" => "value2")
 
           transaction._sample
-          expect(transaction).to include_session_data("data" => "value2")
+          expect(transaction).to include_session_data(
+            "data1" => "value1",
+            "data2" => "value2"
+          )
         end
 
-        it "sets session data with a block on the transaction" do
+        it "adds session data with a block to the transaction" do
           Appsignal.set_session_data { { "data" => "value1" } }
 
           transaction._sample
@@ -988,38 +1002,45 @@ describe Appsignal do
       end
 
       context "without transaction" do
-        it "does not set session data on the transaction" do
+        it "does not add session data to any transaction" do
           Appsignal.set_session_data("a" => "b")
 
-          expect_any_instance_of(Appsignal::Transaction).to_not receive(:set_session_data)
+          expect_any_instance_of(Appsignal::Transaction).to_not receive(:add_session_data)
         end
       end
     end
 
-    describe ".set_headers" do
+    describe ".add_headers" do
       before { start_agent }
+
+      it "has a .set_headers alias" do
+        expect(Appsignal.method(:add_headers)).to eq(Appsignal.method(:set_headers))
+      end
 
       context "with transaction" do
         let(:transaction) { http_request_transaction }
         before { set_current_transaction(transaction) }
 
-        it "sets request headers on the transaction" do
-          Appsignal.set_headers("PATH_INFO" => "/some-path")
+        it "adds request headers to the transaction" do
+          Appsignal.add_headers("PATH_INFO" => "/some-path")
 
           transaction._sample
           expect(transaction).to include_environment("PATH_INFO" => "/some-path")
         end
 
-        it "overwrites the request headers if called multiple times" do
-          Appsignal.set_headers("PATH_INFO" => "/some-path1")
-          Appsignal.set_headers("PATH_INFO" => "/some-path2")
+        it "merges the request headers if called multiple times" do
+          Appsignal.add_headers("PATH_INFO" => "/some-path")
+          Appsignal.add_headers("REQUEST_METHOD" => "GET")
 
           transaction._sample
-          expect(transaction).to include_environment("PATH_INFO" => "/some-path2")
+          expect(transaction).to include_environment(
+            "PATH_INFO" => "/some-path",
+            "REQUEST_METHOD" => "GET"
+          )
         end
 
-        it "sets request headers with a block on the transaction" do
-          Appsignal.set_headers { { "PATH_INFO" => "/some-path" } }
+        it "adds request headers with a block to the transaction" do
+          Appsignal.add_headers { { "PATH_INFO" => "/some-path" } }
 
           transaction._sample
           expect(transaction).to include_environment("PATH_INFO" => "/some-path")
@@ -1027,23 +1048,27 @@ describe Appsignal do
       end
 
       context "without transaction" do
-        it "does not set request headers on the transaction" do
-          Appsignal.set_headers("PATH_INFO" => "/some-path")
+        it "does not add request headers to any transaction" do
+          Appsignal.add_headers("PATH_INFO" => "/some-path")
 
-          expect_any_instance_of(Appsignal::Transaction).to_not receive(:set_headers)
+          expect_any_instance_of(Appsignal::Transaction).to_not receive(:add_headers)
         end
       end
     end
 
-    describe ".set_custom_data" do
+    describe ".add_custom_data" do
       before { start_agent }
+
+      it "has a .set_custom_data alias" do
+        expect(Appsignal.method(:add_custom_data)).to eq(Appsignal.method(:set_custom_data))
+      end
 
       context "with transaction" do
         let(:transaction) { http_request_transaction }
         before { set_current_transaction transaction }
 
-        it "sets custom data on the current transaction" do
-          Appsignal.set_custom_data(
+        it "adds custom data to the current transaction" do
+          Appsignal.add_custom_data(
             :user => { :id => 123 },
             :organization => { :slug => "appsignal" }
           )
@@ -1054,16 +1079,27 @@ describe Appsignal do
             "organization" => { "slug" => "appsignal" }
           )
         end
+
+        it "merges the custom data if called multiple times" do
+          Appsignal.add_custom_data(:abc => "value")
+          Appsignal.add_custom_data(:def => "value")
+
+          transaction._sample
+          expect(transaction).to include_custom_data(
+            "abc" => "value",
+            "def" => "value"
+          )
+        end
       end
 
       context "without transaction" do
-        it "does not set tags on the transaction" do
-          Appsignal.set_custom_data(
+        it "does not add tags any the transaction" do
+          Appsignal.add_custom_data(
             :user => { :id => 123 },
             :organization => { :slug => "appsignal" }
           )
 
-          expect_any_instance_of(Appsignal::Transaction).to_not receive(:set_custom_data)
+          expect_any_instance_of(Appsignal::Transaction).to_not receive(:add_custom_data)
         end
       end
     end
@@ -1104,7 +1140,7 @@ describe Appsignal do
       end
     end
 
-    describe "custom stats" do
+    describe "custom metrics" do
       let(:tags) { { :foo => "bar" } }
 
       describe ".set_gauge" do

--- a/spec/support/matchers/transaction.rb
+++ b/spec/support/matchers/transaction.rb
@@ -171,9 +171,9 @@ RSpec::Matchers.define :include_breadcrumb do |action, category, message, metada
     {
       "action" => action,
       "category" => category,
-      "message" => message,
-      "metadata" => metadata,
-      "time" => time
+      "message" => message || "",
+      "metadata" => metadata || {},
+      "time" => time || kind_of(Integer)
     }
   end
 end


### PR DESCRIPTION
We've received requests in the past to merge sample data. Our API was inconsistent in merging some sample data like tags, but not others (params, headers, session data and custom data).

Support merging sample data for all sample data. All helpers now are called `add_<data type>`. I've added aliases for the `set_<data type>` methods.

This merging behavior is the new default, which is a breaking change.

I've added a SampleData helper class to handle the sample data being merged. Array and Hashes are supported, same as in our extension. Other types are not supported.

If the root value type switches between a Hash and Array between values being merged, the new value is leading, discarding the previous value.

I've kept the behavior that if an application sets custom params/headers/session data/custom data, we do not set it from our integrations. This would merge it with the custom set data from the app, which I don't know if we want to do that.
