### PR TITLE
Multiple errors support

### DIFF
--- a/.changesets/fix-an-issue-where-error-causes-for-the-wrong-error-would-be-shown.md
+++ b/.changesets/fix-an-issue-where-error-causes-for-the-wrong-error-would-be-shown.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix an issue where, when setting several errors for the same transaction, error causes from a different error would be shown for an error that has no causes.

--- a/.changesets/support-adding-multiple-errors-to-a-transaction.md
+++ b/.changesets/support-adding-multiple-errors-to-a-transaction.md
@@ -1,0 +1,10 @@
+---
+bump: patch
+type: add
+---
+
+Support adding multiple errors to a transaction.
+
+Using the `Appsignal.report_error` helper, you can now report more than one error within the same transaction context, up to a maximum of ten errors per transaction. Each error will be reported as a separate sample in the AppSignal UI.
+
+Before this change, using `Appsignal.report_error` or `Appsignal.set_error` helpers, adding a new error within the same transaction would overwrite the previous one.

--- a/ext/agent.rb
+++ b/ext/agent.rb
@@ -6,7 +6,7 @@
 # Modifications to this file will be overwritten with the next agent release.
 
 APPSIGNAL_AGENT_CONFIG = {
-  "version" => "0.35.12",
+  "version" => "0.35.18",
   "mirrors" => [
     "https://appsignal-agent-releases.global.ssl.fastly.net",
     "https://d135dj0rjqvssy.cloudfront.net"
@@ -14,131 +14,131 @@ APPSIGNAL_AGENT_CONFIG = {
   "triples" => {
     "x86_64-darwin" => {
       "static" => {
-        "checksum" => "61210c40be70e0616a356d06040961b096e2d47332021a52f3779912a9fe0e4c",
+        "checksum" => "141313c106bd6591a2c760f2341c1856905847602699df140cf72e45397e2cd2",
         "filename" => "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "dd165289445c80e4dcc148ea09c613b23b001c90ad885aef1de08db65ab5bf1c",
+        "checksum" => "7d1346c584d0aa6f2744059665af55710d3bb877383a296277bf96e12e857795",
         "filename" => "appsignal-x86_64-darwin-all-dynamic.tar.gz"
       }
     },
     "universal-darwin" => {
       "static" => {
-        "checksum" => "61210c40be70e0616a356d06040961b096e2d47332021a52f3779912a9fe0e4c",
+        "checksum" => "141313c106bd6591a2c760f2341c1856905847602699df140cf72e45397e2cd2",
         "filename" => "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "dd165289445c80e4dcc148ea09c613b23b001c90ad885aef1de08db65ab5bf1c",
+        "checksum" => "7d1346c584d0aa6f2744059665af55710d3bb877383a296277bf96e12e857795",
         "filename" => "appsignal-x86_64-darwin-all-dynamic.tar.gz"
       }
     },
     "aarch64-darwin" => {
       "static" => {
-        "checksum" => "9b97c42561450f9af9ae63816d32b8db69be6f2745226f63d6eada4369c68a20",
+        "checksum" => "5e2f089e65153ff26ae2fe9c0a7bf10cd3921057bb73eeab11e50c4d21bd94d1",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "0c81959ab5de3c98c70b7e308826d7deee8e208ee47b7637d505b0a1d70af8c4",
+        "checksum" => "89568c91ce3fe7fa4de631ad74d32dd6d08655bea4ea17d2a5af0ac740ed9a97",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "arm64-darwin" => {
       "static" => {
-        "checksum" => "9b97c42561450f9af9ae63816d32b8db69be6f2745226f63d6eada4369c68a20",
+        "checksum" => "5e2f089e65153ff26ae2fe9c0a7bf10cd3921057bb73eeab11e50c4d21bd94d1",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "0c81959ab5de3c98c70b7e308826d7deee8e208ee47b7637d505b0a1d70af8c4",
+        "checksum" => "89568c91ce3fe7fa4de631ad74d32dd6d08655bea4ea17d2a5af0ac740ed9a97",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "arm-darwin" => {
       "static" => {
-        "checksum" => "9b97c42561450f9af9ae63816d32b8db69be6f2745226f63d6eada4369c68a20",
+        "checksum" => "5e2f089e65153ff26ae2fe9c0a7bf10cd3921057bb73eeab11e50c4d21bd94d1",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "0c81959ab5de3c98c70b7e308826d7deee8e208ee47b7637d505b0a1d70af8c4",
+        "checksum" => "89568c91ce3fe7fa4de631ad74d32dd6d08655bea4ea17d2a5af0ac740ed9a97",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "aarch64-linux" => {
       "static" => {
-        "checksum" => "358db07cfa85d6bd048bd2bb05fc9607d4fe0d4396fd023d658e945e4a675fba",
+        "checksum" => "a6e0be5413b10fc83d243794b26736d6fe7c987ddc16cea21ceb0833742ed951",
         "filename" => "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "9e76651d52f78882ab126d94a8af61794d1ce0cdffa6dd01a3e032599a1b2796",
+        "checksum" => "ad4e4666e45f971bd22ce90248c58452d876a0e25ab69bcc15b64fc81815ff9c",
         "filename" => "appsignal-aarch64-linux-all-dynamic.tar.gz"
       }
     },
     "i686-linux" => {
       "static" => {
-        "checksum" => "315bf1fc5d9c97b6f26e61f5e39919e0ba425b1d96ea6243cdb2f650487c407e",
+        "checksum" => "93725eff06e976abab0e41d6df88a03213e52881ec006739ac67fbb8a7c7255e",
         "filename" => "appsignal-i686-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "8cf0b5e6ef70a7758b98457012bfebb7964acb2d47648f3817c9f32a70bc0ab1",
+        "checksum" => "313bfbfb69292465a12858d5e4e634a0f854743bf5d1df0f256675b97adc9e49",
         "filename" => "appsignal-i686-linux-all-dynamic.tar.gz"
       }
     },
     "x86-linux" => {
       "static" => {
-        "checksum" => "315bf1fc5d9c97b6f26e61f5e39919e0ba425b1d96ea6243cdb2f650487c407e",
+        "checksum" => "93725eff06e976abab0e41d6df88a03213e52881ec006739ac67fbb8a7c7255e",
         "filename" => "appsignal-i686-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "8cf0b5e6ef70a7758b98457012bfebb7964acb2d47648f3817c9f32a70bc0ab1",
+        "checksum" => "313bfbfb69292465a12858d5e4e634a0f854743bf5d1df0f256675b97adc9e49",
         "filename" => "appsignal-i686-linux-all-dynamic.tar.gz"
       }
     },
     "x86_64-linux" => {
       "static" => {
-        "checksum" => "3fe42df2a52706c23f967b8421ac816fa37a38998bd24b1d6aafd59a324b23ff",
+        "checksum" => "0eb24adf1932969a44533d4e1a783ece30a3f8f99075fd11e972f216deba1c0d",
         "filename" => "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "8781f0a4c4810229f19000ebb882b7d8e5e0440ffcf8e5ffea7d68d082be8e69",
+        "checksum" => "eec4491d139db4dfd976eb206263a304380508353e60e775c4d11434448f0e8c",
         "filename" => "appsignal-x86_64-linux-all-dynamic.tar.gz"
       }
     },
     "x86_64-linux-musl" => {
       "static" => {
-        "checksum" => "1fe0ed0c0ca51eccd4c2ec3bb94bb1834bae19bc2c185b67c3f940f704abe9fc",
+        "checksum" => "f489b48913dfb950b13db0e7f4a20c2804ef8feee8872c8acb8ec900d4ffcbf4",
         "filename" => "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "f241f905555e17178a72b217dc373ead33daa97757e100b895f2d1318e4dce0d",
+        "checksum" => "86e460dc5e63e1649566f526d26638bdd3cfad495688b5645b99567f5fb802da",
         "filename" => "appsignal-x86_64-linux-musl-all-dynamic.tar.gz"
       }
     },
     "aarch64-linux-musl" => {
       "static" => {
-        "checksum" => "5027782008872f8091608cc5531a6dd90f0652e9ebb0404f7e86eb73f0807ba0",
+        "checksum" => "6beeb2ae71545f4cf869e70b158a3576e885401334196a1464a197d5c09a27fe",
         "filename" => "appsignal-aarch64-linux-musl-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "ae3147790f25cef200142f61eb6ce1f8b3ac5fa2647ad7a4234f1bbb976bde98",
+        "checksum" => "5e3b0aa90ca974aa1de07f9102057c28ec2b7ac7134da9e9b046158c527166f9",
         "filename" => "appsignal-aarch64-linux-musl-all-dynamic.tar.gz"
       }
     },
     "x86_64-freebsd" => {
       "static" => {
-        "checksum" => "1337268caaddd66bb170298968d50d76cc66f17e808c46a677ba00d1b78eb317",
+        "checksum" => "13d8b96d0e74d47b2c036046d0ea6e48cb0f81d58ba36b16b40c11300ccd1a57",
         "filename" => "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "2b93af244d1d214b59c2657677bf96445f67cade2fa1bfd6cda78c8bec75cbca",
+        "checksum" => "6a50ebe0ab7e0ed5db2e45ebaff2c36e8213180926dcb1c83a20eeaa2cd9c64d",
         "filename" => "appsignal-x86_64-freebsd-all-dynamic.tar.gz"
       }
     },
     "amd64-freebsd" => {
       "static" => {
-        "checksum" => "1337268caaddd66bb170298968d50d76cc66f17e808c46a677ba00d1b78eb317",
+        "checksum" => "13d8b96d0e74d47b2c036046d0ea6e48cb0f81d58ba36b16b40c11300ccd1a57",
         "filename" => "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "2b93af244d1d214b59c2657677bf96445f67cade2fa1bfd6cda78c8bec75cbca",
+        "checksum" => "6a50ebe0ab7e0ed5db2e45ebaff2c36e8213180926dcb1c83a20eeaa2cd9c64d",
         "filename" => "appsignal-x86_64-freebsd-all-dynamic.tar.gz"
       }
     }

--- a/ext/appsignal_extension.c
+++ b/ext/appsignal_extension.c
@@ -273,6 +273,30 @@ static VALUE finish_transaction(VALUE self, VALUE gc_duration_ms) {
   return sample == 1 ? Qtrue : Qfalse;
 }
 
+static VALUE duplicate_transaction(VALUE self, VALUE new_transaction_id) {
+  appsignal_transaction_t* transaction;
+  appsignal_transaction_t* duplicate_transaction;
+
+  Check_Type(new_transaction_id, T_STRING);
+  Data_Get_Struct(self, appsignal_transaction_t, transaction);
+
+  duplicate_transaction = appsignal_duplicate_transaction(
+      transaction,
+      make_appsignal_string(new_transaction_id)
+  );
+
+  if (duplicate_transaction) {
+      return Data_Wrap_Struct(
+          Transaction,
+          NULL,
+          appsignal_free_transaction,
+          duplicate_transaction
+      );
+  } else {
+      return Qnil;
+  }
+}
+
 static VALUE complete_transaction(VALUE self) {
   appsignal_transaction_t* transaction;
 
@@ -858,6 +882,7 @@ void Init_appsignal_extension(void) {
   rb_define_method(Transaction, "set_queue_start", set_transaction_queue_start, 1);
   rb_define_method(Transaction, "set_metadata",    set_transaction_metadata,    2);
   rb_define_method(Transaction, "finish",          finish_transaction,          1);
+  rb_define_method(Transaction, "duplicate",       duplicate_transaction,       1);
   rb_define_method(Transaction, "complete",        complete_transaction,        0);
   rb_define_method(Transaction, "to_json",         transaction_to_json,         0);
 

--- a/lib/appsignal/extension/jruby.rb
+++ b/lib/appsignal/extension/jruby.rb
@@ -132,6 +132,9 @@ module Appsignal
         attach_function :appsignal_complete_transaction,
           [:pointer],
           :void
+        attach_function :appsignal_duplicate_transaction,
+          [:pointer, :appsignal_string],
+          :pointer
         attach_function :appsignal_transaction_to_json,
           [:pointer],
           :appsignal_string
@@ -430,6 +433,17 @@ module Appsignal
 
         def finish(gc_duration_ms)
           Extension.appsignal_finish_transaction(pointer, gc_duration_ms)
+        end
+
+        def duplicate(new_transaction_id)
+          duplicate_transaction = Extension.appsignal_duplicate_transaction(
+            pointer,
+            make_appsignal_string(new_transaction_id)
+          )
+
+          return if !duplicate_transaction || duplicate_transaction.null?
+
+          Transaction.new(duplicate_transaction)
         end
 
         def complete

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -369,8 +369,9 @@ module Appsignal
         return unless active?
 
         has_parent_transaction = Appsignal::Transaction.current?
+        should_use_parent_transaction = has_parent_transaction && !block_given?
         transaction =
-          if has_parent_transaction
+          if should_use_parent_transaction
             Appsignal::Transaction.current
           else
             Appsignal::Transaction.new(
@@ -382,7 +383,7 @@ module Appsignal
         transaction.add_error(exception)
         yield transaction if block_given?
 
-        return if has_parent_transaction
+        return if should_use_parent_transaction
 
         transaction.complete
       end

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -362,7 +362,7 @@ module Appsignal
       # @since 3.10.0
       def report_error(exception)
         unless exception.is_a?(Exception)
-          internal_logger.error "Appsignal.report_error: Cannot set error. " \
+          internal_logger.error "Appsignal.report_error: Cannot add error. " \
             "The given value is not an exception: #{exception.inspect}"
           return
         end
@@ -379,7 +379,7 @@ module Appsignal
             )
           end
 
-        transaction.set_error(exception)
+        transaction.add_error(exception)
         yield transaction if block_given?
 
         return if has_parent_transaction

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -539,7 +539,7 @@ module Appsignal
 
     protected
 
-    attr_writer :ext, :is_duplicate
+    attr_writer :is_duplicate
 
     private
 

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -491,8 +491,6 @@ module Appsignal
         causes << error
       end
 
-      return if causes.empty?
-
       causes_sample_data = causes.map do |e|
         {
           :name => e.class.name,

--- a/spec/lib/appsignal/extension_spec.rb
+++ b/spec/lib/appsignal/extension_spec.rb
@@ -100,6 +100,10 @@ describe Appsignal::Extension do
           subject.finish(0)
         end
 
+        it "should have a duplicate method" do
+          subject.duplicate("request_id")
+        end
+
         it "should have a complete method" do
           subject.complete
         end

--- a/spec/lib/appsignal/integrations/data_mapper_spec.rb
+++ b/spec/lib/appsignal/integrations/data_mapper_spec.rb
@@ -42,7 +42,6 @@ describe Appsignal::Hooks::DataMapperLogListener do
         "title" => "DataMapper Query",
         "body" => "SELECT * from users",
         "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
-        "count" => 0,
         "duration" => 100.0
       )
     end
@@ -67,7 +66,6 @@ describe Appsignal::Hooks::DataMapperLogListener do
           "title" => "DataMapper Query",
           "body" => "",
           "body_format" => Appsignal::EventFormatter::DEFAULT,
-          "count" => 0,
           "duration" => 100.0
         )
       end

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -1410,7 +1410,7 @@ describe Appsignal do
           it "adds the error to the additional errors array" do
             Appsignal.report_error(error)
 
-            expect(transaction.errors).to eq([error])
+            expect(transaction.errors).to eq([other_error, error])
           end
         end
 

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -1345,7 +1345,7 @@ describe Appsignal do
           logs = capture_logs { Appsignal.report_error(error) }
           expect(logs).to contains_log(
             :error,
-            "Appsignal.report_error: Cannot set error. " \
+            "Appsignal.report_error: Cannot add error. " \
               "The given value is not an exception: #{error.inspect}"
           )
         end
@@ -1392,7 +1392,7 @@ describe Appsignal do
           expect(last_transaction).to eq(transaction)
           transaction._sample
           expect(transaction).to have_namespace(Appsignal::Transaction::HTTP_REQUEST)
-          expect(transaction).to have_error("ExampleException", "error message")
+          expect(transaction.errors).to eq([error])
         end
 
         it "does not complete the transaction" do
@@ -1412,7 +1412,7 @@ describe Appsignal do
             transaction._sample
             expect(transaction).to have_namespace("my_namespace")
             expect(transaction).to have_action("my_action")
-            expect(transaction).to have_error("ExampleException", "error message")
+            expect(transaction.errors).to eq([error])
             expect(transaction).to include_tags("tag1" => "value1")
             expect(transaction).to_not be_completed
           end

--- a/spec/support/helpers/transaction_helpers.rb
+++ b/spec/support/helpers/transaction_helpers.rb
@@ -15,8 +15,8 @@ module TransactionHelpers
     Appsignal::Transaction.create(namespace)
   end
 
-  def new_transaction(namespace = default_namespace)
-    Appsignal::Transaction.new(SecureRandom.uuid, namespace)
+  def new_transaction(namespace = default_namespace, ext: nil)
+    Appsignal::Transaction.new(SecureRandom.uuid, namespace, :ext => ext)
   end
 
   def rack_request(env)


### PR DESCRIPTION
See https://github.com/appsignal/appsignal-agent/pull/1186 for context.

⚠️ **The changes in this PR will not work or pass the tests without the changes in the agent PR.** You can test these changes as follows:

```sh
# Replace this with your target OS+arch
TARGET_OS_ARCH=x86_64-apple-darwin

# Build the agent locally
cd appsignal-agent
git fetch; git checkout extension-transaction-duplication
rake build:target:${TARGET_OS_ARCH}

# Copy the agent build to the integration
for file in appsignal-agent/release/${TARGET_OS_ARCH}/release/*; do
  cp $file appsignal-ruby/ext/
done

# Build the Ruby extension
cd appsignal-ruby/ext
rake extconf.rb && make clean && make
```

Also see the test setup: https://github.com/appsignal/test-setups/pull/222

A release of the agent containing the changes in the agent PR will be added to this PR before merging.

---

### [Support multiple errors per transaction](https://github.com/appsignal/appsignal-ruby/commit/85dc75d06c50c17fc3f261026b0addc17c68ae01)

Implement a new `add_error` method that allows for multiple errors
to be added to a transaction. These additional errors are stored on
the Ruby transaction object. When the transaction is completed,
duplicate the current transaction to report each of the errors
in its own duplicate transaction.

https://appsignal.slack.com/archives/CNPP953E2/p1720083599598159

### [Add .duplicate transaction method](https://github.com/appsignal/appsignal-ruby/commit/6f9195c30a1e2d91c30acec6d0e38bbbcf92fc48)

Implement support for the `appsignal_transaction_duplicate` method
implemented in the agent side the extension, in both the Ruby C
extension and the JRuby FFI extension.

Implement a `duplicate` method for the `Transaction` class that
calls the extension's own `duplicate` method to duplicate a
transaction.

### [Always set error causes when setting errors](https://github.com/appsignal/appsignal-ruby/commit/cbec92b1235a374a9dba22e1d49191e57b3751b0)

This fixes a bug where, when overwriting an already set error by
setting an error that has no error causes, the error causes from the
first error would be kept.

### [Avoid reporting performance and error sample](https://github.com/appsignal/appsignal-ruby/commit/c14d40f9a06f479f0f492dcdb5d6259bddb4a3df)

When a transaction does not have an error, but it does have one or
more additional errors, instead of reporting the error-less
transaction alongside its duplicates, set the last additional error
as the error for this transaction.

### [Limit additional errors](https://github.com/appsignal/appsignal-ruby/commit/f6f6ae784b163aeb8fe136f59534a7d6731afd90)

Report at most ten additional errors per transaction. If more errors
are provided, report only the last ten additional errors.

Pass the extension as an option when initialising the transaction
object.

### [Use add_error in report_error helper](https://github.com/appsignal/appsignal-ruby/commit/f5f5927908279a0dbdf119550652869130d27e60)

Within the `report_error` helper, use `add_error` instead of the
`set_error` method, so that multiple errors can be reported from
the same transaction.