### PR TITLE
Fix `.monitor_and_stop` block passing

### DIFF
--- a/.changesets/fix-appsignal-monitor_and_stop-block-passing.md
+++ b/.changesets/fix-appsignal-monitor_and_stop-block-passing.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix `Appsignal.monitor_and_stop` block passing. It would error with a `LocalJumpError`. Thanks to @cwaider.

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -154,8 +154,8 @@ module Appsignal
       # documentation.
       #
       # @see monitor
-      def monitor_and_stop(action:, namespace: nil)
-        monitor(:namespace => namespace, :action => action)
+      def monitor_and_stop(action:, namespace: nil, &block)
+        monitor(:namespace => namespace, :action => action, &block)
       ensure
         Appsignal.stop("monitor_and_stop")
       end

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -745,6 +745,12 @@ describe Appsignal do
 
         expect(Appsignal).to have_received(:stop).with("monitor_and_stop")
       end
+
+      it "passes the block to Appsignal.monitor" do
+        expect do |blk|
+          Appsignal.monitor_and_stop(:action => "My action", &blk)
+        end.to yield_control
+      end
     end
 
     describe ".monitor_transaction" do


### PR DESCRIPTION
Fixes block passing in `.monitor_and_stop`

The block was not passed from `.monitor_and_stop` to `.monitor` causing `LocalJumpError: no block given (yield)` to be raised.