### PR TITLE
Fix loader defaults from overriding other sources

### DIFF
--- a/.changesets/fix-default-env-and-root-path-for-integrations-using-loader-mechanism.md
+++ b/.changesets/fix-default-env-and-root-path-for-integrations-using-loader-mechanism.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix the default env and root path for the integrations using loader mechanism. If `APPSIGNAL_APP_ENV` is set when using `Appsignal.load(...)`, the AppSignal env set in `APPSIGNAL_APP_ENV` is now leading again.

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -121,10 +121,7 @@ module Appsignal
 
       internal_logger.debug("Loading AppSignal gem")
 
-      @config ||= Config.new(
-        Dir.pwd,
-        ENV["APPSIGNAL_APP_ENV"] || ENV["RAILS_ENV"] || ENV.fetch("RACK_ENV", nil)
-      )
+      @config ||= Config.new(Config.determine_root_path, Config.determine_env)
 
       _start_logger
 
@@ -247,9 +244,9 @@ module Appsignal
       if config && config.env == env.to_s
         config
       else
-        self._config = Appsignal::Config.new(
-          Dir.pwd,
-          env || ENV["APPSIGNAL_APP_ENV"] || ENV["RAILS_ENV"] || ENV.fetch("RACK_ENV", nil),
+        @config = Config.new(
+          Config.determine_root_path,
+          Config.determine_env(env),
           {},
           Appsignal.internal_logger,
           nil,

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -209,6 +209,52 @@ describe Appsignal do
         expect(Appsignal.config.env).to eq("env_env")
       end
 
+      it "reads the environment from a loader default" do
+        clear_integration_env_vars!
+        define_loader(:loader_env) do
+          def on_load
+            register_config_defaults(
+              :env => "loader_env"
+            )
+          end
+        end
+        load_loader(:loader_env)
+
+        Appsignal.configure do |config|
+          expect(config.env).to eq("loader_env")
+        end
+
+        expect(Appsignal.config.env).to eq("loader_env")
+      end
+
+      it "reads the root_path from a loader default" do
+        clear_integration_env_vars!
+        define_loader(:loader_path) do
+          def on_load
+            register_config_defaults(
+              :root_path => "/loader_path"
+            )
+          end
+        end
+        load_loader(:loader_path)
+
+        Appsignal.configure do |config|
+          expect(config.app_path).to eq("/loader_path")
+        end
+
+        expect(Appsignal.config.root_path).to eq("/loader_path")
+      end
+
+      it "considers the given env leading above APPSIGNAL_APP_ENV" do
+        ENV["APPSIGNAL_APP_ENV"] = "env_env"
+
+        Appsignal.configure(:dsl_env) do |config|
+          expect(config.env).to eq("dsl_env")
+        end
+
+        expect(Appsignal.config.env).to eq("dsl_env")
+      end
+
       it "allows modification of previously unset config options" do
         expect do
           Appsignal.configure do |config|
@@ -250,6 +296,48 @@ describe Appsignal do
         expect(Appsignal.config[:push_api_key]).to eq("something")
         expect(stderr).to_not include("[ERROR]")
         expect(stdout).to_not include("[ERROR]")
+      end
+
+      it "reads the environment from the loader defaults" do
+        clear_integration_env_vars!
+        define_loader(:loader_env) do
+          def on_load
+            register_config_defaults(:env => "loader_env")
+          end
+        end
+        load_loader(:loader_env)
+
+        Appsignal.start
+
+        expect(Appsignal.config.env).to eq("loader_env")
+      end
+
+      it "reads the root_path from the loader defaults" do
+        define_loader(:loader_path) do
+          def on_load
+            register_config_defaults(:root_path => "/loader_path")
+          end
+        end
+        load_loader(:loader_path)
+
+        Appsignal.start
+
+        expect(Appsignal.config.root_path).to eq("/loader_path")
+      end
+
+      it "chooses APPSIGNAL_APP_ENV over the loader defaults as the default env" do
+        clear_integration_env_vars!
+        ENV["APPSIGNAL_APP_ENV"] = "env_env"
+        define_loader(:loader_env) do
+          def on_load
+            register_config_defaults(:env => "loader_env")
+          end
+        end
+        load_loader(:loader_env)
+
+        Appsignal.start
+
+        expect(Appsignal.config.env).to eq("env_env")
       end
     end
 

--- a/spec/support/helpers/config_helpers.rb
+++ b/spec/support/helpers/config_helpers.rb
@@ -26,4 +26,10 @@ module ConfigHelpers
     Appsignal._config = project_fixture_config(env)
     Appsignal.start
   end
+
+  def clear_integration_env_vars!
+    ENV.delete("RAILS_ENV")
+    ENV.delete("RACK_ENV")
+    ENV.delete("PADRINO_ENV")
+  end
 end


### PR DESCRIPTION
The loader defaults would override the `APPSIGNAL_APP_ENV` env var, making it no longer leading. It would also override the initial env given to the Config initializer, which it shouldn't do.

I made the loader defaults logic in the Config class too complex. I wanted to put all the logic in one place, but it created this mess.

This change reduces the complexity a bunch by not supporting any default config options from the loaders except `env` and `root_path` for now.

Instead of determining the env and root path from all the different sources in the Config initializer, move them to the place the config is initialized (and move them to a helper).

After this change the loader defaults aren't considered anymore if an app calls `Appsignal::Config.new` manually, but that's deprecated and didn't work as expected. Since `Appsignal::Config.new` requires the `root_path` and `env` to always be given to the initializer, it wouldn't do anything anyway.

Fixes #1213