### PR TITLE
Ignore Puma::ConnectionError when reading body

### DIFF
--- a/.changesets/do-not-report-puma--connectionerror-when-instrumenting-response-bodies.md
+++ b/.changesets/do-not-report-puma--connectionerror-when-instrumenting-response-bodies.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Do not report `Puma::ConnectionError` when instrumenting response bodies to avoid reporting errors that cannot be fixed by the application.


### PR DESCRIPTION
We got another report of the `Puma::ConnectionError` error being reported when upgrading our Ruby gem.

It is reported by our response body wrapper that's called when instrumenting response bodies.

In this case the error was:

Puma::ConnectionError: Socket timeout writing data

The cause of this error was this error:

> Errno::EPIPE: Broken pipe

This doesn't look like an error people can act on to fix it, let's ignore it instead.

Related issue https://github.com/appsignal/support/issues/315