### PR TITLE
Make global helpers work in error method callbacks

### DIFF
--- a/.changesets/global-helpers-work-inside-report_error-and-send_error-callbacks.md
+++ b/.changesets/global-helpers-work-inside-report_error-and-send_error-callbacks.md
@@ -1,0 +1,36 @@
+---
+bump: major
+type: change
+---
+
+Global transaction metadata helpers now work inside the `Appsignal.report_error` and `Appsignal.send_error` callbacks. The transaction yield parameter will continue to work, but we recommend using the global `Appsignal.set_*` helpers.
+
+```ruby
+# Before
+Appsignal.report_error(error) do |transaction|
+  transaction.set_namespace("my namespace")
+  transaction.set_action("my action")
+  transaction.add_tags(:tag_a => "value", :tag_b => "value")
+  # etc.
+end
+Appsignal.send_error(error) do |transaction|
+  transaction.set_namespace("my namespace")
+  transaction.set_action("my action")
+  transaction.add_tags(:tag_a => "value", :tag_b => "value")
+  # etc.
+end
+
+# After
+Appsignal.report_error(error) do
+  Appsignal.set_namespace("my namespace")
+  Appsignal.set_action("my action")
+  Appsignal.add_tags(:tag_a => "value", :tag_b => "value")
+  # etc.
+end
+Appsignal.send_error(error) do
+  Appsignal.set_namespace("my namespace")
+  Appsignal.set_action("my action")
+  Appsignal.add_tags(:tag_a => "value", :tag_b => "value")
+  # etc.
+end
+```

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -179,11 +179,11 @@ module Appsignal
       #   end
       #
       # @example Add more metadata to transaction
-      #   Appsignal.send_error(e) do |transaction|
-      #     transaction.set_namespace("my_namespace")
-      #     transaction.set_action("my_action_name")
-      #     transaction.add_params(:search_query => params[:search_query])
-      #     transaction.add_tags(:key => "value")
+      #   Appsignal.send_error(e) do
+      #     Appsignal.set_namespace("my_namespace")
+      #     Appsignal.set_action("my_action_name")
+      #     Appsignal.add_params(:search_query => params[:search_query])
+      #     Appsignal.add_tags(:key => "value")
       #   end
       #
       # @param error [Exception] The error to send to AppSignal.
@@ -213,6 +213,7 @@ module Appsignal
           Appsignal::Transaction::HTTP_REQUEST
         )
         transaction.set_error(error, &block)
+
         transaction.complete
       end
       alias :send_exception :send_error
@@ -245,11 +246,11 @@ module Appsignal
       #   end
       #
       # @example Add more metadata to transaction
-      #   Appsignal.set_error(e) do |transaction|
-      #     transaction.set_namespace("my_namespace")
-      #     transaction.set_action("my_action_name")
-      #     transaction.add_params(:search_query => params[:search_query])
-      #     transaction.add_tags(:key => "value")
+      #   Appsignal.set_error(e) do
+      #     Appsignal.set_namespace("my_namespace")
+      #     Appsignal.set_action("my_action_name")
+      #     Appsignal.add_params(:search_query => params[:search_query])
+      #     Appsignal.add_tags(:key => "value")
       #   end
       #
       # @param exception [Exception] The error to add to the current
@@ -301,11 +302,11 @@ module Appsignal
       #   end
       #
       # @example Add more metadata to transaction
-      #   Appsignal.report_error(error) do |transaction|
-      #     transaction.set_namespace("my_namespace")
-      #     transaction.set_action("my_action_name")
-      #     transaction.add_params(:search_query => params[:search_query])
-      #     transaction.add_tags(:key => "value")
+      #   Appsignal.report_error(error) do
+      #     Appsignal.set_namespace("my_namespace")
+      #     Appsignal.set_action("my_action_name")
+      #     Appsignal.add_params(:search_query => params[:search_query])
+      #     Appsignal.add_tags(:key => "value")
       #   end
       #
       # @param exception [Exception] The error to add to the current

--- a/lib/appsignal/integrations/railtie.rb
+++ b/lib/appsignal/integrations/railtie.rb
@@ -84,9 +84,10 @@ module Appsignal
           # and are caught and recorded by our Rails middleware.
           return if !handled && !is_rails_runner
 
+          namespace, action_name, path, method, params, tags, custom_data =
+            context_for(context.dup)
+
           Appsignal.send_error(error) do |transaction|
-            namespace, action_name, path, method, params, tags, custom_data =
-              context_for(context.dup)
             if namespace
               transaction.set_namespace(namespace)
             elsif is_rails_runner


### PR DESCRIPTION
When using `Appsignal.report_error` and `Appsignal.send_error` (and `Appsignal.set_error`, more on that later), it was required to customize the metadata by calling the `set_*` methods directly on the Transaction object.

This is the only time that is needed in our public API and wasn't ever really documented what methods applications can call, and how they might be different from the helpers on `Appsignal`.

(I don't think there are any differences now, but there were in the past when we didn't have global helpers for custom data, parameters, headers and session data.)

To make matters simpler for our end-user, make the `Appsignal.set_*` helpers work in the callback of `Appsignal.report_error` and `Appsignal.send_error` by temporarily switching the current transaction for the duration of that callback block.

In the `Appsignal.set_error` helper callback, applications could already use `Appsignal.set_*` helpers, because it can only set errors an active transaction so I only updated the API docs for it.

Based on #1210 