### PR TITLE
Ignore calls to start AppSignal twice

### DIFF
--- a/.changesets/do-not-start-appsignal-multiple-times-if--appsignal-start--is-called-more-than-once.md
+++ b/.changesets/do-not-start-appsignal-multiple-times-if--appsignal-start--is-called-more-than-once.md
@@ -1,0 +1,6 @@
+---
+bump: major
+type: change
+---
+
+Do not start Appsignal multiple times if `Appsignal.start` is called more than once. The configuration can no longer be modified after AppSignal has started.

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -38,6 +38,11 @@ module Appsignal
 
     # @api private
     def _config=(conf)
+      if started?
+        internal_logger.warn("Ignoring `Appsignal._config=` call after AppSignal has started")
+        return
+      end
+
       @config = conf
     end
 

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -99,6 +99,11 @@ module Appsignal
     # @return [void]
     # @since 0.7.0
     def start
+      if started?
+        internal_logger.warn("Ignoring call to Appsignal.start after AppSignal has started")
+        return
+      end
+
       unless extension_loaded?
         internal_logger.info("Not starting AppSignal, extension is not loaded")
         return

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -443,6 +443,19 @@ describe Appsignal do
       end
     end
 
+    context "when already started" do
+      it "doesn't start again" do
+        start_agent
+
+        expect(Appsignal::Extension).to_not receive(:start)
+        logs = capture_logs { Appsignal.start }
+        expect(logs).to contains_log(
+          :warn,
+          "Ignoring call to Appsignal.start after AppSignal has started"
+        )
+      end
+    end
+
     context "with debug logging" do
       before { Appsignal._config = project_fixture_config("test") }
 


### PR DESCRIPTION
## Ignore calls to start AppSignal twice

When AppSignal has started, ignore any calls to start it multiple times. If applications change the config after start, it should not start AppSignal again. This type of behavior can cause AppSignal boot loops as two configurations fight to be active.

## Ignore config customization when started

For anyone who finds this private method, ignore any config changes on `Appsignal._config =` when AppSignal has already started.

This way Ruby applications in memory can't claim AppSignal is using one config when inspecting `Appsignal.config`, while it has started with another config.
