### PR TITLE
Add `at_exit` error reporter

### DIFF
--- a/.changesets/add-at_exit-error-reporter.md
+++ b/.changesets/add-at_exit-error-reporter.md
@@ -1,0 +1,31 @@
+---
+bump: major
+type: add
+---
+
+Add an `at_exit` callback error reporter. By default, AppSignal will now report any unhandled errors that crash the process as long as Appsignal started beforehand.
+
+```ruby
+require "appsignal"
+
+Appsignal.start
+
+raise "oh no!"
+
+# Will report the error StandardError "oh no!"
+```
+
+To disable this behavior, set the `enable_at_exit_reporter` config option to `false`.
+
+```ruby
+require "appsignal"
+
+Appsignal.configure do |config|
+  config.enable_at_exit_reporter = false
+end
+Appsignal.start
+
+raise "oh no!"
+
+# Will not report the error
+```

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -55,6 +55,7 @@ module Appsignal
       :ca_file_path => File.expand_path(File.join("../../../resources/cacert.pem"), __FILE__),
       :dns_servers => [],
       :enable_allocation_tracking => true,
+      :enable_at_exit_reporter => true,
       :enable_host_metrics => true,
       :enable_minutely_probes => true,
       :enable_statsd => true,
@@ -130,6 +131,7 @@ module Appsignal
     ENV_BOOLEAN_KEYS = {
       "APPSIGNAL_ACTIVE" => :active,
       "APPSIGNAL_ENABLE_ALLOCATION_TRACKING" => :enable_allocation_tracking,
+      "APPSIGNAL_ENABLE_AT_EXIT_REPORTER" => :enable_at_exit_reporter,
       "APPSIGNAL_ENABLE_HOST_METRICS" => :enable_host_metrics,
       "APPSIGNAL_ENABLE_MINUTELY_PROBES" => :enable_minutely_probes,
       "APPSIGNAL_ENABLE_STATSD" => :enable_statsd,

--- a/lib/appsignal/hooks.rb
+++ b/lib/appsignal/hooks.rb
@@ -72,6 +72,7 @@ module Appsignal
   end
 end
 
+require "appsignal/hooks/at_exit"
 require "appsignal/hooks/action_cable"
 require "appsignal/hooks/action_mailer"
 require "appsignal/hooks/active_job"

--- a/lib/appsignal/hooks/at_exit.rb
+++ b/lib/appsignal/hooks/at_exit.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Appsignal
+  class Hooks
+    # @api private
+    class AtExit < Appsignal::Hooks::Hook
+      register :at_exit
+
+      def dependencies_present?
+        true
+      end
+
+      def install
+        return unless Appsignal.config[:enable_at_exit_reporter]
+
+        Kernel.at_exit(&AtExitCallback.method(:call))
+      end
+
+      # Report any unhandled errors and will crash the Ruby process.
+      #
+      # If this error was previously reported by any of our instrumentation,
+      # the error will not also be reported here. This way we don't report an
+      # error from a Rake task or instrumented script twice.
+      class AtExitCallback
+        def self.call
+          error = $! # rubocop:disable Style/SpecialGlobalVars
+          return if Appsignal::Transaction.last_errors.include?(error)
+
+          Appsignal.report_error(error) do |transaction|
+            transaction.set_namespace("unhandled")
+          end
+          Appsignal.stop("at_exit")
+        end
+      end
+    end
+  end
+end

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -85,6 +85,14 @@ module Appsignal
       def clear_current_transaction!
         Thread.current[:appsignal_transaction] = nil
       end
+
+      # @api private
+      def last_errors
+        @last_errors ||= []
+      end
+
+      # @api private
+      attr_writer :last_errors
     end
 
     # @api private
@@ -139,6 +147,8 @@ module Appsignal
       # On duplicate transactions, the value of the sample flag, which
       # is set on finish, will be duplicated from the original transaction.
       sample_data if !is_duplicate && ext.finish(0)
+
+      self.class.last_errors = errors unless is_duplicate
 
       # Ignore the first error as it is already set in the original
       # transaction.

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -243,6 +243,7 @@ describe Appsignal::Config do
         :ca_file_path                   => File.join(resources_dir, "cacert.pem"),
         :dns_servers                    => [],
         :enable_allocation_tracking     => true,
+        :enable_at_exit_reporter        => true,
         :enable_gvl_global_timer        => true,
         :enable_gvl_waiting_threads     => true,
         :enable_host_metrics            => true,
@@ -482,6 +483,7 @@ describe Appsignal::Config do
         :cpu_count => 1.5,
         :dns_servers => ["8.8.8.8", "8.8.4.4"],
         :enable_allocation_tracking => false,
+        :enable_at_exit_reporter => false,
         :enable_gvl_global_timer => false,
         :enable_gvl_waiting_threads => false,
         :enable_host_metrics => false,
@@ -547,6 +549,7 @@ describe Appsignal::Config do
         # Booleans
         "APPSIGNAL_ACTIVE" => "true",
         "APPSIGNAL_ENABLE_ALLOCATION_TRACKING" => "false",
+        "APPSIGNAL_ENABLE_AT_EXIT_REPORTER" => "false",
         "APPSIGNAL_ENABLE_GVL_GLOBAL_TIMER" => "false",
         "APPSIGNAL_ENABLE_GVL_WAITING_THREADS" => "false",
         "APPSIGNAL_ENABLE_HOST_METRICS" => "false",

--- a/spec/lib/appsignal/hooks/at_exit_spec.rb
+++ b/spec/lib/appsignal/hooks/at_exit_spec.rb
@@ -1,0 +1,72 @@
+describe Appsignal::Hooks::AtExit do
+  describe ".install" do
+    before { start_agent(:options => options) }
+
+    context "with :enable_at_exit_reporter == true" do
+      let(:options) { { :enable_at_exit_reporter => true } }
+
+      it "installs the at_exit hook" do
+        expect(Appsignal::Hooks::AtExit::AtExitCallback).to receive(:call)
+
+        expect(Kernel).to receive(:at_exit).with(no_args) do |*_args, &block|
+          block.call
+        end
+
+        described_class.new.install
+      end
+    end
+
+    context "with :enable_at_exit_reporter == false" do
+      let(:options) { { :enable_at_exit_reporter => false } }
+
+      it "doesn't install the at_exit hook" do
+        expect(Kernel).to_not receive(:at_exit)
+      end
+    end
+  end
+end
+
+describe Appsignal::Hooks::AtExit::AtExitCallback do
+  around { |example| keep_transactions { example.run } }
+  before { start_agent(:options => { :enable_at_exit_reporter => true }) }
+
+  def with_error(error_class, error_message)
+    raise error_class, error_message
+  rescue error_class => error
+    yield error
+  end
+
+  def call_callback
+    Appsignal::Hooks::AtExit::AtExitCallback.call
+  end
+
+  it "reports an error if there's an unhandled error" do
+    expect do
+      with_error(ExampleException, "error message") do
+        call_callback
+      end
+    end.to change { created_transactions.count }.by(1)
+
+    transaction = last_transaction
+    expect(transaction).to have_namespace("unhandled")
+    expect(transaction).to have_error("ExampleException", "error message")
+  end
+
+  it "calls Appsignal.stop" do
+    expect(Appsignal).to receive(:stop).with("at_exit")
+    with_error(ExampleException, "error message") do
+      call_callback
+    end
+  end
+
+  it "doesn't report the error if is also the last error reported" do
+    with_error(ExampleException, "error message") do |error|
+      Appsignal.report_error(error)
+      expect(created_transactions.count).to eq(1)
+
+      expect do
+        call_callback
+      end.to_not change { created_transactions.count }.from(1)
+    end
+  end
+end

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -276,6 +276,14 @@ describe Appsignal::Transaction do
         end
       end
 
+      it "stores the last reported errors" do
+        transaction.add_error(error)
+        transaction.add_error(other_error)
+        transaction.complete
+
+        expect(Appsignal::Transaction.last_errors).to contain_exactly(error, other_error)
+      end
+
       describe "metadata" do
         let(:tags) { { "tag" => "value" } }
         let(:params) { { "param" => "value" } }


### PR DESCRIPTION
We can listen to Ruby's `at_exit` to do things right before the process exits.

In this hook, see if any error was unhandled and will crash the process by checking the `$!` variable. If this is the case and the error was not previously reported on a transaction, report it.