### PR TITLE
Fix app env being reported as empty brackets

### DIFF
--- a/.changesets/fix-env-being-reported-as-----.md
+++ b/.changesets/fix-env-being-reported-as-----.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix the application environment being reported as "[]" when no valid environment could be found.

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -36,6 +36,8 @@ module Appsignal
         env = loader_defaults[:env]
         return env if env
       end
+
+      nil
     end
 
     # Determine which root path AppSignal should initialize with.

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -67,6 +67,10 @@ describe Appsignal::Config do
 
         expect(described_class.determine_env).to eq("loader_env2")
       end
+
+      it "returns nil if no env was found" do
+        expect(described_class.determine_env).to be_nil
+      end
     end
   end
 


### PR DESCRIPTION
In PR #1214, I added the helper `Appsignal::Config.determine_env`. When no valid env could be found it would return `[]`.

If the application is configured through env vars, except the app env, it would report the env as `[]`. That's because it would return the list of loader defaults if no env was found. (It could also return a list of loaded loaders.)

Fix this fallback by returning `nil` if no env is found.