### PR TITLE
Fix configure call without env when it has config

### DIFF
--- a/.changesets/fix-configure-config-reuse.md
+++ b/.changesets/fix-configure-config-reuse.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix `Appsignal.configure` call without `env` argument not reusing the previously configured configuration.

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -241,7 +241,7 @@ module Appsignal
         return
       end
 
-      if config && config.env == env.to_s
+      if config && (env.nil? || config.env == env.to_s)
         config
       else
         @config = Config.new(

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -61,6 +61,28 @@ describe Appsignal do
     end
 
     context "with config but not started" do
+      it "reuses the already loaded config if no env arg is given" do
+        Appsignal._config = Appsignal::Config.new(
+          project_fixture_path,
+          :my_env,
+          :ignore_actions => ["My action"]
+        )
+
+        Appsignal.configure do |config|
+          expect(config.env).to eq("my_env")
+          expect(config.ignore_actions).to eq(["My action"])
+
+          config.active = true
+          config.name = "My app"
+          config.push_api_key = "key"
+        end
+        expect(Appsignal.config.valid?).to be(true)
+        expect(Appsignal.config.env).to eq("my_env")
+        expect(Appsignal.config[:name]).to eq("My app")
+        expect(Appsignal.config[:push_api_key]).to eq("key")
+        expect(Appsignal.config[:ignore_actions]).to eq(["My action"])
+      end
+
       it "reuses the already loaded config if the env is the same" do
         Appsignal._config = Appsignal::Config.new(
           project_fixture_path,


### PR DESCRIPTION
If the application doesn't explicitly give the desired env to `Appsignal.configure`, it should use the automatically detected env, or whatever env is already loaded.

The comparison of `config.env == env.to_s` was not enough because it would compare `"some env"` with `nil` as a String (`""`).