### PR TITLE
Installer improvements

### DIFF
--- a/.changesets/fix-error-on-padrino-require.md
+++ b/.changesets/fix-error-on-padrino-require.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix an error on the Padrino require in the installer CLI. The latest Padrino version will crash the installer on load. Ignore the error when it fails to load.

--- a/.changesets/install-for-unknown-frameworks.md
+++ b/.changesets/install-for-unknown-frameworks.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Configure AppSignal with the install CLI when no known frameworks is found. Automate the configure step so that this doesn't have to be done manually along with the manual setup for the app.

--- a/lib/appsignal/cli/install.rb
+++ b/lib/appsignal/cli/install.rb
@@ -281,7 +281,7 @@ module Appsignal
         def framework_available?(framework_file)
           require framework_file
           true
-        rescue LoadError
+        rescue LoadError, NameError
           false
         end
 

--- a/lib/appsignal/cli/install.rb
+++ b/lib/appsignal/cli/install.rb
@@ -119,11 +119,18 @@ module Appsignal
           puts
           configure(config, %w[development production staging], true)
 
-          puts "Finish Sinatra configuration"
-          puts "  Sinatra requires some manual configuration."
-          puts "  Add this line beneath require 'sinatra':"
+          puts "Sinatra installation"
+          puts "  Sinatra apps requires some manual setup."
+          puts "  Update the `config.ru` (or the application's main file) to " \
+            "look like this:"
           puts
-          puts "  require 'appsignal/integrations/sinatra'"
+          puts %(require "appsignal")
+          puts %(require "sinatra" # or require "sinatra/base")
+          puts
+          puts "Appsignal.load(:sinatra) # Load the Sinatra integration"
+          puts "Appsignal.start # Start AppSignal"
+          puts
+          puts "# Rest of the config.ru file"
           puts
           puts "  You can find more information in the documentation:"
           puts "  https://docs.appsignal.com/ruby/integrations/sinatra.html"
@@ -137,11 +144,14 @@ module Appsignal
           puts
           configure(config, %w[development production staging], true)
 
-          puts "Finish Padrino installation"
-          puts "  Padrino requires some manual configuration."
-          puts "  After installing the gem, add the following line to /config/boot.rb:"
+          puts "Padrino installation"
+          puts "  Padrino apps requires some manual setup."
+          puts "  After installing the gem, add the following lines to `config/boot.rb`:"
           puts
-          puts "  require 'appsignal/integrations/padrino"
+          puts %(require "appsignal")
+          puts
+          puts "Appsignal.load(:padrino) # Load the Padrino integration"
+          puts "Appsignal.start # Start AppSignal"
           puts
           puts "  You can find more information in the documentation:"
           puts "  https://docs.appsignal.com/ruby/integrations/padrino.html"
@@ -157,7 +167,8 @@ module Appsignal
 
           configure(config, %w[development production staging], true)
 
-          puts "Manual Grape configuration needed"
+          puts "Grape installation"
+          puts "  Grape apps require some manual setup."
           puts "  See the installation instructions at:"
           puts "  https://docs.appsignal.com/ruby/integrations/grape.html"
           press_any_key
@@ -170,11 +181,17 @@ module Appsignal
           puts
           configure(config, %w[development production staging], true)
 
-          puts "Finish Hanami installation"
-          puts "  Hanami requires some manual configuration."
-          puts "  After installing the gem, add the following line to config.ru:"
+          puts "Hanami installation"
+          puts "  Hanami apps requires some manual setup."
+          puts "  Update the config.ru file to include the following:"
           puts
-          puts "  require 'appsignal/integrations/hanami'"
+          puts %(  require "appsignal")
+          puts %(  require "hanami/boot")
+          puts
+          puts "Appsignal.load(:hanami) # Load the Hanami integration"
+          puts "Appsignal.start # Start AppSignal"
+          puts
+          puts "# Rest of the config.ru file"
           puts
           puts "  You can find more information in the documentation:"
           puts "  https://docs.appsignal.com/ruby/integrations/hanami.html"

--- a/lib/appsignal/cli/install.rb
+++ b/lib/appsignal/cli/install.rb
@@ -27,7 +27,7 @@ module Appsignal
           puts
           unless push_api_key
             puts colorize "Problem encountered:", :red
-            puts "  No push API key entered."
+            puts "  No Push API key entered."
             puts "  - Sign up for AppSignal and follow the instructions"
             puts "  - Already signed up? Click 'Add app' on the account overview page"
             puts
@@ -37,22 +37,25 @@ module Appsignal
           config = new_config
           config[:push_api_key] = push_api_key
 
-          print "Validating API key"
+          print "Validating Push API key"
           periods
           puts
           begin
             auth_check = Appsignal::AuthCheck.new(config)
             unless auth_check.perform == "200"
-              puts "\n  API key '#{config[:push_api_key]}' is not valid, please get a new one on https://appsignal.com"
+              print colorize("  Error:", :red)
+              puts " Push API key '#{config[:push_api_key]}' is not valid. " \
+                "Please get a new one at https://appsignal.com/accounts"
               return
             end
           rescue => e
-            puts "  There was an error validating your API key:"
+            print colorize("  Error:", :red)
+            puts "There was an error validating your Push API key:"
             puts colorize "'#{e}'", :red
-            puts "  Please try again"
+            puts "  Please check the Push API key and try again"
             return
           end
-          puts colorize "  API key valid!", :green
+          puts colorize "  Push API key valid!", :green
           puts
 
           if installed_frameworks.include?(:rails)

--- a/lib/appsignal/cli/install.rb
+++ b/lib/appsignal/cli/install.rb
@@ -66,12 +66,7 @@ module Appsignal
           elsif installed_frameworks.include?(:sinatra)
             install_for_sinatra(config)
           else
-            print colorize "Warning:", :red
-            puts " We could not detect which framework you are using. " \
-              "We'd be very grateful if you email us on support@appsignal.com " \
-              "with information about your setup."
-            puts
-            done_notice
+            install_for_unknown_framework(config)
           end
         end
 
@@ -214,6 +209,23 @@ module Appsignal
           puts
         end
 
+        def install_for_unknown_framework(config)
+          puts "Installing"
+          config[:name] = required_input("  Enter application name: ")
+          puts
+          configure(config, %w[development production staging], true)
+
+          puts colorize "Warning: We could not detect which framework you are using", :red
+          puts "  Some manual installation is most likely required."
+          puts "  Please check our documentation for supported libraries: "
+          puts "  https://docs.appsignal.com/ruby/integrations.html"
+          puts
+          puts "  We'd be very grateful if you email us on " \
+            "support@appsignal.com with information about your setup."
+          press_any_key
+          done_notice
+        end
+
         def configure(config, environments, name_overwritten)
           install_for_capistrano
 
@@ -257,29 +269,27 @@ module Appsignal
         end
 
         def done_notice
-          sleep 0.3
-          puts colorize "#####################################", :green
-          puts colorize "## AppSignal installation complete ##", :green
-          puts colorize "#####################################", :green
-          sleep 0.3
-          puts
           if Gem.win_platform?
-            puts "The AppSignal agent currently does not work on Microsoft " \
+            print colorize "Warning:", :red
+            puts " The AppSignal agent currently does not work on Microsoft " \
               "Windows. Please push these changes to your staging/production " \
               "environment and make sure some actions are performed. " \
-              "AppSignal should pick up your app after a few minutes."
+              "AppSignal will pick up your app after a few minutes."
           else
-            puts "  Sending example data to AppSignal..."
+            puts "Sending example data to AppSignal..."
             if Appsignal::Demo.transmit
               puts "  Example data sent!"
               puts "  It may take about a minute for the data to appear on https://appsignal.com/accounts"
-              puts
-              puts "  Please return to your browser and follow the instructions."
             else
-              puts "  Couldn't start the AppSignal agent and send example data to AppSignal.com"
-              puts "  Please use `appsignal diagnose` to debug your configuration."
+              print colorize "Error:", :red
+              puts " Couldn't start the AppSignal agent and send example data to AppSignal.com"
+              puts "  Please contact us at support@appsignal.com and " \
+                "send us a diagnose report using `appsignal diagnose`."
+              return
             end
           end
+          puts
+          puts "Please return to your browser and follow the instructions."
         end
 
         def installed_frameworks

--- a/lib/appsignal/cli/install.rb
+++ b/lib/appsignal/cli/install.rb
@@ -18,12 +18,12 @@ module Appsignal
           $stdout.sync = true
 
           puts
-          puts colorize "#######################################", :green
-          puts colorize "## Starting AppSignal Installer      ##", :green
-          puts colorize "## --------------------------------- ##", :green
-          puts colorize "## Need help?  support@appsignal.com ##", :green
-          puts colorize "## Docs?       docs.appsignal.com    ##", :green
-          puts colorize "#######################################", :green
+          puts colorize "############################################", :green
+          puts colorize "## Starting AppSignal Installer           ##", :green
+          puts colorize "## -------------------------------------- ##", :green
+          puts colorize "## Need help?  support@appsignal.com      ##", :green
+          puts colorize "## Docs:       https://docs.appsignal.com ##", :green
+          puts colorize "############################################", :green
           puts
           unless push_api_key
             puts colorize "Problem encountered:", :red

--- a/spec/lib/appsignal/cli/install_spec.rb
+++ b/spec/lib/appsignal/cli/install_spec.rb
@@ -465,8 +465,10 @@ describe Appsignal::CLI::Install do
         let(:installation_instructions) do
           [
             "Installing for Sinatra",
-            "Sinatra requires some manual configuration.",
-            "require 'appsignal/integrations/sinatra'",
+            "Sinatra apps requires some manual setup.",
+            %(require "appsignal"),
+            "Appsignal.load(:sinatra)",
+            "Appsignal.start",
             "https://docs.appsignal.com/ruby/integrations/sinatra.html"
           ]
         end
@@ -533,7 +535,10 @@ describe Appsignal::CLI::Install do
         let(:installation_instructions) do
           [
             "Installing for Padrino",
-            "Padrino requires some manual configuration.",
+            "Padrino apps requires some manual setup.",
+            %(require "appsignal"),
+            "Appsignal.load(:padrino)",
+            "Appsignal.start",
             "https://docs.appsignal.com/ruby/integrations/padrino.html"
           ]
         end
@@ -600,7 +605,7 @@ describe Appsignal::CLI::Install do
         let(:installation_instructions) do
           [
             "Installing for Grape",
-            "Manual Grape configuration needed",
+            "Grape apps require some manual setup.",
             "https://docs.appsignal.com/ruby/integrations/grape.html"
           ]
         end
@@ -624,6 +629,7 @@ describe Appsignal::CLI::Install do
           it "completes the installation" do
             run
 
+            puts output
             expect(output).to include(*installation_instructions)
             expect(output).to include_complete_install
           end
@@ -667,7 +673,10 @@ describe Appsignal::CLI::Install do
         let(:installation_instructions) do
           [
             "Installing for Hanami",
-            "Hanami requires some manual configuration.",
+            "Hanami apps requires some manual setup.",
+            %(require "appsignal"),
+            "Appsignal.load(:hanami)",
+            "Appsignal.start",
             "https://docs.appsignal.com/ruby/integrations/hanami.html"
           ]
         end

--- a/spec/lib/appsignal/cli/install_spec.rb
+++ b/spec/lib/appsignal/cli/install_spec.rb
@@ -105,7 +105,7 @@ describe Appsignal::CLI::Install do
         run
 
         expect(output).to include "Problem encountered:",
-          "No push API key entered"
+          "No Push API key entered"
       end
     end
 
@@ -120,7 +120,7 @@ describe Appsignal::CLI::Install do
           choose_environment_config
           run
 
-          expect(output).to include("Validating API key...", "API key valid")
+          expect(output).to include("Validating Push API key...", "Push API key valid")
         end
       end
 
@@ -129,7 +129,7 @@ describe Appsignal::CLI::Install do
 
         it "prints an error" do
           run
-          expect(output).to include "API key 'my_key' is not valid"
+          expect(output).to include "Push API key 'my_key' is not valid"
         end
       end
 
@@ -140,7 +140,7 @@ describe Appsignal::CLI::Install do
 
         it "prints an error" do
           run
-          expect(output).to include "There was an error validating your API key"
+          expect(output).to include "There was an error validating your Push API key"
         end
       end
     end

--- a/spec/lib/appsignal/cli/install_spec.rb
+++ b/spec/lib/appsignal/cli/install_spec.rb
@@ -738,7 +738,10 @@ describe Appsignal::CLI::Install do
 
         it "prints the instructions in color" do
           run
-          expect(output).to have_colorized_text(:green, "## Starting AppSignal Installer      ##")
+          expect(output).to have_colorized_text(
+            :green,
+            "## Starting AppSignal Installer           ##"
+          )
         end
       end
 
@@ -747,7 +750,10 @@ describe Appsignal::CLI::Install do
 
         it "prints the instructions in color" do
           run
-          expect(output).to have_colorized_text(:green, "## Starting AppSignal Installer      ##")
+          expect(output).to have_colorized_text(
+            :green,
+            "## Starting AppSignal Installer           ##"
+          )
         end
       end
 
@@ -756,7 +762,7 @@ describe Appsignal::CLI::Install do
 
         it "prints the instructions without special colors" do
           run
-          expect(output).to include("Starting AppSignal Installer")
+          expect(output).to include("## Starting AppSignal Installer           ##")
           expect(output).to_not have_color_markers
         end
       end


### PR DESCRIPTION
## Fix Padrino require error

When Padrino is loaded it will raise an error about `Rack::Server` not being found. That's because the constant has been renamed to `Rackup::Server` in newer versions of Rack and Rackup.

The latest version of Padrino is not updated for this yet, so catch the error if it occurs. This makes our detection a bit less accurate, but at least it won't crash the installer.

## Make installer docs link clickable

In my terminal a link needs the URL scheme for it to be clickable.

## Update framework installation instructions

Recently we added the new loader mechanism for integrations. Update the installer to print instructions using the loader mechanism. That way applications don't immediately start printing deprecation warnings.

## Install gem when no known framework found

When no supported framework is installed, the installer would exit. It would try to send the demo data, but this would always fail because there is no valid AppSignal config chosen.

Change the installer that it will configure AppSignal when no supported framework is found, and link to the docs for a list of other libraries we integrate with. Some manual setup is required but we don't known which library docs to link to.

Update the installer output to always point people back to installation instructions in the browser.

Part of #315

## Improve some installer text

Always say "Push API", to differentiate from the personal API key, every time it's mentioned.

Highlight validation errors with color.
