### PR TITLE
Remove config modifier from diagnose report

### DIFF
--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -477,10 +477,6 @@ module Appsignal
               :file => config.file_config,
               :env => config.env_config,
               :override => config.override_config
-            },
-            :modifiers => {
-              "APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR" =>
-                ENV.fetch("APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR", "")
             }
           }
           print_config_options(config)
@@ -522,11 +518,6 @@ module Appsignal
               puts "  #{key}: #{format_config_option(value)}#{sources_label}"
             end
           end
-
-          puts
-          puts "Configuration modifiers"
-          puts "  APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR: " \
-            "#{data[:config][:modifiers]["APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR"].inspect}"
 
           puts "\nRead more about how the diagnose config output is rendered\n" \
             "https://docs.appsignal.com/ruby/command-line/diagnose.html"

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -783,9 +783,6 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
               "file" => {},
               "env" => {},
               "override" => {}
-            },
-            "modifiers" => {
-              "APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR" => ""
             }
           )
         end
@@ -918,28 +915,6 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
           end
         end
 
-        describe "modifiers" do
-          before do
-            ENV["APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR"] = "1"
-            run
-          end
-
-          it "outputs config modifiers" do
-            expect(output).to include(
-              "Configuration modifiers\n" \
-                "  APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR: \"1\""
-            )
-          end
-
-          it "transmits config modifiers in report" do
-            expect(received_report["config"]).to include(
-              "modifiers" => {
-                "APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR" => "1"
-              }
-            )
-          end
-        end
-
         it "transmits config in report" do
           run
           additional_initial_config = {}
@@ -963,9 +938,6 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
               "file" => hash_with_string_keys(config.file_config),
               "env" => {},
               "override" => {}
-            },
-            "modifiers" => {
-              "APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR" => ""
             }
           )
         end
@@ -994,9 +966,6 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
               "file" => hash_with_string_keys(config.file_config),
               "env" => {},
               "override" => {}
-            },
-            "modifiers" => {
-              "APPSIGNAL_INACTIVE_ON_CONFIG_FILE_ERROR" => ""
             }
           )
         end


### PR DESCRIPTION
The config modifier was removed in PR #1201, making it the new default.

Remove the config load modifier from the diagnose report, because it doesn't do anything anymore.

[skip changeset]
[skip review]