### PR TITLE
Load Rails config in diagnose CLI

### DIFF
--- a/.changesets/include-rails-app-config-in-diagnose-report.md
+++ b/.changesets/include-rails-app-config-in-diagnose-report.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+type: change
+---
+
+Include the Rails app config in diagnose report. If AppSignal is configured in a Rails initializer, this config is now included in the diagnose report.

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -103,7 +103,12 @@ module Appsignal
     #
     # @return [void]
     # @since 0.7.0
-    def start
+    def start # rubocop:disable Metrics/AbcSize
+      if ENV.fetch("_APPSIGNAL_DIAGNOSE", false)
+        internal_logger.warn("Skipping start in diagnose context")
+        return
+      end
+
       if started?
         internal_logger.warn("Ignoring call to Appsignal.start after AppSignal has started")
         return

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -632,8 +632,8 @@ module Appsignal
         end
 
         def require_rails_app_if_present
-          # Try and load the Rails gem
-          require "rails"
+          return unless rails_present?
+
           # Mark app as Rails app
           data[:app][:rails] = true
           # Manually require the railtie, because it wasn't loaded when the CLI
@@ -642,8 +642,21 @@ module Appsignal
           require "appsignal/integrations/railtie"
           # Start the Rails app, including railties and initializers.
           require Appsignal::Utils::RailsHelper.environment_config_path
+        rescue LoadError, StandardError => error
+          print_empty_line
+          puts "ERROR: Error encountered while loading the Rails app"
+          puts "#{error.class}: #{error.message}"
+          puts error.backtrace
+          data[:app][:load_error] =
+            "#{error.class}: #{error.message}\n#{error.backtrace.join("\n")}"
+        end
+
+        def rails_present?
+          # Try and load the Rails gem
+          require "rails"
+          true
         rescue LoadError
-          nil
+          false
         end
       end
     end

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -634,6 +634,8 @@ module Appsignal
         def require_rails_app_if_present
           # Try and load the Rails gem
           require "rails"
+          # Mark app as Rails app
+          data[:app][:rails] = true
           # Manually require the railtie, because it wasn't loaded when the CLI
           # started and AppSignal loaded, because the `Rails` constant wasn't
           # present.

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -77,6 +77,10 @@ module Appsignal
         # @return [void]
         # @api private
         def run(options = {})
+          # Do not start AppSignal on `Appsignal.start` and run the extension
+          # and agent in diagnose mode.
+          ENV["_APPSIGNAL_DIAGNOSE"] = "true"
+
           self.coloring = options.delete(:color) { true }
           $stdout.sync = true
           header
@@ -184,21 +188,13 @@ module Appsignal
         end
 
         def configure_appsignal(options)
-          current_path = Dir.pwd
-          initial_config = {}
-          if rails_app?
-            data[:app][:rails] = true
-            current_path = Rails.root
-            initial_config[:name] =
-              Appsignal::Utils::RailsHelper.detected_rails_app_name
-            initial_config[:log_path] = current_path.join("log")
-          end
+          # Try and load the Rails app, if any.
+          # This will configure AppSignal through the config file or an
+          # initializer.
+          require_rails_app_if_present
 
-          Appsignal._config = Appsignal::Config.new(
-            current_path,
-            options.fetch(:environment, ENV.fetch("RACK_ENV", ENV.fetch("RAILS_ENV", nil))),
-            initial_config
-          )
+          # If no config was found by loading the app, load with the defaults.
+          Appsignal.configure(options.fetch(:environment, nil))
           Appsignal.config.write_to_environment
           Appsignal._start_logger
           Appsignal.internal_logger.info("Starting AppSignal diagnose")
@@ -211,9 +207,9 @@ module Appsignal
             return
           end
 
-          ENV["_APPSIGNAL_DIAGNOSE"] = "true"
+          # Requires _APPSIGNAL_DIAGNOSE to be set. This is set at the
+          # beginning of the diagnose CLI.
           diagnostics_report_string = Appsignal::Extension.diagnose
-          ENV.delete("_APPSIGNAL_DIAGNOSE")
 
           begin
             report = JSON.parse(diagnostics_report_string)
@@ -635,12 +631,17 @@ module Appsignal
           puts "\n"
         end
 
-        def rails_app?
+        def require_rails_app_if_present
+          # Try and load the Rails gem
           require "rails"
-          require File.expand_path(File.join(Dir.pwd, "config", "application.rb"))
-          true
+          # Manually require the railtie, because it wasn't loaded when the CLI
+          # started and AppSignal loaded, because the `Rails` constant wasn't
+          # present.
+          require "appsignal/integrations/railtie"
+          # Start the Rails app, including railties and initializers.
+          require Appsignal::Utils::RailsHelper.environment_config_path
         rescue LoadError
-          false
+          nil
         end
       end
     end

--- a/lib/appsignal/integrations/railtie.rb
+++ b/lib/appsignal/integrations/railtie.rb
@@ -27,13 +27,7 @@ module Appsignal
       end
 
       def self.on_load(app)
-        Appsignal::Config.add_loader_defaults(
-          :rails,
-          :root_path => Rails.root,
-          :env => Rails.env,
-          :name => Appsignal::Utils::RailsHelper.detected_rails_app_name,
-          :log_path => Rails.root.join("log")
-        )
+        load_default_config
         Appsignal::Integrations::Railtie.add_instrumentation_middleware(app)
 
         return unless app.config.appsignal.start_at == :on_load
@@ -45,9 +39,19 @@ module Appsignal
         Appsignal::Integrations::Railtie.start if app.config.appsignal.start_at == :after_initialize
       end
 
+      def self.load_default_config
+        Appsignal::Config.add_loader_defaults(
+          :rails,
+          :root_path => Rails.root,
+          :env => Rails.env,
+          :name => Appsignal::Utils::RailsHelper.detected_rails_app_name,
+          :log_path => Rails.root.join("log")
+        )
+      end
+
       def self.start
         Appsignal.start
-        initialize_error_reporter
+        initialize_error_reporter if Appsignal.started?
       end
 
       def self.add_instrumentation_middleware(app)

--- a/lib/appsignal/utils/rails_helper.rb
+++ b/lib/appsignal/utils/rails_helper.rb
@@ -15,6 +15,10 @@ module Appsignal
       def self.application_config_path
         File.expand_path(File.join(Dir.pwd, "config/application.rb"))
       end
+
+      def self.environment_config_path
+        File.expand_path(File.join(Dir.pwd, "config/environment.rb"))
+      end
     end
   end
 end

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -938,6 +938,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
                     "      file:    \"TestApp\"\n"
                 )
 
+                expect(received_report["app"]["rails"]).to be(true)
                 expect(received_report["config"]["sources"]).to include(
                   "loaders" => {
                     "root_path" => root_path,

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -948,6 +948,26 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
                   }
                 )
               end
+
+              context "when there's a problem loading the app" do
+                before do
+                  # A spot where we can mock an error raise
+                  expect(Appsignal::Utils::RailsHelper).to receive(:environment_config_path)
+                    .and_raise(ExampleStandardError, "error message", ["line 1", "line 2"])
+                  run_within_dir(root_path)
+                end
+
+                it "includes a load error" do
+                  expect(output).to include(
+                    "ERROR: Error encountered while loading the Rails app\n" \
+                      "ExampleStandardError: error message"
+                  )
+
+                  pp received_report["app"]
+                  expect(received_report["app"]["load_error"])
+                    .to eq("ExampleStandardError: error message\nline 1\nline 2")
+                end
+              end
             end
           end
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,9 +25,7 @@ Dir[File.join(APPSIGNAL_SPEC_DIR, "support/shared_examples", "*.rb")].sort.each 
   require f
 end
 if DependencyHelper.rails_present?
-  Dir[File.join(DirectoryHelper.support_dir, "rails", "*.rb")].sort.each do |f|
-    require f
-  end
+  require File.join(ConfigHelpers.rails_project_fixture_path, "config/application.rb")
 end
 if DependencyHelper.hanami2_present?
   Dir[File.join(DirectoryHelper.support_dir, "hanami", "*.rb")].sort.each do |f|

--- a/spec/support/fixtures/projects/valid_with_rails_app/config/application.rb
+++ b/spec/support/fixtures/projects/valid_with_rails_app/config/application.rb
@@ -1,0 +1,16 @@
+require "rails"
+
+module MyApp
+  class Application < Rails::Application
+    config.active_support.deprecation = proc { |message, stack| }
+    config.eager_load = false
+
+    def self.initialize!
+      # Prevent errors about Rails being initialized more than once
+      return if defined?(@initialized)
+
+      super
+      @initialized = true
+    end
+  end
+end

--- a/spec/support/fixtures/projects/valid_with_rails_app/config/environment.rb
+++ b/spec/support/fixtures/projects/valid_with_rails_app/config/environment.rb
@@ -1,0 +1,5 @@
+# Load the Rails application.
+require_relative "application"
+
+# Initialize the Rails application.
+MyApp::Application.initialize!

--- a/spec/support/helpers/config_helpers.rb
+++ b/spec/support/helpers/config_helpers.rb
@@ -11,6 +11,7 @@ module ConfigHelpers
       File.join(File.dirname(__FILE__), "../fixtures/projects/valid_with_rails_app")
     )
   end
+  module_function :rails_project_fixture_path
 
   def project_fixture_config( # rubocop:disable Metrics/ParameterLists
     env = "production",

--- a/spec/support/helpers/rails_helper.rb
+++ b/spec/support/helpers/rails_helper.rb
@@ -1,10 +1,10 @@
 module RailsHelper
-  def with_railtie(app)
-    clear_rails_error_reporter! if Rails.respond_to? :error
-    Appsignal::Integrations::Railtie.initialize_appsignal(app)
-    yield
-  ensure
-    clear_rails_error_reporter!
+  def run_appsignal_railtie
+    app = MyApp::Application.new
+    Appsignal::Integrations::Railtie.initializers.each do |initializer|
+      initializer.run(app)
+    end
+    ActiveSupport.run_load_hooks(:after_initialize, app)
   end
 
   def with_rails_error_reporter

--- a/spec/support/rails/my_app.rb
+++ b/spec/support/rails/my_app.rb
@@ -1,6 +1,0 @@
-module MyApp
-  class Application < Rails::Application
-    config.active_support.deprecation = proc { |message, stack| }
-    config.eager_load = false
-  end
-end


### PR DESCRIPTION
Make the diagnose CLI more useful for Rails apps by loading the Rails app to fetch the configuration.

This fixes a couple things:

- Include config defined in Rails initializers.
- Accurately include Rails default config set by the Railtie. Previously
  we duplicated the behavior in the diagnose CLI, but that could diverge
  when changed.

To make this work, require the `config/environment.rb` file which initializes Rails, loads the initializers and does most things but start the Rails server.

The diagnose CLI will also no longer initialize the AppSignal config with the `Appsignal._config =` method, which I'm trying to remove entirely.

Do not start AppSignal in `Appsignal.start` if the `_APPSIGNAL_DIAGNOSE` env is set, so that loading the Rails app in the diagnose CLI doesn't start AppSignal (the agent specifically).

There's a bunch of changes for the test suite so there's only one Rails app loaded, because Rails only allows one at a time, and it can only be initialized once.

Fixes #510
