### PR TITLE
Always register ViewComponent event formatter

### DIFF
--- a/.changesets/fix-viewcomponent-instrumentation-not-loading.md
+++ b/.changesets/fix-viewcomponent-instrumentation-not-loading.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix an issue where, depending on the relative order of the `appsignal` and `view_component` dependencies in the Gemfile, the ViewComponent instrumentation would not load.

--- a/gemfiles/rails-7.1.gemfile
+++ b/gemfiles/rails-7.1.gemfile
@@ -3,7 +3,6 @@ source "https://rubygems.org"
 gem "rails", "~> 7.1.0"
 gem "rake", "> 12.2"
 gem "sidekiq"
-gem "view_component"
 
 # Fix install issue for jruby on gem 3.1.8.
 # No java stub is published.

--- a/lib/appsignal/event_formatter/view_component/render_formatter.rb
+++ b/lib/appsignal/event_formatter/view_component/render_formatter.rb
@@ -21,7 +21,7 @@ module Appsignal
   end
 end
 
-if defined?(Rails) && defined?(ViewComponent)
+if defined?(Rails)
   Appsignal::EventFormatter.register(
     "render.view_component",
     Appsignal::EventFormatter::ViewComponent::RenderFormatter

--- a/spec/lib/appsignal/event_formatter/view_component/render_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/view_component/render_formatter_spec.rb
@@ -1,9 +1,7 @@
 describe Appsignal::EventFormatter::ViewComponent::RenderFormatter do
   let(:klass) { Appsignal::EventFormatter::ViewComponent::RenderFormatter }
 
-  if DependencyHelper.rails_present? && DependencyHelper.view_component_present?
-    require "view_component"
-
+  if DependencyHelper.rails_present?
     context "when in a Rails app" do
       let(:formatter) { klass.new }
       before { allow(Rails.root).to receive(:to_s).and_return("/var/www/app/20130101") }
@@ -31,7 +29,7 @@ describe Appsignal::EventFormatter::ViewComponent::RenderFormatter do
       end
     end
   else
-    context "when not in a Rails app with the ViewComponent gem" do
+    context "when not in a Rails app" do
       it "does not register the event formatter" do
         expect(Appsignal::EventFormatter.registered?("render.view_component",
           klass)).to be_falsy

--- a/spec/support/helpers/dependency_helper.rb
+++ b/spec/support/helpers/dependency_helper.rb
@@ -136,10 +136,6 @@ module DependencyHelper
     hanami_present? && Gem.loaded_specs["hanami"].version >= Gem::Version.new("2.0")
   end
 
-  def view_component_present?
-    dependency_present? "view_component"
-  end
-
   def dependency_present?(dependency_file)
     Gem.loaded_specs.key? dependency_file
   end


### PR DESCRIPTION
When in a Rails application, always register the ViewComponent event formatter, similarly to what we do with most other event formatters.

This fixes #1222, where the relative order of gems in the application's Gemfile causes the ViewComponent event formatter to not be loaded.