### PR TITLE
Add option to customize config root path

### DIFF
--- a/.changesets/deprecate-config-app_path-writer-.md
+++ b/.changesets/deprecate-config-app_path-writer-.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: deprecate
+---
+
+Deprecate the `Appsignal.configure`'s `app_path` writer. Use the `Appsignal.configure`'s `path` keyword argument to configure the path.

--- a/.changesets/deprecate-config-app_path-writer-.md
+++ b/.changesets/deprecate-config-app_path-writer-.md
@@ -3,4 +3,4 @@ bump: patch
 type: deprecate
 ---
 
-Deprecate the `Appsignal.configure`'s `app_path` writer. Use the `Appsignal.configure`'s `path` keyword argument to configure the path.
+Deprecate the `Appsignal.configure`'s `app_path` writer. Use the `Appsignal.configure`'s `root_path` keyword argument to configure the path.

--- a/.changesets/fix-appsignal-configure-path-config.md
+++ b/.changesets/fix-appsignal-configure-path-config.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix the `Appsignal.configure` path config not being customizable. It's now possible to pass a `path` keyword argument to `Appsignal.configure` to customize the path from which AppSignal reads the config file, `config/appsignal.yml`.

--- a/.changesets/fix-appsignal-configure-path-config.md
+++ b/.changesets/fix-appsignal-configure-path-config.md
@@ -3,4 +3,4 @@ bump: patch
 type: fix
 ---
 
-Fix the `Appsignal.configure` path config not being customizable. It's now possible to pass a `path` keyword argument to `Appsignal.configure` to customize the path from which AppSignal reads the config file, `config/appsignal.yml`.
+Fix the `Appsignal.configure` path config not being customizable. It's now possible to pass a `root_path` keyword argument to `Appsignal.configure` to customize the path from which AppSignal reads the config file, `config/appsignal.yml`.

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -234,18 +234,18 @@ module Appsignal
     # @see Config
     # @see https://docs.appsignal.com/ruby/configuration.html Configuration guide
     # @see https://docs.appsignal.com/ruby/configuration/options.html Configuration options
-    def configure(env = nil)
+    def configure(env = nil, path: nil)
       if Appsignal.started?
         Appsignal.internal_logger
           .warn("AppSignal is already started. Ignoring `Appsignal.configure` call.")
         return
       end
 
-      if config && (env.nil? || config.env == env.to_s)
+      if config && ((env.nil? || config.env == env.to_s) && (path.nil? || config.root_path == path))
         config
       else
         @config = Config.new(
-          Config.determine_root_path,
+          path || Config.determine_root_path,
           Config.determine_env(env),
           {},
           Appsignal.internal_logger,

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -228,24 +228,28 @@ module Appsignal
     #   # Or for the environment given as an argument
     #   Appsignal.configure(:production)
     #
+    # @param env [String, Symbol] The environment to load.
+    # @param root_path [String] The path to look the `config/appsignal.yml` config file in.
+    #   Defaults to the current working directory.
     # @yield [Config] Gives the {Config} instance to the block.
     # @return [void]
     # @see config
     # @see Config
     # @see https://docs.appsignal.com/ruby/configuration.html Configuration guide
     # @see https://docs.appsignal.com/ruby/configuration/options.html Configuration options
-    def configure(env = nil, path: nil)
+    def configure(env = nil, root_path: nil)
       if Appsignal.started?
         Appsignal.internal_logger
           .warn("AppSignal is already started. Ignoring `Appsignal.configure` call.")
         return
       end
 
-      if config && ((env.nil? || config.env == env.to_s) && (path.nil? || config.root_path == path))
+      if config && ((env.nil? || config.env == env.to_s) &&
+          (root_path.nil? || config.root_path == root_path))
         config
       else
         @config = Config.new(
-          path || Config.determine_root_path,
+          root_path || Config.determine_root_path,
           Config.determine_env(env),
           {},
           Appsignal.internal_logger,

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -622,8 +622,11 @@ module Appsignal
         @config.root_path
       end
 
-      def app_path=(path)
-        @config.root_path = path
+      def app_path=(_path)
+        Appsignal::Utils::StdoutAndLoggerMessage.warning \
+          "The `Appsignal.configure`'s `app_path=` writer is deprecated. " \
+            "Use the `Appsignal.configure`'s method `path` keyword argument " \
+            "to set the root path."
       end
 
       def env

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -212,7 +212,7 @@ module Appsignal
     # Initialize a new configuration object for AppSignal.
     #
     # @param root_path [String] Root path of the app.
-    # @param env [String] The environment to load when AppSignal is started. It
+    # @param initial_env [String] The environment to load when AppSignal is started. It
     #   will look for an environment with this name in the `config/appsignal.yml`
     #   config file.
     # @param initial_config [Hash<String, Object>] The initial configuration to
@@ -624,8 +624,9 @@ module Appsignal
 
       def app_path=(_path)
         Appsignal::Utils::StdoutAndLoggerMessage.warning \
-          "The `Appsignal.configure`'s `app_path=` writer is deprecated. " \
-            "Use the `Appsignal.configure`'s method `path` keyword argument " \
+          "The `Appsignal.configure`'s `app_path=` writer is deprecated " \
+            "and can no longer be used to set the root path. " \
+            "Use the `Appsignal.configure`'s method `root_path` keyword argument " \
             "to set the root path."
       end
 

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -1448,7 +1448,7 @@ describe Appsignal::Config do
         end
 
         expect(err_stream.read).to include(
-          "appsignal WARNING: The `Appsignal.configure`'s `app_path=` writer is deprecated."
+          "appsignal WARNING: The `Appsignal.configure`'s `app_path=` writer is deprecated"
         )
       end
 
@@ -1459,7 +1459,7 @@ describe Appsignal::Config do
 
         expect(logs).to contains_log(
           :warn,
-          "The `Appsignal.configure`'s `app_path=` writer is deprecated."
+          "The `Appsignal.configure`'s `app_path=` writer is deprecated"
         )
       end
     end

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -1439,5 +1439,29 @@ describe Appsignal::Config do
 
       expect(dsl.cpu_count).to eq(1.0)
     end
+
+    describe "#app_path=" do
+      it "prints a deprecation warning" do
+        err_stream = std_stream
+        capture_std_streams(std_stream, err_stream) do
+          dsl.app_path = "foo"
+        end
+
+        expect(err_stream.read).to include(
+          "appsignal WARNING: The `Appsignal.configure`'s `app_path=` writer is deprecated."
+        )
+      end
+
+      it "logs a deprecation warning" do
+        logs = capture_logs do
+          silence { dsl.app_path = "foo" }
+        end
+
+        expect(logs).to contains_log(
+          :warn,
+          "The `Appsignal.configure`'s `app_path=` writer is deprecated."
+        )
+      end
+    end
   end
 end

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -125,6 +125,28 @@ describe Appsignal do
         expect(Appsignal.config[:push_api_key]).to eq("key")
       end
 
+      it "loads a new config if the path is not the same" do
+        Appsignal._config = Appsignal::Config.new(
+          "/some/path",
+          :my_env,
+          :name => "Some name",
+          :push_api_key => "Some key",
+          :ignore_actions => ["My action"]
+        )
+
+        Appsignal.configure(:my_env, :root_path => project_fixture_path) do |config|
+          expect(config.ignore_actions).to be_empty
+          config.active = true
+          config.name = "My app"
+          config.push_api_key = "key"
+        end
+        expect(Appsignal.config.valid?).to be(true)
+        expect(Appsignal.config.env).to eq("my_env")
+        expect(Appsignal.config[:active]).to be(true)
+        expect(Appsignal.config[:name]).to eq("My app")
+        expect(Appsignal.config[:push_api_key]).to eq("key")
+      end
+
       it "calls configure if not started yet" do
         Appsignal.configure(:my_env) do |config|
           config.active = false
@@ -166,7 +188,7 @@ describe Appsignal do
       end
 
       it "uses the given root path to read the config file" do
-        Appsignal.configure(:test, :path => project_fixture_path)
+        Appsignal.configure(:test, :root_path => project_fixture_path)
 
         Appsignal.start
         expect(Appsignal.config.env).to eq("test")

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -165,6 +165,16 @@ describe Appsignal do
         expect(Appsignal.config.env).to eq("env_arg")
       end
 
+      it "uses the given root path to read the config file" do
+        Appsignal.configure(:test, :path => project_fixture_path)
+
+        Appsignal.start
+        expect(Appsignal.config.env).to eq("test")
+        expect(Appsignal.config[:push_api_key]).to eq("abc")
+        # Ensure it loads from the config file in the given path
+        expect(Appsignal.config.file_config).to_not be_empty
+      end
+
       it "loads the config without a block being given" do
         Dir.chdir project_fixture_path do
           Appsignal.configure(:test)
@@ -172,6 +182,8 @@ describe Appsignal do
 
         expect(Appsignal.config.env).to eq("test")
         expect(Appsignal.config[:push_api_key]).to eq("abc")
+        # Ensure it loads from the config file in the current working directory
+        expect(Appsignal.config.file_config).to_not be_empty
       end
 
       it "allows customization of config in the block" do


### PR DESCRIPTION
I added an option before to customize the root path via the `app_path=` writer on the ConfigDSL. However, this is set too late, after the file config is already read, so it has no effect.

Add a keyword argument to the `Appsignal.configure` helper so that it can still be customized for scenarios where the current working directory is not the place to look for the config file.