### PR TITLE
Deprecate Appsignal.listen_for_error helper

### DIFF
--- a/.changesets/deprecate-appsignal-listen_for_error.md
+++ b/.changesets/deprecate-appsignal-listen_for_error.md
@@ -1,0 +1,21 @@
+---
+bump: patch
+type: deprecate
+---
+
+Deprecate the `Appsignal.listen_for_error` helper. Use a manual error rescue with `Appsignal.report_error`. This method allows for more customization of the reported error.
+
+```ruby
+# Before
+Appsignal.listen_for_error do
+  raise "some error"
+end
+
+begin
+  raise "some error"
+rescue => error
+  Appsignal.report_error(error)
+end
+```
+
+Read our [Exception handling guide](https://docs.appsignal.com/ruby/instrumentation/exception-handling.html) for more information.

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -309,6 +309,11 @@ module Appsignal
         tags = nil,
         namespace = Appsignal::Transaction::HTTP_REQUEST
       )
+        stdout_and_logger_warning \
+          "The `Appsignal.listen_for_error` helper is deprecated. " \
+            "Please use `rescue => error` and `Appsignal.report_error` instead. " \
+            "Read our exception handling documentation: " \
+            "https://docs.appsignal.com/ruby/instrumentation/exception-handling.html"
         yield
       rescue Exception => error # rubocop:disable Lint/RescueException
         send_error(error) do |transaction|

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -1571,6 +1571,24 @@ describe Appsignal do
     describe ".listen_for_error" do
       around { |example| keep_transactions { example.run } }
 
+      it "prints and logs a deprecation warning" do
+        err_stream = std_stream
+        logs =
+          capture_logs do
+            capture_std_streams(std_stream, err_stream) do
+              Appsignal.listen_for_error do
+                # Do nothing
+              end
+            end
+          end
+        expect(err_stream.read)
+          .to include("appsignal WARNING: The `Appsignal.listen_for_error` helper is deprecated.")
+        expect(logs).to contains_log(
+          :warn,
+          "The `Appsignal.listen_for_error` helper is deprecated."
+        )
+      end
+
       it "records the error and re-raise it" do
         expect do
           expect do


### PR DESCRIPTION
As discussed, remove the `listen_for_error` helper. It doesn't allow for as much customization as `report_error` does. We're not going to add a ton of arguments to `listen_for_error` to allow all kinds of metadata to be set that way. Instead, let's remove it in the next version.

https://appsignal.slack.com/archives/C07BBHJCNP9/p1722354302496879