### PR TITLE
Remove FRONTEND namespace constant

### DIFF
--- a/.changesets/remove--private--appsignal--transaction--frontend-constant.md
+++ b/.changesets/remove--private--appsignal--transaction--frontend-constant.md
@@ -1,0 +1,6 @@
+---
+bump: major
+type: remove
+---
+
+Remove (private) `Appsignal::Transaction::FRONTEND` constant. This was previously used for the built-in front-end integration, but this has been absent since version 3 of the Ruby gem.

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -9,8 +9,6 @@ module Appsignal
     # @api private
     ACTION_CABLE   = "action_cable"
     # @api private
-    FRONTEND       = "frontend"
-    # @api private
     BLANK          = ""
     # @api private
     ALLOWED_TAG_KEY_TYPES = [Symbol, String].freeze


### PR DESCRIPTION
This constant is unused by us since Ruby gem 3, but wasn't removed or marked as private then (only later). Remove it now.

[skip review]