### PR TITLE
Register Rails config defaults using loader

### DIFF
--- a/.changesets/set-rails-config-defaults-for-appsignal-configure.md
+++ b/.changesets/set-rails-config-defaults-for-appsignal-configure.md
@@ -1,0 +1,6 @@
+---
+bump: major
+type: change
+---
+
+Set the Rails config defaults for `Appsignal.configure` when used in a Rails initializer. Now when using `Appsignal.configure` in a Rails initializer, the Rails env and root path are set on the AppSignal config as default values and do not need to be manually set.

--- a/lib/appsignal/integrations/railtie.rb
+++ b/lib/appsignal/integrations/railtie.rb
@@ -27,6 +27,13 @@ module Appsignal
       end
 
       def self.on_load(app)
+        Appsignal::Config.add_loader_defaults(
+          :rails,
+          :root_path => Rails.root,
+          :env => Rails.env,
+          :name => Appsignal::Utils::RailsHelper.detected_rails_app_name,
+          :log_path => Rails.root.join("log")
+        )
         Appsignal::Integrations::Railtie.add_instrumentation_middleware(app)
 
         return unless app.config.appsignal.start_at == :on_load
@@ -39,14 +46,6 @@ module Appsignal
       end
 
       def self.start
-        unless Appsignal.config
-          Appsignal._config = Appsignal::Config.new(
-            Rails.root,
-            Rails.env,
-            :name => Appsignal::Utils::RailsHelper.detected_rails_app_name,
-            :log_path => Rails.root.join("log")
-          )
-        end
         Appsignal.start
         initialize_error_reporter
       end

--- a/lib/appsignal/loaders.rb
+++ b/lib/appsignal/loaders.rb
@@ -85,7 +85,7 @@ module Appsignal
       end
 
       def register_config_defaults(options)
-        Appsignal::Config.add_loader_defaults(self.class.loader_name, options)
+        Appsignal::Config.add_loader_defaults(self.class.loader_name, **options)
       end
     end
   end

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -1,4 +1,81 @@
 describe Appsignal::Config do
+  describe ".add_loader_defaults" do
+    it "adds loader defaults to the list" do
+      described_class.add_loader_defaults(:loader1)
+
+      expect(described_class.loader_defaults).to include(
+        :name => :loader1,
+        :root_path => nil,
+        :env => nil,
+        :options => {}
+      )
+    end
+
+    it "registers multiple loaders in order of registration" do
+      described_class.add_loader_defaults(:loader1)
+      described_class.add_loader_defaults(:loader2)
+
+      expect(described_class.loader_defaults).to eq([
+        {
+          :name => :loader1,
+          :root_path => nil,
+          :env => nil,
+          :options => {}
+        },
+        {
+          :name => :loader2,
+          :root_path => nil,
+          :env => nil,
+          :options => {}
+        }
+      ])
+    end
+
+    it "adds loader with env and root_path" do
+      described_class.add_loader_defaults(
+        :loader1,
+        :root_path => "/some-path",
+        :env => "loader_env1"
+      )
+
+      expect(described_class.loader_defaults).to include(
+        :name => :loader1,
+        :root_path => "/some-path",
+        :env => "loader_env1",
+        :options => {}
+      )
+    end
+
+    it "adds loader with options" do
+      described_class.add_loader_defaults(
+        :loader1,
+        :my_option1 => "some value1",
+        :my_option2 => "some value2"
+      )
+
+      expect(described_class.loader_defaults).to include(
+        :name => :loader1,
+        :root_path => nil,
+        :env => nil,
+        :options => {
+          :my_option1 => "some value1",
+          :my_option2 => "some value2"
+        }
+      )
+    end
+
+    it "does not set any nil options" do
+      described_class.add_loader_defaults(:loader1, :nil_option => nil)
+
+      expect(described_class.loader_defaults).to include(
+        :name => :loader1,
+        :root_path => nil,
+        :env => nil,
+        :options => {}
+      )
+    end
+  end
+
   describe ".determine_env" do
     context "with env argument" do
       before { clear_integration_env_vars! }

--- a/spec/lib/appsignal/loaders/hanami_spec.rb
+++ b/spec/lib/appsignal/loaders/hanami_spec.rb
@@ -4,13 +4,12 @@ if DependencyHelper.hanami_present?
       it "registers Hanami default config" do
         load_loader(:hanami)
 
-        expect(Appsignal::Config.loader_defaults).to include([
-          :hanami,
-          {
-            :env => :test,
-            :root_path => Dir.pwd
-          }
-        ])
+        expect(Appsignal::Config.loader_defaults).to include(
+          :name => :hanami,
+          :root_path => Dir.pwd,
+          :env => :test,
+          :options => {}
+        )
       end
     end
 

--- a/spec/lib/appsignal/loaders/padrino_spec.rb
+++ b/spec/lib/appsignal/loaders/padrino_spec.rb
@@ -4,13 +4,12 @@ if DependencyHelper.padrino_present?
       it "registers Padrino default config" do
         load_loader(:padrino)
 
-        expect(Appsignal::Config.loader_defaults).to include([
-          :padrino,
-          {
-            :env => :test,
-            :root_path => Padrino.mounted_root
-          }
-        ])
+        expect(Appsignal::Config.loader_defaults).to include(
+          :name => :padrino,
+          :root_path => Padrino.mounted_root,
+          :env => :test,
+          :options => {}
+        )
       end
     end
 

--- a/spec/lib/appsignal/loaders/sinatra_spec.rb
+++ b/spec/lib/appsignal/loaders/sinatra_spec.rb
@@ -5,13 +5,12 @@ if DependencyHelper.sinatra_present?
         ::Sinatra::Application.settings.root = "/some/path"
         load_loader(:sinatra)
 
-        expect(Appsignal::Config.loader_defaults).to include([
-          :sinatra,
-          {
-            :env => :test,
-            :root_path => "/some/path"
-          }
-        ])
+        expect(Appsignal::Config.loader_defaults).to include(
+          :name => :sinatra,
+          :root_path => "/some/path",
+          :env => :test,
+          :options => {}
+        )
       end
     end
 

--- a/spec/lib/appsignal/loaders_spec.rb
+++ b/spec/lib/appsignal/loaders_spec.rb
@@ -50,7 +50,14 @@ describe Appsignal::Loaders do
       end
       Appsignal::Loaders.load(:test_loader)
 
-      expect(Appsignal::Config.loader_defaults).to eq([[:test_loader, { :my_option => true }]])
+      expect(Appsignal::Config.loader_defaults).to eq([
+        {
+          :name => :test_loader,
+          :env => nil,
+          :root_path => nil,
+          :options => { :my_option => true }
+        }
+      ])
     end
 
     it "does not load errors that aren't registered" do


### PR DESCRIPTION
## Merge loader config options with default config

Revert the changes in #1214 and make them better.

I want to make the Rails railtie use loader defaults as well, so that it can set config defaults that are also used by any `Appsignal.configure` calls from Rails initializers. Currently we only set the defaults if there is no `Appsignal.configure` call in the Rails initializers.

I have separated the behavior for env, root_path and the config options even more so that the env and root_path can't be overwritten by the loader defaults. The loader env and root_path defaults are only read in the Config.determine_env and Config.determine_root_path helpers.

## Add tests for Config.add_loader_defaults

This method will be called on its own without direct use of a loader in the Rails railtie, so make sure it's tested properly.

## Register Rails config defaults using loader

Have the Rails railtie register its config defaults on load, before any initializers are run.

This way, if someone uses `Appsignal.configure` in a Rails initializer, the AppSignal config will be initialized with the railtie config defaults.

The railtie uses the loaders default config mechanism without using an actual loader. Using a Rails-specific loader here adds very little because the railtie can already be considered a loader. We can directly call the `Config.add_loader_defaults` from the railtie to set the config defaults.

This change also removes one of the few remaining usages of the private `Appsignal._config =` call, which I am working to remove altogether.
