### PR TITLE
Refactor diagnose CLI specs

### DIFF
--- a/spec/support/helpers/api_request_helper.rb
+++ b/spec/support/helpers/api_request_helper.rb
@@ -4,7 +4,7 @@ module ApiRequestHelper
       :query => {
         :api_key => config[:push_api_key],
         :name => config[:name],
-        :environment => config.env,
+        :environment => config.respond_to?(:env) ? config.env : config[:environment],
         :hostname => config[:hostname],
         :gem_version => Appsignal::VERSION
       },


### PR DESCRIPTION
Don't use a Config object in the spec to determine the env, root path and app name. With the auto detection not all present in the config class itself, it's a bit annoying to deal with. I refactored it to a plain Hash with the important bits so it's easier to configure the HTTP requests in different scenarios.


[skip changeset]
[skip review]