### PR TITLE
Include loader and DSL source in diagnose report

### DIFF
--- a/.changesets/include-loaders-and-appsignal-configure-config-options-in-diagnose-report.md
+++ b/.changesets/include-loaders-and-appsignal-configure-config-options-in-diagnose-report.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Include the config options from the loaders config defaults and the `Appsignal.configure` helper in diagnose report. The sources for config option values will include the loaders and `Appsignal.configure` helper in the output and the JSON report sent to our severs, when opted-in.

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -473,10 +473,12 @@ module Appsignal
             :sources => {
               :default => Appsignal::Config::DEFAULT_CONFIG,
               :system => config.system_config,
+              :loaders => config.loaders_config,
               :initial => config.initial_config,
               :file => config.file_config,
               :env => config.env_config,
-              :override => config.override_config
+              :override => config.override_config,
+              :dsl => config.dsl_config
             }
           }
           print_config_options(config)

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -204,8 +204,8 @@ module Appsignal
 
     # @api private
     attr_accessor :root_path, :env, :config_hash
-    attr_reader :system_config, :initial_config, :file_config, :env_config,
-      :override_config, :dsl_config
+    attr_reader :system_config, :loaders_config, :initial_config, :file_config,
+      :env_config, :override_config, :dsl_config
     # @api private
     attr_accessor :logger
 
@@ -249,6 +249,7 @@ module Appsignal
       @env = initial_env.to_s
       @config_hash = {}
       @system_config = {}
+      @loaders_config = {}
       @initial_config = initial_config
       @file_config = {}
       @env_config = {}
@@ -279,6 +280,10 @@ module Appsignal
       # loader's defaults overwrite all others
       self.class.loader_defaults.reverse.each do |loader_defaults|
         defaults = loader_defaults[:options]
+        @loaders_config.merge!(defaults.merge(
+          :root_path => loader_defaults[:root_path],
+          :env => loader_defaults[:env]
+        ))
         merge(defaults)
       end
 

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -794,10 +794,12 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
             "sources" => {
               "default" => default_config,
               "system" => {},
+              "loaders" => {},
               "initial" => { "env" => "" },
               "file" => {},
               "env" => {},
-              "override" => {}
+              "override" => {},
+              "dsl" => {}
             }
           )
         end
@@ -954,10 +956,12 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
             "sources" => {
               "default" => hash_with_string_keys(Appsignal::Config::DEFAULT_CONFIG),
               "system" => {},
+              "loaders" => {},
               "initial" => hash_with_string_keys(Appsignal.config.initial_config),
               "file" => hash_with_string_keys(Appsignal.config.file_config),
               "env" => {},
-              "override" => {}
+              "override" => {},
+              "dsl" => {}
             }
           )
         end
@@ -986,10 +990,12 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
             "sources" => {
               "default" => hash_with_string_keys(Appsignal::Config::DEFAULT_CONFIG),
               "system" => {},
+              "loaders" => {},
               "initial" => hash_with_string_keys(Appsignal.config.initial_config),
               "file" => hash_with_string_keys(Appsignal.config.file_config),
               "env" => {},
-              "override" => {}
+              "override" => {},
+              "dsl" => {}
             }
           )
         end


### PR DESCRIPTION
Show all sources for config in the diagnose report. I didn't add this in the PRs that added the loaders and DSL config, because no part of the diagnose command would load code that can modify these sources. Now I'm working on loading a Rails app in the diagnose command, so it's good to include these sources for when we also want to include the config from the Rails app.

[skip review]