### PR TITLE
A couple test suite refactors

### DIFF
--- a/spec/lib/appsignal/cli/demo_spec.rb
+++ b/spec/lib/appsignal/cli/demo_spec.rb
@@ -7,12 +7,6 @@ describe Appsignal::CLI::Demo do
   let(:out_stream) { std_stream }
   let(:output) { out_stream.read }
   before(:context) { Appsignal.stop }
-  before do
-    ENV.delete("APPSIGNAL_APP_ENV")
-    ENV.delete("RAILS_ENV")
-    ENV.delete("RACK_ENV")
-    stub_api_request config, "auth"
-  end
 
   def run
     run_within_dir project_fixture_path
@@ -25,8 +19,6 @@ describe Appsignal::CLI::Demo do
   end
 
   context "without configuration" do
-    let(:config) { Appsignal::Config.new("development", tmp_dir) }
-
     it "returns an error" do
       expect { run_within_dir tmp_dir }.to raise_error(SystemExit)
 
@@ -35,32 +27,20 @@ describe Appsignal::CLI::Demo do
   end
 
   context "with configuration" do
-    let(:config) { project_fixture_config }
     before do
       # Ignore sleeps to speed up the test
       allow(Appsignal::Demo).to receive(:sleep)
     end
+    let(:options) { { :environment => "development" } }
 
-    context "without environment" do
-      it "returns an error" do
-        expect { run_within_dir tmp_dir }.to raise_error(SystemExit)
-
-        expect(output).to include("Error: Unable to start the AppSignal agent")
-      end
+    it "calls Appsignal::Demo transmitter" do
+      expect(Appsignal::Demo).to receive(:transmit).and_return(true)
+      run
     end
 
-    context "with environment" do
-      let(:options) { { :environment => "development" } }
-
-      it "calls Appsignal::Demo transmitter" do
-        expect(Appsignal::Demo).to receive(:transmit).and_return(true)
-        run
-      end
-
-      it "outputs message" do
-        run
-        expect(output).to include("Demonstration sample data sent!")
-      end
+    it "outputs message" do
+      run
+      expect(output).to include("Demonstration sample data sent!")
     end
   end
 end

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -622,9 +622,7 @@ describe Appsignal::Config do
     let(:config) do
       described_class.new(
         "non-existing-path",
-        "production",
-        :running_in_container => true,
-        :debug => true
+        "production"
       )
     end
     let(:working_directory_path) { File.join(tmp_dir, "test_working_directory_path") }
@@ -787,12 +785,12 @@ describe Appsignal::Config do
 
     context "with mixed case `true` env variables values" do
       before do
-        ENV["APPSIGNAL_DEBUG"] = "TRUE"
+        ENV["APPSIGNAL_ENABLE_RAKE_PERFORMANCE_INSTRUMENTATION"] = "TRUE"
         ENV["APPSIGNAL_INSTRUMENT_SEQUEL"] = "True"
       end
 
       it "accepts mixed case `true` values" do
-        expect(config[:debug]).to eq(true)
+        expect(config[:enable_rake_performance_instrumentation]).to eq(true)
         expect(config[:instrument_sequel]).to eq(true)
       end
     end

--- a/spec/lib/appsignal/hooks/activejob_spec.rb
+++ b/spec/lib/appsignal/hooks/activejob_spec.rb
@@ -34,7 +34,6 @@ if DependencyHelper.active_job_present?
     let(:time) { Time.parse("2001-01-01 10:00:00UTC") }
     let(:namespace) { Appsignal::Transaction::BACKGROUND_JOB }
     let(:queue) { "default" }
-    let(:log) { StringIO.new }
     let(:parameterized_given_args) do
       {
         :foo => "Foo",
@@ -77,7 +76,6 @@ if DependencyHelper.active_job_present?
       ActiveJob::Base.queue_adapter = :inline
 
       start_agent(:options => options)
-      Appsignal.internal_logger = test_logger(log)
       class ActiveJobTestJob < ActiveJob::Base
         def perform(*_args)
         end

--- a/spec/lib/appsignal/rack/event_handler_spec.rb
+++ b/spec/lib/appsignal/rack/event_handler_spec.rb
@@ -13,7 +13,7 @@ describe Appsignal::Rack::EventHandler do
   let(:request) { Rack::Request.new(env) }
   let(:response) { nil }
   let(:log_stream) { StringIO.new }
-  let(:log) { log_contents(log_stream) }
+  let(:logs) { log_contents(log_stream) }
   let(:event_handler_instance) { described_class.new }
   let(:appsignal_env) { :default }
   before do
@@ -96,7 +96,7 @@ describe Appsignal::Rack::EventHandler do
       end
 
       it "logs an error" do
-        expect(log).to contains_log(
+        expect(logs).to contains_log(
           :error,
           "Error occurred in Appsignal::Rack::EventHandler's after_reply: " \
             "ExampleStandardError: oh no"
@@ -113,7 +113,7 @@ describe Appsignal::Rack::EventHandler do
       callback = request.env[Appsignal::Rack::RACK_AFTER_REPLY].first
       callback.call
 
-      expect(log).to contains_log(
+      expect(logs).to contains_log(
         :error,
         "Error occurred in Appsignal::Rack::EventHandler's after_reply: ExampleStandardError: oh no"
       )
@@ -125,7 +125,7 @@ describe Appsignal::Rack::EventHandler do
 
       on_start
 
-      expect(log).to contains_log(
+      expect(logs).to contains_log(
         :error,
         "Error occurred in Appsignal::Rack::EventHandler#on_start: ExampleStandardError: oh no"
       )
@@ -168,7 +168,7 @@ describe Appsignal::Rack::EventHandler do
 
       on_error(ExampleStandardError.new("the error"))
 
-      expect(log).to contains_log(
+      expect(logs).to contains_log(
         :error,
         "Error occurred in Appsignal::Rack::EventHandler#on_error: ExampleStandardError: oh no"
       )
@@ -354,8 +354,10 @@ describe Appsignal::Rack::EventHandler do
       end
 
       it "logs an error" do
-        expect(log).to contains_log(:error,
-          "Error occurred in Appsignal::Rack::EventHandler#on_finish: ExampleStandardError: oh no")
+        expect(logs).to contains_log(
+          :error,
+          "Error occurred in Appsignal::Rack::EventHandler#on_finish: ExampleStandardError: oh no"
+        )
       end
     end
 
@@ -430,7 +432,7 @@ describe Appsignal::Rack::EventHandler do
       on_start
       on_finish
 
-      expect(log).to contains_log(
+      expect(logs).to contains_log(
         :error,
         "Error occurred in Appsignal::Rack::EventHandler#on_finish: ExampleStandardError: oh no"
       )

--- a/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
+++ b/spec/lib/appsignal/rack/rails_instrumentation_spec.rb
@@ -2,7 +2,6 @@ if DependencyHelper.rails_present?
   describe Appsignal::Rack::RailsInstrumentation do
     class MockController; end
 
-    let(:log) { StringIO.new }
     let(:transaction) { new_transaction }
     let(:app) { DummyApp.new }
     let(:params) do
@@ -30,7 +29,6 @@ if DependencyHelper.rails_present?
     around { |example| keep_transactions { example.run } }
     before do
       start_agent
-      Appsignal.internal_logger = test_logger(log)
       env[Appsignal::Rack::APPSIGNAL_TRANSACTION] = transaction
     end
 
@@ -105,10 +103,10 @@ if DependencyHelper.rails_present?
       it "does not store the invalid HTTP request method" do
         env[:request_method] = "FOO"
         env["REQUEST_METHOD"] = "FOO"
-        make_request
+        logs = capture_logs { make_request }
 
         expect(last_transaction).to_not include_metadata("method" => anything)
-        expect(log_contents(log)).to contains_log(
+        expect(logs).to contains_log(
           :error,
           "Exception while fetching the HTTP request method: "
         )

--- a/spec/support/helpers/log_helpers.rb
+++ b/spec/support/helpers/log_helpers.rb
@@ -8,6 +8,7 @@ module LogHelpers
   def use_logger_with(log)
     Appsignal.internal_logger = test_logger(log)
     yield
+  ensure
     Appsignal.internal_logger = nil
   end
 


### PR DESCRIPTION
## Small spec refactor for logs

Use the log helpers in more scenarios were possible.

## Clean up Demo CLI spec

- Remove duplicate spec.
- Remove config setup that's unused.

## Update spec using outdated config option

Remove the debug config option. Not sure why running_in_container was set this way, but it's also set in the ENV, which is what the spec is about.

---

[skip changeset]
[skip review]
