### PR TITLE
Remove Appsignal._config= writer

### DIFF
--- a/.changesets/remove-appsignal-config--writer.md
+++ b/.changesets/remove-appsignal-config--writer.md
@@ -1,0 +1,6 @@
+---
+bump: major
+type: remove
+---
+
+Remove the `Appsignal.config=` writer. Use the `Appsignal.configure` helper to configure AppSignal.

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -36,16 +36,6 @@ module Appsignal
     # @see Config
     attr_reader :config
 
-    # @api private
-    def _config=(conf)
-      if started?
-        internal_logger.warn("Ignoring `Appsignal._config=` call after AppSignal has started")
-        return
-      end
-
-      @config = conf
-    end
-
     # Accessor for toggle if the AppSignal C-extension is loaded.
     #
     # Can be `nil` if extension has not been loaded yet. See

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -243,7 +243,6 @@ module Appsignal
         @config = Config.new(
           root_path || Config.determine_root_path,
           Config.determine_env(env),
-          {},
           Appsignal.internal_logger
         )
       end

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -244,7 +244,6 @@ module Appsignal
           Config.determine_env(env),
           {},
           Appsignal.internal_logger,
-          nil,
           false
         )
         config.load_config

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -111,7 +111,7 @@ module Appsignal
 
       internal_logger.debug("Loading AppSignal gem")
 
-      @config ||= Config.new(Config.determine_root_path, Config.determine_env)
+      @config ||= Config.new(Config.determine_root_path, Config.determine_env).tap(&:validate)
 
       _start_logger
 
@@ -243,10 +243,8 @@ module Appsignal
           root_path || Config.determine_root_path,
           Config.determine_env(env),
           {},
-          Appsignal.internal_logger,
-          false
+          Appsignal.internal_logger
         )
-        config.load_config
       end
 
       config_dsl = Appsignal::Config::ConfigDSL.new(config)

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -111,7 +111,8 @@ module Appsignal
 
       internal_logger.debug("Loading AppSignal gem")
 
-      @config ||= Config.new(Config.determine_root_path, Config.determine_env).tap(&:validate)
+      @config ||= Config.new(Config.determine_root_path, Config.determine_env)
+      @config.validate
 
       _start_logger
 
@@ -248,11 +249,10 @@ module Appsignal
       end
 
       config_dsl = Appsignal::Config::ConfigDSL.new(config)
-      if block_given?
-        yield config_dsl
-        config.merge_dsl_options(config_dsl.dsl_options)
-      end
-      config.validate
+      return unless block_given?
+
+      yield config_dsl
+      config.merge_dsl_options(config_dsl.dsl_options)
     end
 
     def forked

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -231,12 +231,11 @@ module Appsignal
     #   Configuration load order
     # @see https://docs.appsignal.com/ruby/instrumentation/integrating-appsignal.html
     #   How to integrate AppSignal manually
-    def initialize( # rubocop:disable Metrics/ParameterLists
+    def initialize(
       root_path,
       initial_env,
       initial_config = {},
       logger = Appsignal.internal_logger,
-      config_file = nil,
       load_on_new = true # rubocop:disable Style/OptionalBooleanParameter
     )
       @root_path = root_path

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -235,8 +235,7 @@ module Appsignal
       root_path,
       initial_env,
       initial_config = {},
-      logger = Appsignal.internal_logger,
-      load_on_new = true # rubocop:disable Style/OptionalBooleanParameter
+      logger = Appsignal.internal_logger
     )
       @root_path = root_path
       @config_file_error = false
@@ -255,10 +254,7 @@ module Appsignal
       @override_config = {}
       @dsl_config = {} # Can be set using `Appsignal.configure`
 
-      return unless load_on_new
-
       load_config
-      validate
     end
 
     # @api private

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -178,11 +178,6 @@ module Appsignal
     #   Used in diagnose report.
     #   @api private
     #   @return [Hash]
-    # @!attribute [r] initial_config
-    #   Config detected on the system level.
-    #   Used in diagnose report.
-    #   @api private
-    #   @return [Hash]
     # @!attribute [r] file_config
     #   Config loaded from `config/appsignal.yml` config file.
     #   Used in diagnose report.
@@ -195,8 +190,8 @@ module Appsignal
     #   @return [Hash]
     # @!attribute [r] config_hash
     #   Config used by the AppSignal gem.
-    #   Combined Hash of the {system_config}, {initial_config}, {file_config},
-    #   {env_config} attributes.
+    #   Combined Hash of the {system_config}, {file_config}, {env_config}
+    #   attributes.
     #   @see #[]
     #   @see #[]=
     #   @api private
@@ -215,9 +210,6 @@ module Appsignal
     # @param initial_env [String] The environment to load when AppSignal is started. It
     #   will look for an environment with this name in the `config/appsignal.yml`
     #   config file.
-    # @param initial_config [Hash<String, Object>] The initial configuration to
-    #   use. This will be overwritten by the file config and environment
-    #   variables config.
     # @param logger [Logger] The logger to use for the AppSignal gem. This is
     #   used by the configuration class only. Default:
     #   {Appsignal.internal_logger}. See also {Appsignal.start}.
@@ -234,7 +226,6 @@ module Appsignal
     def initialize(
       root_path,
       initial_env,
-      initial_config = {},
       logger = Appsignal.internal_logger
     )
       @root_path = root_path
@@ -248,7 +239,7 @@ module Appsignal
       @config_hash = {}
       @system_config = {}
       @loaders_config = {}
-      @initial_config = initial_config
+      @initial_config = {}
       @file_config = {}
       @env_config = {}
       @override_config = {}
@@ -278,8 +269,6 @@ module Appsignal
         merge(defaults)
       end
 
-      # Merge initial config
-      merge(initial_config)
       # Track origin of env
       @initial_config[:env] = @initial_env.to_s
 

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -293,10 +293,6 @@ module Appsignal
       # Track origin of env
       env_loaded_from_env = ENV.fetch("APPSIGNAL_APP_ENV", nil)
       @env_config[:env] = env_loaded_from_env if env_loaded_from_env
-
-      # Load config overrides
-      @override_config = determine_overrides
-      merge(override_config)
     end
 
     # @api private
@@ -419,6 +415,10 @@ module Appsignal
 
     # @api private
     def validate
+      # Apply any overrides for invalid settings.
+      @override_config = determine_overrides
+      merge(override_config)
+
       # Strip path from endpoint so we're backwards compatible with
       # earlier versions of the gem.
       # TODO: Move to its own method, maybe in `#[]=`?

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -257,10 +257,6 @@ module Appsignal
 
       return unless load_on_new
 
-      # Always override environment if set via this env var.
-      # TODO: This is legacy behavior. In the `Appsignal.configure` method the
-      # env argument is leading.
-      @env = ENV["APPSIGNAL_APP_ENV"] if ENV.key?("APPSIGNAL_APP_ENV")
       load_config
       validate
     end

--- a/lib/appsignal/integrations/capistrano/appsignal.cap
+++ b/lib/appsignal/integrations/capistrano/appsignal.cap
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Capistrano 3 integration
 namespace :appsignal do
   task :deploy do
     appsignal_env = fetch(:appsignal_env,
@@ -13,9 +14,7 @@ namespace :appsignal do
       {},
       Logger.new(StringIO.new)
     ).tap do |c|
-      fetch(:appsignal_config, {}).each do |key, value|
-        c[key] = value
-      end
+      c.merge_dsl_options(fetch(:appsignal_config, {}))
       c.validate
     end
 

--- a/lib/appsignal/integrations/capistrano/appsignal.cap
+++ b/lib/appsignal/integrations/capistrano/appsignal.cap
@@ -11,7 +11,6 @@ namespace :appsignal do
     appsignal_config = Appsignal::Config.new(
       Dir.pwd,
       appsignal_env,
-      {},
       Logger.new(StringIO.new)
     ).tap do |c|
       c.merge_dsl_options(fetch(:appsignal_config, {}))

--- a/lib/appsignal/integrations/capistrano/capistrano_2_tasks.rb
+++ b/lib/appsignal/integrations/capistrano/capistrano_2_tasks.rb
@@ -22,9 +22,7 @@ module Appsignal
                 {},
                 Appsignal::Utils::IntegrationLogger.new(StringIO.new)
               ).tap do |c|
-                fetch(:appsignal_config, {}).each do |key, value|
-                  c[key] = value
-                end
+                c.merge_dsl_options(fetch(:appsignal_config, {}))
                 c.validate
               end
 

--- a/lib/appsignal/integrations/capistrano/capistrano_2_tasks.rb
+++ b/lib/appsignal/integrations/capistrano/capistrano_2_tasks.rb
@@ -19,7 +19,6 @@ module Appsignal
               appsignal_config = Appsignal::Config.new(
                 ENV.fetch("PWD", nil),
                 env,
-                {},
                 Appsignal::Utils::IntegrationLogger.new(StringIO.new)
               ).tap do |c|
                 c.merge_dsl_options(fetch(:appsignal_config, {}))

--- a/spec/lib/appsignal/auth_check_spec.rb
+++ b/spec/lib/appsignal/auth_check_spec.rb
@@ -1,5 +1,5 @@
 describe Appsignal::AuthCheck do
-  let(:config) { project_fixture_config }
+  let(:config) { build_config }
   let(:auth_check) { Appsignal::AuthCheck.new(config) }
   let(:auth_url) do
     query = build_uri_query_string(

--- a/spec/lib/appsignal/capistrano2_spec.rb
+++ b/spec/lib/appsignal/capistrano2_spec.rb
@@ -6,7 +6,7 @@ if DependencyHelper.capistrano2_present?
   describe "Capistrano 2 integration" do
     let(:out_stream) { std_stream }
     let(:output) { out_stream.read }
-    let(:config) { project_fixture_config }
+    let(:config) { build_config }
     let(:capistrano_config) do
       Capistrano::Configuration.new.tap do |c|
         c.set(:rails_env, "production")

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -770,63 +770,6 @@ describe Appsignal::Config do
     end
   end
 
-  describe "with config based on overrides" do
-    let(:config) do
-      described_class.new(Dir.pwd, "production", config_options)
-    end
-
-    if DependencyHelper.rails_present?
-      require "active_job"
-
-      context "activejob_report_errors" do
-        let(:config_options) { { :activejob_report_errors => "discard" } }
-
-        if DependencyHelper.rails_version >= Gem::Version.new("7.1.0")
-          context "when Active Job >= 7.1 and 'discard'" do
-            it "does not override the activejob_report_errors value" do
-              expect(config[:activejob_report_errors]).to eq("discard")
-              expect(config.override_config[:activejob_report_errors]).to be_nil
-            end
-          end
-        else
-          context "when Active Job < 7.1 and 'discard'" do
-            it "sets activejob_report_errors to 'all'" do
-              expect(config[:activejob_report_errors]).to eq("all")
-              expect(config.override_config[:activejob_report_errors]).to eq("all")
-            end
-          end
-        end
-      end
-    end
-
-    context "sidekiq_report_errors" do
-      let(:config_options) { { :sidekiq_report_errors => "discard" } }
-      before do
-        if Appsignal::Hooks::SidekiqHook.instance_variable_defined?(:@version_5_1_or_higher)
-          Appsignal::Hooks::SidekiqHook.remove_instance_variable(:@version_5_1_or_higher)
-        end
-      end
-
-      context "when Sidekiq >= 5.1 and 'discard'" do
-        before { stub_const("Sidekiq::VERSION", "5.1.0") }
-
-        it "does not override the sidekiq_report_errors value" do
-          expect(config[:sidekiq_report_errors]).to eq("discard")
-          expect(config.override_config[:sidekiq_report_errors]).to be_nil
-        end
-      end
-
-      context "when Sidekiq < 5.1 and 'discard'" do
-        before { stub_const("Sidekiq::VERSION", "5.0.0") }
-
-        it "sets sidekiq_report_errors to 'all'" do
-          expect(config[:sidekiq_report_errors]).to eq("all")
-          expect(config.override_config[:sidekiq_report_errors]).to eq("all")
-        end
-      end
-    end
-  end
-
   describe "config keys" do
     describe ":endpoint" do
       subject { config[:endpoint] }
@@ -1195,6 +1138,57 @@ describe Appsignal::Config do
     subject { config.valid? }
     let(:config) do
       described_class.new(Dir.pwd, "production", config_options)
+    end
+
+    if DependencyHelper.rails_present?
+      require "active_job"
+
+      context "activejob_report_errors" do
+        let(:config_options) { { :activejob_report_errors => "discard" } }
+
+        if DependencyHelper.rails_version >= Gem::Version.new("7.1.0")
+          context "when Active Job >= 7.1 and 'discard'" do
+            it "does not override the activejob_report_errors value" do
+              expect(config[:activejob_report_errors]).to eq("discard")
+              expect(config.override_config[:activejob_report_errors]).to be_nil
+            end
+          end
+        else
+          context "when Active Job < 7.1 and 'discard'" do
+            it "sets activejob_report_errors to 'all'" do
+              expect(config[:activejob_report_errors]).to eq("all")
+              expect(config.override_config[:activejob_report_errors]).to eq("all")
+            end
+          end
+        end
+      end
+    end
+
+    context "sidekiq_report_errors" do
+      let(:config_options) { { :sidekiq_report_errors => "discard" } }
+      before do
+        if Appsignal::Hooks::SidekiqHook.instance_variable_defined?(:@version_5_1_or_higher)
+          Appsignal::Hooks::SidekiqHook.remove_instance_variable(:@version_5_1_or_higher)
+        end
+      end
+
+      context "when Sidekiq >= 5.1 and 'discard'" do
+        before { stub_const("Sidekiq::VERSION", "5.1.0") }
+
+        it "does not override the sidekiq_report_errors value" do
+          expect(config[:sidekiq_report_errors]).to eq("discard")
+          expect(config.override_config[:sidekiq_report_errors]).to be_nil
+        end
+      end
+
+      context "when Sidekiq < 5.1 and 'discard'" do
+        before { stub_const("Sidekiq::VERSION", "5.0.0") }
+
+        it "sets sidekiq_report_errors to 'all'" do
+          expect(config[:sidekiq_report_errors]).to eq("all")
+          expect(config.override_config[:sidekiq_report_errors]).to eq("all")
+        end
+      end
     end
 
     describe "push_api_key" do

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -593,7 +593,7 @@ describe Appsignal::Config do
       described_class.new(
         "non-existing-path",
         "production"
-      )
+      ).tap(&:validate)
     end
     let(:working_directory_path) { File.join(tmp_dir, "test_working_directory_path") }
     let(:env_config) do

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -203,15 +203,8 @@ describe Appsignal::Config do
           let(:env_env) { "my_env_env" }
           before { ENV["APPSIGNAL_APP_ENV"] = env_env }
 
-          it "uses the environment variable" do
-            expect(config.env).to eq(env_env)
-          end
-
           it "sets the environment as loaded through the env_config" do
-            expect(config.initial_config).to eq(:env => env)
             expect(config.env_config).to eq(:env => env_env)
-            expect(config.config_hash).to_not have_key(:env)
-            expect(config.config_hash).to_not have_key(:root_path)
           end
         end
       end

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -212,7 +212,7 @@ describe Appsignal::Config do
   end
 
   describe "config based on the system" do
-    let(:config) { silence { project_fixture_config(:none) } }
+    let(:config) { silence { build_config(:env => :none) } }
 
     describe ":active" do
       subject { config[:active] }
@@ -488,7 +488,7 @@ describe Appsignal::Config do
   end
 
   context "with a config file" do
-    let(:config) { project_fixture_config("production") }
+    let(:config) { build_config(:env => "production") }
 
     context "with valid config" do
       it "is valid and active" do
@@ -560,7 +560,7 @@ describe Appsignal::Config do
     end
 
     context "with the env name as a symbol" do
-      let(:config) { project_fixture_config(:production) }
+      let(:config) { build_config(:env => :production) }
 
       it "loads the config" do
         expect(config.valid?).to be_truthy
@@ -571,7 +571,7 @@ describe Appsignal::Config do
     end
 
     context "without the selected env" do
-      let(:config) { project_fixture_config("nonsense") }
+      let(:config) { build_config(:env => :nonsense) }
 
       it "is not valid or active" do
         expect(config.valid?).to be_falsy
@@ -771,13 +771,13 @@ describe Appsignal::Config do
   end
 
   describe "config keys" do
+    let(:config) { build_config(:options => options) }
+
     describe ":endpoint" do
       subject { config[:endpoint] }
 
       context "with an pre-0.12-style endpoint" do
-        let(:config) do
-          project_fixture_config("production", :endpoint => "https://push.appsignal.com/1")
-        end
+        let(:options) { { :endpoint => "https://push.appsignal.com/1" } }
 
         it "strips off the path" do
           expect(subject).to eq "https://push.appsignal.com"
@@ -785,7 +785,7 @@ describe Appsignal::Config do
       end
 
       context "with a non-standard port" do
-        let(:config) { project_fixture_config("production", :endpoint => "http://localhost:4567") }
+        let(:options) { { :endpoint => "http://localhost:4567" } }
 
         it "keeps the port" do
           expect(subject).to eq "http://localhost:4567"
@@ -797,7 +797,7 @@ describe Appsignal::Config do
       subject { config[:logging_endpoint] }
 
       context "with a non-standard port" do
-        let(:config) { project_fixture_config("production", :logging_endpoint => "http://localhost:4567") }
+        let(:options) { { :logging_endpoint => "http://localhost:4567" } }
 
         it "keeps the port" do
           expect(subject).to eq "http://localhost:4567"
@@ -807,7 +807,9 @@ describe Appsignal::Config do
   end
 
   describe "#[]" do
-    let(:config) { project_fixture_config(:none, :push_api_key => "foo", :request_headers => []) }
+    let(:config) do
+      build_config(:env => :none, :options => { :push_api_key => "foo", :request_headers => [] })
+    end
 
     context "with existing key" do
       it "gets the value" do
@@ -823,7 +825,7 @@ describe Appsignal::Config do
   end
 
   describe "#[]=" do
-    let(:config) { project_fixture_config(:none) }
+    let(:config) { build_config(:env => :none) }
 
     context "with existing key" do
       it "changes the value" do
@@ -843,7 +845,7 @@ describe Appsignal::Config do
   end
 
   describe "#write_to_environment" do
-    let(:config) { project_fixture_config(:production) }
+    let(:config) { build_config }
     before do
       config[:bind_address] = "0.0.0.0"
       config[:cpu_count] = 1.5
@@ -951,7 +953,7 @@ describe Appsignal::Config do
   describe "#log_file_path" do
     let(:out_stream) { std_stream }
     let(:output) { out_stream.read }
-    let(:config) { project_fixture_config("production", :log_path => log_path) }
+    let(:config) { build_config(:options => { :log_path => log_path }) }
 
     def log_file_path
       capture_stdout(out_stream) { config.log_file_path }
@@ -1137,7 +1139,7 @@ describe Appsignal::Config do
   describe "#validate" do
     subject { config.valid? }
     let(:config) do
-      described_class.new(Dir.pwd, "production", config_options)
+      build_config(:root_path => Dir.pwd, :env => "production", :options => config_options)
     end
 
     if DependencyHelper.rails_present?
@@ -1231,7 +1233,7 @@ describe Appsignal::Config do
 
   describe "#log_level" do
     let(:options) { {} }
-    let(:config) { described_class.new("", nil, options) }
+    let(:config) { build_config(:root_path => "", :env => nil, :options => options) }
     subject { config.log_level }
 
     context "without any config" do
@@ -1292,7 +1294,7 @@ describe Appsignal::Config do
 
   describe Appsignal::Config::ConfigDSL do
     let(:env) { :production }
-    let(:config) { project_fixture_config(env) }
+    let(:config) { build_config(:env => env) }
     let(:dsl) { described_class.new(config) }
 
     describe "default options" do

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -509,29 +509,6 @@ describe Appsignal::Config do
       end
     end
 
-    context "with an overridden config file" do
-      let(:config) do
-        project_fixture_config("production", {}, Appsignal.internal_logger,
-          File.join(project_fixture_path, "config", "appsignal.yml"))
-      end
-
-      it "is valid and active" do
-        expect(config.valid?).to be_truthy
-        expect(config.active?).to be_truthy
-      end
-
-      context "with an invalid overridden config file" do
-        let(:config) do
-          project_fixture_config("production", {}, Appsignal.internal_logger,
-            File.join(project_fixture_path, "config", "missing.yml"))
-        end
-
-        it "is not valid" do
-          expect(config.valid?).to be_falsy
-        end
-      end
-    end
-
     context "with the config file causing an error" do
       let(:config_path) do
         File.expand_path(

--- a/spec/lib/appsignal/extension_spec.rb
+++ b/spec/lib/appsignal/extension_spec.rb
@@ -49,7 +49,7 @@ describe Appsignal::Extension do
 
     context "with a valid config" do
       before do
-        project_fixture_config.write_to_environment
+        build_config.write_to_environment
       end
 
       it "should have a start and stop method" do

--- a/spec/lib/appsignal/marker_spec.rb
+++ b/spec/lib/appsignal/marker_spec.rb
@@ -1,5 +1,5 @@
 describe Appsignal::Marker do
-  let(:config) { project_fixture_config }
+  let(:config) { build_config }
   let(:marker) do
     described_class.new(
       {

--- a/spec/lib/appsignal/transmitter_spec.rb
+++ b/spec/lib/appsignal/transmitter_spec.rb
@@ -1,12 +1,10 @@
 describe Appsignal::Transmitter do
-  let(:config) { project_fixture_config }
+  let(:config) do
+    build_config(:options => { :hostname => "app1.local" }, :logger => Logger.new(log))
+  end
   let(:base_uri) { "action" }
   let(:log) { StringIO.new }
   let(:instance) { Appsignal::Transmitter.new(base_uri, config) }
-  before do
-    config.config_hash[:hostname] = "app1.local"
-    config.logger = Logger.new(log)
-  end
 
   describe "#uri" do
     let(:uri) { instance.uri }
@@ -123,7 +121,7 @@ describe Appsignal::Transmitter do
     subject { instance.send(:http_client) }
 
     context "with a http uri" do
-      let(:config) { project_fixture_config("test") }
+      let(:config) { build_config(:env => :test) }
 
       it { expect(subject).to be_instance_of(Net::HTTP) }
       it { expect(subject.proxy?).to be_falsy }
@@ -131,7 +129,7 @@ describe Appsignal::Transmitter do
     end
 
     context "with a https uri" do
-      let(:config) { project_fixture_config("production") }
+      let(:config) { build_config(:env => :production) }
 
       it { expect(subject).to be_instance_of(Net::HTTP) }
       it { expect(subject.proxy?).to be_falsy }
@@ -141,7 +139,7 @@ describe Appsignal::Transmitter do
     end
 
     context "with a proxy" do
-      let(:config) { project_fixture_config("production", :http_proxy => "http://localhost:8080") }
+      let(:config) { build_config(:options => { :http_proxy => "http://localhost:8080" }) }
 
       it "is of Net::HTTP class" do
         expect(subject).to be_instance_of(Net::HTTP)

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -4,45 +4,6 @@ describe Appsignal do
 
   let(:transaction) { http_request_transaction }
 
-  describe "._config=" do
-    it "sets the config" do
-      config = project_fixture_config
-      expect(Appsignal.internal_logger).to_not receive(:level=)
-
-      Appsignal._config = config
-      expect(Appsignal.config).to eq config
-    end
-
-    context "when already started" do
-      it "doesn't set the config" do
-        Appsignal._config = Appsignal::Config.new(
-          "/first/path", "first env",
-          :active => true,
-          :push_api_key => "something"
-        )
-        Appsignal.start
-        expect(Appsignal.config.env).to eq("first env")
-        expect(Appsignal.config.root_path).to eq("/first/path")
-
-        logs =
-          capture_logs do
-            Appsignal._config = Appsignal::Config.new(
-              "/other/path", "other env",
-              :active => true,
-              :push_api_key => "something"
-            )
-          end
-        Appsignal.start
-        expect(Appsignal.config.env).to eq("first env")
-        expect(Appsignal.config.root_path).to eq("/first/path")
-        expect(logs).to contains_log(
-          :warn,
-          "Ignoring `Appsignal._config=` call after AppSignal has started"
-        )
-      end
-    end
-  end
-
   describe ".configure" do
     context "when active" do
       it "doesn't update the config" do
@@ -73,11 +34,9 @@ describe Appsignal do
 
     context "with config but not started" do
       it "reuses the already loaded config if no env arg is given" do
-        Appsignal._config = Appsignal::Config.new(
-          project_fixture_path,
-          :my_env,
-          :ignore_actions => ["My action"]
-        )
+        Appsignal.configure(:my_env, :root_path => project_fixture_path) do |config|
+          config.ignore_actions = ["My action"]
+        end
 
         Appsignal.configure do |config|
           expect(config.env).to eq("my_env")
@@ -95,11 +54,9 @@ describe Appsignal do
       end
 
       it "reuses the already loaded config if the env is the same" do
-        Appsignal._config = Appsignal::Config.new(
-          project_fixture_path,
-          :my_env,
-          :ignore_actions => ["My action"]
-        )
+        Appsignal.configure(:my_env, :root_path => project_fixture_path) do |config|
+          config.ignore_actions = ["My action"]
+        end
 
         Appsignal.configure(:my_env) do |config|
           expect(config.ignore_actions).to eq(["My action"])
@@ -115,13 +72,11 @@ describe Appsignal do
       end
 
       it "loads a new config if the env is not the same" do
-        Appsignal._config = Appsignal::Config.new(
-          project_fixture_path,
-          :my_env,
-          :name => "Some name",
-          :push_api_key => "Some key",
-          :ignore_actions => ["My action"]
-        )
+        Appsignal.configure(:my_env, :root_path => project_fixture_path) do |config|
+          config.name = "Some name"
+          config.push_api_key = "Some key"
+          config.ignore_actions = ["My action"]
+        end
 
         Appsignal.configure(:my_env2) do |config|
           expect(config.ignore_actions).to be_empty
@@ -137,13 +92,11 @@ describe Appsignal do
       end
 
       it "loads a new config if the path is not the same" do
-        Appsignal._config = Appsignal::Config.new(
-          "/some/path",
-          :my_env,
-          :name => "Some name",
-          :push_api_key => "Some key",
-          :ignore_actions => ["My action"]
-        )
+        Appsignal.configure(:my_env, :root_path => "/some/path") do |config|
+          config.name = "Some name"
+          config.push_api_key = "Some key"
+          config.ignore_actions = ["My action"]
+        end
 
         Appsignal.configure(:my_env, :root_path => project_fixture_path) do |config|
           expect(config.ignore_actions).to be_empty
@@ -409,7 +362,7 @@ describe Appsignal do
     end
 
     context "when config is loaded" do
-      before { Appsignal._config = project_fixture_config }
+      before { Appsignal.configure(:production, :root_path => project_fixture_path) }
 
       it "should initialize logging" do
         Appsignal.start
@@ -542,7 +495,7 @@ describe Appsignal do
     end
 
     context "with debug logging" do
-      before { Appsignal._config = project_fixture_config("test") }
+      before { Appsignal.configure(:test, :root_path => project_fixture_path) }
 
       it "should change the log level" do
         Appsignal.start
@@ -578,7 +531,7 @@ describe Appsignal do
 
     context "when active" do
       before do
-        Appsignal._config = project_fixture_config
+        Appsignal.configure(:production, :root_path => project_fixture_path)
       end
 
       it "starts the logger and extension" do
@@ -625,9 +578,7 @@ describe Appsignal do
     end
 
     context "when started with inactive config" do
-      before do
-        Appsignal._config = project_fixture_config("nonsense")
-      end
+      before { Appsignal.configure(:nonsense, :root_path => project_fixture_path) }
 
       it { is_expected.to be_falsy }
     end
@@ -641,17 +592,13 @@ describe Appsignal do
     end
 
     context "with inactive config" do
-      before do
-        Appsignal._config = project_fixture_config("nonsense")
-      end
+      before { Appsignal.configure(:nonsense, :root_path => project_fixture_path) }
 
       it { is_expected.to be_falsy }
     end
 
     context "with active config" do
-      before do
-        Appsignal._config = project_fixture_config
-      end
+      before { Appsignal.configure(:production, :root_path => project_fixture_path) }
 
       it { is_expected.to be_truthy }
     end
@@ -676,7 +623,7 @@ describe Appsignal do
   end
 
   context "not active" do
-    before { Appsignal._config = project_fixture_config("not_active") }
+    before { Appsignal.configure(:not_active, :root_path => project_fixture_path) }
 
     describe ".send_error" do
       let(:error) { ExampleException.new("specific error") }
@@ -1750,11 +1697,10 @@ describe Appsignal do
     after { FileUtils.rm_rf(log_path) }
 
     def initialize_config
-      Appsignal._config = project_fixture_config(
-        "production",
-        :log_path => log_path,
-        :log_level => log_level
-      )
+      Appsignal.configure(:production, :root_path => project_fixture_path) do |config|
+        config.log_path = log_path
+        config.log_level = log_level
+      end
       Appsignal.internal_logger.error("Log in memory line 1")
       Appsignal.internal_logger.debug("Log in memory line 2")
       expect(Appsignal.in_memory_logger.messages).to_not be_empty

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -46,6 +46,8 @@ describe Appsignal do
           config.name = "My app"
           config.push_api_key = "key"
         end
+        Appsignal.start
+
         expect(Appsignal.config.valid?).to be(true)
         expect(Appsignal.config.env).to eq("my_env")
         expect(Appsignal.config[:name]).to eq("My app")
@@ -64,6 +66,8 @@ describe Appsignal do
           config.name = "My app"
           config.push_api_key = "key"
         end
+        Appsignal.start
+
         expect(Appsignal.config.valid?).to be(true)
         expect(Appsignal.config.env).to eq("my_env")
         expect(Appsignal.config[:active]).to be(true)
@@ -84,6 +88,8 @@ describe Appsignal do
           config.name = "My app"
           config.push_api_key = "key"
         end
+        Appsignal.start
+
         expect(Appsignal.config.valid?).to be(true)
         expect(Appsignal.config.env).to eq("my_env2")
         expect(Appsignal.config[:active]).to be(true)
@@ -104,6 +110,8 @@ describe Appsignal do
           config.name = "My app"
           config.push_api_key = "key"
         end
+        Appsignal.start
+
         expect(Appsignal.config.valid?).to be(true)
         expect(Appsignal.config.env).to eq("my_env")
         expect(Appsignal.config[:active]).to be(true)
@@ -125,6 +133,8 @@ describe Appsignal do
           config.name = "My app"
           config.push_api_key = "key"
         end
+        Appsignal.start
+
         expect(Appsignal.config.valid?).to be(true)
         expect(Appsignal.config.env).to eq("my_env")
         expect(Appsignal.config[:active]).to be(true)
@@ -138,23 +148,23 @@ describe Appsignal do
         Appsignal.configure(:test) do |config|
           config.push_api_key = "key"
         end
-
         Appsignal.start
+
         expect(Appsignal.config[:push_api_key]).to eq("key")
       end
 
       it "uses the given env" do
         ENV["APPSIGNAL_APP_ENV"] = "env_env"
         Appsignal.configure(:env_arg)
-
         Appsignal.start
+
         expect(Appsignal.config.env).to eq("env_arg")
       end
 
       it "uses the given root path to read the config file" do
         Appsignal.configure(:test, :root_path => project_fixture_path)
-
         Appsignal.start
+
         expect(Appsignal.config.env).to eq("test")
         expect(Appsignal.config[:push_api_key]).to eq("abc")
         # Ensure it loads from the config file in the given path
@@ -165,6 +175,7 @@ describe Appsignal do
         Dir.chdir project_fixture_path do
           Appsignal.configure(:test)
         end
+        Appsignal.start
 
         expect(Appsignal.config.env).to eq("test")
         expect(Appsignal.config[:push_api_key]).to eq("abc")
@@ -176,6 +187,7 @@ describe Appsignal do
         Appsignal.configure(:test) do |config|
           config.push_api_key = "key"
         end
+        Appsignal.start
 
         expect(Appsignal.config.valid?).to be(true)
         expect(Appsignal.config.env).to eq("test")
@@ -202,6 +214,7 @@ describe Appsignal do
         Appsignal.configure(:my_env) do |config|
           config.push_api_key = "key"
         end
+        Appsignal.start
 
         expect(Appsignal.config.valid?).to be(true)
       end
@@ -210,6 +223,7 @@ describe Appsignal do
         Appsignal.configure(:my_env) do |config|
           config.push_api_key = ""
         end
+        Appsignal.start
 
         expect(Appsignal.config.valid?).to be(false)
       end
@@ -532,6 +546,7 @@ describe Appsignal do
     context "when active" do
       before do
         Appsignal.configure(:production, :root_path => project_fixture_path)
+        Appsignal.start
       end
 
       it "starts the logger and extension" do
@@ -592,13 +607,19 @@ describe Appsignal do
     end
 
     context "with inactive config" do
-      before { Appsignal.configure(:nonsense, :root_path => project_fixture_path) }
+      before do
+        Appsignal.configure(:nonsense, :root_path => project_fixture_path)
+        Appsignal.start
+      end
 
       it { is_expected.to be_falsy }
     end
 
     context "with active config" do
-      before { Appsignal.configure(:production, :root_path => project_fixture_path) }
+      before do
+        Appsignal.configure(:production, :root_path => project_fixture_path)
+        Appsignal.start
+      end
 
       it { is_expected.to be_truthy }
     end
@@ -623,7 +644,10 @@ describe Appsignal do
   end
 
   context "not active" do
-    before { Appsignal.configure(:not_active, :root_path => project_fixture_path) }
+    before do
+      Appsignal.configure(:not_active, :root_path => project_fixture_path)
+      Appsignal.start
+    end
 
     describe ".send_error" do
       let(:error) { ExampleException.new("specific error") }

--- a/spec/support/helpers/api_request_helper.rb
+++ b/spec/support/helpers/api_request_helper.rb
@@ -14,6 +14,7 @@ module ApiRequestHelper
     }
     body = Appsignal::Utils::JSON.generate(body) if body.is_a? Hash
     options[:body] = body if body
-    stub_request(:post, "#{config[:endpoint]}/1/#{path}").with(options)
+    endpoint = config[:endpoint] || Appsignal::Config::DEFAULT_CONFIG[:endpoint]
+    stub_request(:post, "#{endpoint}/1/#{path}").with(options)
   end
 end

--- a/spec/support/helpers/config_helpers.rb
+++ b/spec/support/helpers/config_helpers.rb
@@ -23,7 +23,7 @@ module ConfigHelpers
       env,
       initial_config,
       logger
-    )
+    ).tap(&:validate)
   end
   module_function :project_fixture_config, :project_fixture_path
 

--- a/spec/support/helpers/config_helpers.rb
+++ b/spec/support/helpers/config_helpers.rb
@@ -21,7 +21,6 @@ module ConfigHelpers
     Appsignal::Config.new(
       project_fixture_path,
       env,
-      {},
       logger
     ).tap do |c|
       c.merge_dsl_options(options)
@@ -39,7 +38,6 @@ module ConfigHelpers
     Appsignal::Config.new(
       root_path,
       env,
-      {},
       logger
     ).tap do |c|
       c.merge_dsl_options(options) if options.any?

--- a/spec/support/helpers/config_helpers.rb
+++ b/spec/support/helpers/config_helpers.rb
@@ -32,7 +32,11 @@ module ConfigHelpers
   def start_agent(env: "production", options: {})
     env = "production" if env == :default
     env ||= "production"
-    Appsignal._config = project_fixture_config(env, options)
+    Appsignal.configure(env, :root_path => project_fixture_path) do |config|
+      options.each do |option, value|
+        config.send("#{option}=", value)
+      end
+    end
     Appsignal.start
   end
 

--- a/spec/support/helpers/config_helpers.rb
+++ b/spec/support/helpers/config_helpers.rb
@@ -15,17 +15,38 @@ module ConfigHelpers
 
   def project_fixture_config(
     env = "production",
-    initial_config = {},
+    options = {},
     logger = Appsignal.internal_logger
   )
     Appsignal::Config.new(
       project_fixture_path,
       env,
-      initial_config,
+      {},
       logger
-    ).tap(&:validate)
+    ).tap do |c|
+      c.merge_dsl_options(options)
+      c.validate
+    end
   end
-  module_function :project_fixture_config, :project_fixture_path
+  module_function :project_fixture_config
+
+  def build_config(
+    root_path: project_fixture_path,
+    env: "production",
+    options: {},
+    logger: Appsignal.internal_logger
+  )
+    Appsignal::Config.new(
+      root_path,
+      env,
+      {},
+      logger
+    ).tap do |c|
+      c.merge_dsl_options(options) if options.any?
+      c.validate
+    end
+  end
+  module_function :build_config
 
   def start_agent(env: "production", options: {})
     env = "production" if env == :default

--- a/spec/support/helpers/config_helpers.rb
+++ b/spec/support/helpers/config_helpers.rb
@@ -13,18 +13,16 @@ module ConfigHelpers
   end
   module_function :rails_project_fixture_path
 
-  def project_fixture_config( # rubocop:disable Metrics/ParameterLists
+  def project_fixture_config(
     env = "production",
     initial_config = {},
-    logger = Appsignal.internal_logger,
-    config_file = nil
+    logger = Appsignal.internal_logger
   )
     Appsignal::Config.new(
       project_fixture_path,
       env,
       initial_config,
-      logger,
-      config_file
+      logger
     )
   end
   module_function :project_fixture_config, :project_fixture_path

--- a/spec/support/mocks/appsignal_mock.rb
+++ b/spec/support/mocks/appsignal_mock.rb
@@ -7,9 +7,9 @@ class AppsignalMock
   end
 
   def config
-    ConfigHelpers.project_fixture_config.tap do |conf|
-      conf[:hostname] = @hostname if @hostname
-    end
+    options = {}
+    options[:hostname] = @hostname if @hostname
+    ConfigHelpers.build_config(:options => options)
   end
 
   def set_gauge(*args)


### PR DESCRIPTION
## Remove Appsignal.config= writer

Now that no part of our gem is using the `Appsignal.config=` writer anymore to configure AppSignal, remove it. Recommend apps use `Appsignal.configure` instead.

## Remove custom config file config parameter

Applications can't manually initialize a Config instance anymore and they can't customize this config file parameter anymore. Let's remove it.

## Remove app env key logic from Config initializer

The AppSignal env config is determined by the `Config.determine_env` helper, so it's no longer necessary to have this override in the Config initializer. We can be sure the initialize method receives the final env.

## Do not auto validate config on initialize

I'm working on standardizing again how to the Config is loaded, remove the difference between how the config is loaded on `Appsignal.configure` and `Appsignal.start`.

## Validate config right before start

With the introduction of the `Appsignal.configure` helper it accidentally became possible to override the overrides as they were set before the DSL config was set.

Fix this by delaying the overrides from being set right before AppSignal is started, along with the config validation.

## Update Capistrano integrations config

Don't modify the config options hash directly, but use the DSL option merge helper.

## Add new build_config spec helper

Update specs to use this new helper that's a bit more flexible. Also update the config being set using the `Config#merge_dsl_options` helper, and not with the initial config so that can be removed from the initializer.

## Remove initial config from Config class

Applications can no longer manually initialize the Config class and assign it as the config for the gem, so remove the initial config options. They will never be set.


[skip review]