### PR TITLE
Do not report HTTP gem errors

### DIFF
--- a/.changesets/remove-http-gem-exception-handling.md
+++ b/.changesets/remove-http-gem-exception-handling.md
@@ -1,0 +1,14 @@
+---
+bump: minor
+type: change
+---
+
+Remove the HTTP gem's exception handling. Errors from the HTTP gem will no longer always be reported. The error will be reported only when an HTTP request is made in an instrumented context. This gives applications the opportunity to add their own custom exception handling.
+
+```ruby
+begin
+  HTTP.get("https://appsignal.com/error")
+rescue => error
+  # Either handle the error or report it to AppSignal
+end
+```

--- a/lib/appsignal/integrations/http.rb
+++ b/lib/appsignal/integrations/http.rb
@@ -8,13 +8,8 @@ module Appsignal
         parsed_request_uri = uri.is_a?(URI) ? uri : URI.parse(uri.to_s)
         request_uri = "#{parsed_request_uri.scheme}://#{parsed_request_uri.host}"
 
-        begin
-          Appsignal.instrument("request.http_rb", "#{verb.upcase} #{request_uri}") do
-            super
-          end
-        rescue Exception => error # rubocop:disable Lint/RescueException
-          Appsignal.set_error(error)
-          raise error
+        Appsignal.instrument("request.http_rb", "#{verb.upcase} #{request_uri}") do
+          super
         end
       end
     end

--- a/spec/lib/appsignal/integrations/http_spec.rb
+++ b/spec/lib/appsignal/integrations/http_spec.rb
@@ -67,27 +67,6 @@ if DependencyHelper.http_present?
       end
     end
 
-    context "with an HTTP exception" do
-      let(:error) { ExampleException.new("oh no!") }
-
-      it "reports the exception and re-raises it" do
-        stub_request(:get, "https://www.google.com").and_raise(error)
-
-        expect do
-          HTTP.get("https://www.google.com")
-        end.to raise_error(ExampleException)
-
-        expect(transaction).to have_namespace(Appsignal::Transaction::HTTP_REQUEST)
-        expect(transaction).to include_event(
-          "body" => "",
-          "body_format" => Appsignal::EventFormatter::DEFAULT,
-          "name" => "request.http_rb",
-          "title" => "GET https://www.google.com"
-        )
-        expect(transaction).to have_error(error.class.name, error.message)
-      end
-    end
-
     context "with various URI objects" do
       it "parses an object responding to #to_s" do
         request_uri = Struct.new(:uri) do


### PR DESCRIPTION
Remove the error reporting from the HTTP gem. By always reporting errors from the HTTP gem we make it impossible for applications to add their own error handling and not report the error to our system.

Fixes #1237