### PR TITLE
Add helper to unset parameters sample data

### DIFF
--- a/.changesets/allow-parameters-to-be-unset.md
+++ b/.changesets/allow-parameters-to-be-unset.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Add a helper for parameters sample data to be unset. This is a private method until we stabilize it.

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -552,6 +552,20 @@ module Appsignal
       end
       alias :set_params :add_params
 
+      # Mark the parameters sample data to be set as an empty value.
+      #
+      # @api private
+      # @since 4.0.0
+      # @return [void]
+      # @see Helpers::Instrumentation#set_empty_params!
+      def set_empty_params!
+        return unless active?
+        return unless Appsignal::Transaction.current?
+
+        transaction = Appsignal::Transaction.current
+        transaction.set_empty_params!
+      end
+
       # Add session data to the current transaction.
       #
       # Session data is automatically added by most of our integrations. It

--- a/lib/appsignal/sample_data.rb
+++ b/lib/appsignal/sample_data.rb
@@ -7,9 +7,11 @@ module Appsignal
       @key = key
       @accepted_type = accepted_type
       @blocks = []
+      @empty = false
     end
 
     def add(data = nil, &block)
+      @empty = false
       if block_given?
         @blocks << block
       elsif accepted_type?(data)
@@ -17,6 +19,12 @@ module Appsignal
       else
         log_unsupported_data_type(data)
       end
+    end
+
+    # @api private
+    def set_empty_value!
+      @empty = true
+      @blocks.clear
     end
 
     def value
@@ -42,6 +50,11 @@ module Appsignal
 
     def value?
       @blocks.any?
+    end
+
+    # @api private
+    def empty?
+      @empty
     end
 
     protected

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -246,6 +246,14 @@ module Appsignal
     end
     alias :set_params :add_params
 
+    # @api private
+    # @since 4.0.0
+    # @return [void]
+    # @see Helpers::Instrumentation#set_empty_params!
+    def set_empty_params!
+      @params.set_empty_value!
+    end
+
     # Add parameters to the transaction if not already set.
     #
     # @api private
@@ -257,7 +265,7 @@ module Appsignal
     #
     # @see #add_params
     def add_params_if_nil(given_params = nil, &block)
-      add_params(given_params, &block) unless @params.value?
+      add_params(given_params, &block) if !@params.value? && !@params.empty?
     end
     alias :set_params_if_nil :add_params_if_nil
 

--- a/spec/lib/appsignal/sample_data_spec.rb
+++ b/spec/lib/appsignal/sample_data_spec.rb
@@ -142,6 +142,45 @@ describe Appsignal::SampleData do
     end
   end
 
+  describe "#set_empty_value!" do
+    it "clears the set values" do
+      data.add(["abc"])
+      data.add(["def"])
+      data.set_empty_value!
+
+      expect(data.value).to be_nil
+    end
+
+    it "allows values to be added afterwards" do
+      data.add(["abc"])
+      data.set_empty_value!
+
+      expect(data.value).to be_nil
+
+      data.add(["def"])
+      expect(data.value).to eq(["def"])
+    end
+  end
+
+  describe "#cleared?" do
+    it "returns false if not cleared" do
+      expect(data.empty?).to be(false)
+    end
+
+    it "returns true if cleared" do
+      data.set_empty_value!
+
+      expect(data.empty?).to be(true)
+    end
+
+    it "returns false if cleared and then new values were added" do
+      data.set_empty_value!
+      data.add(["abc"])
+
+      expect(data.empty?).to be(false)
+    end
+  end
+
   describe "#duplicate" do
     it "duplicates the internal Hash state without modifying the original" do
       data = described_class.new(:my_key, Hash)

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -732,6 +732,17 @@ describe Appsignal::Transaction do
         expect(transaction).to include_params(preset_params)
       end
     end
+
+    context "when the params were set as an empty value" do
+      it "does not set params on the transaction" do
+        transaction.add_params("key1" => "value")
+        transaction.set_empty_params!
+        transaction.add_params_if_nil("key2" => "value")
+
+        transaction._sample
+        expect(transaction).to_not include_params
+      end
+    end
   end
 
   describe "#add_session_data" do

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -935,6 +935,23 @@ describe Appsignal do
       end
     end
 
+    describe ".set_empty_params!" do
+      before { start_agent }
+
+      context "with transaction" do
+        let(:transaction) { http_request_transaction }
+        before { set_current_transaction(transaction) }
+
+        it "marks parameters to be sent as an empty value" do
+          Appsignal.add_params("key1" => "value")
+          Appsignal.set_empty_params!
+
+          transaction._sample
+          expect(transaction).to_not include_params
+        end
+      end
+    end
+
     describe ".add_session_data" do
       before { start_agent }
 


### PR DESCRIPTION
Our own projects unset the parameters to a nil or empty value sometimes for specific endpoints.

Add a helper to replace this old method of doing it:

```ruby
Appsignal::Transaction.current.params = {}
```

I've kept the method private for now. We can make it stable if we're happy with how it works and the naming of it, which I didn't spend too much time on. The whole `.value?` and `.empty?` being able to contradict each other is a bit weird.