### PR TITLE
Remove Transaction ID argument for initializer

### DIFF
--- a/.changesets/remove-transaction-id-argument.md
+++ b/.changesets/remove-transaction-id-argument.md
@@ -1,0 +1,6 @@
+---
+bump: major
+type: remove
+---
+
+Remove the `Transaction.new` method Transaction ID argument. The Transaction ID will always be automatically generated.

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -208,10 +208,8 @@ module Appsignal
           return
         end
 
-        transaction = Appsignal::Transaction.new(
-          SecureRandom.uuid,
-          Appsignal::Transaction::HTTP_REQUEST
-        )
+        transaction =
+          Appsignal::Transaction.new(Appsignal::Transaction::HTTP_REQUEST)
         transaction.set_error(error, &block)
 
         transaction.complete
@@ -333,10 +331,7 @@ module Appsignal
           if has_parent_transaction
             Appsignal::Transaction.current
           else
-            Appsignal::Transaction.new(
-              SecureRandom.uuid,
-              Appsignal::Transaction::HTTP_REQUEST
-            )
+            Appsignal::Transaction.new(Appsignal::Transaction::HTTP_REQUEST)
           end
 
         transaction.add_error(exception, &block)

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -39,7 +39,7 @@ describe Appsignal::Transaction do
       let(:ext) { "some_ext" }
 
       it "assigns the extension transaction to the transaction" do
-        expect(new_transaction(:ext => ext).ext).to be(ext)
+        expect(described_class.new("web", :ext => ext).ext).to be(ext)
       end
     end
 

--- a/spec/support/helpers/transaction_helpers.rb
+++ b/spec/support/helpers/transaction_helpers.rb
@@ -16,7 +16,7 @@ module TransactionHelpers
   end
 
   def new_transaction(namespace = default_namespace, ext: nil)
-    Appsignal::Transaction.new(SecureRandom.uuid, namespace, :ext => ext)
+    Appsignal::Transaction.new(namespace, :ext => ext)
   end
 
   def rack_request(env)


### PR DESCRIPTION
There's no reason anyone should be able to customize the Transaction ID. If the `request_id` tag needs to be customized, it can be set with `Appsignal.add_tags(:request_id => "...")`.

[skip review]