### PR TITLE
Fix default transaction store value

### DIFF
--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -123,7 +123,7 @@ module Appsignal
       @discarded = false
       @tags = {}
       @breadcrumbs = []
-      @store = Hash.new({})
+      @store = Hash.new { |hash, key| hash[key] = {} }
       @error_blocks = Hash.new { |hash, key| hash[key] = [] }
       @is_duplicate = false
       @error_set = nil

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -590,6 +590,13 @@ describe Appsignal::Transaction do
 
       expect(transaction.store("test")).to eql("transaction" => "value")
     end
+
+    it "has a default value of a Hash for store values" do
+      transaction.store("abc")["def"] = "123"
+
+      expect(transaction.store("abc")).to eq("def" => "123")
+      expect(transaction.store("xyz")).to eq({})
+    end
   end
 
   describe "#add_params" do


### PR DESCRIPTION
When a Hash is initialize with a default value for its values, like `Hash.new({})`, the given Hash is shared between the values.

Use a block to initialize new Hash values and create a new Hash for each value so they don't share values between Hash store keys.

[skip changeset] because it's a private API
[skip review]