### PR TITLE
Ignore closed pipe error in response body wrapper

### DIFF
--- a/.changesets/ignore-errno--epipe-when-instrumenting-response-bodies.md
+++ b/.changesets/ignore-errno--epipe-when-instrumenting-response-bodies.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Ignore `Errno::EPIPE` errors when instrumenting response bodies. We've noticed this error gets reported when the connection is broken between server and client. This happens in normal scenarios so we'll ignore this error in this scenario to avoid error reports from errors that cannot be resolved.

--- a/lib/appsignal/rack/body_wrapper.rb
+++ b/lib/appsignal/rack/body_wrapper.rb
@@ -4,6 +4,8 @@ module Appsignal
   module Rack
     # @api private
     class BodyWrapper
+      IGNORED_ERRORS = [Errno::EPIPE].freeze
+
       def self.wrap(original_body, appsignal_transaction)
         # The logic of how Rack treats a response body differs based on which methods
         # the body responds to. This means that to support the Rack 3.x spec in full
@@ -49,6 +51,8 @@ module Appsignal
           Appsignal.instrument("close_response_body.rack") { @body.close }
         end
         @body_already_closed = true
+      rescue *IGNORED_ERRORS # Do not report
+        raise
       rescue Exception => error # rubocop:disable Lint/RescueException
         @transaction.set_error(error)
         raise error
@@ -75,6 +79,8 @@ module Appsignal
         Appsignal.instrument("process_response_body.rack", "Process Rack response body (#each)") do
           @body.each(&blk)
         end
+      rescue *IGNORED_ERRORS # Do not report
+        raise
       rescue Exception => error # rubocop:disable Lint/RescueException
         @transaction.set_error(error)
         raise error
@@ -94,6 +100,8 @@ module Appsignal
         Appsignal.instrument("process_response_body.rack", "Process Rack response body (#call)") do
           @body.call(stream)
         end
+      rescue *IGNORED_ERRORS # Do not report
+        raise
       rescue Exception => error # rubocop:disable Lint/RescueException
         @transaction.set_error(error)
         raise error
@@ -118,6 +126,8 @@ module Appsignal
         ) do
           @body.to_ary
         end
+      rescue *IGNORED_ERRORS # Do not report
+        raise
       rescue Exception => error # rubocop:disable Lint/RescueException
         @transaction.set_error(error)
         raise error
@@ -134,6 +144,8 @@ module Appsignal
         ) do
           @body.to_path
         end
+      rescue *IGNORED_ERRORS # Do not report
+        raise
       rescue Exception => error # rubocop:disable Lint/RescueException
         @transaction.set_error(error)
         raise error


### PR DESCRIPTION
Do not report closed pipe errors when instrumenting the response body in the body wrapper classes. We've gotten reports of this error being reported when a user clicks a link, but before the page managed to load, click away to another page. We shouldn't report this error when this happens.

---

Related issue https://github.com/appsignal/support/issues/315