### PR TITLE
Small refactors and cleanup

### DIFF
--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -107,7 +107,7 @@ module Appsignal
     end
 
     # @api private
-    attr_reader :transaction_id, :action, :namespace, :error_blocks
+    attr_reader :transaction_id, :action, :namespace
 
     # Use {.create} to create new transactions.
     #

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -108,7 +108,7 @@ module Appsignal
 
     # @api private
     attr_reader :transaction_id, :action, :namespace, :request, :paused,
-      :tags, :breadcrumbs, :is_duplicate, :error_blocks
+      :tags, :breadcrumbs, :error_blocks
 
     # Use {.create} to create new transactions.
     #
@@ -141,6 +141,11 @@ module Appsignal
     end
 
     # @api private
+    def duplicate?
+      @is_duplicate
+    end
+
+    # @api private
     def nil_transaction?
       false
     end
@@ -160,7 +165,7 @@ module Appsignal
       # create duplicates for errors, which are always sampled.
       should_sample = true
 
-      unless is_duplicate
+      unless duplicate?
         self.class.last_errors = @error_blocks.keys
         should_sample = @ext.finish(0)
       end

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -107,8 +107,8 @@ module Appsignal
     end
 
     # @api private
-    attr_reader :transaction_id, :action, :namespace, :request, :paused,
-      :tags, :breadcrumbs, :error_blocks
+    attr_reader :transaction_id, :action, :namespace, :paused, :tags,
+      :breadcrumbs, :error_blocks
 
     # Use {.create} to create new transactions.
     #

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -107,8 +107,7 @@ module Appsignal
     end
 
     # @api private
-    attr_reader :transaction_id, :action, :namespace, :tags, :breadcrumbs,
-      :error_blocks
+    attr_reader :transaction_id, :action, :namespace, :tags, :error_blocks
 
     # Use {.create} to create new transactions.
     #
@@ -594,6 +593,8 @@ module Appsignal
       :session_data, :headers
 
     private
+
+    attr_reader :breadcrumbs
 
     def _set_error(error)
       backtrace = cleaned_backtrace(error.backtrace)

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -107,7 +107,7 @@ module Appsignal
     end
 
     # @api private
-    attr_reader :transaction_id, :action, :namespace, :tags, :error_blocks
+    attr_reader :transaction_id, :action, :namespace, :error_blocks
 
     # Use {.create} to create new transactions.
     #

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -107,8 +107,8 @@ module Appsignal
     end
 
     # @api private
-    attr_reader :transaction_id, :action, :namespace, :paused, :tags,
-      :breadcrumbs, :error_blocks
+    attr_reader :transaction_id, :action, :namespace, :tags, :breadcrumbs,
+      :error_blocks
 
     # Use {.create} to create new transactions.
     #
@@ -295,7 +295,7 @@ module Appsignal
     def add_tags(given_tags = {})
       @tags.merge!(given_tags)
     end
-    alias :set_tags add_tags
+    alias :set_tags :add_tags
 
     # Add session data to the transaction.
     #

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -108,7 +108,7 @@ module Appsignal
 
     # @api private
     attr_reader :ext, :transaction_id, :action, :namespace, :request, :paused,
-      :tags, :options, :breadcrumbs, :is_duplicate, :error_blocks
+      :tags, :breadcrumbs, :is_duplicate, :error_blocks
 
     # Use {.create} to create new transactions.
     #

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -107,7 +107,7 @@ module Appsignal
     end
 
     # @api private
-    attr_reader :ext, :transaction_id, :action, :namespace, :request, :paused,
+    attr_reader :transaction_id, :action, :namespace, :request, :paused,
       :tags, :breadcrumbs, :is_duplicate, :error_blocks
 
     # Use {.create} to create new transactions.
@@ -162,7 +162,7 @@ module Appsignal
 
       unless is_duplicate
         self.class.last_errors = @error_blocks.keys
-        should_sample = ext.finish(0)
+        should_sample = @ext.finish(0)
       end
 
       @error_blocks.each do |error, blocks|
@@ -189,7 +189,7 @@ module Appsignal
         end
       end
       sample_data if should_sample
-      ext.complete
+      @ext.complete
     end
 
     # @api private
@@ -678,7 +678,7 @@ module Appsignal
       self.class.new(
         namespace,
         :id => new_transaction_id,
-        :ext => ext.duplicate(new_transaction_id)
+        :ext => @ext.duplicate(new_transaction_id)
       ).tap do |transaction|
         transaction.is_duplicate = true
         transaction.tags = @tags.dup

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -517,7 +517,7 @@ describe Appsignal::Transaction do
       it "changes the pause flag to true" do
         expect do
           transaction.pause!
-        end.to change(transaction, :paused).from(false).to(true)
+        end.to change(transaction, :paused?).from(false).to(true)
       end
     end
 
@@ -527,7 +527,7 @@ describe Appsignal::Transaction do
       it "changes the pause flag to false" do
         expect do
           transaction.resume!
-        end.to change(transaction, :paused).from(true).to(false)
+        end.to change(transaction, :paused?).from(true).to(false)
       end
     end
 

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -338,11 +338,11 @@ describe Appsignal::Transaction do
           expect(original_transaction.ext).to_not eq(duplicate_transaction.ext)
         end
 
-        it "sets is_duplicate set to true on the duplicate transaction" do
+        it "marks transaction as duplicate on the duplicate transaction" do
           original_transaction, duplicate_transaction = created_transactions
 
-          expect(original_transaction.is_duplicate).to be(false)
-          expect(duplicate_transaction.is_duplicate).to be(true)
+          expect(original_transaction.duplicate?).to be(false)
+          expect(duplicate_transaction.duplicate?).to be(true)
         end
       end
 

--- a/spec/support/testing.rb
+++ b/spec/support/testing.rb
@@ -168,7 +168,7 @@ module AppsignalTest
   module Transaction
     module ClassMethods
       def self.extended(base)
-        base.attr_reader :ext
+        base.attr_reader :ext, :error_blocks
       end
 
       # Override the {Appsignal::Transaction.new} method so we can track which

--- a/spec/support/testing.rb
+++ b/spec/support/testing.rb
@@ -167,6 +167,10 @@ end
 module AppsignalTest
   module Transaction
     module ClassMethods
+      def self.extended(base)
+        base.attr_reader :ext
+      end
+
       # Override the {Appsignal::Transaction.new} method so we can track which
       # transactions are created on the {Appsignal::Testing.transactions} list.
       #


### PR DESCRIPTION
## Remove unused options reader from Transaction

The options were removed when we removed the request object from the Transaction in PR #1200. Clean up leftover from that refactor.

## Remove public Transaction extension reader

Remove the reader for the Transaction extension from the public API (even if it's API doc is private) so no one can access it. Except for us in the test suite.

## Rename Transaction duplicate method

Create a more Ruby-esque helper method `duplicate?` to query if the Transaction is a duplicate transaction or not.

## Remove unused request reader from Transaction

The request was removed when we removed the request object from the Transaction in PR #1200. Clean up leftover from that refactor.

## Remove paused attribute from Transaction

We already have a `paused?` helper for this. They return the same, no need for both.

## Remove Transaction breadcrumbs attr_reader

No need for this to be publicly accessible, even if the API doc for it says it's private.

## Remove Transaction tags attr_reader

No need for this to be publicly accessible, even if the API doc for it says it's private.

## Remove Transaction error_blocks attr_reader

No need for this to be publicly accessible, even if the API doc for it says it's private.

We can still access it in the test suite.


---

[skip changeset]
[skip review]