### PR TITLE
Do not report `Sidekiq::JobRetry::Skip` errors

### DIFF
--- a/.changesets/do-not-report-sidekiq--jobretry--skip-errors.md
+++ b/.changesets/do-not-report-sidekiq--jobretry--skip-errors.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Do not report `Sidekiq::JobRetry::Skip` errors. These errors would be reported by our Rails error subscriber. This is an internal Sidekiq error we do not need to report.

--- a/lib/appsignal/integrations/railtie.rb
+++ b/lib/appsignal/integrations/railtie.rb
@@ -80,6 +80,8 @@ module Appsignal
     class RailsErrorReporterSubscriber
       class << self
         def report(error, handled:, severity:, context: {}, source: nil) # rubocop:disable Lint/UnusedMethodArgument
+          return if ignored_error?(error)
+
           is_rails_runner = source == "application.runner.railties"
           namespace, action_name, tags, custom_data = context_for(context.dup)
 
@@ -99,6 +101,15 @@ module Appsignal
         end
 
         private
+
+        IGNORED_ERRORS = [
+          # We don't need to alert every Sidekiq job skip error
+          "Sidekiq::JobRetry::Skip"
+        ].freeze
+
+        def ignored_error?(error)
+          IGNORED_ERRORS.include?(error.class.name)
+        end
 
         def context_for(context)
           tags = {}

--- a/lib/appsignal/integrations/railtie.rb
+++ b/lib/appsignal/integrations/railtie.rb
@@ -103,7 +103,8 @@ module Appsignal
         private
 
         IGNORED_ERRORS = [
-          # We don't need to alert every Sidekiq job skip error
+          # We don't need to alert Sidekiq job skip errors.
+          # This is an internal Sidekiq error.
           "Sidekiq::JobRetry::Skip"
         ].freeze
 

--- a/spec/lib/appsignal/integrations/railtie_spec.rb
+++ b/spec/lib/appsignal/integrations/railtie_spec.rb
@@ -229,6 +229,17 @@ if DependencyHelper.rails_present?
           expect(last_transaction).to have_error("ExampleStandardError", "error message")
         end
 
+        it "ignores Sidekiq::JobRetry::Skip errors" do
+          require "sidekiq"
+          require "sidekiq/job_retry"
+
+          with_rails_error_reporter do
+            Rails.error.handle { raise Sidekiq::JobRetry::Skip, "error message" }
+          end
+
+          expect(last_transaction).to_not have_error
+        end
+
         context "when no transaction is active" do
           it "reports the error on a new transaction" do
             with_rails_error_reporter do


### PR DESCRIPTION
These errors would be reported by our Rails error subscriber. This is an internal Sidekiq error we do not need to report.