### PR TITLE
Do not report SystemExit errors in at_exit handler

### DIFF
--- a/.changesets/do-not-report-systemexit-errors-from-our--at_exit--error-reporter.md
+++ b/.changesets/do-not-report-systemexit-errors-from-our--at_exit--error-reporter.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Do not report `SystemExit` errors from our `at_exit` error reporter.

--- a/spec/lib/appsignal/hooks/at_exit_spec.rb
+++ b/spec/lib/appsignal/hooks/at_exit_spec.rb
@@ -59,8 +59,19 @@ describe Appsignal::Hooks::AtExit::AtExitCallback do
     end
   end
 
-  it "doesn't report the error if is also the last error reported" do
+  it "doesn't report the error if it is also the last error reported" do
     with_error(ExampleException, "error message") do |error|
+      Appsignal.report_error(error)
+      expect(created_transactions.count).to eq(1)
+
+      expect do
+        call_callback
+      end.to_not change { created_transactions.count }.from(1)
+    end
+  end
+
+  it "doesn't report the error if it is a SystemExit exception" do
+    with_error(SystemExit, "error message") do |error|
       Appsignal.report_error(error)
       expect(created_transactions.count).to eq(1)
 


### PR DESCRIPTION
The SystemExit can be a normal shutdown or a shutdown by the host. We do not need to report those normal events.

If people do want to report this error they can add their own `at_exit` handler, but let's not report it by default.