### PR TITLE
Fix Rails session data not being reported

### DIFF
--- a/.changesets/do-not-log-warning-for-nil-data-in-sample-data-but-silently-ignore-it.md
+++ b/.changesets/do-not-log-warning-for-nil-data-in-sample-data-but-silently-ignore-it.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Do not log a warning for `nil` data being added as sample data, but silently ignore it because we don't support it.

--- a/.changesets/fix-rails-session-data-not-being-reported.md
+++ b/.changesets/fix-rails-session-data-not-being-reported.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix Rails session data not being reported.

--- a/lib/appsignal/rack/abstract_middleware.rb
+++ b/lib/appsignal/rack/abstract_middleware.rb
@@ -142,9 +142,7 @@ module Appsignal
         transaction.set_metadata("method", request_method) if request_method
 
         transaction.add_params { params_for(request) }
-        transaction.add_session_data do
-          request.session if request.respond_to?(:session)
-        end
+        transaction.add_session_data { session_data_for(request) }
         transaction.add_headers do
           request.env if request.respond_to?(:env)
         end
@@ -170,6 +168,18 @@ module Appsignal
       rescue => error
         Appsignal.internal_logger.error(
           "Exception while fetching the HTTP request method: #{error.class}: #{error}"
+        )
+        nil
+      end
+
+      def session_data_for(request)
+        return unless request.respond_to?(:session)
+
+        request.session.to_h
+      rescue => error
+        Appsignal.internal_logger.error(
+          "Exception while fetching session data from '#{@request_class}': " \
+            "#{error.class} #{error}"
         )
         nil
       end

--- a/lib/appsignal/sample_data.rb
+++ b/lib/appsignal/sample_data.rb
@@ -28,7 +28,7 @@ module Appsignal
     end
 
     def value
-      value = nil
+      value = UNSET_VALUE
       @blocks.map! do |block_or_value|
         new_value =
           if block_or_value.respond_to?(:call)
@@ -63,6 +63,8 @@ module Appsignal
 
     private
 
+    UNSET_VALUE = nil
+
     # Method called by `dup` and `clone` to create a duplicate instance.
     # Make sure the `@blocks` variable is also properly duplicated.
     def initialize_copy(original)
@@ -81,11 +83,13 @@ module Appsignal
 
     def merge_values(value_original, value_new)
       unless value_new.instance_of?(value_original.class)
-        Appsignal.internal_logger.warn(
-          "The sample data '#{@key}' changed type from " \
-            "'#{value_original.class}' to '#{value_new.class}'. " \
-            "These types can not be merged. Using new '#{value_new.class}' type."
-        )
+        unless value_original == UNSET_VALUE
+          Appsignal.internal_logger.warn(
+            "The sample data '#{@key}' changed type from " \
+              "'#{value_original.class}' to '#{value_new.class}'. " \
+              "These types can not be merged. Using new '#{value_new.class}' type."
+          )
+        end
         return value_new
       end
 

--- a/spec/lib/appsignal/rack/abstract_middleware_spec.rb
+++ b/spec/lib/appsignal/rack/abstract_middleware_spec.rb
@@ -1,4 +1,14 @@
 describe Appsignal::Rack::AbstractMiddleware do
+  class HashLike < Hash
+    def initialize(value)
+      @value = value
+    end
+
+    def to_h
+      @value
+    end
+  end
+
   let(:app) { DummyApp.new }
   let(:request_path) { "/some/path" }
   let(:env) do
@@ -260,6 +270,13 @@ describe Appsignal::Rack::AbstractMiddleware do
           make_request
 
           expect(last_transaction).to include_session_data("session" => "data", "user_id" => 123)
+        end
+
+        it "sets session data if the session is a Hash-like type" do
+          env["rack.session"] = HashLike.new("hash-like" => "value", "user_id" => 123)
+          make_request
+
+          expect(last_transaction).to include_session_data("hash-like" => "value", "user_id" => 123)
         end
       end
 


### PR DESCRIPTION
## Do not warn about nil being set as SampleData

The default value is nil so it would always log this warning when the value gets set for the first time.

## Fix Rails session data not being reported

The Rails session data was a non Hash object. It would not be stored on the transaction because it wasn't a Hash. It can be cast to a Hash, so let's explicitly cast it before setting the session data.


[skip review]