### PR TITLE
Remove deprecated app_path config DSL writer

### DIFF
--- a/.changesets/remove-app_path-writer-in-appsignal-configure-helper.md
+++ b/.changesets/remove-app_path-writer-in-appsignal-configure-helper.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+type: remove
+---
+
+Remove the `app_path` writer in the `Appsignal.configure` helper. This was deprecated in version 3.x. It is removed now in the next major version.
+
+Use the `root_path` keyword argument in the `Appsignal.configure` helper (`Appsignal.configure(:root_path => "...")`) to change the AppSignal root path if necessary.

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -560,14 +560,6 @@ module Appsignal
         @config.root_path
       end
 
-      def app_path=(_path)
-        Appsignal::Utils::StdoutAndLoggerMessage.warning \
-          "The `Appsignal.configure`'s `app_path=` writer is deprecated " \
-            "and can no longer be used to set the root path. " \
-            "Use the `Appsignal.configure`'s method `root_path` keyword argument " \
-            "to set the root path."
-      end
-
       def env
         @config.env
       end

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -1363,30 +1363,5 @@ describe Appsignal::Config do
 
       expect(dsl.cpu_count).to eq(1.0)
     end
-
-    describe "#app_path=" do
-      it "prints a deprecation warning" do
-        err_stream = std_stream
-        capture_std_streams(std_stream, err_stream) do
-          dsl.app_path = "foo"
-        end
-
-        expect(err_stream.read).to include(
-          "appsignal WARNING: The `Appsignal.configure`'s `app_path=` writer is deprecated"
-        )
-      end
-
-      it "logs a deprecation warning" do
-        logs =
-          capture_logs do
-            silence { dsl.app_path = "foo" }
-          end
-
-        expect(logs).to contains_log(
-          :warn,
-          "The `Appsignal.configure`'s `app_path=` writer is deprecated"
-        )
-      end
-    end
   end
 end


### PR DESCRIPTION
This should have been removed in the 4.0 release, but I missed it. Remove it now.

[skip review]