### PR TITLE
Do not report internal Sidekiq errors

### DIFF
--- a/.changesets/do-not-report-sidekiq-internal-errors.md
+++ b/.changesets/do-not-report-sidekiq-internal-errors.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Do not report Sidekiq `Sidekiq::JobRetry::Handled` and `Sidekiq::JobRetry::Skip` errors. These errors would be reported by our Rails error subscriber. These are an internal Sidekiq errors we do not need to report.

--- a/lib/appsignal/integrations/railtie.rb
+++ b/lib/appsignal/integrations/railtie.rb
@@ -102,14 +102,9 @@ module Appsignal
 
         private
 
-        IGNORED_ERRORS = [
-          # We don't need to alert Sidekiq job skip errors.
-          # This is an internal Sidekiq error.
-          "Sidekiq::JobRetry::Skip"
-        ].freeze
-
         def ignored_error?(error)
-          IGNORED_ERRORS.include?(error.class.name)
+          # We don't need to alert about Sidekiq job internal errors.
+          defined?(Sidekiq::JobRetry::Handled) && error.is_a?(Sidekiq::JobRetry::Handled)
         end
 
         def context_for(context)


### PR DESCRIPTION
Sidekiq uses errors for skipping and rescheduling jobs. These errors are not errors we need to report.

This is different from errors that happen inside Sidekiq while parsing the jobs in Redis, which we do still report.

Fixes #1260