### PR TITLE
Fix error calling body methods on BodyWrapper

### DIFF
--- a/.changesets/make-our-rack-bodywrapper-behave-like-a-rack-bodyproxy.md
+++ b/.changesets/make-our-rack-bodywrapper-behave-like-a-rack-bodyproxy.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Make our Rack BodyWrapper behave like a Rack BodyProxy. If a method doesn't exist on our BodyWrapper class, but it does exist on the body, behave like the Rack BodyProxy and call the method on the wrapped body.

--- a/lib/appsignal/rack/body_wrapper.rb
+++ b/lib/appsignal/rack/body_wrapper.rb
@@ -57,6 +57,21 @@ module Appsignal
         @transaction.set_error(error)
         raise error
       end
+
+      # Return whether the wrapped body responds to the method if this class does not.
+      # Based on:
+      # https://github.com/rack/rack/blob/0ed580bbe3858ffe5d530adf1bdad9ef9c03407c/lib/rack/body_proxy.rb#L16-L24
+      def respond_to_missing?(method_name, include_all = false)
+        super || @body.respond_to?(method_name, include_all)
+      end
+
+      # Delegate missing methods to the wrapped body.
+      # Based on:
+      # https://github.com/rack/rack/blob/0ed580bbe3858ffe5d530adf1bdad9ef9c03407c/lib/rack/body_proxy.rb#L44-L61
+      def method_missing(method_name, *args, &block)
+        @body.__send__(method_name, *args, &block)
+      end
+      ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
     end
 
     # The standard Rack body wrapper which exposes "each" for iterating


### PR DESCRIPTION
When a method exists on the wrapped body but not on `Appsignal::Rack::BodyWrapper` forward the method call to the body, like the `Rack::BodyProxy` does as well.

This way, we mimic the behavior better, and applications won't know they're talking to our wrapper. They shouldn't have to change their code to accommodate the AppSignal gem.

The risk is that an application calls the wrong body method (`each`, `call`, `to_ary` or `to_path`), and the body gets processed by bypassing our wrapper. This risk is quite small. Our wrapper selects the best wrapper depending on the methods the original body supports. In the scenario a body supports both `each` and `call`, and we wrap it with the `each` wrapper, but if the application calls `call`, we will not instrument the body.

Fixes #1265