### PR TITLE
Do not report `SignalException` in at_exit handler

### DIFF
--- a/.changesets/do-not-report--signalexception-from-our--at_exit--error-reporter-.md
+++ b/.changesets/do-not-report--signalexception-from-our--at_exit--error-reporter-.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Do not report `SignalException` errors from our `at_exit` error reporter.

--- a/lib/appsignal/hooks/at_exit.rb
+++ b/lib/appsignal/hooks/at_exit.rb
@@ -35,7 +35,8 @@ module Appsignal
 
         IGNORED_ERRORS = [
           # Normal exits from the application we do not need to report
-          SystemExit
+          SystemExit,
+          SignalException
         ].freeze
 
         def self.ignored_error?(error)

--- a/spec/lib/appsignal/hooks/at_exit_spec.rb
+++ b/spec/lib/appsignal/hooks/at_exit_spec.rb
@@ -80,4 +80,15 @@ describe Appsignal::Hooks::AtExit::AtExitCallback do
       end.to_not change { created_transactions.count }.from(1)
     end
   end
+
+  it "doesn't report the error if it is a SignalException exception" do
+    with_error(SignalException, "TERM") do |error|
+      Appsignal.report_error(error)
+      expect(created_transactions.count).to eq(1)
+
+      expect do
+        call_callback
+      end.to_not change { created_transactions.count }.from(1)
+    end
+  end
 end


### PR DESCRIPTION
The `SignalException` can be a normal signal that leads to a shutdown. We do not need to report those normal events.

If people do want to report this error they can add their own `at_exit` handler, but let's not report it by default.