### PR TITLE
Fix spec that fetches gems from Bundler

### DIFF
--- a/spec/lib/appsignal/environment_spec.rb
+++ b/spec/lib/appsignal/environment_spec.rb
@@ -120,7 +120,7 @@ describe Appsignal::Environment do
 
       expect(logs).to be_empty
 
-      if Bundler.rubygems.respond_to?(:all_specs)
+      unless Bundler.rubygems.respond_to?(:all_specs)
         skip "Using new Bundler version without `all_specs` method"
       end
       bundle_gem_specs = silence { ::Bundler.rubygems.all_specs }


### PR DESCRIPTION
I ran into a situation where it skipped both specs, which is not what we want. Fix the condition in which one spec is skipped.

[skip changeset]
[skip review]