### PR TITLE
Report low-level Puma errors

### DIFF
--- a/.changesets/drop-support-for-puma-2-and-lower.md
+++ b/.changesets/drop-support-for-puma-2-and-lower.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: remove
+---
+
+Drop support for Puma version 2 and lower.

--- a/.changesets/rename-path-and-method-transaction-metadata.md
+++ b/.changesets/rename-path-and-method-transaction-metadata.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Rename the `path` and `method` transaction metadata to `request_path` and `request_method` to make it more clear what context this metadata is from. The `path` and `method` metadata will continue to be reported until the next major/minor version.

--- a/.changesets/report-puma-low-level-errors.md
+++ b/.changesets/report-puma-low-level-errors.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Report Puma low-level errors using the `lowlevel_error` reporter. This will report errors previously not caught by our instrumentation middleware.

--- a/lib/appsignal/hooks/puma.rb
+++ b/lib/appsignal/hooks/puma.rb
@@ -12,6 +12,9 @@ module Appsignal
       end
 
       def install
+        require "appsignal/integrations/puma"
+        ::Puma::Server.prepend(Appsignal::Integrations::PumaServer)
+
         return unless defined?(::Puma::Cluster)
 
         # For clustered mode with multiple workers

--- a/lib/appsignal/hooks/puma.rb
+++ b/lib/appsignal/hooks/puma.rb
@@ -7,7 +7,8 @@ module Appsignal
       register :puma
 
       def dependencies_present?
-        defined?(::Puma)
+        defined?(::Puma) &&
+          Gem::Version.new(Puma::Const::VERSION) >= Gem::Version.new("3.0.0")
       end
 
       def install

--- a/lib/appsignal/integrations/puma.rb
+++ b/lib/appsignal/integrations/puma.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Appsignal
+  module Integrations
+    # @api private
+    module PumaServer
+      def lowlevel_error(error, env, response_status = 500)
+        response =
+          if method(:lowlevel_error).super_method.arity.abs == 3 # Puma >= 5
+            super
+          else # Puma <= 4
+            super(error, env)
+          end
+
+        unless PumaServerHelper.ignored_error?(error)
+          Appsignal.report_error(error) do |transaction|
+            Appsignal::Rack::ApplyRackRequest
+              .new(::Rack::Request.new(env))
+              .apply_to(transaction)
+            transaction.add_tags(
+              :reported_by_puma_lowlevel_error => true,
+              :response_status => response_status
+            )
+          end
+        end
+
+        response
+      end
+    end
+
+    module PumaServerHelper
+      IGNORED_ERRORS = [
+        # Ignore internal Puma Client IO errors
+        # https://github.com/puma/puma/blob/9ee922d28e1fffd02c1d5480a9e13376f92f46a3/lib/puma/server.rb#L536-L544
+        "Puma::MiniSSL::SSLError",
+        "Puma::HttpParserError",
+        "Puma::HttpParserError501"
+      ].freeze
+
+      def self.ignored_error?(error)
+        IGNORED_ERRORS.include?(error.class.to_s)
+      end
+    end
+  end
+end

--- a/lib/appsignal/integrations/puma.rb
+++ b/lib/appsignal/integrations/puma.rb
@@ -18,7 +18,7 @@ module Appsignal
               .new(::Rack::Request.new(env))
               .apply_to(transaction)
             transaction.add_tags(
-              :reported_by_puma_lowlevel_error => true,
+              :reported_by => :puma_lowlevel_error,
               :response_status => response_status
             )
           end

--- a/lib/appsignal/rack.rb
+++ b/lib/appsignal/rack.rb
@@ -66,7 +66,7 @@ module Appsignal
       private
 
       def params_for(request)
-        return unless request.respond_to?(@params_method)
+        return if !@params_method || !request.respond_to?(@params_method)
 
         request.send(@params_method)
       rescue => error

--- a/lib/appsignal/rack.rb
+++ b/lib/appsignal/rack.rb
@@ -48,10 +48,17 @@ module Appsignal
       end
 
       def apply_to(transaction)
-        transaction.set_metadata("path", request.path)
+        request_path = request.path
+        transaction.set_metadata("request_path", request_path)
+        # TODO: Remove in next major/minor version
+        transaction.set_metadata("path", request_path)
 
         request_method = request_method_for(request)
-        transaction.set_metadata("method", request_method) if request_method
+        if request_method
+          transaction.set_metadata("request_method", request_method)
+          # TODO: Remove in next major/minor version
+          transaction.set_metadata("method", request_method)
+        end
 
         transaction.add_params { params_for(request) }
         transaction.add_session_data { session_data_for(request) }

--- a/lib/appsignal/rack.rb
+++ b/lib/appsignal/rack.rb
@@ -37,5 +37,66 @@ module Appsignal
         end
       end
     end
+
+    class ApplyRackRequest
+      attr_reader :request, :options
+
+      def initialize(request, options = {})
+        @request = request
+        @options = options
+        @params_method = options.fetch(:params_method, :params)
+      end
+
+      def apply_to(transaction)
+        transaction.set_metadata("path", request.path)
+
+        request_method = request_method_for(request)
+        transaction.set_metadata("method", request_method) if request_method
+
+        transaction.add_params { params_for(request) }
+        transaction.add_session_data { session_data_for(request) }
+        transaction.add_headers do
+          request.env if request.respond_to?(:env)
+        end
+
+        queue_start = Appsignal::Rack::Utils.queue_start_from(request.env)
+        transaction.set_queue_start(queue_start) if queue_start
+      end
+
+      private
+
+      def params_for(request)
+        return unless request.respond_to?(@params_method)
+
+        request.send(@params_method)
+      rescue => error
+        Appsignal.internal_logger.error(
+          "Exception while fetching params from '#{request.class}##{@params_method}': " \
+            "#{error.class} #{error}"
+        )
+        nil
+      end
+
+      def request_method_for(request)
+        request.request_method
+      rescue => error
+        Appsignal.internal_logger.error(
+          "Exception while fetching the HTTP request method: #{error.class}: #{error}"
+        )
+        nil
+      end
+
+      def session_data_for(request)
+        return unless request.respond_to?(:session)
+
+        request.session.to_h
+      rescue => error
+        Appsignal.internal_logger.error(
+          "Exception while fetching session data from '#{request.class}': " \
+            "#{error.class} #{error}"
+        )
+        nil
+      end
+    end
   end
 end

--- a/lib/appsignal/rack/event_handler.rb
+++ b/lib/appsignal/rack/event_handler.rb
@@ -79,6 +79,8 @@ module Appsignal
             #
             # The EventHandler.on_finish callback should be called first, this is
             # just a fallback if that doesn't get called.
+            #
+            # One such scenario is when a Puma "lowlevel_error" occurs.
             Appsignal::Transaction.complete_current!
           end
           transaction.start_event

--- a/lib/appsignal/rack/hanami_middleware.rb
+++ b/lib/appsignal/rack/hanami_middleware.rb
@@ -5,12 +5,16 @@ module Appsignal
     # @api private
     class HanamiMiddleware < AbstractMiddleware
       def initialize(app, options = {})
-        options[:params_method] ||= :params
+        options[:params_method] = nil
         options[:instrument_event_name] ||= "process_action.hanami"
         super
       end
 
       private
+
+      def add_transaction_metadata_after(transaction, request)
+        transaction.add_params { params_for(request) }
+      end
 
       def params_for(request)
         ::Hanami::Action.params_class.new(request.env).to_h

--- a/spec/lib/appsignal/integrations/puma_spec.rb
+++ b/spec/lib/appsignal/integrations/puma_spec.rb
@@ -1,0 +1,148 @@
+require "appsignal/integrations/puma"
+
+describe Appsignal::Integrations::PumaServer do
+  describe "#lowlevel_error" do
+    before do
+      stub_const("Puma", PumaMock)
+      stub_const("Puma::Server", puma_server)
+      start_agent
+    end
+    let(:queue_start_time) { fixed_time * 1_000 }
+    let(:env) do
+      Rack::MockRequest.env_for(
+        "/some/path",
+        "REQUEST_METHOD" => "GET",
+        :params => { "page" => 2, "query" => "lorem" },
+        "rack.session" => { "session" => "data", "user_id" => 123 },
+        "HTTP_X_REQUEST_START" => "t=#{queue_start_time.to_i}" # in milliseconds
+      )
+    end
+    let(:server) { Puma::Server.new }
+    let(:error) { ExampleException.new("error message") }
+    around { |example| keep_transactions { example.run } }
+    before { Appsignal::Hooks::PumaHook.new.install }
+
+    def lowlevel_error(error, env, status = nil)
+      result =
+        if status
+          server.lowlevel_error(error, env, status)
+        else
+          server.lowlevel_error(error, env)
+        end
+      # Transaction is normally closed by the EventHandler's RACK_AFTER_REPLY hook
+      last_transaction&.complete
+      result
+    end
+
+    describe "error reporting" do
+      let(:puma_server) { default_puma_server_mock }
+
+      context "with active transaction" do
+        before { create_transaction }
+
+        it "reports the error to the transaction" do
+          expect do
+            lowlevel_error(error, env)
+          end.to_not(change { created_transactions.count })
+
+          expect(last_transaction).to have_error("ExampleException", "error message")
+          expect(last_transaction).to include_tags("reported_by_puma_lowlevel_error" => true)
+        end
+      end
+
+      # This shouldn't happen if the EventHandler is set up correctly, but if
+      # it's not it will create a new transaction.
+      context "without active transaction" do
+        it "creates a new transaction with the error" do
+          expect do
+            lowlevel_error(error, env)
+          end.to change { created_transactions.count }.by(1)
+
+          expect(last_transaction).to have_error("ExampleException", "error message")
+          expect(last_transaction).to include_tags("reported_by_puma_lowlevel_error" => true)
+        end
+      end
+
+      it "doesn't report internal Puma errors" do
+        expect do
+          lowlevel_error(Puma::MiniSSL::SSLError.new("error message"), env)
+          lowlevel_error(Puma::HttpParserError.new("error message"), env)
+          lowlevel_error(Puma::HttpParserError501.new("error message"), env)
+        end.to_not(change { created_transactions.count })
+      end
+
+      describe "request metadata" do
+        it "sets request metadata" do
+          lowlevel_error(error, env)
+
+          expect(last_transaction).to include_metadata(
+            "method" => "GET",
+            "path" => "/some/path"
+          )
+          expect(last_transaction).to include_environment(
+            "REQUEST_METHOD" => "GET",
+            "PATH_INFO" => "/some/path"
+            # and more, but we don't need to test Rack mock defaults
+          )
+        end
+
+        it "sets request parameters" do
+          lowlevel_error(error, env)
+
+          expect(last_transaction).to include_params(
+            "page" => "2",
+            "query" => "lorem"
+          )
+        end
+
+        it "sets session data" do
+          lowlevel_error(error, env)
+
+          expect(last_transaction).to include_session_data("session" => "data", "user_id" => 123)
+        end
+
+        it "sets the queue start" do
+          lowlevel_error(error, env)
+
+          expect(last_transaction).to have_queue_start(queue_start_time)
+        end
+      end
+    end
+
+    context "with Puma::Server#lowlevel_error accepting 3 arguments" do
+      let(:puma_server) { default_puma_server_mock }
+
+      it "calls the super class with 3 arguments" do
+        result = lowlevel_error(error, env, 501)
+        expect(result).to eq([501, {}, ""])
+
+        expect(last_transaction).to include_tags("response_status" => 501)
+      end
+    end
+
+    context "with Puma::Server#lowlevel_error accepting 2 arguments" do
+      let(:puma_server) do
+        Class.new do
+          def lowlevel_error(_error, _env)
+            [500, {}, ""]
+          end
+        end
+      end
+
+      it "calls the super class with 3 arguments" do
+        result = lowlevel_error(error, env)
+        expect(result).to eq([500, {}, ""])
+
+        expect(last_transaction).to include_tags("response_status" => 500)
+      end
+    end
+  end
+
+  def default_puma_server_mock
+    Class.new do
+      def lowlevel_error(_error, _env, status = 500)
+        [status, {}, ""]
+      end
+    end
+  end
+end

--- a/spec/lib/appsignal/integrations/puma_spec.rb
+++ b/spec/lib/appsignal/integrations/puma_spec.rb
@@ -76,7 +76,9 @@ describe Appsignal::Integrations::PumaServer do
           lowlevel_error(error, env)
 
           expect(last_transaction).to include_metadata(
+            "request_method" => "GET",
             "method" => "GET",
+            "request_path" => "/some/path",
             "path" => "/some/path"
           )
           expect(last_transaction).to include_environment(

--- a/spec/lib/appsignal/integrations/puma_spec.rb
+++ b/spec/lib/appsignal/integrations/puma_spec.rb
@@ -46,7 +46,7 @@ describe Appsignal::Integrations::PumaServer do
           end.to_not(change { created_transactions.count })
 
           expect(last_transaction).to have_error("ExampleException", "error message")
-          expect(last_transaction).to include_tags("reported_by_puma_lowlevel_error" => true)
+          expect(last_transaction).to include_tags("reported_by" => "puma_lowlevel_error")
         end
       end
 
@@ -59,7 +59,7 @@ describe Appsignal::Integrations::PumaServer do
           end.to change { created_transactions.count }.by(1)
 
           expect(last_transaction).to have_error("ExampleException", "error message")
-          expect(last_transaction).to include_tags("reported_by_puma_lowlevel_error" => true)
+          expect(last_transaction).to include_tags("reported_by" => "puma_lowlevel_error")
         end
       end
 

--- a/spec/lib/appsignal/rack/abstract_middleware_spec.rb
+++ b/spec/lib/appsignal/rack/abstract_middleware_spec.rb
@@ -171,7 +171,9 @@ describe Appsignal::Rack::AbstractMiddleware do
           make_request
 
           expect(last_transaction).to include_metadata(
+            "request_method" => "GET",
             "method" => "GET",
+            "request_path" => "/some/path",
             "path" => "/some/path"
           )
           expect(last_transaction).to include_environment(

--- a/spec/lib/appsignal/rack/abstract_middleware_spec.rb
+++ b/spec/lib/appsignal/rack/abstract_middleware_spec.rb
@@ -1,19 +1,8 @@
 describe Appsignal::Rack::AbstractMiddleware do
-  class HashLike < Hash
-    def initialize(value)
-      @value = value
-    end
-
-    def to_h
-      @value
-    end
-  end
-
   let(:app) { DummyApp.new }
-  let(:request_path) { "/some/path" }
   let(:env) do
     Rack::MockRequest.env_for(
-      request_path,
+      "/some/path",
       "REQUEST_METHOD" => "GET",
       :params => { "page" => 2, "query" => "lorem" },
       "rack.session" => { "session" => "data", "user_id" => 123 }
@@ -174,6 +163,8 @@ describe Appsignal::Rack::AbstractMiddleware do
         end
       end
 
+      # Partial duplicate tests from Appsignal::Rack::ApplyRackRequest that
+      # ensure the request metadata is set on via the AbstractMiddleware.
       describe "request metadata" do
         it "sets request metadata" do
           env.merge!("PATH_INFO" => "/some/path", "REQUEST_METHOD" => "GET")
@@ -190,36 +181,6 @@ describe Appsignal::Rack::AbstractMiddleware do
           )
         end
 
-        context "with an invalid HTTP request method" do
-          it "stores the invalid HTTP request method" do
-            env["REQUEST_METHOD"] = "FOO"
-            make_request
-
-            expect(last_transaction).to include_metadata("method" => "FOO")
-          end
-        end
-
-        context "when fetching the request method raises an error" do
-          class BrokenRequestMethodRequest < Rack::Request
-            def request_method
-              raise "uh oh!"
-            end
-          end
-
-          let(:options) { { :request_class => BrokenRequestMethodRequest } }
-
-          it "does not store the invalid HTTP request method" do
-            env["REQUEST_METHOD"] = "FOO"
-            logs = capture_logs { make_request }
-
-            expect(last_transaction).to_not include_metadata("method" => anything)
-            expect(logs).to contains_log(
-              :error,
-              "Exception while fetching the HTTP request method: RuntimeError: uh oh"
-            )
-          end
-        end
-
         it "sets request parameters" do
           make_request
 
@@ -229,107 +190,63 @@ describe Appsignal::Rack::AbstractMiddleware do
           )
         end
 
-        context "when setting custom params" do
-          let(:app) do
-            DummyApp.new do |_env|
-              Appsignal::Transaction.current.set_params("custom" => "param")
-            end
-          end
-
-          it "allow custom request parameters to be set" do
-            make_request
-
-            expect(last_transaction).to include_params("custom" => "param")
-          end
-        end
-
-        context "when fetching the request method raises an error" do
-          class BrokenRequestParamsRequest < Rack::Request
-            def params
-              raise "uh oh!"
-            end
-          end
-
-          let(:options) do
-            { :request_class => BrokenRequestParamsRequest, :params_method => :params }
-          end
-
-          it "does not store the invalid HTTP request method" do
-            logs = capture_logs { make_request }
-
-            expect(last_transaction).to_not include_params
-            expect(logs).to contains_log(
-              :error,
-              "Exception while fetching params " \
-                "from 'BrokenRequestParamsRequest#params': RuntimeError uh oh!"
-            )
-          end
-        end
-
         it "sets session data" do
           make_request
 
           expect(last_transaction).to include_session_data("session" => "data", "user_id" => 123)
         end
 
-        it "sets session data if the session is a Hash-like type" do
-          env["rack.session"] = HashLike.new("hash-like" => "value", "user_id" => 123)
-          make_request
+        context "with queue start header" do
+          let(:queue_start_time) { fixed_time * 1_000 }
 
-          expect(last_transaction).to include_session_data("hash-like" => "value", "user_id" => 123)
-        end
-      end
+          it "sets the queue start" do
+            env["HTTP_X_REQUEST_START"] = "t=#{queue_start_time.to_i}" # in milliseconds
+            make_request
 
-      context "with queue start header" do
-        let(:queue_start_time) { fixed_time * 1_000 }
-
-        it "sets the queue start" do
-          env["HTTP_X_REQUEST_START"] = "t=#{queue_start_time.to_i}" # in milliseconds
-          make_request
-
-          expect(last_transaction).to have_queue_start(queue_start_time)
-        end
-      end
-
-      class FilteredRequest
-        attr_reader :env
-
-        def initialize(env)
-          @env = env
+            expect(last_transaction).to have_queue_start(queue_start_time)
+          end
         end
 
-        def path
-          "/static/path"
+        class SomeFilteredRequest
+          attr_reader :env
+
+          def initialize(env)
+            @env = env
+          end
+
+          def path
+            "/static/path"
+          end
+
+          def request_method
+            "GET"
+          end
+
+          def filtered_params
+            { "abc" => "123" }
+          end
+
+          def session
+            { "data" => "value" }
+          end
         end
 
-        def request_method
-          "GET"
-        end
+        context "with overridden request class and params method" do
+          let(:options) do
+            { :request_class => SomeFilteredRequest, :params_method => :filtered_params }
+          end
 
-        def filtered_params
-          { "abc" => "123" }
-        end
+          it "uses the overridden request class and params method to fetch params" do
+            make_request
 
-        def session
-          { "data" => "value" }
-        end
-      end
+            expect(last_transaction).to include_params("abc" => "123")
+          end
 
-      context "with overridden request class and params method" do
-        let(:options) do
-          { :request_class => FilteredRequest, :params_method => :filtered_params }
-        end
+          it "uses the overridden request class to fetch session data" do
+            make_request
 
-        it "uses the overridden request class and params method to fetch params" do
-          make_request
-
-          expect(last_transaction).to include_params("abc" => "123")
-        end
-
-        it "uses the overridden request class to fetch session data" do
-          make_request
-
-          expect(last_transaction).to include_session_data("data" => "value")
+            expect(last_transaction).to include_session_data("data" => "value")
+          end
         end
       end
 

--- a/spec/lib/appsignal/rack_spec.rb
+++ b/spec/lib/appsignal/rack_spec.rb
@@ -140,6 +140,16 @@ describe Appsignal::Rack::ApplyRackRequest do
       )
     end
 
+    context "when params_method isn't set" do
+      let(:options) { { :params_method => nil } }
+
+      it "reports no params" do
+        apply_to(transaction)
+
+        expect(transaction).to_not include_params
+      end
+    end
+
     context "when fetching the request method raises an error" do
       class BrokenRequestParamsRequest < Rack::Request
         def params

--- a/spec/lib/appsignal/rack_spec.rb
+++ b/spec/lib/appsignal/rack_spec.rb
@@ -61,3 +61,173 @@ describe Appsignal::Rack::Utils do
     end
   end
 end
+
+describe Appsignal::Rack::ApplyRackRequest do
+  describe "#apply_to" do
+    let(:merged_env) do
+      Rack::MockRequest.env_for(
+        "/some/path",
+        {
+          "REQUEST_METHOD" => "GET",
+          :params => { "page" => 2, "query" => "lorem" },
+          "rack.session" => { "session" => "data", "user_id" => 123 }
+        }.merge(env)
+      )
+    end
+    let(:env) { {} }
+    let(:request) { ::Rack::Request.new(merged_env) }
+    let(:options) { {} }
+    let(:helper) { described_class.new(request, options) }
+    let(:transaction) { http_request_transaction }
+    before { start_agent }
+
+    def apply_to(transaction)
+      helper.apply_to(transaction)
+      transaction._sample
+    end
+
+    it "sets request metadata" do
+      apply_to(transaction)
+
+      expect(transaction).to include_metadata(
+        "method" => "GET",
+        "path" => "/some/path"
+      )
+      expect(transaction).to include_environment(
+        "REQUEST_METHOD" => "GET",
+        "PATH_INFO" => "/some/path"
+        # and more, but we don't need to test Rack mock defaults
+      )
+    end
+
+    context "with an invalid HTTP request method" do
+      let(:env) { { "REQUEST_METHOD" => "FOO" } }
+
+      it "stores the invalid HTTP request method" do
+        apply_to(transaction)
+
+        expect(transaction).to include_metadata("method" => "FOO")
+      end
+    end
+
+    context "when fetching the request method raises an error" do
+      class BrokenRequestMethodRequest < Rack::Request
+        def request_method
+          raise "uh oh!"
+        end
+      end
+
+      let(:env) { { "REQUEST_METHOD" => "FOO" } }
+      let(:request) { BrokenRequestMethodRequest.new(merged_env) }
+
+      it "does not store the invalid HTTP request method" do
+        logs = capture_logs { apply_to(transaction) }
+
+        expect(transaction).to_not include_metadata("method" => anything)
+        expect(logs).to contains_log(
+          :error,
+          "Exception while fetching the HTTP request method: RuntimeError: uh oh"
+        )
+      end
+    end
+
+    it "sets request parameters" do
+      apply_to(transaction)
+
+      expect(transaction).to include_params(
+        "page" => "2",
+        "query" => "lorem"
+      )
+    end
+
+    context "when fetching the request method raises an error" do
+      class BrokenRequestParamsRequest < Rack::Request
+        def params
+          raise "uh oh!"
+        end
+      end
+
+      let(:request) { BrokenRequestParamsRequest.new(merged_env) }
+      let(:options) { { :params_method => :params } }
+
+      it "does not store the invalid HTTP request method" do
+        logs = capture_logs { apply_to(transaction) }
+
+        expect(transaction).to_not include_params
+        expect(logs).to contains_log(
+          :error,
+          "Exception while fetching params " \
+            "from 'BrokenRequestParamsRequest#params': RuntimeError uh oh!"
+        )
+      end
+    end
+
+    it "sets session data" do
+      apply_to(transaction)
+
+      expect(transaction).to include_session_data("session" => "data", "user_id" => 123)
+    end
+
+    context "with Hash-like session data" do
+      let(:env) { { "rack.session" => HashLike.new("hash-like" => "value", "user_id" => 123) } }
+
+      it "sets session data" do
+        apply_to(transaction)
+
+        expect(transaction).to include_session_data("hash-like" => "value", "user_id" => 123)
+      end
+    end
+
+    context "with queue start header" do
+      let(:queue_start_time) { fixed_time * 1_000 }
+      let(:env) { { "HTTP_X_REQUEST_START" => "t=#{queue_start_time.to_i}" } } # in milliseconds
+
+      it "sets the queue start" do
+        apply_to(transaction)
+
+        expect(transaction).to have_queue_start(queue_start_time)
+      end
+    end
+
+    class RackFilteredRequest
+      attr_reader :env
+
+      def initialize(env)
+        @env = env
+      end
+
+      def path
+        "/static/path"
+      end
+
+      def request_method
+        "GET"
+      end
+
+      def filtered_params
+        { "abc" => "123" }
+      end
+
+      def session
+        { "data" => "value" }
+      end
+    end
+
+    context "with overridden request class and params method" do
+      let(:request) { RackFilteredRequest.new(env) }
+      let(:options) { { :params_method => :filtered_params } }
+
+      it "uses the overridden request class and params method to fetch params" do
+        apply_to(transaction)
+
+        expect(transaction).to include_params("abc" => "123")
+      end
+
+      it "uses the overridden request class to fetch session data" do
+        apply_to(transaction)
+
+        expect(transaction).to include_session_data("data" => "value")
+      end
+    end
+  end
+end

--- a/spec/support/mocks/hash_like.rb
+++ b/spec/support/mocks/hash_like.rb
@@ -1,0 +1,10 @@
+class HashLike < Hash
+  def initialize(value)
+    super
+    @value = value
+  end
+
+  def to_h
+    @value
+  end
+end

--- a/spec/support/mocks/puma_mock.rb
+++ b/spec/support/mocks/puma_mock.rb
@@ -1,0 +1,43 @@
+class PumaMock
+  module MiniSSL
+    class SSLError < StandardError
+      def self.to_s
+        "Puma::MiniSSL::SSLError"
+      end
+    end
+  end
+
+  class HttpParserError < StandardError
+    def self.to_s
+      "Puma::HttpParserError"
+    end
+  end
+
+  class HttpParserError501 < StandardError
+    def self.to_s
+      "Puma::HttpParserError501"
+    end
+  end
+
+  def self.stats
+  end
+
+  def self.cli_config
+    @cli_config ||= CliConfig.new
+  end
+
+  class Server
+  end
+
+  module Const
+    VERSION = "6.0.0".freeze
+  end
+
+  class CliConfig
+    attr_accessor :options
+
+    def initialize
+      @options = {}
+    end
+  end
+end


### PR DESCRIPTION
## Extract Rack request metadata helpers to class

Create a new class for the Rack request metadata extraction so it can be reused in other places more easily too.

Some of the specs are duplicated. I've moved all the specs for edge cases to the class with the actual implementation. The AbstractMiddleware just tests the basics that we expect that class to handle.

## Install Puma hook only for Puma 3 and newer

Set some limit for our Puma hook so we don't break apps using an older Puma. Version 2 and 3 have the biggest difference I could find for the things we rely on so I've set the limit there.

## Report low-level Puma errors

When an error is reported by Puma's `lowlevel_error` reporter, it doesn't arrive at our `EventHandler`'s `on_error` callback or through the `AbstractMiddleware` instrumentation. This resulted in the report in issue #1269 of an error not being reported.

Report the error through a patch on the `Puma::Server` class. I first wanted to add it as described in their docs: https://puma.io/puma/index.html#error-handling This method only works if you can configure it through the Puma config file. It would also require us to determine the response in the block given to that setting. This patch will call the super method, which will determine the response and also allows applications to specify their own `lowlevel_error` handler.

Use the `Appsignal::Rack::ApplyRackRequest` helper to set the request metadata on the transaction, so it's hopefully a bit easier for people who view errors reported this way to debug the issue. This error doesn't flow normally through our instrumentation, so it needs this metadata set manually like this. The transaction is closed through the `RACK_AFTER_REPLY` hook set in the EventHandler. Usuallly, the EventHandler still creates the transaction for the request. If the EventHandler doesn't create the transaction because it's not set up correctly, the `report_error` helper will create a new transaction for this error.

Since version 4 of the Ruby gem we've gotten a couple of reports of applications suddenly reporting new errors, usually internal errors developers can't really fix. This patch will ignore a couple of internal errors from Puma as well to prevent those issues from appearing in the next couple of days.

Closes #1247 Fixes #1269

## Fix Hanami request params not being set

The Hanami integration has a different way from setting the params from other Rack apps. Set it manually, rather than rely on the `ApplyRackRequest` helper.

Add logic to not even try to set the params if the `params_method` option is set to nil.
