### PR TITLE
Fix error log message from at_exit without error

### DIFF
--- a/.changesets/fix-error-about-reporting-no-error-on-process-exit-.md
+++ b/.changesets/fix-error-about-reporting-no-error-on-process-exit-.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix the error log message about our `at_exit` hook reporting no error on process exit when the process exits without an error.

--- a/lib/appsignal/hooks/at_exit.rb
+++ b/lib/appsignal/hooks/at_exit.rb
@@ -24,6 +24,7 @@ module Appsignal
       class AtExitCallback
         def self.call
           error = $! # rubocop:disable Style/SpecialGlobalVars
+          return unless error
           return if ignored_error?(error)
           return if Appsignal::Transaction.last_errors.include?(error)
 

--- a/spec/lib/appsignal/hooks/at_exit_spec.rb
+++ b/spec/lib/appsignal/hooks/at_exit_spec.rb
@@ -40,6 +40,17 @@ describe Appsignal::Hooks::AtExit::AtExitCallback do
     Appsignal::Hooks::AtExit::AtExitCallback.call
   end
 
+  it "reports no transaction if the process didn't exit with an error" do
+    logs =
+      capture_logs do
+        expect do
+          call_callback
+        end.to_not(change { created_transactions.count })
+      end
+
+    expect(logs).to_not contains_log(:error, "Appsignal.report_error: Cannot add error.")
+  end
+
   it "reports an error if there's an unhandled error" do
     expect do
       with_error(ExampleException, "error message") do


### PR DESCRIPTION
When a process exits normally (without an error) the `report_error` helper would log an error about the error value (`nil`) not being a valid exception.

Only continue to `report_error` helper if the Ruby last error object is not `nil`.

Fixes #1271