### PR TITLE
Log a warning for loader defaults after configure

### DIFF
--- a/.changesets/log-warning-for-loader-defaults.md
+++ b/.changesets/log-warning-for-loader-defaults.md
@@ -1,0 +1,16 @@
+---
+bump: patch
+type: change
+---
+
+Log a warning when loader defaults are added after AppSignal has already been configured.
+
+```ruby
+# Bad
+Appsignal.configure # or Appsignal.start
+Appsignal.load(:sinatra)
+
+# Good
+Appsignal.load(:sinatra)
+Appsignal.configure # or Appsignal.start
+```

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -15,6 +15,13 @@ module Appsignal
 
     # @api private
     def self.add_loader_defaults(name, env: nil, root_path: nil, **options)
+      if Appsignal.config
+        Appsignal.internal_logger.warn(
+          "The config defaults from the '#{name}' loader are ignored since " \
+            "the AppSignal config has already been initialized."
+        )
+      end
+
       loader_defaults << {
         :name => name,
         :env => env,

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -1,5 +1,18 @@
 describe Appsignal::Config do
   describe ".add_loader_defaults" do
+    context "when the config is initialized" do
+      before { Appsignal.configure(:test) }
+
+      it "logs a warning" do
+        logs = capture_logs { described_class.add_loader_defaults(:loader1) }
+
+        expect(logs).to contains_log(
+          :warn,
+          "The config defaults from the 'loader1' loader are ignored"
+        )
+      end
+    end
+
     it "adds loader defaults to the list" do
       described_class.add_loader_defaults(:loader1)
 


### PR DESCRIPTION
When an app loads a loader after AppSignal has been configure or has started, log a warning to indicate that this is not supported.

[skip review]