### PR TITLE
Rename the path and method transaction metadata

### DIFF
--- a/.changesets/rename-path-and-method-transaction-metadata.md
+++ b/.changesets/rename-path-and-method-transaction-metadata.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Rename the `path` and `method` transaction metadata to `request_path` and `request_method` to make it more clear what context this metadata is from. The `path` and `method` metadata will continue to be reported until the next major/minor version.

--- a/lib/appsignal/rack.rb
+++ b/lib/appsignal/rack.rb
@@ -48,10 +48,17 @@ module Appsignal
       end
 
       def apply_to(transaction)
-        transaction.set_metadata("path", request.path)
+        request_path = request.path
+        transaction.set_metadata("request_path", request_path)
+        # TODO: Remove in next major/minor version
+        transaction.set_metadata("path", request_path)
 
         request_method = request_method_for(request)
-        transaction.set_metadata("method", request_method) if request_method
+        if request_method
+          transaction.set_metadata("request_method", request_method)
+          # TODO: Remove in next major/minor version
+          transaction.set_metadata("method", request_method)
+        end
 
         transaction.add_params { params_for(request) }
         transaction.add_session_data { session_data_for(request) }

--- a/spec/lib/appsignal/integrations/puma_spec.rb
+++ b/spec/lib/appsignal/integrations/puma_spec.rb
@@ -76,7 +76,9 @@ describe Appsignal::Integrations::PumaServer do
           lowlevel_error(error, env)
 
           expect(last_transaction).to include_metadata(
+            "request_method" => "GET",
             "method" => "GET",
+            "request_path" => "/some/path",
             "path" => "/some/path"
           )
           expect(last_transaction).to include_environment(

--- a/spec/lib/appsignal/rack/abstract_middleware_spec.rb
+++ b/spec/lib/appsignal/rack/abstract_middleware_spec.rb
@@ -171,7 +171,9 @@ describe Appsignal::Rack::AbstractMiddleware do
           make_request
 
           expect(last_transaction).to include_metadata(
+            "request_method" => "GET",
             "method" => "GET",
+            "request_path" => "/some/path",
             "path" => "/some/path"
           )
           expect(last_transaction).to include_environment(


### PR DESCRIPTION
The `path` and `method` metadata naming was a bit confusing. Add the `request_` prefix to make clear it's about the request.

We can remove the old context in the next major/minor version.

Based on #1270 