### PR TITLE
Clean up probes spec

### DIFF
--- a/spec/lib/appsignal/probes_spec.rb
+++ b/spec/lib/appsignal/probes_spec.rb
@@ -244,12 +244,7 @@ describe Appsignal::Probes do
   end
 
   describe ".unregister" do
-    let(:log_stream) { StringIO.new }
-    let(:log) { log_contents(log_stream) }
-    before do
-      Appsignal.internal_logger = test_logger(log_stream)
-      speed_up_tests!
-    end
+    before { speed_up_tests! }
 
     it "does not call the initialized probe after unregistering" do
       probe1_calls = 0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -168,13 +168,6 @@ RSpec.configure do |config|
   end
 
   def stop_minutely_probes
-    thread =
-      begin
-        Appsignal::Probes.class_variable_get(:@@thread) # Fetch old thread
-      rescue NameError
-        nil
-      end
     Appsignal::Probes.stop
-    thread&.join # Wait for old thread to exit
   end
 end


### PR DESCRIPTION
## Remove duplicate probes clean up in specs

Calling `Probes.stop` already kills the thread.

## Remove unused internal logger mock from spec

No log assertions are done so remove this mock.

[skip review]
[skip changeset]