### PR TITLE
Refactor check-in specs logging

### DIFF
--- a/spec/lib/appsignal/check_in/cron_spec.rb
+++ b/spec/lib/appsignal/check_in/cron_spec.rb
@@ -1,85 +1,68 @@
 describe Appsignal::CheckIn::Cron do
+  let(:log_stream) { std_stream }
+  let(:logs) { log_contents(log_stream) }
+  let(:appsignal_options) { {} }
   let(:config) { project_fixture_config }
   let(:cron_checkin) { described_class.new(:identifier => "cron-checkin-name") }
   let(:transmitter) { Appsignal::Transmitter.new("https://checkin-endpoint.invalid") }
   let(:scheduler) { Appsignal::CheckIn::Scheduler.new }
 
   before do
-    allow(Appsignal).to receive(:active?).and_return(true)
-    config.logger = Logger.new(StringIO.new)
+    start_agent(
+      :options => appsignal_options,
+      :internal_logger => test_logger(log_stream)
+    )
     allow(Appsignal::CheckIn).to receive(:scheduler).and_return(scheduler)
     allow(Appsignal::CheckIn).to receive(:transmitter).and_return(transmitter)
   end
+  after { stop_scheduler }
 
-  after do
+  def stop_scheduler
     scheduler.stop
   end
 
   describe "when Appsignal is not active" do
-    it "should not transmit any events" do
-      allow(Appsignal).to receive(:active?).and_return(false)
+    let(:appsignal_options) { { :active => false } }
 
-      expect(Appsignal.internal_logger).to receive(:debug).with(satisfy do |message|
-        message.include?("Cannot transmit cron check-in `cron-checkin-name` start event") &&
-        message.include?("AppSignal is not active")
-      end)
+    it "does not transmit any events" do
+      expect(Appsignal).to_not be_started
 
       cron_checkin.start
-
-      expect(Appsignal.internal_logger).to receive(:debug).with(satisfy do |message|
-        message.include?("Cannot transmit cron check-in `cron-checkin-name` finish event") &&
-        message.include?("AppSignal is not active")
-      end)
-
       cron_checkin.finish
+      stop_scheduler
 
-      expect(transmitter).not_to receive(:transmit)
-
-      scheduler.stop
+      expect(logs).to contains_log(
+        :debug,
+        /Cannot transmit cron check-in `cron-checkin-name` start event .+: AppSignal is not active/
+      )
+      expect(logs).to contains_log(
+        :debug,
+        /Cannot transmit cron check-in `cron-checkin-name` finish event .+: AppSignal is not active/
+      )
     end
   end
 
   describe "when AppSignal is stopped" do
-    it "should not transmit any events" do
-      expect(transmitter).not_to receive(:transmit)
-
-      expect(Appsignal.internal_logger).to receive(:debug).with("Stopping AppSignal")
-
+    it "does not transmit any events" do
       Appsignal.stop
-
-      expect(Appsignal.internal_logger).to receive(:debug).with(satisfy do |message|
-        message.include?("Cannot transmit cron check-in `cron-checkin-name` start event") &&
-        message.include?("AppSignal is stopped")
-      end)
 
       cron_checkin.start
-
-      expect(Appsignal.internal_logger).to receive(:debug).with(satisfy do |message|
-        message.include?("Cannot transmit cron check-in `cron-checkin-name` finish event") &&
-        message.include?("AppSignal is stopped")
-      end)
-
       cron_checkin.finish
 
-      expect(Appsignal.internal_logger).to receive(:debug).with("Stopping AppSignal")
-
-      Appsignal.stop
+      expect(logs).to contains_log(
+        :debug,
+        "Cannot transmit cron check-in `cron-checkin-name` start event"
+      )
+      expect(logs).to contains_log(
+        :debug,
+        "Cannot transmit cron check-in `cron-checkin-name` finish event"
+      )
     end
   end
 
   describe "#start" do
-    it "should send a cron check-in start" do
-      expect(Appsignal.internal_logger).not_to receive(:error)
-
-      expect(Appsignal.internal_logger).to receive(:debug).with(satisfy do |message|
-        message.include?("Scheduling cron check-in `cron-checkin-name` start event")
-      end)
-
+    it "sends a cron check-in start" do
       cron_checkin.start
-
-      expect(Appsignal.internal_logger).to receive(:debug).with(satisfy do |message|
-        message.include?("Transmitted cron check-in `cron-checkin-name` start event")
-      end)
 
       expect(transmitter).to receive(:transmit).with([hash_including(
         :identifier => "cron-checkin-name",
@@ -88,19 +71,20 @@ describe Appsignal::CheckIn::Cron do
       )], :format => :ndjson).and_return(Net::HTTPResponse.new(nil, "200", nil))
 
       scheduler.stop
+
+      expect(logs).to_not contains_log(:error)
+      expect(logs).to contains_log(
+        :debug,
+        "Scheduling cron check-in `cron-checkin-name` start event"
+      )
+      expect(logs).to contains_log(
+        :debug,
+        "Transmitted cron check-in `cron-checkin-name` start event"
+      )
     end
 
-    it "should log an error if it fails" do
-      expect(Appsignal.internal_logger).to receive(:debug).with(satisfy do |message|
-        message.include?("Scheduling cron check-in `cron-checkin-name` start event")
-      end)
-
+    it "logs an error if it fails" do
       cron_checkin.start
-
-      expect(Appsignal.internal_logger).to receive(:error).with(satisfy do |message|
-        message.include?("Failed to transmit cron check-in `cron-checkin-name` start event") &&
-          message.include?("499 status code")
-      end)
 
       expect(transmitter).to receive(:transmit).with([hash_including(
         :identifier => "cron-checkin-name",
@@ -109,22 +93,21 @@ describe Appsignal::CheckIn::Cron do
       )], :format => :ndjson).and_return(Net::HTTPResponse.new(nil, "499", nil))
 
       scheduler.stop
+
+      expect(logs).to contains_log(
+        :debug,
+        "Scheduling cron check-in `cron-checkin-name` start event"
+      )
+      expect(logs).to contains_log(
+        :error,
+        /Failed to transmit cron check-in `cron-checkin-name` start event .+: 499 status code/
+      )
     end
   end
 
   describe "#finish" do
-    it "should send a cron check-in finish" do
-      expect(Appsignal.internal_logger).not_to receive(:error)
-
-      expect(Appsignal.internal_logger).to receive(:debug).with(satisfy do |message|
-        message.include?("Scheduling cron check-in `cron-checkin-name` finish event")
-      end)
-
+    it "sends a cron check-in finish" do
       cron_checkin.finish
-
-      expect(Appsignal.internal_logger).to receive(:debug).with(satisfy do |message|
-        message.include?("Transmitted cron check-in `cron-checkin-name` finish event")
-      end)
 
       expect(transmitter).to receive(:transmit).with([hash_including(
         :identifier => "cron-checkin-name",
@@ -133,19 +116,19 @@ describe Appsignal::CheckIn::Cron do
       )], :format => :ndjson).and_return(Net::HTTPResponse.new(nil, "200", nil))
 
       scheduler.stop
+      expect(logs).to_not contains_log(:error)
+      expect(logs).to contains_log(
+        :debug,
+        "Scheduling cron check-in `cron-checkin-name` finish event"
+      )
+      expect(logs).to contains_log(
+        :debug,
+        "Transmitted cron check-in `cron-checkin-name` finish event"
+      )
     end
 
-    it "should log an error if it fails" do
-      expect(Appsignal.internal_logger).to receive(:debug).with(satisfy do |message|
-        message.include?("Scheduling cron check-in `cron-checkin-name` finish event")
-      end)
-
+    it "logs an error if it fails" do
       cron_checkin.finish
-
-      expect(Appsignal.internal_logger).to receive(:error).with(satisfy do |message|
-        message.include?("Failed to transmit cron check-in `cron-checkin-name` finish event") &&
-          message.include?("499 status code")
-      end)
 
       expect(transmitter).to receive(:transmit).with([hash_including(
         :identifier => "cron-checkin-name",
@@ -154,12 +137,21 @@ describe Appsignal::CheckIn::Cron do
       )], :format => :ndjson).and_return(Net::HTTPResponse.new(nil, "499", nil))
 
       scheduler.stop
+
+      expect(logs).to contains_log(
+        :debug,
+        "Scheduling cron check-in `cron-checkin-name` finish event"
+      )
+      expect(logs).to contains_log(
+        :error,
+        /Failed to transmit cron check-in `cron-checkin-name` finish event .+: 499 status code/
+      )
     end
   end
 
   describe ".cron" do
     describe "when a block is given" do
-      it "should send a cron check-in start and finish and return the block output" do
+      it "sends a cron check-in start and finish and return the block output" do
         expect(scheduler).to receive(:schedule).with(hash_including(
           :kind => "start",
           :identifier => "cron-checkin-with-block",
@@ -176,7 +168,7 @@ describe Appsignal::CheckIn::Cron do
         expect(output).to eq("output")
       end
 
-      it "should not send a cron check-in finish event when an error is raised" do
+      it "does not send a cron check-in finish event when an error is raised" do
         expect(scheduler).to receive(:schedule).with(hash_including(
           :kind => "start",
           :identifier => "cron-checkin-with-block",
@@ -196,7 +188,7 @@ describe Appsignal::CheckIn::Cron do
     end
 
     describe "when no block is given" do
-      it "should only send a cron check-in finish event" do
+      it "only sends a cron check-in finish event" do
         expect(scheduler).to receive(:schedule).with(hash_including(
           :kind => "finish",
           :identifier => "cron-checkin-without-block",

--- a/spec/support/helpers/config_helpers.rb
+++ b/spec/support/helpers/config_helpers.rb
@@ -46,7 +46,7 @@ module ConfigHelpers
   end
   module_function :build_config
 
-  def start_agent(env: "production", options: {})
+  def start_agent(env: "production", options: {}, internal_logger: nil)
     env = "production" if env == :default
     env ||= "production"
     Appsignal.configure(env, :root_path => project_fixture_path) do |config|
@@ -55,6 +55,7 @@ module ConfigHelpers
       end
     end
     Appsignal.start
+    Appsignal.internal_logger = internal_logger if internal_logger
   end
 
   def clear_integration_env_vars!

--- a/spec/support/matchers/contains_log.rb
+++ b/spec/support/matchers/contains_log.rb
@@ -1,14 +1,21 @@
 RSpec::Matchers.define :contains_log do |level, message|
-  expected_log_line = "[#{level.upcase}] #{message}"
+  log_level_prefix = level.upcase
 
   match do |actual|
-    actual.include?(expected_log_line)
+    case message
+    when Regexp
+      /\[#{log_level_prefix}\] #{message}/.match?(actual)
+    else
+      expected_log_line = "[#{log_level_prefix}] #{message}"
+      actual.include?(expected_log_line)
+    end
   end
 
   failure_message do |actual|
     <<~MESSAGE
       Did not contain log line:
-      #{expected_log_line}
+      Log level: #{log_level_prefix}
+      Message: #{message}
 
       Received logs:
       #{actual}


### PR DESCRIPTION
Don't assert method calls. Check what's written to the logs.

[skip changeset] because it's only spec changes