### PR TITLE
Add dummy logs to probes spec to debug spec issue

### DIFF
--- a/spec/lib/appsignal/probes_spec.rb
+++ b/spec/lib/appsignal/probes_spec.rb
@@ -43,6 +43,9 @@ describe Appsignal::Probes do
     let(:log) { log_contents(log_stream) }
     before do
       Appsignal.internal_logger = test_logger(log_stream)
+      # TODO: These logs are here to debug an issue on CI
+      Appsignal.internal_logger.info("a" * 100)
+      Appsignal.internal_logger.info("b" * 100)
       speed_up_tests!
     end
 


### PR DESCRIPTION
The start of the log is always cut off if it fails on JRuby builds. Add some dummy data at the start to debug the issue further.

[skip changeset]
[skip review]