### PR TITLE
Refactor Check-In request specs

### DIFF
--- a/lib/appsignal/check_in/scheduler.rb
+++ b/lib/appsignal/check_in/scheduler.rb
@@ -98,16 +98,15 @@ module Appsignal
           response = CheckIn.transmitter.transmit(events, :format => :ndjson)
 
           if (200...300).include?(response.code.to_i)
-            Appsignal.internal_logger.debug(
-              "Transmitted #{description}"
-            )
+            Appsignal.internal_logger.debug("Transmitted #{description}")
           else
             Appsignal.internal_logger.error(
               "Failed to transmit #{description}: #{response.code} status code"
             )
           end
         rescue => e
-          Appsignal.internal_logger.error("Failed to transmit #{description}: #{e.message}")
+          Appsignal.internal_logger
+            .error("Failed to transmit #{description}: #{e.class}: #{e.message}")
         end
       end
 

--- a/spec/lib/appsignal/check_in/scheduler_spec.rb
+++ b/spec/lib/appsignal/check_in/scheduler_spec.rb
@@ -5,29 +5,26 @@ describe Appsignal::CheckIn::Scheduler do
   let(:log_stream) { std_stream }
   let(:logs) { log_contents(log_stream) }
   let(:appsignal_options) { {} }
-  let(:transmitter) { Appsignal::Transmitter.new("http://checkin-endpoint.invalid") }
+  let(:scheduler) { Appsignal::CheckIn.scheduler }
 
   before do
     start_agent(:options => appsignal_options, :internal_logger => test_logger(log_stream))
-    allow(transmitter).to receive(:transmit).and_return(Net::HTTPSuccess.new("1.1", 200, "OK"))
-    allow(Appsignal::CheckIn).to receive(:transmitter).and_return(transmitter)
-    allow(Appsignal::CheckIn).to receive(:scheduler).and_return(subject)
     # Shorten debounce intervals to make the tests run faster.
     stub_const("Appsignal::CheckIn::Scheduler::INITIAL_DEBOUNCE_SECONDS", 0.1)
     stub_const("Appsignal::CheckIn::Scheduler::BETWEEN_TRANSMISSIONS_DEBOUNCE_SECONDS", 0.1)
   end
 
   after do
-    subject.stop
+    scheduler.stop
   end
 
   describe "when no event is sent" do
     it "does not start a thread" do
-      expect(subject.thread).to be_nil
+      expect(scheduler.thread).to be_nil
     end
 
     it "does not schedule a debounce" do
-      expect(subject.waker).to be_nil
+      expect(scheduler.waker).to be_nil
     end
 
     it "can be stopped" do
@@ -38,7 +35,7 @@ describe Appsignal::CheckIn::Scheduler do
       stub_const("Appsignal::CheckIn::Scheduler::BETWEEN_TRANSMISSIONS_DEBOUNCE_SECONDS", 10)
 
       take_at_most(0.1) do
-        expect { subject.stop }.not_to raise_error
+        expect { scheduler.stop }.not_to raise_error
       end
     end
 
@@ -50,44 +47,60 @@ describe Appsignal::CheckIn::Scheduler do
       stub_const("Appsignal::CheckIn::Scheduler::BETWEEN_TRANSMISSIONS_DEBOUNCE_SECONDS", 10)
 
       take_at_most(0.1) do
-        expect { subject.stop }.not_to raise_error
-        expect { subject.stop }.not_to raise_error
+        expect { scheduler.stop }.not_to raise_error
+        expect { scheduler.stop }.not_to raise_error
       end
     end
 
     it "closes the queue when stopped" do
-      subject.stop
-      expect(subject.queue.closed?).to be(true)
+      scheduler.stop
+      expect(scheduler.queue.closed?).to be(true)
     end
   end
 
   describe "when an event is sent" do
     it "starts a thread" do
+      stub_check_in_request(
+        :events => [
+          "identifier" => "test",
+          "kind" => "finish",
+          "check_in_type" => "cron"
+        ]
+      )
       Appsignal::CheckIn.cron("test")
-      expect(subject.thread).to be_a(Thread)
+      expect(scheduler.thread).to be_a(Thread)
     end
 
     it "schedules a debounce" do
+      stub_check_in_request(
+        :events => [
+          "identifier" => "test",
+          "kind" => "finish",
+          "check_in_type" => "cron"
+        ]
+      )
       Appsignal::CheckIn.cron("test")
-      expect(subject.waker).to be_a(Thread)
+      expect(scheduler.waker).to be_a(Thread)
     end
 
     it "schedules the event to be transmitted" do
-      expect(transmitter).to receive(:transmit).with([hash_including(
-        :identifier => "test",
-        :check_in_type => "cron",
-        :kind => "finish"
-      )], :format => :ndjson)
+      stub_check_in_request(
+        :events => [
+          "identifier" => "test",
+          "kind" => "finish",
+          "check_in_type" => "cron"
+        ]
+      )
 
-      expect(subject.events).to be_empty
+      expect(scheduler.events).to be_empty
 
       Appsignal::CheckIn.cron("test")
 
-      expect(subject.events).not_to be_empty
+      expect(scheduler.events).not_to be_empty
 
-      wait_for("the event to be transmitted") { subject.transmitted == 1 }
+      wait_for("the event to be transmitted") { scheduler.transmitted == 1 }
 
-      expect(subject.events).to be_empty
+      expect(scheduler.events).to be_empty
 
       expect(logs).to contains_log(:debug, "Scheduling cron check-in `test` finish event")
       expect(logs).to contains_log(:debug, "Transmitted cron check-in `test` finish event")
@@ -101,25 +114,27 @@ describe Appsignal::CheckIn::Scheduler do
       stub_const("Appsignal::CheckIn::Scheduler::INITIAL_DEBOUNCE_SECONDS", 10)
       stub_const("Appsignal::CheckIn::Scheduler::BETWEEN_TRANSMISSIONS_DEBOUNCE_SECONDS", 10)
 
-      expect(transmitter).to receive(:transmit).with([hash_including(
-        :identifier => "test",
-        :check_in_type => "cron",
-        :kind => "finish"
-      )], :format => :ndjson)
+      stub_check_in_request(
+        :events => [
+          "identifier" => "test",
+          "kind" => "finish",
+          "check_in_type" => "cron"
+        ]
+      )
 
       Appsignal::CheckIn.cron("test")
 
-      expect(subject.events).not_to be_empty
+      expect(scheduler.events).not_to be_empty
 
       take_at_most(0.1) do
-        expect { subject.stop }.not_to raise_error
+        expect { scheduler.stop }.not_to raise_error
       end
 
       # Check that the thread wasn't killed before the transmission was
       # completed.
-      expect(subject.transmitted).to eq(1)
+      expect(scheduler.transmitted).to eq(1)
 
-      expect(subject.events).to be_empty
+      expect(scheduler.events).to be_empty
 
       expect(logs).to contains_log(:debug, "Scheduling cron check-in `test` finish event")
       expect(logs).to contains_log(:debug, "Transmitted cron check-in `test` finish event")
@@ -133,59 +148,87 @@ describe Appsignal::CheckIn::Scheduler do
       stub_const("Appsignal::CheckIn::Scheduler::INITIAL_DEBOUNCE_SECONDS", 10)
       stub_const("Appsignal::CheckIn::Scheduler::BETWEEN_TRANSMISSIONS_DEBOUNCE_SECONDS", 10)
 
+      stub_check_in_request(
+        :events => [
+          "identifier" => "test",
+          "kind" => "finish",
+          "check_in_type" => "cron"
+        ]
+      )
       Appsignal::CheckIn.cron("test")
       take_at_most(0.1) do
-        expect { subject.stop }.not_to raise_error
+        expect { scheduler.stop }.not_to raise_error
       end
 
       # Check that the thread wasn't killed before the transmission was
       # completed.
-      expect(subject.transmitted).to eq(1)
+      expect(scheduler.transmitted).to eq(1)
 
       take_at_most(0.1) do
-        expect { subject.stop }.not_to raise_error
+        expect { scheduler.stop }.not_to raise_error
       end
     end
 
     it "closes the queue when stopped" do
+      stub_check_in_request(
+        :events => [
+          "identifier" => "test",
+          "kind" => "finish",
+          "check_in_type" => "cron"
+        ]
+      )
       Appsignal::CheckIn.cron("test")
-      subject.stop
-      expect(subject.queue.closed?).to be(true)
+      scheduler.stop
+      expect(scheduler.queue.closed?).to be(true)
     end
 
     it "kills the thread when stopped" do
+      stub_check_in_request(
+        :events => [
+          "identifier" => "test",
+          "kind" => "finish",
+          "check_in_type" => "cron"
+        ]
+      )
       Appsignal::CheckIn.cron("test")
-      subject.stop
-      expect(subject.thread.alive?).to be(false)
+      scheduler.stop
+      expect(scheduler.thread.alive?).to be(false)
     end
 
     it "unschedules the debounce when stopped" do
+      stub_check_in_request(
+        :events => [
+          "identifier" => "test",
+          "kind" => "finish",
+          "check_in_type" => "cron"
+        ]
+      )
       Appsignal::CheckIn.cron("test")
-      waker = subject.waker
-      subject.stop
+      waker = scheduler.waker
+      scheduler.stop
       expect(waker.alive?).to be(false)
-      expect(subject.waker).to be_nil
+      expect(scheduler.waker).to be_nil
     end
   end
 
   describe "when many events are sent" do
     describe "within the short debounce interval" do
       it "transmits all events at once" do
-        expect(transmitter).to receive(:transmit).with(
-          ["first", "second", "third"].map do |identifier|
-            hash_including(
-              :identifier => identifier,
-              :check_in_type => "cron",
-              :kind => "finish"
-            )
-          end, :format => :ndjson
-        )
+        ["first", "second", "third"].map do |identifier|
+          stub_check_in_request(
+            :events => [
+              "identifier" => identifier,
+              "kind" => "finish",
+              "check_in_type" => "cron"
+            ]
+          )
+        end
 
         Appsignal::CheckIn.cron("first")
         Appsignal::CheckIn.cron("second")
         Appsignal::CheckIn.cron("third")
 
-        wait_for("the events to be transmitted") { subject.transmitted == 1 }
+        wait_for("the events to be transmitted") { scheduler.transmitted == 1 }
       end
 
       it "transmits all events at once when stopped" do
@@ -195,42 +238,58 @@ describe Appsignal::CheckIn::Scheduler do
         # stopped.
         stub_const("Appsignal::CheckIn::Scheduler::INITIAL_DEBOUNCE_SECONDS", 10)
 
-        expect(transmitter).to receive(:transmit).with(
-          ["first", "second", "third"].map do |identifier|
-            hash_including(
-              :identifier => identifier,
-              :check_in_type => "cron",
-              :kind => "finish"
-            )
-          end, :format => :ndjson
-        )
+        ["first", "second", "third"].map do |identifier|
+          stub_check_in_request(
+            :events => [
+              "identifier" => identifier,
+              "kind" => "finish",
+              "check_in_type" => "cron"
+            ]
+          )
+        end
 
         Appsignal::CheckIn.cron("first")
         Appsignal::CheckIn.cron("second")
         Appsignal::CheckIn.cron("third")
 
-        subject.stop
+        scheduler.stop
 
-        wait_for("the events to be transmitted") { subject.transmitted == 1 }
+        wait_for("the events to be transmitted") { scheduler.transmitted == 1 }
       end
     end
 
     describe "further apart than the short debounce interval" do
       it "transmits the first event and enqueues future events" do
-        expect(transmitter).to receive(:transmit).with([hash_including(
-          :identifier => "first",
-          :check_in_type => "cron",
-          :kind => "finish"
-        )], :format => :ndjson)
+        stub_check_in_request(
+          :events => [
+            "identifier" => "first",
+            "kind" => "finish",
+            "check_in_type" => "cron"
+          ]
+        )
 
         Appsignal::CheckIn.cron("first")
 
-        wait_for("the first event to be transmitted") { subject.transmitted == 1 }
+        wait_for("the first event to be transmitted") { scheduler.transmitted == 1 }
 
+        stub_check_in_request(
+          :events => [
+            {
+              "identifier" => "second",
+              "kind" => "finish",
+              "check_in_type" => "cron"
+            },
+            {
+              "identifier" => "third",
+              "kind" => "finish",
+              "check_in_type" => "cron"
+            }
+          ]
+        )
         Appsignal::CheckIn.cron("second")
         Appsignal::CheckIn.cron("third")
 
-        expect(subject.events).to match(["second", "third"].map do |identifier|
+        expect(scheduler.events).to match(["second", "third"].map do |identifier|
           hash_including({
             :identifier => identifier,
             :check_in_type => "cron",
@@ -240,30 +299,40 @@ describe Appsignal::CheckIn::Scheduler do
       end
 
       it "transmits the other events after the debounce interval" do
-        expect(transmitter).to receive(:transmit)
-
+        stub_check_in_request(
+          :events => [
+            "identifier" => "first",
+            "kind" => "finish",
+            "check_in_type" => "cron"
+          ]
+        )
         Appsignal::CheckIn.cron("first")
 
-        wait_for("the first event to be transmitted") { subject.transmitted == 1 }
+        wait_for("the first event to be transmitted") { scheduler.transmitted == 1 }
 
-        expect(transmitter).to receive(:transmit).with(
-          ["second", "third"].map do |identifier|
-            hash_including(
-              :identifier => identifier,
-              :check_in_type => "cron",
-              :kind => "finish"
-            )
-          end, :format => :ndjson
+        stub_check_in_request(
+          :events => [
+            {
+              "identifier" => "second",
+              "kind" => "finish",
+              "check_in_type" => "cron"
+            },
+            {
+              "identifier" => "third",
+              "kind" => "finish",
+              "check_in_type" => "cron"
+            }
+          ]
         )
 
         Appsignal::CheckIn.cron("second")
         Appsignal::CheckIn.cron("third")
 
-        expect(subject.events).to_not be_empty
+        expect(scheduler.events).to_not be_empty
 
-        wait_for("the other events to be transmitted") { subject.transmitted == 2 }
+        wait_for("the other events to be transmitted") { scheduler.transmitted == 2 }
 
-        expect(subject.events).to be_empty
+        expect(scheduler.events).to be_empty
 
         expect(logs).to contains_log(:debug, "Scheduling cron check-in `first` finish event")
         expect(logs).to contains_log(:debug, "Transmitted cron check-in `first` finish event")
@@ -279,32 +348,42 @@ describe Appsignal::CheckIn::Scheduler do
         # immediately when the scheduler is stopped.
         stub_const("Appsignal::CheckIn::Scheduler::BETWEEN_TRANSMISSIONS_DEBOUNCE_SECONDS", 10)
 
-        expect(transmitter).to receive(:transmit)
-
+        stub_check_in_request(
+          :events => [
+            "identifier" => "first",
+            "kind" => "finish",
+            "check_in_type" => "cron"
+          ]
+        )
         Appsignal::CheckIn.cron("first")
 
-        wait_for("the event to be transmitted") { subject.transmitted == 1 }
+        wait_for("the event to be transmitted") { scheduler.transmitted == 1 }
 
-        expect(transmitter).to receive(:transmit).with(
-          ["second", "third"].map do |identifier|
-            hash_including(
-              :identifier => identifier,
-              :check_in_type => "cron",
-              :kind => "finish"
-            )
-          end, :format => :ndjson
+        stub_check_in_request(
+          :events => [
+            {
+              "identifier" => "second",
+              "kind" => "finish",
+              "check_in_type" => "cron"
+            },
+            {
+              "identifier" => "third",
+              "kind" => "finish",
+              "check_in_type" => "cron"
+            }
+          ]
         )
 
         Appsignal::CheckIn.cron("second")
         Appsignal::CheckIn.cron("third")
 
-        expect(subject.events).to_not be_empty
+        expect(scheduler.events).to_not be_empty
 
-        subject.stop
+        scheduler.stop
 
-        wait_for("the other events to be transmitted") { subject.transmitted == 2 }
+        wait_for("the other events to be transmitted") { scheduler.transmitted == 2 }
 
-        expect(subject.events).to be_empty
+        expect(scheduler.events).to be_empty
 
         expect(logs).to contains_log(:debug, "Scheduling cron check-in `first` finish event")
         expect(logs).to contains_log(:debug, "Transmitted cron check-in `first` finish event")
@@ -321,16 +400,18 @@ describe Appsignal::CheckIn::Scheduler do
       # `.cron` helper would use a different digest for each invocation.
       cron = Appsignal::CheckIn::Cron.new(:identifier => "test")
 
-      expect(transmitter).to receive(:transmit).with([hash_including(
-        :identifier => "test",
-        :check_in_type => "cron",
-        :kind => "start"
-      )], :format => :ndjson)
+      stub_check_in_request(
+        :events => [
+          "identifier" => "test",
+          "kind" => "start",
+          "check_in_type" => "cron"
+        ]
+      )
 
       cron.start
       cron.start
 
-      wait_for("the event to be transmitted") { subject.transmitted == 1 }
+      wait_for("the event to be transmitted") { scheduler.transmitted == 1 }
 
       expect(logs).to contains_log(
         :debug,
@@ -353,13 +434,11 @@ describe Appsignal::CheckIn::Scheduler do
 
   describe "when the scheduler is stopped" do
     it "does not schedule any events to be transmitted" do
-      expect(transmitter).not_to receive(:transmit)
-
-      subject.stop
+      scheduler.stop
 
       Appsignal::CheckIn.cron("test")
 
-      expect(subject.events).to be_empty
+      expect(scheduler.events).to be_empty
 
       expect(logs).to contains_log(
         :debug,
@@ -372,11 +451,11 @@ describe Appsignal::CheckIn::Scheduler do
     let(:appsignal_options) { { :active => false } }
 
     it "does not schedule any events to be transmitted" do
-      subject.stop
+      scheduler.stop
 
       Appsignal::CheckIn.cron("test")
 
-      expect(subject.events).to be_empty
+      expect(scheduler.events).to be_empty
 
       expect(logs).to contains_log(
         :debug,
@@ -387,21 +466,45 @@ describe Appsignal::CheckIn::Scheduler do
 
   describe "when transmitting returns a non-success response code" do
     it "logs the error and continues" do
-      expect(transmitter).to receive(:transmit).and_return(
-        Net::HTTPNotFound.new("1.1", 404, "Not Found")
+      stub_check_in_request(
+        :events => [
+          "identifier" => "first",
+          "kind" => "start",
+          "check_in_type" => "cron"
+        ],
+        :response => { :status => 404 }
+      )
+      stub_check_in_request(
+        :events => [
+          "identifier" => "first",
+          "kind" => "finish",
+          "check_in_type" => "cron"
+        ],
+        :response => { :status => 404 }
       )
 
       Appsignal::CheckIn.cron("first")
 
-      wait_for("the first event to be transmitted") { subject.transmitted == 1 }
+      wait_for("the first event to be transmitted") { scheduler.transmitted == 1 }
 
-      expect(transmitter).to receive(:transmit).and_return(
-        Net::HTTPSuccess.new("1.1", 200, "OK")
+      stub_check_in_request(
+        :events => [
+          "identifier" => "second",
+          "kind" => "start",
+          "check_in_type" => "cron"
+        ]
+      )
+      stub_check_in_request(
+        :events => [
+          "identifier" => "second",
+          "kind" => "finish",
+          "check_in_type" => "cron"
+        ]
       )
 
       Appsignal::CheckIn.cron("second")
 
-      wait_for("the second event to be transmitted") { subject.transmitted == 2 }
+      wait_for("the second event to be transmitted") { scheduler.transmitted == 2 }
 
       expect(logs).to contains_log(
         :error,
@@ -416,23 +519,34 @@ describe Appsignal::CheckIn::Scheduler do
 
   describe "when transmitting throws an error" do
     it "logs the error and continues" do
-      expect(transmitter).to receive(:transmit).and_raise("Something went wrong")
+      stub_check_in_request(
+        :events => [
+          "identifier" => "first",
+          "kind" => "finish",
+          "check_in_type" => "cron"
+        ],
+        :response => ExampleStandardError.new("Something went wrong")
+      )
 
       Appsignal::CheckIn.cron("first")
 
-      wait_for("the first event to be transmitted") { subject.transmitted == 1 }
+      wait_for("the first event to be transmitted") { scheduler.transmitted == 1 }
 
-      expect(transmitter).to receive(:transmit).and_return(
-        Net::HTTPSuccess.new("1.1", 200, "OK")
+      stub_check_in_request(
+        :events => [
+          "identifier" => "second",
+          "kind" => "finish",
+          "check_in_type" => "cron"
+        ]
       )
 
       Appsignal::CheckIn.cron("second")
 
-      wait_for("the second event to be transmitted") { subject.transmitted == 2 }
+      wait_for("the second event to be transmitted") { scheduler.transmitted == 2 }
 
       expect(logs).to contains_log(
         :error,
-        /Failed to transmit cron check-in `first` finish event .+: Something went wrong/
+        /Failed to transmit cron check-in `first` finish event .+: ExampleStandardError: Something went wrong/ # rubocop:disable Layout/LineLength
       )
       expect(logs).to contains_log(
         :debug,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -85,6 +85,10 @@ RSpec.configure do |config|
     File.join(tmp_dir, "system-tmp")
   end
 
+  config.before :suite do
+    WebMock.disable_net_connect!
+  end
+
   config.before :context do
     FileUtils.rm_rf(tmp_dir)
     FileUtils.mkdir_p(spec_system_tmp_dir)
@@ -94,6 +98,8 @@ RSpec.configure do |config|
     Appsignal.clear!
     Appsignal::Testing.clear!
     Appsignal::Loaders.clear!
+    Appsignal::CheckIn.clear!
+
     clear_current_transaction!
     stop_minutely_probes
     ENV["RAILS_ENV"] ||= "test"

--- a/spec/support/helpers/api_request_helper.rb
+++ b/spec/support/helpers/api_request_helper.rb
@@ -17,4 +17,44 @@ module ApiRequestHelper
     endpoint = config[:endpoint] || Appsignal::Config::DEFAULT_CONFIG[:endpoint]
     stub_request(:post, "#{endpoint}/1/#{path}").with(options)
   end
+
+  def stub_check_in_request(events:, response: { :status => 200 })
+    config = Appsignal.config
+    options = {
+      :query => {
+        :api_key => config[:push_api_key],
+        :name => config[:name],
+        :environment => config.respond_to?(:env) ? config.env : config[:environment],
+        :hostname => config[:hostname],
+        :gem_version => Appsignal::VERSION
+      },
+      :headers => { "Content-Type" => "application/x-ndjson; charset=UTF-8" }
+    }
+
+    request_stub =
+      stub_request(
+        :post,
+        "#{config[:logging_endpoint]}/check_ins/json"
+      ).with(options) do |request|
+        # Parse each line as JSON per the NDJSON format
+        payloads = request.body.split("\n").map { |line| JSON.parse(line) }
+        formatted_events =
+          events.map do |event|
+            {
+              "identifier" => nil,
+              "digest" => kind_of(String),
+              "kind" => "start",
+              "timestamp" => kind_of(Integer),
+              "check_in_type" => "cron"
+            }.merge(event)
+          end
+        expect(payloads).to include(*formatted_events)
+      end
+
+    if response.is_a?(Exception)
+      request_stub.to_raise(response)
+    else
+      request_stub.to_return(response)
+    end
+  end
 end

--- a/spec/support/testing.rb
+++ b/spec/support/testing.rb
@@ -47,6 +47,15 @@ module Appsignal
     end
   end
 
+  module CheckIn
+    class << self
+      def clear!
+        @transmitter = nil
+        @scheduler = nil
+      end
+    end
+  end
+
   # @api private
   module Testing
     class << self


### PR DESCRIPTION
Do not assert method calls to the transmitter and scheduler, but assert the actual requests being made. This way we are certain the entire chain works, the right format is used and what request are being made.

Also improve the failed transmission log message by including the error type.

[skip changeset] because it's only a spec change.