### PR TITLE
Stub constants in specs

### DIFF
--- a/spec/lib/appsignal/cli/install_spec.rb
+++ b/spec/lib/appsignal/cli/install_spec.rb
@@ -631,7 +631,6 @@ describe Appsignal::CLI::Install do
           it "completes the installation" do
             run
 
-            puts output
             expect(output).to include(*installation_instructions)
             expect(output).to include_complete_install
           end

--- a/spec/lib/appsignal/hooks/data_mapper_spec.rb
+++ b/spec/lib/appsignal/hooks/data_mapper_spec.rb
@@ -1,19 +1,10 @@
 describe Appsignal::Hooks::DataMapperHook do
   context "with datamapper" do
-    before :context do
-      module DataMapper
-      end
-
-      module DataObjects
-        class Connection
-        end
-      end
+    before do
+      stub_const("DataMapper", Module.new)
+      stub_const("DataObjects", Module.new)
+      stub_const("DataObjects::Connection", Class.new)
       Appsignal::Hooks::DataMapperHook.new.install
-    end
-
-    after :context do
-      Object.send(:remove_const, :DataMapper)
-      Object.send(:remove_const, :DataObjects)
     end
 
     describe "#dependencies_present?" do

--- a/spec/lib/appsignal/hooks/delayed_job_spec.rb
+++ b/spec/lib/appsignal/hooks/delayed_job_spec.rb
@@ -1,21 +1,17 @@
 describe Appsignal::Hooks::DelayedJobHook do
   context "with delayed job" do
-    before(:context) do
-      module Delayed
-        class Plugin
-          def self.callbacks
-          end
+    before do
+      stub_const("Delayed::Plugin", Class.new do
+        def self.callbacks
         end
-
-        class Worker
-          def self.plugins
-            @plugins ||= []
-          end
+      end)
+      stub_const("Delayed::Worker", Class.new do
+        def self.plugins
+          @plugins ||= []
         end
-      end
+      end)
+      start_agent
     end
-    after(:context) { Object.send(:remove_const, :Delayed) }
-    before { start_agent }
 
     describe "#dependencies_present?" do
       subject { described_class.new.dependencies_present? }

--- a/spec/lib/appsignal/hooks/excon_spec.rb
+++ b/spec/lib/appsignal/hooks/excon_spec.rb
@@ -2,15 +2,14 @@ describe Appsignal::Hooks::ExconHook do
   before { start_agent }
 
   context "with Excon" do
-    before(:context) do
-      class Excon
+    before do
+      stub_const("Excon", Class.new do
         def self.defaults
           @defaults ||= {}
         end
-      end
+      end)
       Appsignal::Hooks::ExconHook.new.install
     end
-    after(:context) { Object.send(:remove_const, :Excon) }
 
     describe "#dependencies_present?" do
       subject { described_class.new.dependencies_present? }

--- a/spec/lib/appsignal/hooks/gvl_spec.rb
+++ b/spec/lib/appsignal/hooks/gvl_spec.rb
@@ -32,13 +32,9 @@ describe Appsignal::Hooks::GvlHook do
     end
 
     context "with old versions of GVLTools" do
-      before(:context) do
-        module GVLTools
-          VERSION = "0.1.0".freeze
-        end
+      before do
+        stub_const("GVLTools::VERSION", "0.1.0")
       end
-
-      after(:context) { Object.send(:remove_const, :GVLTools) }
 
       before(:each) { expect_gvltools_require }
 
@@ -50,23 +46,18 @@ describe Appsignal::Hooks::GvlHook do
     end
 
     context "with new versions of GVLTools" do
-      before(:context) do
-        module GVLTools
-          VERSION = "0.2.0".freeze
-
-          module GlobalTimer
-            def self.enable
-            end
+      before do
+        stub_const("GVLTools", Module.new)
+        stub_const("GVLTools::VERSION", "0.2.0")
+        stub_const("GVLTools::GlobalTimer", Module.new do
+          def self.enable
           end
-
-          module WaitingThreads
-            def self.enable
-            end
+        end)
+        stub_const("GVLTools::WaitingThreads", Module.new do
+          def self.enable
           end
-        end
+        end)
       end
-
-      after(:context) { Object.send(:remove_const, :GVLTools) }
 
       describe "#dependencies_present?" do
         before(:each) { expect_gvltools_require }

--- a/spec/lib/appsignal/hooks/mongo_ruby_driver_spec.rb
+++ b/spec/lib/appsignal/hooks/mongo_ruby_driver_spec.rb
@@ -7,19 +7,14 @@ describe Appsignal::Hooks::MongoRubyDriverHook do
       allow(Appsignal::Hooks::MongoMonitorSubscriber).to receive(:new).and_return(subscriber)
     end
 
-    before(:context) do
-      module Mongo
-        module Monitoring
-          COMMAND = "command".freeze
-
-          class Global
-            def subscribe
-            end
-          end
+    before do
+      stub_const("Mongo::Monitoring", Module.new)
+      stub_const("Mongo::Monitoring::COMMAND", "command")
+      stub_const("Mongo::Monitoring::Global", Class.new do
+        def subscribe
         end
-      end
+      end)
     end
-    after(:context) { Object.send(:remove_const, :Mongo) }
 
     describe "#dependencies_present?" do
       subject { described_class.new.dependencies_present? }

--- a/spec/lib/appsignal/hooks/passenger_spec.rb
+++ b/spec/lib/appsignal/hooks/passenger_spec.rb
@@ -1,10 +1,8 @@
 describe Appsignal::Hooks::PassengerHook do
   context "with passenger" do
-    before(:context) do
-      module PhusionPassenger
-      end
+    before do
+      stub_const("PhusionPassenger", Module.new)
     end
-    after(:context) { Object.send(:remove_const, :PhusionPassenger) }
 
     describe "#dependencies_present?" do
       subject { described_class.new.dependencies_present? }

--- a/spec/lib/appsignal/hooks/shoryuken_spec.rb
+++ b/spec/lib/appsignal/hooks/shoryuken_spec.rb
@@ -1,15 +1,11 @@
 describe Appsignal::Hooks::ShoryukenHook do
   context "with shoryuken" do
-    before(:context) do
-      module Shoryuken
+    before do
+      stub_const("Shoryuken", Module.new do
         def self.configure_server
         end
-      end
+      end)
       Appsignal::Hooks::ShoryukenHook.new.install
-    end
-
-    after(:context) do
-      Object.send(:remove_const, :Shoryuken)
     end
 
     describe "#dependencies_present?" do

--- a/spec/lib/appsignal/hooks/unicorn_spec.rb
+++ b/spec/lib/appsignal/hooks/unicorn_spec.rb
@@ -1,30 +1,27 @@
 describe Appsignal::Hooks::UnicornHook do
   context "with unicorn" do
-    before :context do
-      module Unicorn
-        class HttpServer
-          def worker_loop(_worker)
-            @worker_loop = true
-          end
-
-          def worker_loop?
-            @worker_loop == true
-          end
+    before do
+      stub_const("Unicorn", Module.new)
+      stub_const("Unicorn::HttpServer", Class.new do
+        def worker_loop(_worker)
+          @worker_loop = true
         end
 
-        class Worker
-          def close
-            @close = true
-          end
-
-          def close?
-            @close == true
-          end
+        def worker_loop?
+          @worker_loop == true
         end
-      end
+      end)
+      stub_const("Unicorn::Worker", Class.new do
+        def close
+          @close = true
+        end
+
+        def close?
+          @close == true
+        end
+      end)
       Appsignal::Hooks::UnicornHook.new.install
     end
-    after(:context) { Object.send(:remove_const, :Unicorn) }
 
     describe "#dependencies_present?" do
       subject { described_class.new.dependencies_present? }

--- a/spec/lib/appsignal/integrations/delayed_job_plugin_spec.rb
+++ b/spec/lib/appsignal/integrations/delayed_job_plugin_spec.rb
@@ -1,22 +1,19 @@
 describe "Appsignal::Integrations::DelayedJobHook" do
-  before(:context) do
-    module Delayed
-      class Plugin
-        def self.callbacks
-        end
-      end
-
-      class Worker
-        def self.plugins
-          @plugins ||= []
-        end
-      end
-    end
-    require "appsignal/integrations/delayed_job_plugin"
-  end
-  after(:context) { Object.send(:remove_const, :Delayed) }
   let(:options) { {} }
-  before { start_agent(:options => options) }
+  before do
+    stub_const("Delayed", Module.new)
+    stub_const("Delayed::Plugin", Class.new do
+      def self.callbacks
+      end
+    end)
+    stub_const("Delayed::Worker", Class.new do
+      def self.plugins
+        @plugins ||= []
+      end
+    end)
+    require "appsignal/integrations/delayed_job_plugin"
+    start_agent(:options => options)
+  end
 
   # We haven't found a way to test the hooks, we'll have to do that manually
 

--- a/spec/lib/appsignal/integrations/object_spec.rb
+++ b/spec/lib/appsignal/integrations/object_spec.rb
@@ -87,14 +87,13 @@ describe Object do
 
         context "with named class" do
           before do
-            class NamedClass
+            stub_const("NamedClass", Class.new do
               def foo
                 1
               end
               appsignal_instrument_method :foo
-            end
+            end)
           end
-          after { Object.send(:remove_const, :NamedClass) }
           let(:klass) { NamedClass }
 
           it "instruments the method and calls it" do
@@ -106,18 +105,13 @@ describe Object do
 
         context "with nested named class" do
           before do
-            module MyModule
-              module NestedModule
-                class NamedClass
-                  def bar
-                    2
-                  end
-                  appsignal_instrument_method :bar
-                end
+            stub_const("MyModule::NestedModule::NamedClass", Class.new do
+              def bar
+                2
               end
-            end
+              appsignal_instrument_method :bar
+            end)
           end
-          after { Object.send(:remove_const, :MyModule) }
           let(:klass) { MyModule::NestedModule::NamedClass }
 
           it "instruments the method and calls it" do
@@ -257,14 +251,13 @@ describe Object do
 
         context "with named class" do
           before do
-            class NamedClass
+            stub_const("NamedClass", Class.new do
               def self.bar
                 2
               end
               appsignal_instrument_class_method :bar
-            end
+            end)
           end
-          after { Object.send(:remove_const, :NamedClass) }
           let(:klass) { NamedClass }
 
           it "instruments the method and calls it" do
@@ -276,18 +269,13 @@ describe Object do
 
           context "with nested named class" do
             before do
-              module MyModule
-                module NestedModule
-                  class NamedClass
-                    def self.bar
-                      2
-                    end
-                    appsignal_instrument_class_method :bar
-                  end
+              stub_const("MyModule::NestedModule::NamedClass", Class.new do
+                def self.bar
+                  2
                 end
-              end
+                appsignal_instrument_class_method :bar
+              end)
             end
-            after { Object.send(:remove_const, :MyModule) }
             let(:klass) { MyModule::NestedModule::NamedClass }
 
             it "instruments the method and calls it" do

--- a/spec/lib/appsignal/integrations/resque_spec.rb
+++ b/spec/lib/appsignal/integrations/resque_spec.rb
@@ -14,25 +14,21 @@ if DependencyHelper.resque_present?
     before do
       start_agent(:options => options)
 
-      class ResqueTestJob
+      stub_const("ResqueTestJob", Class.new do
         def self.perform(*_args)
         end
-      end
+      end)
 
-      class ResqueErrorTestJob
+      stub_const("ResqueErrorTestJob", Class.new do
         def self.perform
           raise "resque job error"
         end
-      end
+      end)
 
       expect(Appsignal).to receive(:stop) # Resque calls stop after every job
     end
     around do |example|
       keep_transactions { example.run }
-    end
-    after do
-      Object.send(:remove_const, :ResqueTestJob)
-      Object.send(:remove_const, :ResqueErrorTestJob)
     end
 
     it "tracks a transaction on perform" do

--- a/spec/lib/appsignal/integrations/sidekiq_spec.rb
+++ b/spec/lib/appsignal/integrations/sidekiq_spec.rb
@@ -526,30 +526,26 @@ if DependencyHelper.active_job_present?
       Appsignal.internal_logger = test_logger(log)
       ActiveJob::Base.queue_adapter = :sidekiq
 
-      class ActiveJobSidekiqTestJob < ActiveJob::Base
+      stub_const("ActiveJobSidekiqTestJob", Class.new(ActiveJob::Base) do
         self.queue_adapter = :sidekiq
 
         def perform(*_args)
         end
-      end
+      end)
 
-      class ActiveJobSidekiqErrorTestJob < ActiveJob::Base
+      stub_const("ActiveJobSidekiqErrorTestJob", Class.new(ActiveJob::Base) do
         self.queue_adapter = :sidekiq
 
         def perform(*_args)
           raise "uh oh"
         end
-      end
+      end)
       # Manually add the AppSignal middleware for the Testing environment.
       # It doesn't use configured middlewares by default looks like.
       # We test somewhere else if the middleware is installed properly.
       Sidekiq::Testing.server_middleware do |chain|
         chain.add Appsignal::Integrations::SidekiqMiddleware
       end
-    end
-    after do
-      Object.send(:remove_const, :ActiveJobSidekiqTestJob)
-      Object.send(:remove_const, :ActiveJobSidekiqErrorTestJob)
     end
 
     it "reports the transaction from the ActiveJob integration" do

--- a/spec/lib/appsignal/rack/grape_middleware_spec.rb
+++ b/spec/lib/appsignal/rack/grape_middleware_spec.rb
@@ -19,12 +19,12 @@ if DependencyHelper.grape_present?
     end
     let(:middleware) { Appsignal::Rack::GrapeMiddleware.new(api_endpoint) }
     let(:transaction) { http_request_transaction }
-    before { start_agent }
+    before do
+      stub_const("GrapeExample::Api", app)
+      start_agent
+    end
     around do |example|
-      GrapeExample = Module.new
-      GrapeExample.send(:const_set, :Api, app)
       keep_transactions { example.run }
-      Object.send(:remove_const, :GrapeExample)
     end
 
     def make_request(env)

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -520,10 +520,7 @@ describe Appsignal do
 
   describe ".load" do
     before do
-      TestLoader = define_loader(:appsignal_loader)
-    end
-    after do
-      Object.send(:remove_const, :TestLoader)
+      stub_const("TestLoader", define_loader(:appsignal_loader))
     end
 
     it "loads a loader" do


### PR DESCRIPTION
Instead of defining constants and manually removing them with `remove_const` use the built-in RSpec helper `stub_const`. This will prevent constants from leaking into other specs.

[skip review]
[skip changeset]

Part of #299