### PR TITLE
Format Date and Time objects stored in sample data

### DIFF
--- a/.changesets/format-date-and-time-objects-in-a-human-friendly-way.md
+++ b/.changesets/format-date-and-time-objects-in-a-human-friendly-way.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Format the Date and Time objects in a human-friendly way. Previously, dates and times stored in sample data, like session data, would be shown as `#<Date>` and `#<Time>`. Now they will show as `#<Date: 2024-09-11>` and `#<Time: Time: 2024-09-12T13:14:15+02:00>` (UTC offset may be different for your time objects depending on the server setting).

--- a/lib/appsignal/utils/hash_sanitizer.rb
+++ b/lib/appsignal/utils/hash_sanitizer.rb
@@ -21,6 +21,10 @@ module Appsignal
             sanitize_array(value, filter_keys, seen)
           when TrueClass, FalseClass, NilClass, Integer, String, Symbol, Float
             unmodified(value)
+          when Time
+            "#<Time: #{value.iso8601}>"
+          when Date
+            "#<Date: #{value.iso8601}>"
           else
             inspected(value)
           end

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -797,6 +797,17 @@ describe Appsignal::Transaction do
       expect(transaction).to include_session_data(block_data)
     end
 
+    it "adds certain Ruby objects as Strings" do
+      transaction.add_session_data("time" => Time.utc(2024, 9, 12, 13, 14, 15))
+      transaction.add_session_data("date" => Date.new(2024, 9, 11))
+
+      transaction._sample
+      expect(transaction).to include_session_data(
+        "time" => "#<Time: 2024-09-12T13:14:15Z>",
+        "date" => "#<Date: 2024-09-11>"
+      )
+    end
+
     it "logs an error if an error occurred storing the session data" do
       transaction.add_session_data { raise "uh oh" }
 

--- a/spec/lib/appsignal/utils/hash_sanitizer_spec.rb
+++ b/spec/lib/appsignal/utils/hash_sanitizer_spec.rb
@@ -10,6 +10,7 @@ describe Appsignal::Utils::HashSanitizer do
       :float => 0.0,
       :bool_true => true,
       :bool_false => false,
+      :date => Date.new(2024, 9, 11),
       # Non-recursive appearances of the same array instance
       :some_arrays => [some_array, some_array],
       # Non-recursive appearances of the same hash instance
@@ -57,18 +58,31 @@ describe Appsignal::Utils::HashSanitizer do
       expect(subject[:float]).to eq(0.0)
       expect(subject[:bool_true]).to be(true)
       expect(subject[:bool_false]).to be(false)
+      expect(subject[:date]).to eq("#<Date: 2024-09-11>")
       expect(subject[:nil]).to be_nil
       expect(subject[:int]).to eq(1)
       expect(subject[:int64]).to eq(1 << 64)
       expect(subject[:some_arrays]).to eq([[1, 2, 3], [1, 2, 3]])
-      expect(subject[:some_hashes]).to eq({ :a => { :a => 1, :b => 2 },
-:b => { :a => 1, :b => 2 } })
+      expect(subject[:some_hashes]).to eq(:a => { :a => 1, :b => 2 }, :b => { :a => 1, :b => 2 })
     end
 
     it "does not change the original params" do
       subject
       expect(params[:file]).to eq(file)
       expect(params[:hash][:nested_array][2]).to eq(file)
+    end
+
+    describe "time objects" do
+      it "returns a hash with normalized Time objects" do
+        args = {
+          :time_in_utc => Time.utc(2024, 9, 12, 13, 14, 15),
+          :time_with_timezone => Time.new(2024, 9, 12, 13, 14, 15, "+09:00")
+        }
+        expect(described_class.sanitize(args)).to eq(
+          :time_in_utc => "#<Time: 2024-09-12T13:14:15Z>",
+          :time_with_timezone => "#<Time: 2024-09-12T13:14:15+09:00>"
+        )
+      end
     end
 
     describe ":hash key" do


### PR DESCRIPTION
Format the Date and Time objects in a human-friendly way. Previously, dates and times stored in sample data, like session data, would be shown as `#<Date>` and `#<Time>`.

They will now be show as `#<Date: 2024-09-11>` and `#<Time: Time: 2024-09-12T13:14:15+02:00>`.
(The time zone will be based on the setting in Ruby.)

The UTC offset is included in the Time object on purpose. Casting it to UTC will lose the timezone information.