### PR TITLE
Refactor Resque parameters storage

### DIFF
--- a/lib/appsignal/integrations/resque.rb
+++ b/lib/appsignal/integrations/resque.rb
@@ -16,12 +16,7 @@ module Appsignal
       ensure
         if transaction
           transaction.set_action_if_nil("#{payload["class"]}#perform")
-          args =
-            Appsignal::Utils::HashSanitizer.sanitize(
-              ResqueHelpers.arguments(payload),
-              Appsignal.config[:filter_parameters]
-            )
-          transaction.add_params_if_nil(args)
+          transaction.add_params_if_nil { ResqueHelpers.arguments(payload) }
           transaction.add_tags("queue" => queue)
 
           Appsignal::Transaction.complete_current!


### PR DESCRIPTION
The Resque integration is sanitizing the parameters. This is already done in the Transaction class, so we don't need to do it again in the integration.

Move the value being set to a block, so the parameters are only fetched when the transaction is sampled.

[skip changeset]
[skip review]