### PR TITLE
Add logger gem as a dependency

### DIFF
--- a/.changesets/add-logger-as-dependency.md
+++ b/.changesets/add-logger-as-dependency.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Add the logger gem as a dependency. This fixes the deprecation warning on Ruby 3.3.

--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -56,6 +56,7 @@ Gem::Specification.new do |gem| # rubocop:disable Metrics/BlockLength
     "source_code_uri" => "https://github.com/appsignal/appsignal-ruby"
   }
 
+  gem.add_dependency "logger"
   gem.add_dependency "rack"
 
   gem.add_development_dependency "pry"


### PR DESCRIPTION
I saw this deprecation warning on Ruby 3.3 about the logger gem no longer being included as a standard gem from Ruby 3.5 onward. Add it to the dependencies to fix the warning.

> appsignal.rb:7: warning: logger was loaded from the standard library,
> but will no longer be part of the default gems starting from Ruby
> 3.5.0.
> You can add logger to your Gemfile or gemspec to silence this warning.