### PR TITLE
Fix the RuboCop paths in the gemspec to ignore

### DIFF
--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -17,8 +17,8 @@ IGNORED_PATHS = [
   ".yardopts",
   "benchmark.rake",
   "mono.yml",
-  "rubocop.yml",
-  "rubocop_todo.yml"
+  ".rubocop.yml",
+  ".rubocop_todo.yml"
 ].freeze
 
 Gem::Specification.new do |gem| # rubocop:disable Metrics/BlockLength


### PR DESCRIPTION
They start with a dot and were still included because of this mismatch. This will make sure these files aren't included in the next release.

[skip changeset]
[skip review]