### PR TITLE
Refactor sample data sanitizer specs

### DIFF
--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -707,7 +707,7 @@ module Appsignal
       return unless Appsignal.config[:send_params]
 
       filter_keys = Appsignal.config[:filter_parameters] || []
-      Appsignal::Utils::HashSanitizer.sanitize params, filter_keys
+      Appsignal::Utils::SampleDataSanitizer.sanitize(params, filter_keys)
     end
 
     def session_data
@@ -720,7 +720,8 @@ module Appsignal
 
     # Returns sanitized session data.
     #
-    # The session data is sanitized by the {Appsignal::Utils::HashSanitizer}.
+    # The session data is sanitized by the
+    # {Appsignal::Utils::SampleDataSanitizer}.
     #
     # @return [nil] if `:send_session_data` config is set to `false`.
     # @return [nil] if the {#request} object doesn't respond to `#session`.
@@ -729,8 +730,9 @@ module Appsignal
     def sanitized_session_data
       return unless Appsignal.config[:send_session_data]
 
-      Appsignal::Utils::HashSanitizer.sanitize(
-        session_data, Appsignal.config[:filter_session_data]
+      Appsignal::Utils::SampleDataSanitizer.sanitize(
+        session_data,
+        Appsignal.config[:filter_session_data]
       )
     end
 

--- a/lib/appsignal/utils.rb
+++ b/lib/appsignal/utils.rb
@@ -9,7 +9,7 @@ end
 require "appsignal/utils/integration_memory_logger"
 require "appsignal/utils/stdout_and_logger_message"
 require "appsignal/utils/data"
-require "appsignal/utils/hash_sanitizer"
+require "appsignal/utils/sample_data_sanitizer"
 require "appsignal/utils/integration_logger"
 require "appsignal/utils/json"
 require "appsignal/utils/ndjson"

--- a/lib/appsignal/utils/sample_data_sanitizer.rb
+++ b/lib/appsignal/utils/sample_data_sanitizer.rb
@@ -2,7 +2,7 @@
 
 module Appsignal
   module Utils
-    class HashSanitizer
+    class SampleDataSanitizer
       FILTERED = "[FILTERED]"
       RECURSIVE = "[RECURSIVE VALUE]"
 

--- a/spec/lib/appsignal/utils/hash_sanitizer_spec.rb
+++ b/spec/lib/appsignal/utils/hash_sanitizer_spec.rb
@@ -1,195 +1,157 @@
 describe Appsignal::Utils::HashSanitizer do
-  let(:file) { uploaded_file }
-  let(:some_array) { [1, 2, 3] }
-  let(:some_hash) { { :a => 1, :b => 2 } }
-  let(:params) do
-    {
-      :text => "string",
-      "string" => "string key value",
-      :file => file,
-      :float => 0.0,
-      :bool_true => true,
-      :bool_false => false,
-      :date => Date.new(2024, 9, 11),
-      # Non-recursive appearances of the same array instance
-      :some_arrays => [some_array, some_array],
-      # Non-recursive appearances of the same hash instance
-      :some_hashes => { :a => some_hash, :b => some_hash },
-      :nil => nil,
-      :int => 1, # Fixnum
-      :int64 => 1 << 64, # Bignum
-      :hash => {
-        :nested_text => "string",
-        :nested_array => [
-          "something",
-          "else",
-          file,
-          {
-            :key => "value",
-            :file => file
-          }.tap do |hsh|
-            # Recursive hash-in-hash (should be [:nested_array][3][:recursive_hash])
-            hsh[:recursive_hash] = hsh
-          end
-        ].tap do |ary|
-          # Recursive array-in-array (should be [:nested_array][4])
-          ary << ary
-          # Recursive array-in-hash (should be [:nested_array][3][:recursive_array])
-          ary[3][:recursive_array] = ary
-        end
-      }.tap do |hsh|
-        # Recursive hash-in-array (should be [:nested_array][5])
-        hsh[:nested_array] << hsh
-      end
-    }
-  end
-
   describe ".sanitize" do
-    let(:sanitized_params) { described_class.sanitize(params) }
-    subject { sanitized_params }
-
-    it "returns a sanitized Hash" do
-      expect(subject).to_not eq(params)
-      is_expected.to be_instance_of Hash
-      expect(subject[:text]).to eq("string")
-      expect(subject["string"]).to eq("string key value")
-      expect(subject[:file]).to be_instance_of String
-      expect(subject[:file]).to include "::UploadedFile"
-      expect(subject[:float]).to eq(0.0)
-      expect(subject[:bool_true]).to be(true)
-      expect(subject[:bool_false]).to be(false)
-      expect(subject[:date]).to eq("#<Date: 2024-09-11>")
-      expect(subject[:nil]).to be_nil
-      expect(subject[:int]).to eq(1)
-      expect(subject[:int64]).to eq(1 << 64)
-      expect(subject[:some_arrays]).to eq([[1, 2, 3], [1, 2, 3]])
-      expect(subject[:some_hashes]).to eq(:a => { :a => 1, :b => 2 }, :b => { :a => 1, :b => 2 })
+    def sanitize(value, filter_keys = [])
+      described_class.sanitize(value, filter_keys)
     end
 
-    it "does not change the original params" do
-      subject
-      expect(params[:file]).to eq(file)
-      expect(params[:hash][:nested_array][2]).to eq(file)
+    it "accepts String values" do
+      # Hashes
+      expect(sanitize(:a => "abc")).to eq(:a => "abc")
+      expect(sanitize("a" => "abc")).to eq("a" => "abc")
+      expect(sanitize("a" => { "b" => "abc" })).to eq("a" => { "b" => "abc" })
     end
 
-    describe "time objects" do
-      it "returns a hash with normalized Time objects" do
-        args = {
-          :time_in_utc => Time.utc(2024, 9, 12, 13, 14, 15),
-          :time_with_timezone => Time.new(2024, 9, 12, 13, 14, 15, "+09:00")
-        }
-        expect(described_class.sanitize(args)).to eq(
-          :time_in_utc => "#<Time: 2024-09-12T13:14:15Z>",
-          :time_with_timezone => "#<Time: 2024-09-12T13:14:15+09:00>"
-        )
-      end
+    it "accepts Symbol values" do
+      expect(sanitize(:a => :abc)).to eq(:a => :abc)
+      expect(sanitize("a" => :abc)).to eq("a" => :abc)
     end
 
-    describe ":hash key" do
-      subject { sanitized_params[:hash] }
-
-      it "returns a sanitized Hash" do
-        expect(subject).to_not eq(params[:hash])
-        is_expected.to be_instance_of Hash
-        expect(subject[:nested_text]).to eq("string")
-      end
-
-      describe ":nested_array key" do
-        subject { sanitized_params[:hash][:nested_array] }
-
-        it "returns a sanitized Array" do
-          expect(subject).to_not eq(params[:hash][:nested_array])
-          is_expected.to be_instance_of Array
-          expect(subject[0]).to eq("something")
-          expect(subject[1]).to eq("else")
-          expect(subject[2]).to be_instance_of String
-          expect(subject[2]).to include "::UploadedFile"
-        end
-
-        describe "nested hash" do
-          subject { sanitized_params[:hash][:nested_array][3] }
-
-          it "returns a sanitized Hash" do
-            expect(subject).to_not eq(params[:hash][:nested_array][3])
-            is_expected.to be_instance_of Hash
-            expect(subject[:key]).to eq("value")
-            expect(subject[:file]).to be_instance_of String
-            expect(subject[:file]).to include "::UploadedFile"
-          end
-
-          it "replaces a recursive array" do
-            expect(subject[:recursive_array]).to eq("[RECURSIVE VALUE]")
-          end
-
-          it "replaces a recursive hash" do
-            expect(subject[:recursive_hash]).to eq("[RECURSIVE VALUE]")
-          end
-        end
-
-        describe "nested array" do
-          it "replaces a recursive array" do
-            expect(sanitized_params[:hash][:nested_array][4]).to eq("[RECURSIVE VALUE]")
-          end
-
-          it "replaces a recursive hash" do
-            expect(sanitized_params[:hash][:nested_array][5]).to eq("[RECURSIVE VALUE]")
-          end
-        end
-      end
+    it "accepts Boolean values" do
+      expect(sanitize(:a => true, :b => false)).to eq(:a => true, :b => false)
     end
 
-    context "with filter_keys" do
-      let(:sanitized_params) do
-        described_class.sanitize(params, %w[text hash])
+    it "accepts nil values" do
+      expect(sanitize(:a => nil)).to eq(:a => nil)
+    end
+
+    it "accepts number values" do
+      expect(sanitize(:a => 123, :b => 123.45)).to eq(:a => 123, :b => 123.45)
+    end
+
+    it "normalizes Date objects" do
+      expect(sanitize(:date => Date.new(2024, 9, 11)))
+        .to eq(:date => "#<Date: 2024-09-11>")
+    end
+
+    it "normalizes unsupported objects" do
+      expect(sanitize(:file => uploaded_file)[:file])
+        .to include("::UploadedFile")
+
+      expect(sanitize(:file => [:file => uploaded_file])[:file].first[:file])
+        .to include("::UploadedFile")
+
+      expect(sanitize(:object => Object.new))
+        .to eq(:object => "#<Object>")
+    end
+
+    it "normalizes Time objects" do
+      expect(sanitize(:time_in_utc => Time.utc(2024, 9, 12, 13, 14, 15)))
+        .to eq(:time_in_utc => "#<Time: 2024-09-12T13:14:15Z>")
+
+      expect(sanitize(:time_with_timezone => Time.new(2024, 9, 12, 13, 14, 15, "+09:00")))
+        .to eq(:time_with_timezone => "#<Time: 2024-09-12T13:14:15+09:00>")
+    end
+
+    it "accepts nested Hash values" do
+      expect(sanitize(:abc => 123)).to eq(:abc => 123)
+      expect(sanitize("abc" => [456])).to eq("abc" => [456])
+      expect(sanitize("abc" => { :a => { :b => ["c"] } }))
+        .to eq("abc" => { :a => { :b => ["c"] } })
+    end
+
+    it "accepts nested Array values" do
+      expect(sanitize([:abc, 123])).to eq([:abc, 123])
+      expect(sanitize(["abc", [456]])).to eq(["abc", [456]])
+      expect(sanitize(["abc", { :a => { :b => ["c"] } }]))
+        .to eq(["abc", { :a => { :b => ["c"] } }])
+    end
+
+    it "doesn't filter non-recursive Hash values" do
+      hash = { :a => :b }
+      expect(sanitize([hash, hash])).to eq([{ :a => :b }, { :a => :b }])
+
+      hash = { :a => :b }
+      expect(sanitize(:x => hash, :y => hash)).to eq(:x => { :a => :b }, :y => { :a => :b })
+    end
+
+    it "filters recursive Hash values" do
+      hash = { :a => :b }
+      hash[:c] = hash
+      expect(sanitize(hash)).to eq(:a => :b, :c => "[RECURSIVE VALUE]")
+
+      hash = {}
+      hash[:c] = { :d => hash }
+      expect(sanitize(hash)).to eq(:c => { :d => "[RECURSIVE VALUE]" })
+    end
+
+    it "doesn't filters non-recursive Array values" do
+      array = [:a, :b]
+      expect(sanitize([array, array])).to eq([[:a, :b], [:a, :b]])
+    end
+
+    it "filters recursive Array values" do
+      array = [:a, :b]
+      array << array
+      expect(sanitize(array)).to eq([:a, :b, "[RECURSIVE VALUE]"])
+
+      array = [:a, :b]
+      array << [array]
+      expect(sanitize(array)).to eq([:a, :b, ["[RECURSIVE VALUE]"]])
+    end
+
+    it "doesn't change the original value" do
+      file = uploaded_file
+      expect { sanitize(:a => file) }.to_not(change { file })
+
+      file = "text"
+      expect { sanitize(:a => file) }.to_not(change { file })
+    end
+
+    describe "filter keys" do
+      it "sanitizes values from string keys" do
+        object = { "password" => "secret", "user_id" => 123 }
+        expect(sanitize(object, ["password"]))
+          .to eq("password" => "[FILTERED]", "user_id" => 123)
+
+        object = { "user" => { "password" => "secret", "id" => 123 } }
+        expect(sanitize(object, ["password"]))
+          .to eq("user" => { "password" => "[FILTERED]", "id" => 123 })
       end
-      subject { sanitized_params }
 
-      it "returns a sanitized Hash with the given keys filtered out" do
-        expect(subject).to_not eq(params)
-        expect(subject[:text]).to eq(described_class::FILTERED)
-        expect(subject[:hash]).to eq(described_class::FILTERED)
+      it "sanitizes values from symbol keys" do
+        object = { :password => "secret", :user_id => 123 }
+        expect(sanitize(object, ["password"]))
+          .to eq(:password => "[FILTERED]", :user_id => 123)
 
-        expect(subject[:file]).to be_instance_of String
-        expect(subject[:file]).to include "::UploadedFile"
-        expect(subject[:float]).to eq(0.0)
-        expect(subject[:bool_true]).to be(true)
-        expect(subject[:bool_false]).to be(false)
-        expect(subject[:nil]).to be_nil
-        expect(subject[:int]).to eq(1)
+        object = { :user => { :password => "secret", :id => 123 } }
+        expect(sanitize(object, ["password"]))
+          .to eq(:user => { :password => "[FILTERED]", :id => 123 })
       end
 
-      context "with strings as key filter values" do
-        let(:sanitized_params) do
-          described_class.sanitize(params, %w[string])
-        end
-
-        it "sanitizes values" do
-          expect(subject["string"]).to eq("[FILTERED]")
-        end
+      it "sanitizes values in a nested objects" do
+        object = [
+          :users => [
+            { :password => "secret", :id => 123 },
+            { :password => ["shhhhh"], :id => 456 },
+            { :password => { :obj => "shhhhh" }, :id => 789 }
+          ]
+        ]
+        expect(sanitize(object, ["password"])).to eq([
+          :users => [
+            { :password => "[FILTERED]", :id => 123 },
+            { :password => "[FILTERED]", :id => 456 },
+            { :password => "[FILTERED]", :id => 789 }
+          ]
+        ])
       end
 
-      describe ":hash key" do
-        let(:sanitized_params) do
-          described_class.sanitize(params, %w[nested_text])
-        end
-        subject { sanitized_params[:hash] }
-
-        it "sanitizes values in nested hashes" do
-          expect(subject[:nested_text]).to eq("[FILTERED]")
-        end
-
-        describe ":nested_array" do
-          describe ":nested_hash" do
-            let(:sanitized_params) do
-              described_class.sanitize(params, %w[key])
-            end
-            subject { sanitized_params[:hash][:nested_array][3] }
-
-            it "sanitizes values in deeply nested hashes and arrays" do
-              expect(subject[:key]).to eq("[FILTERED]")
-            end
-          end
-        end
+      it "doesn't change the original value" do
+        password = "secret"
+        expect do
+          object = { :password => password, :user_id => 123 }
+          expect(sanitize(object, ["password"]))
+            .to eq(:password => "[FILTERED]", :user_id => 123)
+        end.to_not(change { password })
       end
     end
   end

--- a/spec/lib/appsignal/utils/sample_data_sanitizer_spec.rb
+++ b/spec/lib/appsignal/utils/sample_data_sanitizer_spec.rb
@@ -1,11 +1,10 @@
-describe Appsignal::Utils::HashSanitizer do
+describe Appsignal::Utils::SampleDataSanitizer do
   describe ".sanitize" do
     def sanitize(value, filter_keys = [])
       described_class.sanitize(value, filter_keys)
     end
 
     it "accepts String values" do
-      # Hashes
       expect(sanitize(:a => "abc")).to eq(:a => "abc")
       expect(sanitize("a" => "abc")).to eq("a" => "abc")
       expect(sanitize("a" => { "b" => "abc" })).to eq("a" => { "b" => "abc" })
@@ -126,6 +125,12 @@ describe Appsignal::Utils::HashSanitizer do
         object = { :user => { :password => "secret", :id => 123 } }
         expect(sanitize(object, ["password"]))
           .to eq(:user => { :password => "[FILTERED]", :id => 123 })
+      end
+
+      it "sanitizes multiple values" do
+        object = { :password => "secret", :email => "my email", :user_id => 123 }
+        expect(sanitize(object, ["password", "email"]))
+          .to eq(:password => "[FILTERED]", :email => "[FILTERED]", :user_id => 123)
       end
 
       it "sanitizes values in a nested objects" do


### PR DESCRIPTION
## Refactor HashSanitizer specs

Make it easier to test the cases on an individual basis. This way not all the tests break if I want to change one thing about them.

## Rename HashSanitizer to SampleDataSanitizer

It doesn't just sanitize Hashes, but also Arrays (as the root object).

[skip changeset]
[skip review]
