### PR TITLE
Add first backtrace line to error causes

### DIFF
--- a/.changesets/include-first-backtrace-line-from-error-causes.md
+++ b/.changesets/include-first-backtrace-line-from-error-causes.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Include the first backtrace line from error causes to show where each cause originated in the interface.

--- a/spec/support/helpers/config_helpers.rb
+++ b/spec/support/helpers/config_helpers.rb
@@ -46,10 +46,15 @@ module ConfigHelpers
   end
   module_function :build_config
 
-  def start_agent(env: "production", options: {}, internal_logger: nil)
+  def start_agent(
+    env: "production",
+    root_path: nil,
+    options: {},
+    internal_logger: nil
+  )
     env = "production" if env == :default
     env ||= "production"
-    Appsignal.configure(env, :root_path => project_fixture_path) do |config|
+    Appsignal.configure(env, :root_path => root_path || project_fixture_path) do |config|
       options.each do |option, value|
         config.send("#{option}=", value)
       end


### PR DESCRIPTION
## Add first backtrace line to error causes

To give a bit more context about the error causes, include the first backtrace line, showing where it originates.

The server needs to be updated to show this in the UI.

Part of https://github.com/appsignal/feature-requests/issues/387

## Run error cause backtrace lines through filters

If the Rails backtrace cleaner filter is present also run the error cause backtrace through the filter as well.

Replicate our processor behavior for the error causes by stripping of the app/root path in the Ruby gem.
