### PR TITLE
Refactor specs

### DIFF
--- a/spec/lib/appsignal/check_in/cron_spec.rb
+++ b/spec/lib/appsignal/check_in/cron_spec.rb
@@ -2,7 +2,7 @@ describe Appsignal::CheckIn::Cron do
   let(:log_stream) { std_stream }
   let(:logs) { log_contents(log_stream) }
   let(:appsignal_options) { {} }
-  let(:config) { project_fixture_config }
+  let(:config) { build_config }
   let(:cron_checkin) { described_class.new(:identifier => "cron-checkin-name") }
   let(:scheduler) { Appsignal::CheckIn.scheduler }
   let(:stubs) { [] }

--- a/spec/lib/appsignal/transmitter_spec.rb
+++ b/spec/lib/appsignal/transmitter_spec.rb
@@ -1,6 +1,10 @@
 describe Appsignal::Transmitter do
+  let(:options) { {} }
   let(:config) do
-    build_config(:options => { :hostname => "app1.local" }, :logger => Logger.new(log))
+    build_config(
+      :options => { :hostname => "app1.local" }.merge(options),
+      :logger => Logger.new(log)
+    )
   end
   let(:base_uri) { "action" }
   let(:log) { StringIO.new }
@@ -89,9 +93,7 @@ describe Appsignal::Transmitter do
 
     context "with ca_file_path config option set" do
       context "when file does not exist" do
-        before do
-          config.config_hash[:ca_file_path] = File.join(resources_dir, "cacert.pem")
-        end
+        let(:options) { { :ca_file_path => File.join(resources_dir, "cacert.pem") } }
 
         it "ignores the config and logs a warning" do
           expect(response).to be_kind_of(Net::HTTPResponse)
@@ -102,9 +104,7 @@ describe Appsignal::Transmitter do
       end
 
       context "when not existing file" do
-        before do
-          config.config_hash[:ca_file_path] = File.join(tmp_dir, "ca_file_that_does_not_exist")
-        end
+        let(:options) { { :ca_file_path => File.join(tmp_dir, "ca_file_that_does_not_exist") } }
 
         it "ignores the config and logs a warning" do
           expect(response).to be_kind_of(Net::HTTPResponse)
@@ -116,8 +116,8 @@ describe Appsignal::Transmitter do
 
       context "when not readable file" do
         let(:file) { File.join(tmp_dir, "ca_file") }
+        let(:options) { { :ca_file_path => file } }
         before do
-          config.config_hash[:ca_file_path] = file
           File.open(file, "w") { |f| f.chmod 0o000 }
         end
 

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -376,7 +376,14 @@ describe Appsignal do
     end
 
     context "when config is loaded" do
-      before { Appsignal.configure(:production, :root_path => project_fixture_path) }
+      let(:options) { {} }
+      before do
+        configure(
+          :env => :production,
+          :root_path => project_fixture_path,
+          :options => options
+        )
+      end
 
       it "should initialize logging" do
         Appsignal.start
@@ -395,7 +402,7 @@ describe Appsignal do
           Appsignal.config[:ignore_actions] << "my action"
         end
         expect_frozen_error do
-          Appsignal.config.config_hash[:ignore_actions] << "my action"
+          Appsignal.config[:ignore_actions] << "my action"
         end
         expect_frozen_error do
           Appsignal.config.config_hash.merge!(:option => :value)
@@ -410,8 +417,8 @@ describe Appsignal do
       end
 
       context "when allocation tracking has been enabled" do
+        let(:options) { { :enable_allocation_tracking => true } }
         before do
-          Appsignal.config.config_hash[:enable_allocation_tracking] = true
           capture_environment_metadata_report_calls
         end
 
@@ -426,12 +433,12 @@ describe Appsignal do
       end
 
       context "when allocation tracking has been disabled" do
+        let(:options) { { :enable_allocation_tracking => false } }
         before do
-          Appsignal.config.config_hash[:enable_allocation_tracking] = false
           capture_environment_metadata_report_calls
         end
 
-        it "should not install the allocation event hook" do
+        it "doesn't install the allocation event hook" do
           expect(Appsignal::Extension).not_to receive(:install_allocation_event_hook)
           Appsignal.start
           expect_not_environment_metadata("ruby_allocation_tracking_enabled")
@@ -439,22 +446,18 @@ describe Appsignal do
       end
 
       context "when minutely metrics has been enabled" do
-        before do
-          Appsignal.config.config_hash[:enable_minutely_probes] = true
-        end
+        let(:options) { { :enable_minutely_probes => true } }
 
-        it "should start minutely" do
+        it "starts minutely probes" do
           expect(Appsignal::Probes).to receive(:start)
           Appsignal.start
         end
       end
 
       context "when minutely metrics has been disabled" do
-        before do
-          Appsignal.config.config_hash[:enable_minutely_probes] = false
-        end
+        let(:options) { { :enable_minutely_probes => false } }
 
-        it "should not start minutely" do
+        it "does not start minutely probes" do
           expect(Appsignal::Probes).to_not receive(:start)
           Appsignal.start
         end

--- a/spec/support/helpers/config_helpers.rb
+++ b/spec/support/helpers/config_helpers.rb
@@ -30,12 +30,7 @@ module ConfigHelpers
   end
   module_function :build_config
 
-  def start_agent(
-    env: "production",
-    root_path: nil,
-    options: {},
-    internal_logger: nil
-  )
+  def configure(env: :default, root_path: nil, options: {})
     env = "production" if env == :default
     env ||= "production"
     Appsignal.configure(env, :root_path => root_path || project_fixture_path) do |config|
@@ -43,6 +38,15 @@ module ConfigHelpers
         config.send("#{option}=", value)
       end
     end
+  end
+
+  def start_agent(
+    env: "production",
+    root_path: nil,
+    options: {},
+    internal_logger: nil
+  )
+    configure(:env => env, :root_path => root_path, :options => options)
     Appsignal.start
     Appsignal.internal_logger = internal_logger if internal_logger
   end

--- a/spec/support/helpers/config_helpers.rb
+++ b/spec/support/helpers/config_helpers.rb
@@ -13,22 +13,6 @@ module ConfigHelpers
   end
   module_function :rails_project_fixture_path
 
-  def project_fixture_config(
-    env = "production",
-    options = {},
-    logger = Appsignal.internal_logger
-  )
-    Appsignal::Config.new(
-      project_fixture_path,
-      env,
-      logger
-    ).tap do |c|
-      c.merge_dsl_options(options)
-      c.validate
-    end
-  end
-  module_function :project_fixture_config
-
   def build_config(
     root_path: project_fixture_path,
     env: "production",


### PR DESCRIPTION
## Remove old config spec helper

Use the new `build_config` helper instead.

## Don't interact with config_hash in specs

Let's use the public interface for how to set config options in the specs to replicate how people use it.

[skip changeset]
[skip review]