### PR TITLE
Fix internal logger in Capistrano tasks and remove Config logger instance

### DIFF
--- a/.changesets/fix-no-logs-appearing-from-capistrano-tasks.md
+++ b/.changesets/fix-no-logs-appearing-from-capistrano-tasks.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix no AppSignal internal logs being logged from Capistrano tasks.

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -244,8 +244,7 @@ module Appsignal
       else
         @config = Config.new(
           root_path || Config.determine_root_path,
-          Config.determine_env(env),
-          Appsignal.internal_logger
+          Config.determine_env(env)
         )
       end
 

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -208,8 +208,6 @@ module Appsignal
     attr_accessor :root_path, :env, :config_hash
     attr_reader :system_config, :loaders_config, :initial_config, :file_config,
       :env_config, :override_config, :dsl_config
-    # @api private
-    attr_accessor :logger
 
     # Initialize a new configuration object for AppSignal.
     #
@@ -217,9 +215,6 @@ module Appsignal
     # @param env [String] The environment to load when AppSignal is started. It
     #   will look for an environment with this name in the `config/appsignal.yml`
     #   config file.
-    # @param logger [Logger] The logger to use for the AppSignal gem. This is
-    #   used by the configuration class only. Default:
-    #   {Appsignal.internal_logger}. See also {Appsignal.start}.
     #
     # @api private
     # @see https://docs.appsignal.com/ruby/configuration/
@@ -230,13 +225,11 @@ module Appsignal
     #   How to integrate AppSignal manually
     def initialize(
       root_path,
-      env,
-      logger = Appsignal.internal_logger
+      env
     )
       @root_path = root_path
       @config_file_error = false
       @config_file = config_file
-      @logger = logger
       @valid = false
 
       @env = env.to_s
@@ -426,7 +419,7 @@ module Appsignal
       push_api_key = config_hash[:push_api_key] || ""
       if push_api_key.strip.empty?
         @valid = false
-        @logger.error "Push API key not set after loading config"
+        logger.error "Push API key not set after loading config"
       else
         @valid = true
       end
@@ -444,6 +437,10 @@ module Appsignal
     end
 
     private
+
+    def logger
+      Appsignal.internal_logger
+    end
 
     def config_file
       @config_file ||=
@@ -546,7 +543,7 @@ module Appsignal
 
     def merge(new_config)
       new_config.each do |key, value|
-        @logger.debug("Config key '#{key}' is being overwritten") unless config_hash[key].nil?
+        logger.debug("Config key '#{key}' is being overwritten") unless config_hash[key].nil?
         config_hash[key] = value
       end
     end

--- a/lib/appsignal/integrations/capistrano/appsignal.cap
+++ b/lib/appsignal/integrations/capistrano/appsignal.cap
@@ -10,8 +10,7 @@ namespace :appsignal do
 
     appsignal_config = Appsignal::Config.new(
       Dir.pwd,
-      appsignal_env,
-      Appsignal.internal_logger
+      appsignal_env
     ).tap do |c|
       c.merge_dsl_options(fetch(:appsignal_config, {}))
       c.validate

--- a/lib/appsignal/integrations/capistrano/appsignal.cap
+++ b/lib/appsignal/integrations/capistrano/appsignal.cap
@@ -11,11 +11,12 @@ namespace :appsignal do
     appsignal_config = Appsignal::Config.new(
       Dir.pwd,
       appsignal_env,
-      Logger.new(StringIO.new)
+      Appsignal.internal_logger
     ).tap do |c|
       c.merge_dsl_options(fetch(:appsignal_config, {}))
       c.validate
     end
+    Appsignal._start_logger
 
     if appsignal_config&.active?
       marker_data = {

--- a/lib/appsignal/integrations/capistrano/capistrano_2_tasks.rb
+++ b/lib/appsignal/integrations/capistrano/capistrano_2_tasks.rb
@@ -18,8 +18,7 @@ module Appsignal
 
               appsignal_config = Appsignal::Config.new(
                 ENV.fetch("PWD", nil),
-                env,
-                Appsignal.internal_logger
+                env
               ).tap do |c|
                 c.merge_dsl_options(fetch(:appsignal_config, {}))
                 c.validate

--- a/lib/appsignal/integrations/capistrano/capistrano_2_tasks.rb
+++ b/lib/appsignal/integrations/capistrano/capistrano_2_tasks.rb
@@ -19,11 +19,12 @@ module Appsignal
               appsignal_config = Appsignal::Config.new(
                 ENV.fetch("PWD", nil),
                 env,
-                Appsignal::Utils::IntegrationLogger.new(StringIO.new)
+                Appsignal.internal_logger
               ).tap do |c|
                 c.merge_dsl_options(fetch(:appsignal_config, {}))
                 c.validate
               end
+              Appsignal._start_logger
 
               if appsignal_config&.active?
                 marker_data = {

--- a/lib/appsignal/transmitter.rb
+++ b/lib/appsignal/transmitter.rb
@@ -107,7 +107,7 @@ module Appsignal
           if ca_file && File.exist?(ca_file) && File.readable?(ca_file)
             http.ca_file = ca_file
           else
-            config.logger.warn "Ignoring non-existing or unreadable " \
+            Appsignal.internal_logger.warn "Ignoring non-existing or unreadable " \
               "`ca_file_path`: #{ca_file}"
           end
         end

--- a/spec/lib/appsignal/transmitter_spec.rb
+++ b/spec/lib/appsignal/transmitter_spec.rb
@@ -1,14 +1,15 @@
 describe Appsignal::Transmitter do
   let(:options) { {} }
   let(:config) do
-    build_config(
-      :options => { :hostname => "app1.local" }.merge(options),
-      :logger => Logger.new(log)
-    )
+    build_config(:options => { :hostname => "app1.local" }.merge(options))
   end
   let(:base_uri) { "action" }
-  let(:log) { StringIO.new }
   let(:instance) { Appsignal::Transmitter.new(base_uri, config) }
+  let(:log_stream) { StringIO.new }
+  let(:logs) { log_contents(log_stream) }
+  before do
+    Appsignal.internal_logger = test_logger(log_stream)
+  end
 
   describe "#uri" do
     let(:uri) { instance.uri }
@@ -98,7 +99,7 @@ describe Appsignal::Transmitter do
         it "ignores the config and logs a warning" do
           expect(response).to be_kind_of(Net::HTTPResponse)
           expect(response.code).to eq "200"
-          expect(log.string).to_not include "Ignoring non-existing or unreadable " \
+          expect(logs).to_not include "Ignoring non-existing or unreadable " \
             "`ca_file_path`: #{config[:ca_file_path]}"
         end
       end
@@ -109,8 +110,11 @@ describe Appsignal::Transmitter do
         it "ignores the config and logs a warning" do
           expect(response).to be_kind_of(Net::HTTPResponse)
           expect(response.code).to eq "200"
-          expect(log.string).to include "Ignoring non-existing or unreadable " \
-            "`ca_file_path`: #{config[:ca_file_path]}"
+          expect(logs).to contains_log(
+            :warn,
+            "Ignoring non-existing or unreadable " \
+              "`ca_file_path`: #{config[:ca_file_path]}"
+          )
         end
       end
 
@@ -124,8 +128,11 @@ describe Appsignal::Transmitter do
         it "ignores the config and logs a warning" do
           expect(response).to be_kind_of(Net::HTTPResponse)
           expect(response.code).to eq "200"
-          expect(log.string).to include "Ignoring non-existing or unreadable " \
-            "`ca_file_path`: #{config[:ca_file_path]}"
+          expect(logs).to contains_log(
+            :warn,
+            "Ignoring non-existing or unreadable " \
+              "`ca_file_path`: #{config[:ca_file_path]}"
+          )
         end
 
         after { File.delete file }

--- a/spec/support/helpers/config_helpers.rb
+++ b/spec/support/helpers/config_helpers.rb
@@ -16,13 +16,11 @@ module ConfigHelpers
   def build_config(
     root_path: project_fixture_path,
     env: "production",
-    options: {},
-    logger: Appsignal.internal_logger
+    options: {}
   )
     Appsignal::Config.new(
       root_path,
-      env,
-      logger
+      env
     ).tap do |c|
       c.merge_dsl_options(options) if options.any?
       c.validate


### PR DESCRIPTION
## Use internal logger from in transmitter

The transmitter logged partially through the `Appsignal.internal_logger` and the logger from the Config class. Make this consistent, like any other place in the gem, by logging via `Appsignal.internal_logger`.

## Fix Capistrano tasks not logging anything

The loggers given to the Config class in the Capistrano tasks write to a StringIO which is never read afterwards. Call `_start_logger` to initialize the logger and write the buffered log messages either to STDOUT or the AppSignal log file after the config has loaded.

## Remove logger from config class

Directly access the `Appsignal.internal_logger` method instead of the Config class having its own logger instance that could be different from the configured logger.

## Assert the logger works in Capistrano

Follow up on the previous commits to remove the logger instance from the Config class, which was set by Capistrano.

It didn't actually log anything before, as it wrote to a `StringIO.new`. Log now to the configured logger based on the application's config.

I see no harm in making the logger work. By default it will log to the `appsignal.log` file. If apps have configured it to log to stdout, they have deliberately configured that so there should be no problem.
