### PR TITLE
Fix DSL config source in diagnose report

### DIFF
--- a/.changesets/report-all-dsl-config-options-in-config-source.md
+++ b/.changesets/report-all-dsl-config-options-in-config-source.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Report all the config options set via `Appsignal.config` in the DSL config source in the diagnose report. Previously, it would only report the options from the last time `Appsignal.configure` was called.

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -395,7 +395,7 @@ module Appsignal
 
     # @api private
     def merge_dsl_options(options)
-      @dsl_config = options
+      @dsl_config.merge!(options)
       merge(options)
     end
 

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -729,6 +729,11 @@ describe Appsignal::Config do
       expect(config.dsl_config).to eq(dsl_config)
     end
 
+    it "merges the options when called multiple times" do
+      config.merge_dsl_options(:extra_option => "yes")
+      expect(config.dsl_config).to eq(dsl_config.merge(:extra_option => "yes"))
+    end
+
     describe "overriding system detected config" do
       describe ":running_in_container" do
         let(:dsl_config) { { :running_in_container => true } }


### PR DESCRIPTION
It would only report the config options set the last time `Appsignal.configure` was called, not all of them combined.

[skip review]