### PR TITLE
Add reported_by tag to Rails error reporter errors

### DIFF
--- a/.changesets/add-reported_by-tag-to-rails-error-reporter.md
+++ b/.changesets/add-reported_by-tag-to-rails-error-reporter.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Add the `reported_by` tag to errors reported by the Rails error reporter so the source of the error is easier to identify.

--- a/lib/appsignal/integrations/railtie.rb
+++ b/lib/appsignal/integrations/railtie.rb
@@ -94,6 +94,7 @@ module Appsignal
             transaction.set_action(action_name) if action_name
             transaction.add_custom_data(custom_data) if custom_data
 
+            tags[:reported_by] = :rails_error_reporter
             tags[:severity] = severity
             tags[:source] = source.to_s if source
             transaction.add_tags(tags)

--- a/spec/lib/appsignal/integrations/railtie_spec.rb
+++ b/spec/lib/appsignal/integrations/railtie_spec.rb
@@ -295,6 +295,7 @@ if DependencyHelper.rails_present?
                 expect(transaction).to have_action("CustomAction")
                 expect(transaction).to have_error("ExampleStandardError", "error message")
                 expect(transaction).to include_tags(
+                  "reported_by" => "rails_error_reporter",
                   "duplicated_tag" => "duplicated value",
                   "severity" => "warning"
                 )
@@ -317,11 +318,15 @@ if DependencyHelper.rails_present?
                     current_transaction.complete
                   end.to change { created_transactions.count }.by(1)
 
+                  expect(current_transaction)
+                    .to_not include_tags("reported_by" => "rails_error_reporter")
+
                   transaction = last_transaction
                   expect(transaction).to have_namespace("custom")
                   expect(transaction).to have_action("CustomAction")
                   expect(transaction).to have_error("ExampleStandardError", "other message")
                   expect(transaction).to include_tags(
+                    "reported_by" => "rails_error_reporter",
                     "duplicated_tag" => "duplicated value",
                     "severity" => "warning"
                   )
@@ -359,6 +364,7 @@ if DependencyHelper.rails_present?
                   expect(transaction).to have_action("ContextAction")
                   expect(transaction).to have_error("ExampleStandardError", "other message")
                   expect(transaction).to include_tags(
+                    "reported_by" => "rails_error_reporter",
                     "duplicated_tag" => "duplicated value",
                     "severity" => "warning"
                   )
@@ -382,6 +388,7 @@ if DependencyHelper.rails_present?
                 current_transaction.complete
 
                 expect(current_transaction).to include_tags(
+                  "reported_by" => "rails_error_reporter",
                   "tag1" => "value1",
                   "tag2" => "value2",
                   "severity" => "warning"
@@ -431,7 +438,10 @@ if DependencyHelper.rails_present?
             expect(transaction).to have_namespace("runner")
             expect(transaction).to_not have_action
             expect(transaction).to have_error("ExampleStandardError", "error message")
-            expect(transaction).to include_tags("source" => "application.runner.railties")
+            expect(transaction).to include_tags(
+              "reported_by" => "rails_error_reporter",
+              "source" => "application.runner.railties"
+            )
           end
         end
 
@@ -446,6 +456,7 @@ if DependencyHelper.rails_present?
           end
 
           expect(last_transaction).to include_tags(
+            "reported_by" => "rails_error_reporter",
             "tag1" => "value1",
             "tag2" => "value2",
             "severity" => "warning"


### PR DESCRIPTION
Make it easier to identify errors reported by the Rails error reporter by adding the `reported_by` tag to errors reported by it.

This uses the same tag as we use for the Puma `lowlevel_error` reporter.