### PR TITLE
Fix Pathname to String conversion error

### DIFF
--- a/.changesets/fix-no-implicit-conversion-of-pathname-into-string-error.md
+++ b/.changesets/fix-no-implicit-conversion-of-pathname-into-string-error.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix 'no implicit conversion of Pathname into String' error when parsing backtrace lines of error causes in Rails apps.

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -212,7 +212,7 @@ module Appsignal
       root_path,
       env
     )
-      @root_path = root_path
+      @root_path = root_path.to_s
       @config_file_error = false
       @config_file = config_file
       @valid = false

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -371,6 +371,15 @@ describe Appsignal::Config do
     end
   end
 
+  context "when root path is Pathname instance" do
+    let(:config) { described_class.new(Pathname.new("/path"), "production") }
+
+    it "converts it to a String" do
+      expect(config.root_path).to eq("/path")
+      expect(config.root_path).to be_instance_of(String)
+    end
+  end
+
   context "without config file" do
     let(:config) { described_class.new(tmp_dir, "production") }
 

--- a/spec/lib/appsignal/integrations/railtie_spec.rb
+++ b/spec/lib/appsignal/integrations/railtie_spec.rb
@@ -71,7 +71,7 @@ if DependencyHelper.rails_present?
         it "sets the Rails app path as root_path" do
           initialize_railtie(event)
 
-          expect(Appsignal.config.root_path).to eq(Pathname.new(rails_project_fixture_path))
+          expect(Appsignal.config.root_path).to eq(rails_project_fixture_path)
         end
 
         it "loads the Rails app name in the initial config" do


### PR DESCRIPTION
In Rails apps the app root path is a Pathname instance. We can't use it the same way as a String when using it in `.start_with?` when comparing backtrace lines for error causes in
`Transaction#first_formatted_backtrace_line`.

Fix this by casting the root_path always to a String in the Config initializer so we're always sure it's a String and can use it as such.

[skip review]