### PR TITLE
Use bsearch instead of find for supported gem reporting

### DIFF
--- a/lib/appsignal/environment.rb
+++ b/lib/appsignal/environment.rb
@@ -128,7 +128,7 @@ module Appsignal
           ::Bundler.rubygems.all_specs
         end
       SUPPORTED_GEMS.each do |gem_name|
-        gem_spec = bundle_gem_specs.find { |spec| spec.name == gem_name }
+        gem_spec = bundle_gem_specs.bsearch { |spec| spec.name <=> gem_name }
         next unless gem_spec
 
         report("ruby_#{gem_name}_version") { gem_spec.version.to_s }


### PR DESCRIPTION
- Tiny optimization at the reporting part that is ran at `report_supported_gems`.
 ```
       bundle_gem_specs =
        if ::Bundler.rubygems.respond_to?(:installed_specs)
          ::Bundler.rubygems.installed_specs
        else
          ::Bundler.rubygems.all_specs
        end
 ```  
 If I'm not mistaken the gemspecs in the block above are already being returned sorted alphabetically meaning we can use `bsearch` instead of `find` as it will be faster to retrieve the gems.
 - I also understand that in the future this list may not be sorted and reporting might not work as intended so let me know if you disagree with the change
 - Let me know if I should add anything else
 - If possible can this be added to Hacktoberfest ?