### PR TITLE
Add cache key to ActiveSupport::Cache events

### DIFF
--- a/.changesets/add-cache-key-to-events.md
+++ b/.changesets/add-cache-key-to-events.md
@@ -1,0 +1,6 @@
+---
+bump: "minor"
+type: "add"
+---
+
+Add cache key(s) to events of `ActiveSupport::Cache`

--- a/lib/appsignal/event_formatter/active_support/cache_formatter.rb
+++ b/lib/appsignal/event_formatter/active_support/cache_formatter.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Appsignal
+  class EventFormatter
+    # @api private
+    module ActiveSupport
+      class CacheFormatter
+        def format(payload)
+          key = payload[:key]
+          title = case key
+                  when Hash then key.keys
+                  when Array then key
+                  else [key]
+                  end.map(&:to_s).sort.join(", ")
+          [title, nil]
+        end
+      end
+    end
+  end
+end
+
+[
+  :delete,
+  :delete_multi,
+  :exist?,
+  :fetch,
+  :read,
+  :read_multi,
+  :write,
+  :write_multi
+].each do |action|
+  Appsignal::EventFormatter.register(
+    "cache_#{action}.active_support",
+    Appsignal::EventFormatter::ActiveSupport::CacheFormatter
+  )
+end

--- a/spec/lib/appsignal/event_formatter/active_support/cache_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/active_support/cache_formatter_spec.rb
@@ -1,0 +1,85 @@
+describe Appsignal::EventFormatter::ActiveSupport::CacheFormatter do
+  let(:klass)     { described_class }
+  let(:formatter) { klass.new }
+
+  it "should register cache_delete.active_support" do
+    expect(Appsignal::EventFormatter.registered?("cache_delete.active_support", klass)).to be_truthy
+  end
+
+  it "should register cache_delete_multi.active_support" do
+    expect(Appsignal::EventFormatter.registered?("cache_delete_multi.active_support",
+      klass)).to be_truthy
+  end
+
+  it "should register cache_exist?.active_support" do
+    expect(Appsignal::EventFormatter.registered?("cache_exist?.active_support", klass)).to be_truthy
+  end
+
+  it "should register cache_fetch.active_support" do
+    expect(Appsignal::EventFormatter.registered?("cache_fetch.active_support", klass)).to be_truthy
+  end
+
+  it "should register cache_read.active_support" do
+    expect(Appsignal::EventFormatter.registered?("cache_read.active_support", klass)).to be_truthy
+  end
+
+  it "should register cache_read_multi.active_support" do
+    expect(Appsignal::EventFormatter.registered?("cache_read_multi.active_support",
+      klass)).to be_truthy
+  end
+
+  it "should register cache_write.active_support" do
+    expect(Appsignal::EventFormatter.registered?("cache_write.active_support", klass)).to be_truthy
+  end
+
+  it "should register cache_write_multi.active_support" do
+    expect(Appsignal::EventFormatter.registered?("cache_write.active_support", klass)).to be_truthy
+  end
+
+  describe "#format" do
+    context "when a single key event is given" do
+      let(:payload) do
+        {
+          :key => "cache_key",
+          :store => "ActiveSupport::Cache::RedisCacheStore",
+          :namespace => "my_rails_app",
+          :expires_in => 1
+        }
+      end
+
+      subject { formatter.format(payload) }
+
+      it { is_expected.to eq ["cache_key", nil] }
+    end
+
+    context "when a multi key event is given" do
+      let(:payload) do
+        {
+          :key => ["cache_key", :another_key],
+          :store => "ActiveSupport::Cache::RedisCacheStore",
+          :namespace => "my_rails_app",
+          :expires_in => 1
+        }
+      end
+
+      subject { formatter.format(payload) }
+
+      it { is_expected.to eq ["another_key, cache_key", nil] }
+    end
+
+    context "when the write_multi event is given" do
+      let(:payload) do
+        {
+          :key => { "cache_key" => "value", :another_key => "another_value" },
+          :store => "ActiveSupport::Cache::RedisCacheStore",
+          :namespace => "my_rails_app",
+          :expires_in => 1
+        }
+      end
+
+      subject { formatter.format(payload) }
+
+      it { is_expected.to eq ["another_key, cache_key", nil] }
+    end
+  end
+end


### PR DESCRIPTION
Improves performance debugging by adding cache key info to ActiveSupport::Cache events. Doesn't affect #fetch_multi (already uses read events) or 'fetch_hit' and 'generate' sub-events (info comes from parent events).
This change makes it easier to track down cache-related performance issues by providing more context in the main cache operation events.

Background:
When tracking down performance issues, it's currently hard to distinguish between different cache operations. We're using a Redis-based cache, but even there we don't get a hint about which specific cache is being accessed (see issue #822).