### PR TITLE
Fix heartbeat test bug

### DIFF
--- a/spec/lib/appsignal/check_in/heartbeat_spec.rb
+++ b/spec/lib/appsignal/check_in/heartbeat_spec.rb
@@ -120,7 +120,7 @@ describe "Appsignal::CheckIn.heartbeat" do
         end
       )
 
-      wait_for("the event to be transmitted") { scheduler.transmitted == 2 }
+      wait_for("the event to be transmitted") { scheduler.transmitted >= 2 }
       expect(stub.count).to be >= 2
     end
   end


### PR DESCRIPTION
I don't know if this is what has caused the test suite to intermittently hang (probably not?) but I fixed this bug on the Python test suite, so I'm fixing it here as well.