### PR TITLE
Automatically ignore Rails' health-check

### DIFF
--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -81,7 +81,9 @@ module Appsignal
       :filter_metadata => [],
       :filter_parameters => [],
       :filter_session_data => [],
-      :ignore_actions => [],
+      :ignore_actions => [
+        "Rails::HealthController#show"
+      ],
       :ignore_errors => [],
       :ignore_logs => [],
       :ignore_namespaces => [],

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -941,7 +941,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
                 expect(output).to include(
                   "  ignore_actions: [\"Action from DSL\"]\n" \
                     "    Sources:\n" \
-                    "      default: []\n" \
+                    "      default: [\"Rails::HealthController#show\"]\n" \
                     "      dsl:     [\"Action from DSL\"]\n"
                 )
 

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -713,7 +713,7 @@ describe Appsignal::Config do
         :filter_metadata                => [],
         :filter_parameters              => [],
         :filter_session_data            => [],
-        :ignore_actions                 => [],
+        :ignore_actions                 => ["Rails::HealthController#show"],
         :ignore_errors                  => [],
         :ignore_logs                    => [],
         :ignore_namespaces              => [],

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -35,12 +35,12 @@ describe Appsignal do
     context "with config but not started" do
       it "reuses the already loaded config if no env arg is given" do
         Appsignal.configure(:my_env, :root_path => project_fixture_path) do |config|
-          config.ignore_actions = ["My action"]
+          config.ignore_errors = ["My error"]
         end
 
         Appsignal.configure do |config|
           expect(config.env).to eq("my_env")
-          expect(config.ignore_actions).to eq(["My action"])
+          expect(config.ignore_errors).to eq(["My error"])
 
           config.active = true
           config.name = "My app"
@@ -52,16 +52,16 @@ describe Appsignal do
         expect(Appsignal.config.env).to eq("my_env")
         expect(Appsignal.config[:name]).to eq("My app")
         expect(Appsignal.config[:push_api_key]).to eq("key")
-        expect(Appsignal.config[:ignore_actions]).to eq(["My action"])
+        expect(Appsignal.config[:ignore_errors]).to eq(["My error"])
       end
 
       it "reuses the already loaded config if the env is the same" do
         Appsignal.configure(:my_env, :root_path => project_fixture_path) do |config|
-          config.ignore_actions = ["My action"]
+          config.ignore_errors = ["My error"]
         end
 
         Appsignal.configure(:my_env) do |config|
-          expect(config.ignore_actions).to eq(["My action"])
+          expect(config.ignore_errors).to eq(["My error"])
           config.active = true
           config.name = "My app"
           config.push_api_key = "key"
@@ -79,11 +79,11 @@ describe Appsignal do
         Appsignal.configure(:my_env, :root_path => project_fixture_path) do |config|
           config.name = "Some name"
           config.push_api_key = "Some key"
-          config.ignore_actions = ["My action"]
+          config.ignore_errors = ["My error"]
         end
 
         Appsignal.configure(:my_env2) do |config|
-          expect(config.ignore_actions).to be_empty
+          expect(config.ignore_errors).to be_empty
           config.active = true
           config.name = "My app"
           config.push_api_key = "key"
@@ -101,11 +101,11 @@ describe Appsignal do
         Appsignal.configure(:my_env, :root_path => "/some/path") do |config|
           config.name = "Some name"
           config.push_api_key = "Some key"
-          config.ignore_actions = ["My action"]
+          config.ignore_errors = ["My error"]
         end
 
         Appsignal.configure(:my_env, :root_path => project_fixture_path) do |config|
-          expect(config.ignore_actions).to be_empty
+          expect(config.ignore_errors).to be_empty
           config.active = true
           config.name = "My app"
           config.push_api_key = "key"
@@ -128,7 +128,7 @@ describe Appsignal do
         expect(Appsignal.started?).to be_falsy
 
         Appsignal.configure(:my_env) do |config|
-          expect(config.ignore_actions).to be_empty
+          expect(config.ignore_errors).to be_empty
           config.active = true
           config.name = "My app"
           config.push_api_key = "key"
@@ -292,12 +292,12 @@ describe Appsignal do
       it "allows modification of previously unset config options" do
         expect do
           Appsignal.configure do |config|
-            config.ignore_actions << "My action"
+            config.ignore_errors << "My error"
             config.request_headers << "My allowed header"
           end
         end.to_not(change { Appsignal::Config::DEFAULT_CONFIG })
 
-        expect(Appsignal.config[:ignore_actions]).to eq(["My action"])
+        expect(Appsignal.config[:ignore_errors]).to eq(["My error"])
         expect(Appsignal.config[:request_headers])
           .to eq(Appsignal::Config::DEFAULT_CONFIG[:request_headers] + ["My allowed header"])
       end
@@ -399,16 +399,16 @@ describe Appsignal do
         Appsignal.start
 
         expect_frozen_error do
-          Appsignal.config[:ignore_actions] << "my action"
+          Appsignal.config[:ignore_errors] << "my error"
         end
         expect_frozen_error do
-          Appsignal.config[:ignore_actions] << "my action"
+          Appsignal.config[:ignore_errors] << "my error"
         end
         expect_frozen_error do
           Appsignal.config.config_hash.merge!(:option => :value)
         end
         expect_frozen_error do
-          Appsignal.config[:ignore_actions] = "my action"
+          Appsignal.config[:ignore_errors] = "my error"
         end
       end
 


### PR DESCRIPTION
Suggested by a customer: https://app.intercom.com/a/inbox/yzor8gyw/inbox/shared/unassigned/conversation/16410700366724#part_id=comment-16410700366724-21909575460

(leaving this as a draft to not forget; will make a proper PR later)

Adds `Rails::HealthController#show` to the default `ignore_actions`
value.

Modified some existing tests that used `ignore_actions` as an array
config option that defaulted to empty, so that they use `ignore_errors`
instead.

See https://github.com/appsignal/diagnose_tests/compare/add-ignore-actions-ruby-default-value for diagnose tests changes.