### PR TITLE
Send error causes line number as integer

### DIFF
--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -641,7 +641,7 @@ module Appsignal
     end
 
     BACKTRACE_REGEX =
-      %r{(?<gem>[\w-]+ \(.+\) )?(?<path>:?/?\w+?.+?):(?<line>:?\d+)(?<group>:in `(?<method>.+)')?$}.freeze # rubocop:disable Layout/LineLength
+      %r{(?<gem>[\w-]+ \(.+\) )?(?<path>:?/?\w+?.+?):(?<line>:?\d+)(?::in `(?<method>.+)')?$}.freeze
 
     def first_formatted_backtrace_line(error)
       backtrace = cleaned_backtrace(error.backtrace)
@@ -655,7 +655,6 @@ module Appsignal
         .merge("original" => first_line)
         .tap do |c|
           config = Appsignal.config
-          c.delete("group") # Unused key, only for easier matching
           # Strip of whitespace at the end of the gem name
           c["gem"] = c["gem"]&.strip
           # Strip the app path from the path if present
@@ -667,6 +666,8 @@ module Appsignal
           end
           # Add revision for linking to the repository from the UI
           c["revision"] = config[:revision]
+          # Convert line number to an integer
+          c["line"] = c["line"].to_i
         end
     end
 

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -1871,7 +1871,7 @@ describe Appsignal::Transaction do
       end
       let(:options) { { :revision => "my_revision" } }
 
-      it "sends the causes information as sample data" do
+      it "sends the error causes information as sample data" do
         # Hide Rails so we can test the normal Ruby behavior. The Rails
         # behavior is tested in another spec.
         hide_const("Rails")
@@ -1896,7 +1896,7 @@ describe Appsignal::Transaction do
                 "original" => "my_gem (1.2.3) /absolute/path/example.rb:123:in `my_method'",
                 "gem" => "my_gem (1.2.3)",
                 "path" => "/absolute/path/example.rb",
-                "line" => "123",
+                "line" => 123,
                 "method" => "my_method",
                 "revision" => "my_revision"
               }
@@ -1908,7 +1908,7 @@ describe Appsignal::Transaction do
                 "original" => "src/example.rb:123:in `my_method'",
                 "gem" => nil,
                 "path" => "src/example.rb",
-                "line" => "123",
+                "line" => 123,
                 "method" => "my_method",
                 "revision" => "my_revision"
               }
@@ -1945,7 +1945,7 @@ describe Appsignal::Transaction do
           e
         end
 
-        it "sends the causes information as sample data" do
+        it "sends the error causes information as sample data" do
           # Hide Rails so we can test the normal Ruby behavior. The Rails
           # behavior is tested in another spec.
           hide_const("Rails")
@@ -1963,7 +1963,7 @@ describe Appsignal::Transaction do
                 "original" => "#{original_path}:123:in `my_method'",
                 "gem" => nil,
                 "path" => path,
-                "line" => "123",
+                "line" => 123,
                 "method" => "my_method",
                 "revision" => "my_revision"
               }
@@ -2005,7 +2005,7 @@ describe Appsignal::Transaction do
                   "original" => "#{original_path}:123:in `my_method'",
                   "gem" => nil,
                   "path" => path,
-                  "line" => "123",
+                  "line" => 123,
                   "method" => "my_method",
                   "revision" => "my_revision"
                 }
@@ -2038,7 +2038,7 @@ describe Appsignal::Transaction do
                   "original" => "app/views/search/_navigation_tabs.html.haml:17",
                   "gem" => nil,
                   "path" => "app/views/search/_navigation_tabs.html.haml",
-                  "line" => "17",
+                  "line" => 17,
                   "method" => nil,
                   "revision" => "my_revision"
                 }


### PR DESCRIPTION
The Ruby integration was sending this as a string, while the processor expected a number. The processor has since been amended to accept either a number or a string, but the Ruby integration should have been sending a number to begin with.

See [Slack conversation][slack] and [processor PR][pr] for context.

[slack]: https://appsignal.slack.com/archives/C02A6H085/p1728551389181029
[pr]: https://github.com/appsignal/appsignal-processor-rs/pull/1577/files

[skip changeset] because this change has no effect to the customer.