### PR TITLE
Automatically ignore Rails' health-check

### DIFF
--- a/.changesets/ignore-rails-healthcheck-by-default.md
+++ b/.changesets/ignore-rails-healthcheck-by-default.md
@@ -1,0 +1,31 @@
+---
+bump: patch
+type: change
+---
+
+Ignore the Rails healthcheck endpoint (Rails::HealthController#show) by default for Rails apps.
+
+If the `ignore_actions` option is set in the `config/appsignal.yml` file, the default is overwritten.
+If the `APPSIGNAL_IGNORE_ACTIONS` environment variable is set, the default is overwritten.
+When using the `Appsignal.configure` helper, add more actions to the default like so:
+
+```ruby
+# config/appsignal.rb
+Appsignal.configure do |config|
+  # Add more actions to ignore
+  config.ignore_actions << "My action"
+end
+```
+
+To overwrite the default using the `Appsignal.configure` helper, do either of the following:
+
+```ruby
+# config/appsignal.rb
+Appsignal.configure do |config|
+  # Overwrite the default value, ignoring all actions ignored by default
+  config.ignore_actions = ["My action"]
+
+  # To only remove the healtcheck endpoint
+  config.ignore_actions.delete("Rails::HealthController#show")
+end
+```

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -243,15 +243,26 @@ module Appsignal
       @system_config = detect_from_system
       merge(system_config)
 
-      # Set defaults from loaders in reverse order so the first register
+      # Set defaults from loaders in reverse order so the first registered
       # loader's defaults overwrite all others
       self.class.loader_defaults.reverse.each do |loader_defaults|
+        options = config_hash
+        new_loader_defaults = {}
         defaults = loader_defaults[:options]
-        @loaders_config.merge!(defaults.merge(
+        defaults.each do |option, value|
+          new_loader_defaults[option] =
+            if ARRAY_OPTIONS.key?(option)
+              # Merge arrays: new value first
+              value + options[option]
+            else
+              value
+            end
+        end
+        @loaders_config.merge!(new_loader_defaults.merge(
           :root_path => loader_defaults[:root_path],
           :env => loader_defaults[:env]
         ))
-        merge(defaults)
+        merge(new_loader_defaults)
       end
 
       # Track origin of env

--- a/lib/appsignal/integrations/railtie.rb
+++ b/lib/appsignal/integrations/railtie.rb
@@ -45,7 +45,8 @@ module Appsignal
           :root_path => Rails.root,
           :env => Rails.env,
           :name => Appsignal::Utils::RailsHelper.detected_rails_app_name,
-          :log_path => Rails.root.join("log")
+          :log_path => Rails.root.join("log"),
+          :ignore_actions => ["Rails::HealthController#show"]
         )
       end
 

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -942,6 +942,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
                   "  ignore_actions: [\"Action from DSL\"]\n" \
                     "    Sources:\n" \
                     "      default: []\n" \
+                    "      loaders: [\"Rails::HealthController#show\"]\n" \
                     "      dsl:     [\"Action from DSL\"]\n"
                 )
 
@@ -951,7 +952,8 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
                     "root_path" => root_path,
                     "env" => "test",
                     "log_path" => File.join(rails_project_fixture_path, "log"),
-                    "name" => "MyApp"
+                    "name" => "MyApp",
+                    "ignore_actions" => ["Rails::HealthController#show"]
                   }
                 )
                 # Includes values from the DSL

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -926,7 +926,9 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
                 # Workaround to not being able to require the railtie file
                 # multiple times and triggering the Rails initialization process.
                 # This will be used whtn the MyApp app has already been loaded.
-                Appsignal::Integrations::Railtie.load_default_config if defined?(MyApp)
+                if defined?(MyApp) && MyApp::Application.initialized?
+                  Appsignal::Integrations::Railtie.load_default_config
+                end
                 run_within_dir(root_path)
               end
 

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -313,7 +313,7 @@ describe Appsignal::Config do
           register_config_defaults(
             :env => "loader_env",
             :root_path => "loader-path",
-            :ignore_actions => ["loader-action"],
+            :ignore_actions => ["loader 1 action"],
             :my_option => "my_value",
             :nil_option => nil
           )
@@ -323,7 +323,7 @@ describe Appsignal::Config do
     end
 
     it "overrides the default config option values" do
-      expect(config[:ignore_actions]).to eq(["loader-action"])
+      expect(config[:ignore_actions]).to eq(["loader 1 action"])
     end
 
     it "does not set any nil values" do
@@ -346,7 +346,8 @@ describe Appsignal::Config do
           def on_load
             register_config_defaults(
               :my_option => "second_value",
-              :second_option => "second_value"
+              :second_option => "second_value",
+              :ignore_actions => ["loader 2 action"]
             )
           end
         end
@@ -358,6 +359,26 @@ describe Appsignal::Config do
           :my_option => "my_value",
           :second_option => "second_value"
         )
+        expect(config.loaders_config).to include(
+          :my_option => "my_value",
+          :second_option => "second_value"
+        )
+      end
+
+      it "merges options with array values" do
+        expect(config.config_hash).to include(
+          :ignore_actions => ["loader 1 action", "loader 2 action"]
+        )
+        expect(config.loaders_config).to include(
+          :ignore_actions => ["loader 1 action", "loader 2 action"]
+        )
+
+        # Doesn't modify defaults
+        defaults = Appsignal::Config.loader_defaults
+        expect(defaults.find { |d| d[:name] == :options_loader }[:options][:ignore_actions])
+          .to eq(["loader 1 action"])
+        expect(defaults.find { |d| d[:name] == :options_loader2 }[:options][:ignore_actions])
+          .to eq(["loader 2 action"])
       end
     end
   end

--- a/spec/lib/appsignal/integrations/railtie_spec.rb
+++ b/spec/lib/appsignal/integrations/railtie_spec.rb
@@ -82,6 +82,8 @@ if DependencyHelper.rails_present?
           expect(rails_defaults[:options][:name]).to eq("MyApp")
           expect(rails_defaults[:options][:log_path])
             .to eq(Pathname.new(File.join(rails_project_fixture_path, "log")))
+          expect(rails_defaults[:options][:ignore_actions])
+            .to eq(["Rails::HealthController#show"])
         end
 
         it "loads the app name from the project's appsignal.yml file" do


### PR DESCRIPTION
## Merge array option values from loaders

Loaders can set config defaults. If more than one loader set a config option that contains an array, they would overwrite each other. I think it's a good default to merge array values from loaders. This will prevent options like `ignore_actions` from being overwritten by another loader, and reported actions that should be ignored.

## Automatically ignore Rails' health-check

Adds the `Rails::HealthController#show` endpoint to the default `ignore_actions` config by adding it to the Railtie loader defaults.

Suggested by a customer in: https://app.intercom.com/a/inbox/yzor8gyw/inbox/shared/unassigned/conversation/16410700366724#part_id=comment-16410700366724-21909575460


## Fix duplicate Railtie default config in specs

In the diagnose CLI spec the Railtie config defaults would be set twice, failing the specs.

This was because the spec only checked beforehand if the MyApp constant was present or not, which it is most of the time in this spec. Now also check if the app is already initialized, so the Railtie isn't triggered again, and then trigger it manually.
