### PR TITLE
Add Config active_if_environment helper

### DIFF
--- a/.changesets/add-activate_if_environment-helper.md
+++ b/.changesets/add-activate_if_environment-helper.md
@@ -1,0 +1,22 @@
+---
+bump: patch
+type: add
+---
+
+Add `activate_if_environment` helper for `Appsignal.configure`. Avoid having to add conditionals to your configuration file and use the `activate_if_environment` helper to specify for which environments AppSignal should become active. AppSignal will automatically detect the environment and activate itself it the environment matches one of the listed environments.
+
+```ruby
+# Before
+Appsignal.configure do |config|
+  config.active = Rails.env.production? || Rails.env.staging?
+end
+
+# After
+Appsignal.configure do |config|
+  # Activate for one environment
+  config.active_if_environment(:production)
+
+  # Activate for multiple environments
+  config.active_if_environment(:production, :staging)
+end
+```

--- a/.changesets/add-activate_if_environment-helper.md
+++ b/.changesets/add-activate_if_environment-helper.md
@@ -14,9 +14,9 @@ end
 # After
 Appsignal.configure do |config|
   # Activate for one environment
-  config.active_if_environment(:production)
+  config.activate_if_environment(:production)
 
   # Activate for multiple environments
-  config.active_if_environment(:production, :staging)
+  config.activate_if_environment(:production, :staging)
 end
 ```

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -564,6 +564,10 @@ module Appsignal
         @config.env
       end
 
+      def activate_if_environment(*envs)
+        self.active = envs.map(&:to_s).include?(env)
+      end
+
       Appsignal::Config::STRING_OPTIONS.each_key do |option|
         define_method(option) do
           fetch_option(option)

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -1416,5 +1416,23 @@ describe Appsignal::Config do
 
       expect(dsl.cpu_count).to eq(1.0)
     end
+
+    describe "#activate_if_environment" do
+      it "sets active to true if loaded env matches argument" do
+        dsl.activate_if_environment(:production)
+        expect(dsl.active).to be(true)
+
+        dsl.activate_if_environment(:staging, :production)
+        expect(dsl.active).to be(true)
+      end
+
+      it "sets active to false if loaded env doesn't match argument" do
+        dsl.activate_if_environment(:qa)
+        expect(dsl.active).to be(false)
+
+        dsl.activate_if_environment(:qa, :beta)
+        expect(dsl.active).to be(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
Help people configure AppSignal using the `Appsignal.configure` helper more easily by adding the `activate_if_environment` helper within that DSL context.

This helper will automate setting `active` to `true` if the loaded environment matches one of the values given.

This way people don't have build their own conditionals to set active true for certain environments.