### PR TITLE
Lower diagnose log message to info level

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -94,7 +94,7 @@ module Appsignal
     # @since 0.7.0
     def start # rubocop:disable Metrics/AbcSize
       if ENV.fetch("_APPSIGNAL_DIAGNOSE", false)
-        internal_logger.warn("Skipping start in diagnose context")
+        internal_logger.info("Skipping start in diagnose context")
         return
       end
 


### PR DESCRIPTION
It's not a warning that the start call is ignored in the diagnose context. A warning sounds like it could be a problem, but it's operating as it should.

[skip changeset]
[skip review]