### PR TITLE
Add Ruby config file option to installer

### DIFF
--- a/.changesets/add-ruby-config-file-method-to-installer.md
+++ b/.changesets/add-ruby-config-file-method-to-installer.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Add the `config/appsignal.rb` Ruby config file method to installer, `appsignal install`.

--- a/resources/appsignal.rb.erb
+++ b/resources/appsignal.rb.erb
@@ -1,0 +1,32 @@
+# AppSignal Ruby gem configuration
+# Visit our documentation for a list of all available configuration options.
+# https://docs.appsignal.com/ruby/configuration/options.html
+Appsignal.configure do |config|
+  config.activate_if_environment(<%= environments.map(&:inspect).join(", ") %>)
+  config.name = <%= app_name.inspect %>
+  # The application's Push API key
+  # We recommend removing this line and setting this option with the
+  # APPSIGNAL_PUSH_API_KEY environment variable instead.
+  # https://docs.appsignal.com/ruby/configuration/options.html#option-push_api_key
+  config.push_api_key = "<%= push_api_key %>"
+
+  # Actions that should not be monitored by AppSignal
+  # config.ignore_actions << "ApplicationController#isup"
+
+  # Errors that should not be recorded by AppSignal
+  # For more information see our docs:
+  # https://docs.appsignal.com/ruby/configuration/ignore-errors.html
+  # config.ignore_errors += [
+  #   "Exception",
+  #   "NoMemoryError",
+  #   "ScriptError",
+  #   "LoadError",
+  #   "NotImplementedError",
+  #   "SyntaxError",
+  #   "SecurityError",
+  #   "SignalException",
+  #   "Interrupt",
+  #   "SystemExit",
+  #   "SystemStackError"
+  # ]
+end

--- a/resources/appsignal.rb.erb
+++ b/resources/appsignal.rb.erb
@@ -10,23 +10,13 @@ Appsignal.configure do |config|
   # https://docs.appsignal.com/ruby/configuration/options.html#option-push_api_key
   config.push_api_key = "<%= push_api_key %>"
 
-  # Actions that should not be monitored by AppSignal
+  # Configure actions that should not be monitored by AppSignal.
+  # For more information see our docs:
+  # https://docs.appsignal.com/ruby/configuration/ignore-actions.html
   # config.ignore_actions << "ApplicationController#isup"
 
-  # Errors that should not be recorded by AppSignal
+  # Configure errors that should not be recorded by AppSignal.
   # For more information see our docs:
   # https://docs.appsignal.com/ruby/configuration/ignore-errors.html
-  # config.ignore_errors += [
-  #   "Exception",
-  #   "NoMemoryError",
-  #   "ScriptError",
-  #   "LoadError",
-  #   "NotImplementedError",
-  #   "SyntaxError",
-  #   "SecurityError",
-  #   "SignalException",
-  #   "Interrupt",
-  #   "SystemExit",
-  #   "SystemStackError"
-  # ]
+  # config.ignore_errors << "MyCustomError"
 end

--- a/spec/lib/appsignal/cli/install_spec.rb
+++ b/spec/lib/appsignal/cli/install_spec.rb
@@ -7,8 +7,8 @@ describe Appsignal::CLI::Install do
   let(:output) { out_stream.read }
   let(:push_api_key) { "my_key" }
   let(:config) { Appsignal::Config.new(tmp_dir, "") }
-  let(:config_file_path) { File.join(tmp_dir, "config", "appsignal.yml") }
-  let(:config_file) { File.read(config_file_path) }
+  let(:yaml_config_file_path) { File.join(tmp_dir, "config", "appsignal.yml") }
+  let(:yaml_config_file) { File.read(yaml_config_file_path) }
   let(:options) { {} }
   before do
     stub_api_validation_request
@@ -45,22 +45,22 @@ describe Appsignal::CLI::Install do
     end
   end
 
-  define :configure_app_name do |name|
+  define :configure_yaml_app_name do |name|
     match do |file_contents|
       file_contents =~ /^  name: "#{name}"/
     end
   end
-  define :configure_push_api_key do |key|
+  define :configure_yaml_push_api_key do |key|
     match do |file_contents|
       file_contents =~ /^  push_api_key: "#{key}"/
     end
   end
-  define :configure_environment do |env|
+  define :configure_yaml_environment do |env|
     match do |file_contents|
       file_contents =~ /^#{env}:$/
     end
   end
-  define :include_file_config do
+  define :include_yaml_file_config do
     match do |log|
       log.include?("Config file written to config/appsignal.yml")
     end
@@ -80,7 +80,7 @@ describe Appsignal::CLI::Install do
 
   alias_method :enter_app_name, :add_cli_input
 
-  def choose_config_file
+  def choose_yaml_config_file
     add_cli_input "1"
   end
 
@@ -266,18 +266,18 @@ describe Appsignal::CLI::Install do
           File.delete(File.join(environments_dir, "development.rb"))
           File.delete(File.join(environments_dir, "staging.rb"))
           add_cli_input "n"
-          choose_config_file
+          choose_yaml_config_file
         end
 
         it "only configures the available environments" do
           run
 
-          expect(output).to include_file_config
-          expect(config_file).to configure_app_name(app_name)
-          expect(config_file).to configure_push_api_key(push_api_key)
-          expect(config_file).to_not configure_environment("development")
-          expect(config_file).to_not configure_environment("staging")
-          expect(config_file).to configure_environment("production")
+          expect(output).to include_yaml_file_config
+          expect(yaml_config_file).to configure_yaml_app_name(app_name)
+          expect(yaml_config_file).to configure_yaml_push_api_key(push_api_key)
+          expect(yaml_config_file).to_not configure_yaml_environment("development")
+          expect(yaml_config_file).to_not configure_yaml_environment("staging")
+          expect(yaml_config_file).to configure_yaml_environment("production")
 
           expect(output).to include(*installation_instructions)
           expect(output).to include_complete_install
@@ -313,7 +313,7 @@ describe Appsignal::CLI::Install do
         end
 
         context "with configuration using a configuration file" do
-          before { choose_config_file }
+          before { choose_yaml_config_file }
 
           it_behaves_like "windows installation"
           it_behaves_like "capistrano install"
@@ -322,12 +322,12 @@ describe Appsignal::CLI::Install do
           it "writes configuration to file" do
             run
 
-            expect(output).to include_file_config
-            expect(config_file).to configure_app_name(app_name)
-            expect(config_file).to configure_push_api_key(push_api_key)
-            expect(config_file).to configure_environment("development")
-            expect(config_file).to configure_environment("staging")
-            expect(config_file).to configure_environment("production")
+            expect(output).to include_yaml_file_config
+            expect(yaml_config_file).to configure_yaml_app_name(app_name)
+            expect(yaml_config_file).to configure_yaml_push_api_key(push_api_key)
+            expect(yaml_config_file).to configure_yaml_environment("development")
+            expect(yaml_config_file).to configure_yaml_environment("staging")
+            expect(yaml_config_file).to configure_yaml_environment("production")
           end
 
           it "completes the installation" do
@@ -382,7 +382,7 @@ describe Appsignal::CLI::Install do
         context "with configuration using a configuration file" do
           before do
             enter_app_name app_name
-            choose_config_file
+            choose_yaml_config_file
           end
 
           it_behaves_like "windows installation"
@@ -392,12 +392,12 @@ describe Appsignal::CLI::Install do
           it "writes configuration to file" do
             run
 
-            expect(output).to include_file_config
-            expect(config_file).to configure_app_name(app_name)
-            expect(config_file).to configure_push_api_key(push_api_key)
-            expect(config_file).to configure_environment("development")
-            expect(config_file).to configure_environment("staging")
-            expect(config_file).to configure_environment("production")
+            expect(output).to include_yaml_file_config
+            expect(yaml_config_file).to configure_yaml_app_name(app_name)
+            expect(yaml_config_file).to configure_yaml_push_api_key(push_api_key)
+            expect(yaml_config_file).to configure_yaml_environment("development")
+            expect(yaml_config_file).to configure_yaml_environment("staging")
+            expect(yaml_config_file).to configure_yaml_environment("production")
           end
 
           it "completes the installation" do
@@ -439,20 +439,20 @@ describe Appsignal::CLI::Install do
 
         it "prompts the user to fill in an app name" do
           enter_app_name app_name
-          choose_config_file
+          choose_yaml_config_file
           run
 
           expect(output).to include("Installing for Ruby on Rails")
           expect(output).to include("Unable to automatically detect your Rails app's name.")
           expect(output).to include("Choose your app's display name for AppSignal.com:")
-          expect(output).to include_file_config
+          expect(output).to include_yaml_file_config
           expect(output).to include_complete_install
 
-          expect(config_file).to configure_app_name(app_name)
-          expect(config_file).to configure_push_api_key(push_api_key)
-          expect(config_file).to configure_environment("development")
-          expect(config_file).to configure_environment("staging")
-          expect(config_file).to configure_environment("production")
+          expect(yaml_config_file).to configure_yaml_app_name(app_name)
+          expect(yaml_config_file).to configure_yaml_push_api_key(push_api_key)
+          expect(yaml_config_file).to configure_yaml_environment("development")
+          expect(yaml_config_file).to configure_yaml_environment("staging")
+          expect(yaml_config_file).to configure_yaml_environment("production")
         end
       end
     end
@@ -500,7 +500,7 @@ describe Appsignal::CLI::Install do
         end
 
         describe "configure with a configuration file" do
-          before { choose_config_file }
+          before { choose_yaml_config_file }
 
           it_behaves_like "windows installation"
           it_behaves_like "capistrano install"
@@ -509,12 +509,12 @@ describe Appsignal::CLI::Install do
           it "writes configuration to file" do
             run
 
-            expect(output).to include_file_config
-            expect(config_file).to configure_app_name(app_name)
-            expect(config_file).to configure_push_api_key(push_api_key)
-            expect(config_file).to configure_environment("development")
-            expect(config_file).to configure_environment("staging")
-            expect(config_file).to configure_environment("production")
+            expect(output).to include_yaml_file_config
+            expect(yaml_config_file).to configure_yaml_app_name(app_name)
+            expect(yaml_config_file).to configure_yaml_push_api_key(push_api_key)
+            expect(yaml_config_file).to configure_yaml_environment("development")
+            expect(yaml_config_file).to configure_yaml_environment("staging")
+            expect(yaml_config_file).to configure_yaml_environment("production")
           end
 
           it "completes the installation" do
@@ -570,7 +570,7 @@ describe Appsignal::CLI::Install do
         end
 
         describe "configure with a configuration file" do
-          before { choose_config_file }
+          before { choose_yaml_config_file }
 
           it_behaves_like "windows installation"
           it_behaves_like "capistrano install"
@@ -579,12 +579,12 @@ describe Appsignal::CLI::Install do
           it "writes configuration to file" do
             run
 
-            expect(output).to include_file_config
-            expect(config_file).to configure_app_name(app_name)
-            expect(config_file).to configure_push_api_key(push_api_key)
-            expect(config_file).to configure_environment("development")
-            expect(config_file).to configure_environment("staging")
-            expect(config_file).to configure_environment("production")
+            expect(output).to include_yaml_file_config
+            expect(yaml_config_file).to configure_yaml_app_name(app_name)
+            expect(yaml_config_file).to configure_yaml_push_api_key(push_api_key)
+            expect(yaml_config_file).to configure_yaml_environment("development")
+            expect(yaml_config_file).to configure_yaml_environment("staging")
+            expect(yaml_config_file).to configure_yaml_environment("production")
           end
 
           it "completes the installation" do
@@ -637,7 +637,7 @@ describe Appsignal::CLI::Install do
         end
 
         describe "configure with a configuration file" do
-          before { choose_config_file }
+          before { choose_yaml_config_file }
 
           it_behaves_like "windows installation"
           it_behaves_like "capistrano install"
@@ -646,12 +646,12 @@ describe Appsignal::CLI::Install do
           it "writes configuration to file" do
             run
 
-            expect(output).to include_file_config
-            expect(config_file).to configure_app_name(app_name)
-            expect(config_file).to configure_push_api_key(push_api_key)
-            expect(config_file).to configure_environment("development")
-            expect(config_file).to configure_environment("staging")
-            expect(config_file).to configure_environment("production")
+            expect(output).to include_yaml_file_config
+            expect(yaml_config_file).to configure_yaml_app_name(app_name)
+            expect(yaml_config_file).to configure_yaml_push_api_key(push_api_key)
+            expect(yaml_config_file).to configure_yaml_environment("development")
+            expect(yaml_config_file).to configure_yaml_environment("staging")
+            expect(yaml_config_file).to configure_yaml_environment("production")
           end
 
           it "completes the installation" do
@@ -707,7 +707,7 @@ describe Appsignal::CLI::Install do
         end
 
         describe "configure with a configuration file" do
-          before { choose_config_file }
+          before { choose_yaml_config_file }
 
           it_behaves_like "windows installation"
           it_behaves_like "capistrano install"
@@ -715,12 +715,12 @@ describe Appsignal::CLI::Install do
 
           it "writes configuration to file" do
             run
-            expect(output).to include_file_config
-            expect(config_file).to configure_app_name(app_name)
-            expect(config_file).to configure_push_api_key(push_api_key)
-            expect(config_file).to configure_environment("development")
-            expect(config_file).to configure_environment("staging")
-            expect(config_file).to configure_environment("production")
+            expect(output).to include_yaml_file_config
+            expect(yaml_config_file).to configure_yaml_app_name(app_name)
+            expect(yaml_config_file).to configure_yaml_push_api_key(push_api_key)
+            expect(yaml_config_file).to configure_yaml_environment("development")
+            expect(yaml_config_file).to configure_yaml_environment("staging")
+            expect(yaml_config_file).to configure_yaml_environment("production")
           end
 
           it "completes the installation" do
@@ -777,7 +777,7 @@ describe Appsignal::CLI::Install do
         end
 
         describe "configure with a configuration file" do
-          before { choose_config_file }
+          before { choose_yaml_config_file }
 
           it_behaves_like "windows installation"
           it_behaves_like "capistrano install"
@@ -785,12 +785,12 @@ describe Appsignal::CLI::Install do
 
           it "writes configuration to file" do
             run
-            expect(output).to include_file_config
-            expect(config_file).to configure_app_name(app_name)
-            expect(config_file).to configure_push_api_key(push_api_key)
-            expect(config_file).to configure_environment("development")
-            expect(config_file).to configure_environment("staging")
-            expect(config_file).to configure_environment("production")
+            expect(output).to include_yaml_file_config
+            expect(yaml_config_file).to configure_yaml_app_name(app_name)
+            expect(yaml_config_file).to configure_yaml_push_api_key(push_api_key)
+            expect(yaml_config_file).to configure_yaml_environment("development")
+            expect(yaml_config_file).to configure_yaml_environment("staging")
+            expect(yaml_config_file).to configure_yaml_environment("production")
           end
 
           it "completes the installation" do

--- a/spec/lib/appsignal/cli/install_spec.rb
+++ b/spec/lib/appsignal/cli/install_spec.rb
@@ -9,6 +9,8 @@ describe Appsignal::CLI::Install do
   let(:config) { Appsignal::Config.new(tmp_dir, "") }
   let(:yaml_config_file_path) { File.join(tmp_dir, "config", "appsignal.yml") }
   let(:yaml_config_file) { File.read(yaml_config_file_path) }
+  let(:ruby_config_file_path) { File.join(tmp_dir, "config", "appsignal.rb") }
+  let(:ruby_config_file) { File.read(ruby_config_file_path) }
   let(:options) { {} }
   before do
     stub_api_validation_request
@@ -42,6 +44,28 @@ describe Appsignal::CLI::Install do
   define :include_env_app_name do |name|
     match do |actual|
       actual.include?("export APPSIGNAL_APP_NAME=#{name}")
+    end
+  end
+
+  define :configure_ruby_app_name do |name|
+    match do |file_contents|
+      file_contents =~ /config\.name = "#{name}"/
+    end
+  end
+  define :configure_ruby_push_api_key do |key|
+    match do |file_contents|
+      file_contents =~ /config\.push_api_key = "#{key}"/
+    end
+  end
+  define :configure_ruby_environment do |env|
+    match do |file_contents|
+      match = /config\.activate_if_environment\((.*)\)$/.match(file_contents)
+      match[1].include?(env)
+    end
+  end
+  define :include_ruby_file_config do
+    match do |log|
+      log.include?("Config file written to config/appsignal.rb")
     end
   end
 
@@ -80,12 +104,16 @@ describe Appsignal::CLI::Install do
 
   alias_method :enter_app_name, :add_cli_input
 
-  def choose_yaml_config_file
+  def choose_ruby_config_file
     add_cli_input "1"
   end
 
-  def choose_environment_config
+  def choose_yaml_config_file
     add_cli_input "2"
+  end
+
+  def choose_environment_config
+    add_cli_input "3"
   end
 
   def run
@@ -266,18 +294,18 @@ describe Appsignal::CLI::Install do
           File.delete(File.join(environments_dir, "development.rb"))
           File.delete(File.join(environments_dir, "staging.rb"))
           add_cli_input "n"
-          choose_yaml_config_file
+          choose_ruby_config_file
         end
 
         it "only configures the available environments" do
           run
 
-          expect(output).to include_yaml_file_config
-          expect(yaml_config_file).to configure_yaml_app_name(app_name)
-          expect(yaml_config_file).to configure_yaml_push_api_key(push_api_key)
-          expect(yaml_config_file).to_not configure_yaml_environment("development")
-          expect(yaml_config_file).to_not configure_yaml_environment("staging")
-          expect(yaml_config_file).to configure_yaml_environment("production")
+          expect(output).to include_ruby_file_config
+          expect(ruby_config_file).to configure_ruby_app_name(app_name)
+          expect(ruby_config_file).to configure_ruby_push_api_key(push_api_key)
+          expect(ruby_config_file).to_not configure_ruby_environment("development")
+          expect(ruby_config_file).to_not configure_ruby_environment("staging")
+          expect(ruby_config_file).to configure_ruby_environment("production")
 
           expect(output).to include(*installation_instructions)
           expect(output).to include_complete_install
@@ -312,7 +340,33 @@ describe Appsignal::CLI::Install do
           end
         end
 
-        context "with configuration using a configuration file" do
+        context "with configuration using a Ruby configuration file" do
+          before { choose_ruby_config_file }
+
+          it_behaves_like "windows installation"
+          it_behaves_like "capistrano install"
+          it_behaves_like "demo data"
+
+          it "writes configuration to file" do
+            run
+
+            expect(output).to include_ruby_file_config
+            expect(ruby_config_file).to configure_ruby_app_name(app_name)
+            expect(ruby_config_file).to configure_ruby_push_api_key(push_api_key)
+            expect(ruby_config_file).to configure_ruby_environment("development")
+            expect(ruby_config_file).to configure_ruby_environment("staging")
+            expect(ruby_config_file).to configure_ruby_environment("production")
+          end
+
+          it "completes the installation" do
+            run
+
+            expect(output).to include(*installation_instructions)
+            expect(output).to include_complete_install
+          end
+        end
+
+        context "with configuration using a YAML configuration file" do
           before { choose_yaml_config_file }
 
           it_behaves_like "windows installation"
@@ -379,7 +433,36 @@ describe Appsignal::CLI::Install do
           end
         end
 
-        context "with configuration using a configuration file" do
+        context "with configuration using a Ruby configuration file" do
+          before do
+            enter_app_name app_name
+            choose_ruby_config_file
+          end
+
+          it_behaves_like "windows installation"
+          it_behaves_like "capistrano install"
+          it_behaves_like "demo data"
+
+          it "writes configuration to file" do
+            run
+
+            expect(output).to include_ruby_file_config
+            expect(ruby_config_file).to configure_ruby_app_name(app_name)
+            expect(ruby_config_file).to configure_ruby_push_api_key(push_api_key)
+            expect(ruby_config_file).to configure_ruby_environment("development")
+            expect(ruby_config_file).to configure_ruby_environment("staging")
+            expect(ruby_config_file).to configure_ruby_environment("production")
+          end
+
+          it "completes the installation" do
+            run
+
+            expect(output).to include(*installation_instructions)
+            expect(output).to include_complete_install
+          end
+        end
+
+        context "with configuration using a YAML configuration file" do
           before do
             enter_app_name app_name
             choose_yaml_config_file
@@ -439,20 +522,20 @@ describe Appsignal::CLI::Install do
 
         it "prompts the user to fill in an app name" do
           enter_app_name app_name
-          choose_yaml_config_file
+          choose_ruby_config_file
           run
 
           expect(output).to include("Installing for Ruby on Rails")
           expect(output).to include("Unable to automatically detect your Rails app's name.")
           expect(output).to include("Choose your app's display name for AppSignal.com:")
-          expect(output).to include_yaml_file_config
+          expect(output).to include_ruby_file_config
           expect(output).to include_complete_install
 
-          expect(yaml_config_file).to configure_yaml_app_name(app_name)
-          expect(yaml_config_file).to configure_yaml_push_api_key(push_api_key)
-          expect(yaml_config_file).to configure_yaml_environment("development")
-          expect(yaml_config_file).to configure_yaml_environment("staging")
-          expect(yaml_config_file).to configure_yaml_environment("production")
+          expect(ruby_config_file).to configure_ruby_app_name(app_name)
+          expect(ruby_config_file).to configure_ruby_push_api_key(push_api_key)
+          expect(ruby_config_file).to configure_ruby_environment("development")
+          expect(ruby_config_file).to configure_ruby_environment("staging")
+          expect(ruby_config_file).to configure_ruby_environment("production")
         end
       end
     end
@@ -499,7 +582,33 @@ describe Appsignal::CLI::Install do
           end
         end
 
-        describe "configure with a configuration file" do
+        describe "configure with a Ruby configuration file" do
+          before { choose_ruby_config_file }
+
+          it_behaves_like "windows installation"
+          it_behaves_like "capistrano install"
+          it_behaves_like "demo data"
+
+          it "writes configuration to file" do
+            run
+
+            expect(output).to include_ruby_file_config
+            expect(ruby_config_file).to configure_ruby_app_name(app_name)
+            expect(ruby_config_file).to configure_ruby_push_api_key(push_api_key)
+            expect(ruby_config_file).to configure_ruby_environment("development")
+            expect(ruby_config_file).to configure_ruby_environment("staging")
+            expect(ruby_config_file).to configure_ruby_environment("production")
+          end
+
+          it "completes the installation" do
+            run
+
+            expect(output).to include(*installation_instructions)
+            expect(output).to include_complete_install
+          end
+        end
+
+        describe "configure with a YAML configuration file" do
           before { choose_yaml_config_file }
 
           it_behaves_like "windows installation"
@@ -569,7 +678,33 @@ describe Appsignal::CLI::Install do
           end
         end
 
-        describe "configure with a configuration file" do
+        describe "configure with a Ruby configuration file" do
+          before { choose_ruby_config_file }
+
+          it_behaves_like "windows installation"
+          it_behaves_like "capistrano install"
+          it_behaves_like "demo data"
+
+          it "writes configuration to file" do
+            run
+
+            expect(output).to include_ruby_file_config
+            expect(ruby_config_file).to configure_ruby_app_name(app_name)
+            expect(ruby_config_file).to configure_ruby_push_api_key(push_api_key)
+            expect(ruby_config_file).to configure_ruby_environment("development")
+            expect(ruby_config_file).to configure_ruby_environment("staging")
+            expect(ruby_config_file).to configure_ruby_environment("production")
+          end
+
+          it "completes the installation" do
+            run
+
+            expect(output).to include(*installation_instructions)
+            expect(output).to include_complete_install
+          end
+        end
+
+        describe "configure with a YAML configuration file" do
           before { choose_yaml_config_file }
 
           it_behaves_like "windows installation"
@@ -636,7 +771,33 @@ describe Appsignal::CLI::Install do
           end
         end
 
-        describe "configure with a configuration file" do
+        describe "configure with a Ruby configuration file" do
+          before { choose_ruby_config_file }
+
+          it_behaves_like "windows installation"
+          it_behaves_like "capistrano install"
+          it_behaves_like "demo data"
+
+          it "writes configuration to file" do
+            run
+
+            expect(output).to include_ruby_file_config
+            expect(ruby_config_file).to configure_ruby_app_name(app_name)
+            expect(ruby_config_file).to configure_ruby_push_api_key(push_api_key)
+            expect(ruby_config_file).to configure_ruby_environment("development")
+            expect(ruby_config_file).to configure_ruby_environment("staging")
+            expect(ruby_config_file).to configure_ruby_environment("production")
+          end
+
+          it "completes the installation" do
+            run
+
+            expect(output).to include(*installation_instructions)
+            expect(output).to include_complete_install
+          end
+        end
+
+        describe "configure with a YAML configuration file" do
           before { choose_yaml_config_file }
 
           it_behaves_like "windows installation"
@@ -706,7 +867,32 @@ describe Appsignal::CLI::Install do
           end
         end
 
-        describe "configure with a configuration file" do
+        describe "configure with a Ruby configuration file" do
+          before { choose_ruby_config_file }
+
+          it_behaves_like "windows installation"
+          it_behaves_like "capistrano install"
+          it_behaves_like "demo data"
+
+          it "writes configuration to file" do
+            run
+            expect(output).to include_ruby_file_config
+            expect(ruby_config_file).to configure_ruby_app_name(app_name)
+            expect(ruby_config_file).to configure_ruby_push_api_key(push_api_key)
+            expect(ruby_config_file).to configure_ruby_environment("development")
+            expect(ruby_config_file).to configure_ruby_environment("staging")
+            expect(ruby_config_file).to configure_ruby_environment("production")
+          end
+
+          it "completes the installation" do
+            run
+
+            expect(output).to include(*installation_instructions)
+            expect(output).to include_complete_install
+          end
+        end
+
+        describe "configure with a YAML configuration file" do
           before { choose_yaml_config_file }
 
           it_behaves_like "windows installation"
@@ -776,7 +962,32 @@ describe Appsignal::CLI::Install do
           end
         end
 
-        describe "configure with a configuration file" do
+        describe "configure with a Ruby configuration file" do
+          before { choose_ruby_config_file }
+
+          it_behaves_like "windows installation"
+          it_behaves_like "capistrano install"
+          it_behaves_like "demo data"
+
+          it "writes configuration to file" do
+            run
+            expect(output).to include_ruby_file_config
+            expect(ruby_config_file).to configure_ruby_app_name(app_name)
+            expect(ruby_config_file).to configure_ruby_push_api_key(push_api_key)
+            expect(ruby_config_file).to configure_ruby_environment("development")
+            expect(ruby_config_file).to configure_ruby_environment("staging")
+            expect(ruby_config_file).to configure_ruby_environment("production")
+          end
+
+          it "completes the installation" do
+            run
+
+            expect(output).to include(*installation_instructions)
+            expect(output).to include_complete_install
+          end
+        end
+
+        describe "configure with a YAML configuration file" do
           before { choose_yaml_config_file }
 
           it_behaves_like "windows installation"


### PR DESCRIPTION
Based on #1324

## Rename matchers in installer spec

Differentiate between YAML install method and others in the matcher names so it's easier to add ones for the Ruby config file later.

## Add Ruby config file option to installer

To replace the YAML config file people need to know they can configure the gem with a Ruby config file too. Add this option to the installer so people can choose this config option when installing AppSignal in their application.

I've made it the first listed method as it's the most flexible configuration method. The YAML file option has the "legacy" label next to it now to discourage people from using it.
