### PR TITLE
Add timeout to checkin scheduler spec

### DIFF
--- a/spec/lib/appsignal/check_in/scheduler_spec.rb
+++ b/spec/lib/appsignal/check_in/scheduler_spec.rb
@@ -23,6 +23,12 @@ describe Appsignal::CheckIn::Scheduler do
     end
   end
 
+  around do |example|
+    Timeout.timeout(5 * 60) do # in seconds
+      example.run
+    end
+  end
+
   describe "when no event is sent" do
     it "does not start a thread" do
       expect(scheduler.thread).to be_nil


### PR DESCRIPTION
There are times the spec runs for hours (6 hours on the CI) and that's very wasteful. If it's stuck after 5 minutes it's not getting unstuck so let's time it out.

[skip review]
[skip changeset]