### PR TITLE
Add Appsignal.configure .env? helper

### DIFF
--- a/.changesets/add-appsignal-configure-env--helper.md
+++ b/.changesets/add-appsignal-configure-env--helper.md
@@ -1,0 +1,22 @@
+---
+bump: patch
+type: add
+---
+
+Add `Appsignal.configure` context `env?` helper method. Check if the loaded environment matches the given environment using the `.env?(:env_name)` helper.
+
+Example:
+
+```ruby
+Appsignal.configure do |config|
+  # Symbols work as the argument
+  if config.env?(:production)
+    config.ignore_actions << "My production action"
+  end
+
+  # Strings also work as the argument
+  if config.env?("staging")
+    config.ignore_actions << "My staging action"
+  end
+end
+```

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -609,6 +609,15 @@ module Appsignal
         @config.env
       end
 
+      # Returns true if the given environment name matches the loaded
+      # environment name.
+      #
+      # @param given_env [String, Symbol]
+      # @return [TrueClass, FalseClass]
+      def env?(given_env)
+        env == given_env.to_s
+      end
+
       def activate_if_environment(*envs)
         self.active = envs.map(&:to_s).include?(env)
       end

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -1367,6 +1367,18 @@ describe Appsignal::Config do
       expect(dsl.env).to eq("production")
     end
 
+    describe "#env?" do
+      it "returns true if the env matches" do
+        expect(dsl.env?("production")).to be(true)
+        expect(dsl.env?(:production)).to be(true)
+      end
+
+      it "returns false if the env doesn't match" do
+        expect(dsl.env?("staging")).to be(false)
+        expect(dsl.env?(:staging)).to be(false)
+      end
+    end
+
     it "sets config options" do
       dsl.push_api_key = "my push key"
       dsl.ignore_actions = ["My ignored action"]


### PR DESCRIPTION
When adding environment specific config with an if-statement comparing the current environment, they need to use a String. If apps compare a String with a Symbol like `config.env == :production` it would return false.

Apps can call `Appsignal.configure(:production)` with a Symbol and we'll cast it to a String. The environment in the Config class is always a String.

Add the `config.env?` helper to handle the casting of the environment value so that our users don't have to bother with casting the environment value to a String.