### PR TITLE
Move up creation of Rack instrumentation event

### DIFF
--- a/.changesets/reduce-rack-transaction-event-creation.md
+++ b/.changesets/reduce-rack-transaction-event-creation.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Minimize difference between Rack transaction duration and total child event durations.

--- a/lib/appsignal/rack/event_handler.rb
+++ b/lib/appsignal/rack/event_handler.rb
@@ -59,6 +59,7 @@ module Appsignal
           return unless request_handler?(request.env[APPSIGNAL_EVENT_HANDLER_ID])
 
           transaction = Appsignal::Transaction.create(Appsignal::Transaction::HTTP_REQUEST)
+          transaction.start_event
           request.env[APPSIGNAL_TRANSACTION] = transaction
 
           request.env[RACK_AFTER_REPLY] ||= []
@@ -83,7 +84,6 @@ module Appsignal
             # One such scenario is when a Puma "lowlevel_error" occurs.
             Appsignal::Transaction.complete_current!
           end
-          transaction.start_event
         end
       end
 


### PR DESCRIPTION
We see a small difference between the transaction duration and the total duration of child span groups.

Move up the transaction's Rack event creation so it happens directly after the transaction is created to minimize this difference.

Context:
https://appsignal.slack.com/archives/C7XHXQ7N0/p1733142713081549?thread_ts=1733126790.603229&cid=C7XHXQ7N0