### PR TITLE
Add Ruby 3.4 preview 2 to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 # This is a generated file by the `rake build_matrix:github:generate` task.
 # See `build_matrix.yml` for the build matrix.
 # Generate this file with `rake build_matrix:github:generate`.
-# Generated job count: 127
+# Generated job count: 151
 ---
 name: Ruby gem CI
 'on':
@@ -73,6 +73,658 @@ jobs:
       working-directory: spec/integration/diagnose
       env:
         LANGUAGE: ruby
+  ruby_3-4-0-preview2_ubuntu-latest:
+    name: Ruby 3.4.0-preview2
+    needs: validation
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.0-preview2
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    - name: Run tests without extension
+      run: "./script/bundler_wrapper exec rake test:failure"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/no_dependencies.gemfile
+  ruby_3-4-0-preview2__capistrano2_ubuntu-latest:
+    name: Ruby 3.4.0-preview2 - capistrano2
+    needs: ruby_3-4-0-preview2_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.0-preview2
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/capistrano2.gemfile
+  ruby_3-4-0-preview2__capistrano3_ubuntu-latest:
+    name: Ruby 3.4.0-preview2 - capistrano3
+    needs: ruby_3-4-0-preview2_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.0-preview2
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/capistrano3.gemfile
+  ruby_3-4-0-preview2__dry-monitor_ubuntu-latest:
+    name: Ruby 3.4.0-preview2 - dry-monitor
+    needs: ruby_3-4-0-preview2_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.0-preview2
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/dry-monitor.gemfile
+  ruby_3-4-0-preview2__grape_ubuntu-latest:
+    name: Ruby 3.4.0-preview2 - grape
+    needs: ruby_3-4-0-preview2_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.0-preview2
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/grape.gemfile
+  ruby_3-4-0-preview2__hanami-2-0_ubuntu-latest:
+    name: Ruby 3.4.0-preview2 - hanami-2.0
+    needs: ruby_3-4-0-preview2_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.0-preview2
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/hanami-2.0.gemfile
+  ruby_3-4-0-preview2__hanami-2-1_ubuntu-latest:
+    name: Ruby 3.4.0-preview2 - hanami-2.1
+    needs: ruby_3-4-0-preview2_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.0-preview2
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/hanami-2.1.gemfile
+  ruby_3-4-0-preview2__hanami-2-2_ubuntu-latest:
+    name: Ruby 3.4.0-preview2 - hanami-2.2
+    needs: ruby_3-4-0-preview2_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.0-preview2
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/hanami-2.2.gemfile
+  ruby_3-4-0-preview2__http5_ubuntu-latest:
+    name: Ruby 3.4.0-preview2 - http5
+    needs: ruby_3-4-0-preview2_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.0-preview2
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/http5.gemfile
+  ruby_3-4-0-preview2__padrino_ubuntu-latest:
+    name: Ruby 3.4.0-preview2 - padrino
+    needs: ruby_3-4-0-preview2_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.0-preview2
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/padrino.gemfile
+  ruby_3-4-0-preview2__psych-3_ubuntu-latest:
+    name: Ruby 3.4.0-preview2 - psych-3
+    needs: ruby_3-4-0-preview2_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.0-preview2
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/psych-3.gemfile
+  ruby_3-4-0-preview2__psych-4_ubuntu-latest:
+    name: Ruby 3.4.0-preview2 - psych-4
+    needs: ruby_3-4-0-preview2_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.0-preview2
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/psych-4.gemfile
+  ruby_3-4-0-preview2__que-1_ubuntu-latest:
+    name: Ruby 3.4.0-preview2 - que-1
+    needs: ruby_3-4-0-preview2_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.0-preview2
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/que-1.gemfile
+  ruby_3-4-0-preview2__que-2_ubuntu-latest:
+    name: Ruby 3.4.0-preview2 - que-2
+    needs: ruby_3-4-0-preview2_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.0-preview2
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/que-2.gemfile
+  ruby_3-4-0-preview2__rails-7-0_ubuntu-latest:
+    name: Ruby 3.4.0-preview2 - rails-7.0
+    needs: ruby_3-4-0-preview2_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.0-preview2
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/rails-7.0.gemfile
+  ruby_3-4-0-preview2__rails-7-1_ubuntu-latest:
+    name: Ruby 3.4.0-preview2 - rails-7.1
+    needs: ruby_3-4-0-preview2_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.0-preview2
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/rails-7.1.gemfile
+  ruby_3-4-0-preview2__rails-7-2_ubuntu-latest:
+    name: Ruby 3.4.0-preview2 - rails-7.2
+    needs: ruby_3-4-0-preview2_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.0-preview2
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/rails-7.2.gemfile
+  ruby_3-4-0-preview2__rails-8-0_ubuntu-latest:
+    name: Ruby 3.4.0-preview2 - rails-8.0
+    needs: ruby_3-4-0-preview2_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.0-preview2
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/rails-8.0.gemfile
+  ruby_3-4-0-preview2__sequel_ubuntu-latest:
+    name: Ruby 3.4.0-preview2 - sequel
+    needs: ruby_3-4-0-preview2_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.0-preview2
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/sequel.gemfile
+  ruby_3-4-0-preview2__sinatra_ubuntu-latest:
+    name: Ruby 3.4.0-preview2 - sinatra
+    needs: ruby_3-4-0-preview2_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.0-preview2
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/sinatra.gemfile
+  ruby_3-4-0-preview2__webmachine2_ubuntu-latest:
+    name: Ruby 3.4.0-preview2 - webmachine2
+    needs: ruby_3-4-0-preview2_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.0-preview2
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/webmachine2.gemfile
+  ruby_3-4-0-preview2__redis-4_ubuntu-latest:
+    name: Ruby 3.4.0-preview2 - redis-4
+    needs: ruby_3-4-0-preview2_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.0-preview2
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/redis-4.gemfile
+  ruby_3-4-0-preview2__redis-5_ubuntu-latest:
+    name: Ruby 3.4.0-preview2 - redis-5
+    needs: ruby_3-4-0-preview2_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.0-preview2
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/redis-5.gemfile
+  ruby_3-4-0-preview2_macos-14:
+    name: Ruby 3.4.0-preview2 (macos-14)
+    needs: validation
+    runs-on: macos-14
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.0-preview2
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    - name: Run tests without extension
+      run: "./script/bundler_wrapper exec rake test:failure"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/no_dependencies.gemfile
   ruby_3-3-4_ubuntu-latest:
     name: Ruby 3.3.4
     needs: validation

--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,5 @@ ext/*.bundle
 ext/*.o
 ext/*.so
 ext/*.report
+ext/*.bundle.dSYM
 pkg/

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -88,6 +88,7 @@ matrix:
       - "rails-8.0"
 
   ruby:
+    - ruby: "3.4.0-preview2"
     - ruby: "3.3.4"
     - ruby: "3.2.5"
     - ruby: "3.1.6"
@@ -102,6 +103,7 @@ matrix:
     - gem: "dry-monitor"
       only:
         ruby:
+          - "3.4.0-preview2"
           - "3.3.4"
           - "3.2.5"
           - "3.1.6"
@@ -110,6 +112,7 @@ matrix:
     - gem: "hanami-2.0"
       only:
         ruby:
+          - "3.4.0-preview2"
           - "3.3.4"
           - "3.2.5"
           - "3.1.6"
@@ -117,6 +120,7 @@ matrix:
     - gem: "hanami-2.1"
       only:
         ruby:
+          - "3.4.0-preview2"
           - "3.3.4"
           - "3.2.5"
           - "3.1.6"
@@ -124,6 +128,7 @@ matrix:
     - gem: "hanami-2.2"
       only:
         ruby:
+          - "3.4.0-preview2"
           - "3.3.4"
           - "3.2.5"
           - "3.1.6"
@@ -132,6 +137,7 @@ matrix:
     - gem: "psych-3"
       only:
         ruby:
+          - "3.4.0-preview2"
           - "3.3.4"
           - "3.2.5"
           - "3.1.6"
@@ -140,6 +146,7 @@ matrix:
     - gem: "psych-4"
       only:
         ruby:
+          - "3.4.0-preview2"
           - "3.3.4"
           - "3.2.5"
           - "3.1.6"
@@ -165,6 +172,7 @@ matrix:
     - gem: "rails-7.0"
       only:
         ruby:
+          - "3.4.0-preview2"
           - "3.3.4"
           - "3.2.5"
           - "3.1.6"
@@ -174,6 +182,7 @@ matrix:
     - gem: "rails-7.1"
       only:
         ruby:
+          - "3.4.0-preview2"
           - "3.3.4"
           - "3.2.5"
           - "3.1.6"
@@ -182,6 +191,7 @@ matrix:
     - gem: "rails-7.2"
       only:
         ruby:
+          - "3.4.0-preview2"
           - "3.3.4"
           - "3.2.5"
           - "3.1.6"
@@ -189,6 +199,7 @@ matrix:
     - gem: "rails-8.0"
       only:
         ruby:
+          - "3.4.0-preview2"
           - "3.3.4"
           - "3.2.5"
     - gem: "sequel"

--- a/gemfiles/padrino.gemfile
+++ b/gemfiles/padrino.gemfile
@@ -1,7 +1,8 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'padrino', "~> 0.15"
-gem 'rack', "~> 2"
-gem 'sinatra', "~> 2"
+gem "base64" # Ruby 3.4 requirement
+gem "padrino", "~> 0.15"
+gem "rack", "~> 2"
+gem "sinatra", "~> 2"
 
-gemspec :path => '../'
+gemspec :path => "../"

--- a/gemfiles/rails-7.0.gemfile
+++ b/gemfiles/rails-7.0.gemfile
@@ -1,5 +1,8 @@
 source "https://rubygems.org"
 
+gem "base64" # Ruby 3.4 requirement
+gem "drb" # Ruby 3.4 requirement
+gem "mutex_m" # Ruby 3.4 requirement
 gem "rails", "~> 7.0.1"
 gem "rake", "> 12.2"
 gem "sidekiq"

--- a/gemfiles/webmachine2.gemfile
+++ b/gemfiles/webmachine2.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "mutex_m" # Ruby 3.4 requirement
 gem "webmachine", "~> 2.0"
 gem "webrick"
 

--- a/lib/appsignal/probes/sidekiq.rb
+++ b/lib/appsignal/probes/sidekiq.rb
@@ -59,7 +59,11 @@ module Appsignal
         is_sidekiq7 = self.class.sidekiq7_and_greater?
         @adapter = is_sidekiq7 ? Sidekiq7Adapter : Sidekiq6Adapter
 
-        config_string = " with config: #{config}" unless config.empty?
+        unless config.empty?
+          formatted_config =
+            config.map { |key, value| "#{key}: #{value.inspect}" }.join(", ")
+          config_string = " with config: #{formatted_config}"
+        end
         Appsignal.internal_logger.debug("Initializing Sidekiq probe#{config_string}")
         require "sidekiq/api"
       end

--- a/spec/lib/appsignal/event_formatter/elastic_search/search_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/elastic_search/search_formatter_spec.rb
@@ -18,9 +18,15 @@ describe Appsignal::EventFormatter::ElasticSearch::SearchFormatter do
     end
 
     it "should return a payload with name and sanitized body" do
+      query =
+        if DependencyHelper.ruby_3_4_or_newer?
+          "{index: \"users\", type: \"user\", q: \"?\"}"
+        else
+          "{:index=>\"users\", :type=>\"user\", :q=>\"?\"}"
+        end
       expect(formatter.format(payload)).to eql([
         "Search: User",
-        "{:index=>\"users\", :type=>\"user\", :q=>\"?\"}"
+        query
       ])
     end
   end

--- a/spec/lib/appsignal/probes/sidekiq_spec.rb
+++ b/spec/lib/appsignal/probes/sidekiq_spec.rb
@@ -312,7 +312,7 @@ describe Appsignal::Probes::SidekiqProbe do
         log = capture_logs { probe }
         expect(log).to contains_log(
           :debug,
-          %(Initializing Sidekiq probe with config: {:hostname=>"#{redis_hostname}"})
+          %(Initializing Sidekiq probe with config: hostname: "#{redis_hostname}")
         )
         log = capture_logs { probe.call }
         expect(log).to contains_log(

--- a/spec/lib/appsignal/utils/data_spec.rb
+++ b/spec/lib/appsignal/utils/data_spec.rb
@@ -108,7 +108,11 @@ describe Appsignal::Utils::Data do
 
           it "casts unsupported key types to string" do
             expect(generate([1, 2] => "abc").to_s).to eq(%({"[1, 2]":"abc"}))
-            expect(generate({ :a => "b" } => "abc").to_s).to eq(%({"{:a=>\\"b\\"}":"abc"}))
+            if DependencyHelper.ruby_3_4_or_newer?
+              expect(generate({ :a => "b" } => "abc").to_s).to eq(%({"{a: \\"b\\"}":"abc"}))
+            else
+              expect(generate({ :a => "b" } => "abc").to_s).to eq(%({"{:a=>\\"b\\"}":"abc"}))
+            end
           end
         end
       end

--- a/spec/support/helpers/dependency_helper.rb
+++ b/spec/support/helpers/dependency_helper.rb
@@ -17,6 +17,10 @@ module DependencyHelper
     ruby_version >= Gem::Version.new("3.2.0")
   end
 
+  def ruby_3_4_or_newer?
+    ruby_version >= Gem::Version.new("3.4.0")
+  end
+
   def running_jruby?
     Appsignal::System.jruby?
   end


### PR DESCRIPTION
## Add Ruby 3.4 preview 2 to the CI

Test against the latest prerelease to test if any issues arise.

[skip changeset]

## Update Sidekiq probe config logging

In Ruby 3.4 the internal representation of Hashes has changed when called with `to_s`/`inspect`. Instead of `{:abc => :def}` it is now `{abc: :def}`.

Use own config formatter so we are not relying on the Ruby format and tests don't break over different Ruby versions.

## Update Hash representation in Strings

In Ruby 3.4 the internal representation of Hashes has changed when called with `to_s`/`inspect`. Instead of `{:abc => :def}` it is now `{abc: :def}`.

Update the Data struct spec to match both formats. We don't really rely on the String representation of Data structs so it's fine.

For the ElasticSearch event formatter it does impact how we detect unique events. It will no longer match the event between Ruby 3.3 and Ruby 3.4 as the same event, meaning event metrics will be restarted after upgrading to Ruby 3.4. This is already what happens upgrading to Ruby 3.4 with published versions of the Ruby gem. And adding our own formatter for arbitrary search parameters seems brittle. We'd have to keep the Ruby format prior to Ruby 3.4 too.

## Update gitignore for macOS Ruby 3.4 artifacts

We generate a bunch more artifacts on Ruby 3.4 on macOS. Git ignore them so we don't accidentally commit them.

## Add required gems for tests on Ruby 3.4

Ruby 3.4 removed a couple of standard gems. Add them manually so the tests work.
