### PR TITLE
Fix JRuby jar-dependencies gem install issue

### DIFF
--- a/gemfiles/rails-7.1.gemfile
+++ b/gemfiles/rails-7.1.gemfile
@@ -4,8 +4,12 @@ gem "rails", "~> 7.1.0"
 gem "rake", "> 12.2"
 gem "sidekiq"
 
-# Fix install issue for jruby on gem 3.1.8.
-# No java stub is published.
-gem "bigdecimal", "3.1.7" if RUBY_PLATFORM == "java"
+if RUBY_PLATFORM == "java"
+  # Fix install issue for jruby on gem 3.1.8.
+  # No java stub is published.
+  gem "bigdecimal", "3.1.7"
+  # Fix default gem install issue
+  gem "jar-dependencies", "0.4.1"
+end
 
 gemspec :path => "../"

--- a/gemfiles/rails-7.2.gemfile
+++ b/gemfiles/rails-7.2.gemfile
@@ -4,8 +4,12 @@ gem "rails", "~> 7.2.0"
 gem "rake", "> 12.2"
 gem "sidekiq"
 
-# Fix install issue for jruby on gem 3.1.8.
-# No java stub is published.
-gem "bigdecimal", "3.1.7" if RUBY_PLATFORM == "java"
+if RUBY_PLATFORM == "java"
+  # Fix install issue for jruby on gem 3.1.8.
+  # No java stub is published.
+  gem "bigdecimal", "3.1.7"
+  # Fix default gem install issue
+  gem "jar-dependencies", "0.4.1"
+end
 
 gemspec :path => "../"


### PR DESCRIPTION
Try and fix error that occurs on the CI:

> Gem::LoadError: You have already activated jar-dependencies 0.4.1, but
> your Gemfile requires jar-dependencies 0.5.0. Since jar-dependencies
> is a default gem, you can either remove your dependency on it or try
> updating to a newer version of bundler that supports jar-dependencies
> as a default gem.


[skip changeset]
[skip review]