### PR TITLE
Add ActiveSupport tagged logging support

### DIFF
--- a/.changesets/add-rails-activesupport-tagged-logging.md
+++ b/.changesets/add-rails-activesupport-tagged-logging.md
@@ -1,0 +1,14 @@
+---
+bump: patch
+type: add
+---
+
+Support Rails/ActiveSupport tagged logging. When tags are set in apps using `Rails.logger.tagged { ... }` or with the `Rails.application.config.log_tags = [...]` config option, these tags are now included in the collected log messages.
+
+```ruby
+Rails.logger.tagged(["Tag 1", "Tag 2"]) { Rails.logger.info("My message") }
+```
+
+Reports this log message:
+
+> [Tag 1] [Tag 2] My message

--- a/lib/appsignal/logger.rb
+++ b/lib/appsignal/logger.rb
@@ -37,6 +37,7 @@ module Appsignal
       @format = format
       @mutex = Mutex.new
       @default_attributes = attributes
+      @appsignal_attributes = {}
     end
 
     # We support the various methods in the Ruby
@@ -159,17 +160,13 @@ module Appsignal
 
     private
 
-    attr_reader :default_attributes
+    attr_reader :default_attributes, :appsignal_attributes
 
     def add_with_attributes(severity, message, group, attributes)
-      Thread.current[:appsignal_logger_attributes] = default_attributes.merge(attributes)
+      @appsignal_attributes = default_attributes.merge(attributes)
       add(severity, message, group)
     ensure
-      Thread.current[:appsignal_logger_attributes] = nil
-    end
-
-    def appsignal_attributes
-      Thread.current.fetch(:appsignal_logger_attributes, {})
+      @appsignal_attributes = {}
     end
   end
 end


### PR DESCRIPTION
## Don't use thread vars in logger

To temporarily set the attributes in the logger instance, use instance variables instead of Thread variables.

I don't know why Thread variables are used here. I don't think it's needed.

## Add ActiveSupport tagged logging support

Our logger did not support Rails ActiveSupport tagged logging yet. This was because our logger didn't listen to the `tagged`, `push_tags` and `pop_tags` methods.

Implement these methods to have the logger that wraps our logger call these methods to set tags.

The format is the same as Rails formats it: `[My tag value]` I decide not to set these as attributes, because they're only values. They have no key and the value can be anything and change frequently.
