### PR TITLE
Initialise check-in singletons under mutexes

### DIFF
--- a/.changesets/make-check-in-scheduler-thread-safe.md
+++ b/.changesets/make-check-in-scheduler-thread-safe.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix a thread safety issue where sending check-in events simultaneously from different threads would cause several check-in schedulers to be initialised internally. This could cause some of the scheduled check-in events to never be sent to AppSignal when `Appsignal.stop` is called.

--- a/lib/appsignal/check_in.rb
+++ b/lib/appsignal/check_in.rb
@@ -4,7 +4,6 @@ module Appsignal
   module CheckIn
     HEARTBEAT_CONTINUOUS_INTERVAL_SECONDS = 30
     NEW_SCHEDULER_MUTEX = Mutex.new
-    NEW_TRANSMITTER_MUTEX = Mutex.new
 
     class << self
       # @api private
@@ -83,19 +82,6 @@ module Appsignal
 
         event = Event.heartbeat(:identifier => identifier)
         scheduler.schedule(event)
-      end
-
-      # @api private
-      def transmitter
-        return @transmitter if @transmitter
-
-        NEW_TRANSMITTER_MUTEX.synchronize do
-          @transmitter ||= Transmitter.new(
-            "#{Appsignal.config[:logging_endpoint]}/check_ins/json"
-          )
-        end
-
-        @transmitter
       end
 
       # @api private

--- a/lib/appsignal/check_in/scheduler.rb
+++ b/lib/appsignal/check_in/scheduler.rb
@@ -95,7 +95,11 @@ module Appsignal
         description = Event.describe(events)
 
         begin
-          response = CheckIn.transmitter.transmit(events, :format => :ndjson)
+          @transmitter ||= Transmitter.new(
+            "#{Appsignal.config[:logging_endpoint]}/check_ins/json"
+          )
+
+          response = @transmitter.transmit(events, :format => :ndjson)
 
           if (200...300).include?(response.code.to_i)
             Appsignal.internal_logger.debug("Transmitted #{description}")


### PR DESCRIPTION
Fixes #1343.

This makes initialisation of the check-in scheduler (and the check-in transmitter, for good measure) thread-safe, by having it take place inside a mutex.

This fixes an issue where sending check-ins from different threads simultaneously would cause several check-in schedulers to be instantiated. On shutdown, only one of those check-in schedulers would have its `#stop` method called, meaning check-in events scheduled in the other schedulers would not be sent to AppSignal when `Appsignal.stop` is called.