### PR TITLE
Fix tagged logging push_tags for Rails 8

### DIFF
--- a/.changesets/fix-tagged-logging-for-rails-8.md
+++ b/.changesets/fix-tagged-logging-for-rails-8.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix tagged logging ArgumentError error for Rails 8.

--- a/lib/appsignal/logger.rb
+++ b/lib/appsignal/logger.rb
@@ -159,7 +159,7 @@ module Appsignal
     end
 
     # Listen to ActiveSupport tagged logging tags set with `Rails.config.log_tags`.
-    def push_tags(tags)
+    def push_tags(*tags)
       @tags.append(*tags)
     end
 

--- a/spec/lib/appsignal/logger_spec.rb
+++ b/spec/lib/appsignal/logger_spec.rb
@@ -315,6 +315,25 @@ describe Appsignal::Logger do
           )
       end
 
+      it "logs messages with tags from Rails 8 application.config.log_tags" do
+        allow(Appsignal::Extension).to receive(:log)
+
+        appsignal_logger = Appsignal::Logger.new("group")
+        logger = ActiveSupport::TaggedLogging.new(appsignal_logger)
+
+        # This is how Rails sets the `log_tags` values
+        logger.push_tags("Request tag", "Second tag")
+        logger.tagged("First message", "My other tag") { logger.info("Some message") }
+        expect(Appsignal::Extension).to have_received(:log)
+          .with(
+            "group",
+            3,
+            0,
+            "[Request tag] [Second tag] [First message] [My other tag] Some message\n",
+            Appsignal::Utils::Data.generate({})
+          )
+      end
+
       it "clears all tags with clear_tags!" do
         allow(Appsignal::Extension).to receive(:log)
 


### PR DESCRIPTION
In Rails 8 the `push_tags` arguments are positional, where previously it was an array of values. Support both by adding a `*` to the argument.

Fixes #1348