### PR TITLE
Allow `#tagged` to be called without a block

### DIFF
--- a/.changesets/allow--logger-tagged--to-be-called-without-a-block.md
+++ b/.changesets/allow--logger-tagged--to-be-called-without-a-block.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+type: fix
+---
+
+Allow `Appsignal::Logger#tagged` to be called without a block, in the same way as `ActiveSupport::TaggedLogging`:
+
+```ruby
+Appsignal::Logger.new("rails").tagged("some tag").info("message")
+# => logs "[some tag] message"
+```


### PR DESCRIPTION
When `#tagged` is called without a block, it should return a new logger that applies the tags it is given to all log lines, instead of modifying the current logger.

This commit implements that behaviour, in order to match the behaviour exposed by `ActiveSupport::TaggedLogging`.