### PR TITLE
Implement silence logger functionality

### DIFF
--- a/.changesets/fix---silence--implementation-for-logger.md
+++ b/.changesets/fix---silence--implementation-for-logger.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix `#silence` implementation for `Appsignal::Logger`.

--- a/lib/appsignal/logger.rb
+++ b/lib/appsignal/logger.rb
@@ -199,7 +199,7 @@ module Appsignal
     # Links:
     #
     # - https://github.com/rails/rails/blob/e11ebc04cfbe41c06cdfb70ee5a9fdbbd98bb263/activesupport/lib/active_support/logger.rb#L60-L76
-    # - https://github.com/rails/rails/blob/main/activesupport/e11ebc04cfbe41c06cdfb70ee5a9fdbbd98bb263/active_support/logger_silence.rb
+    # - https://github.com/rails/rails/blob/e11ebc04cfbe41c06cdfb70ee5a9fdbbd98bb263/activesupport/lib/active_support/logger_silence.rb
     def silence(_severity = ERROR, &block)
       block.call
     end

--- a/lib/appsignal/logger.rb
+++ b/lib/appsignal/logger.rb
@@ -201,7 +201,7 @@ module Appsignal
     # - https://github.com/rails/rails/blob/e11ebc04cfbe41c06cdfb70ee5a9fdbbd98bb263/activesupport/lib/active_support/logger.rb#L60-L76
     # - https://github.com/rails/rails/blob/e11ebc04cfbe41c06cdfb70ee5a9fdbbd98bb263/activesupport/lib/active_support/logger_silence.rb
     def silence(_severity = ERROR, &block)
-      block.call
+      block.call(self)
     end
 
     private

--- a/lib/appsignal/logger.rb
+++ b/lib/appsignal/logger.rb
@@ -192,16 +192,17 @@ module Appsignal
 
     # When using ActiveSupport::TaggedLogging without the broadcast feature,
     # the passed logger is required to respond to the `silence` method.
-    # In our case it behaves as the broadcast feature of the Rails logger, but
-    # we don't have to check if the parent logger has the `silence` method defined
-    # as our logger directly inherits from Ruby base logger.
     #
-    # Links:
+    # Reference links:
     #
     # - https://github.com/rails/rails/blob/e11ebc04cfbe41c06cdfb70ee5a9fdbbd98bb263/activesupport/lib/active_support/logger.rb#L60-L76
     # - https://github.com/rails/rails/blob/e11ebc04cfbe41c06cdfb70ee5a9fdbbd98bb263/activesupport/lib/active_support/logger_silence.rb
-    def silence(_severity = ERROR, &block)
+    def silence(severity = ERROR, &block)
+      previous_level = @level
+      @level = severity
       block.call(self)
+    ensure
+      @level = previous_level
     end
 
     private

--- a/spec/lib/appsignal/logger_spec.rb
+++ b/spec/lib/appsignal/logger_spec.rb
@@ -336,6 +336,43 @@ describe Appsignal::Logger do
       expect(num).to eq(2)
       expect(Appsignal::Extension).not_to receive(:log)
     end
+
+    it "silences the logger up to, but not including, the given level" do
+      # Expect not to receive info
+      expect(Appsignal::Extension).not_to receive(:log)
+        .with("group", 3, 0, "Log message", instance_of(Appsignal::Extension::Data))
+
+      # Expect to receive warn
+      expect(Appsignal::Extension).to receive(:log)
+        .with("group", 5, 0, "Log message", instance_of(Appsignal::Extension::Data))
+
+      logger.silence(::Logger::WARN) do
+        logger.info("Log message")
+        logger.warn("Log message")
+      end
+    end
+
+    it "silences the logger to error level by default" do
+      # Expect not to receive debug, info or warn
+      [2, 3, 5].each do |severity|
+        expect(Appsignal::Extension).not_to receive(:log)
+          .with("group", severity, 0, "Log message", instance_of(Appsignal::Extension::Data))
+      end
+
+      # Expect to receive error and fatal
+      [6, 7].each do |severity|
+        expect(Appsignal::Extension).to receive(:log)
+          .with("group", severity, 0, "Log message", instance_of(Appsignal::Extension::Data))
+      end
+
+      logger.silence do
+        logger.debug("Log message")
+        logger.info("Log message")
+        logger.warn("Log message")
+        logger.error("Log message")
+        logger.fatal("Log message")
+      end
+    end
   end
 
   [


### PR DESCRIPTION
Our current implementation of the `#silence` method does not
actually silence anything. If we are implementing the method, we
should actually implement its functionality.