### PR TITLE
Set formatter on all broadcasted loggers

### DIFF
--- a/.changesets/fix-double-newlines-in-broadcasted-loggers.md
+++ b/.changesets/fix-double-newlines-in-broadcasted-loggers.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix an issue where loggers, when broadcasted to by `Appsignal::Logger#broadcast_to`, would format again messages that have already been formatted by the broadcaster, causing the resulting message emitted by the logger to contain double newlines.

--- a/lib/appsignal/logger.rb
+++ b/lib/appsignal/logger.rb
@@ -41,6 +41,14 @@ module Appsignal
       @loggers = []
     end
 
+    # When a formatter is set on the logger (e.g. when wrapping the logger in
+    # `ActiveSupport::TaggedLogging`) we want to set that formatter on all the
+    # loggers that are being broadcasted to.
+    def formatter=(formatter)
+      super
+      @loggers.each { |logger| logger.formatter = formatter }
+    end
+
     # We support the various methods in the Ruby
     # logger class by supplying this method.
     # @api private
@@ -59,8 +67,6 @@ module Appsignal
       end
       return if message.nil?
 
-      message = formatter.call(severity, Time.now, group, message) if formatter
-
       @loggers.each do |logger|
         logger.add(severity, message, group)
       rescue
@@ -73,6 +79,8 @@ module Appsignal
         )
         return
       end
+
+      message = formatter.call(severity, Time.now, group, message) if formatter
 
       Appsignal::Extension.log(
         group,

--- a/spec/lib/appsignal/logger_spec.rb
+++ b/spec/lib/appsignal/logger_spec.rb
@@ -5,7 +5,7 @@ shared_examples "tagged logging" do
         "group",
         3,
         0,
-        a_string_starting_with("[My tag] [My other tag] Some message"),
+        "[My tag] [My other tag] Some message\n",
         Appsignal::Utils::Data.generate({})
       )
 
@@ -20,9 +20,7 @@ shared_examples "tagged logging" do
         "group",
         3,
         0,
-        a_string_starting_with(
-          "[My tag] [My other tag] [Nested tag] [Nested other tag] Some message"
-        ),
+        "[My tag] [My other tag] [Nested tag] [Nested other tag] Some message\n",
         Appsignal::Utils::Data.generate({})
       )
 
@@ -44,9 +42,7 @@ shared_examples "tagged logging" do
         "group",
         3,
         0,
-        a_string_starting_with(
-          "[Request tag] [Second tag] [First message] [My other tag] Some message"
-        ),
+        "[Request tag] [Second tag] [First message] [My other tag] Some message\n",
         Appsignal::Utils::Data.generate({})
       )
 
@@ -58,7 +54,7 @@ shared_examples "tagged logging" do
         "group",
         3,
         0,
-        a_string_starting_with("[Request tag] [Second tag] [Second message] Some message"),
+        "[Request tag] [Second tag] [Second message] Some message\n",
         Appsignal::Utils::Data.generate({})
       )
 
@@ -71,7 +67,7 @@ shared_examples "tagged logging" do
         "group",
         3,
         0,
-        a_string_starting_with("[Third message] Some message"),
+        "[Third message] Some message\n",
         Appsignal::Utils::Data.generate({})
       )
   end
@@ -87,9 +83,7 @@ shared_examples "tagged logging" do
         "group",
         3,
         0,
-        a_string_starting_with(
-          "[Request tag] [Second tag] [First message] [My other tag] Some message"
-        ),
+        "[Request tag] [Second tag] [First message] [My other tag] Some message\n",
         Appsignal::Utils::Data.generate({})
       )
   end
@@ -105,9 +99,7 @@ shared_examples "tagged logging" do
         "group",
         3,
         0,
-        a_string_starting_with(
-          "[Request tag] [Second tag] [First message] [My other tag] Some message"
-        ),
+        "[Request tag] [Second tag] [First message] [My other tag] Some message\n",
         Appsignal::Utils::Data.generate({})
       )
 
@@ -118,7 +110,7 @@ shared_examples "tagged logging" do
         "group",
         3,
         0,
-        a_string_starting_with("[First message] [My other tag] Some message"),
+        "[First message] [My other tag] Some message\n",
         Appsignal::Utils::Data.generate({})
       )
   end
@@ -129,7 +121,7 @@ shared_examples "tagged logging" do
         "group",
         3,
         0,
-        a_string_starting_with("[My tag] [My other tag] Some message"),
+        "[My tag] [My other tag] Some message\n",
         Appsignal::Utils::Data.generate({})
       )
 
@@ -150,7 +142,7 @@ shared_examples "tagged logging" do
             "group",
             3,
             0,
-            a_string_starting_with("[My tag] [My other tag] Some message"),
+            "[My tag] [My other tag] Some message\n",
             Appsignal::Utils::Data.generate({})
           )
 
@@ -163,7 +155,7 @@ shared_examples "tagged logging" do
             "group",
             3,
             0,
-            a_string_starting_with("[My tag] [My other tag] Some message"),
+            "[My tag] [My other tag] Some message\n",
             Appsignal::Utils::Data.generate({})
           )
 
@@ -175,7 +167,7 @@ shared_examples "tagged logging" do
             "group",
             3,
             0,
-            a_string_starting_with("Some message"),
+            "Some message\n",
             Appsignal::Utils::Data.generate({})
           )
 
@@ -188,7 +180,7 @@ shared_examples "tagged logging" do
             "group",
             3,
             0,
-            a_string_starting_with("[My tag] [My other tag] [My third tag] Some message"),
+            "[My tag] [My other tag] [My third tag] Some message\n",
             Appsignal::Utils::Data.generate({})
           )
 
@@ -201,7 +193,7 @@ shared_examples "tagged logging" do
             "group",
             3,
             0,
-            a_string_starting_with("[My tag] [My other tag] [My third tag] Some message"),
+            "[My tag] [My other tag] [My third tag] Some message\n",
             Appsignal::Utils::Data.generate({})
           )
 
@@ -219,7 +211,7 @@ shared_examples "tagged logging" do
             "group",
             3,
             0,
-            a_string_starting_with("[My tag] [My other tag] [My third tag] Some message"),
+            "[My tag] [My other tag] [My third tag] Some message\n",
             Appsignal::Utils::Data.generate({})
           )
 
@@ -407,7 +399,7 @@ describe Appsignal::Logger do
               "group",
               3,
               0,
-              a_string_starting_with("[My tag] [My other tag] Some message"),
+              "[My tag] [My other tag] Some message\n",
               Appsignal::Utils::Data.generate({})
             )
 
@@ -416,7 +408,7 @@ describe Appsignal::Logger do
           end
 
           expect(other_stream.string)
-            .to include("INFO -- group: [My tag] [My other tag] Some message")
+            .to eq("[My tag] [My other tag] Some message\n")
         end
       end
     end


### PR DESCRIPTION
When a formatter is set for the broadcast logger, also set that same formatter for all the loggers that it broadcasts to.

Before this change, the already-formatted message would be passed on to the broadcasted loggers, which would format it once again.

This issue was masked by the tests matching the resulting log line using `a_string_starting_with`, which I introduced in #1351 to smooth out differences between our custom instrumentation of tagged logging, since removed, and that of `ActiveSupport::TaggedLogging`. Ensure all matching is done against specific strings.

Fixes issue #1360, in which the twice-applied formatting causes additional newlines to appear in the message emitted by the broadcasted loggers.