### PR TITLE
Require `logger` before all other gems

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ ENV["PADRINO_ENV"] ||= "test"
 APPSIGNAL_SPEC_DIR = File.expand_path(__dir__)
 $LOAD_PATH.unshift(File.join(APPSIGNAL_SPEC_DIR, "support/stubs"))
 
+require "logger"
 Bundler.require :default
 require "cgi"
 require "rack"


### PR DESCRIPTION
See [Slack conversation](https://appsignal.slack.com/archives/CNPP953E2/p1737017545342519) and [failed build](https://github.com/appsignal/appsignal-ruby/actions/runs/12799324663/job/35692739604) for context.

Due to a mismatch in expectations between the latest version of `concurrent-ruby` and older versions of Rails, `logger` must be required before other dependencies are required: https://github.com/rails/rails/issues/54260

[skip changeset] because it's a change to the tests