### PR TITLE
Fix HTTP.rb non-ascii URI parsing

### DIFF
--- a/lib/appsignal/integrations/http.rb
+++ b/lib/appsignal/integrations/http.rb
@@ -5,7 +5,7 @@ module Appsignal
     # @api private
     module HttpIntegration
       def request(verb, uri, opts = {})
-        parsed_request_uri = uri.is_a?(URI) ? uri : URI.parse(uri.to_s)
+        parsed_request_uri = uri.is_a?(URI) ? uri : Addressable::URI.parse(uri.to_s)
         request_uri = "#{parsed_request_uri.scheme}://#{parsed_request_uri.host}"
 
         Appsignal.instrument("request.http_rb", "#{verb.upcase} #{request_uri}") do

--- a/spec/lib/appsignal/integrations/http_spec.rb
+++ b/spec/lib/appsignal/integrations/http_spec.rb
@@ -106,6 +106,17 @@ if DependencyHelper.http_present?
           "title" => "GET http://www.google.com"
         )
       end
+
+      it "parses a URI object with non ascii characters" do
+        stub_request(:get, "http://www.example.com/áéíóúãÔù")
+
+        HTTP.get("http://www.example.com/áéíóúãÔù")
+
+        expect(transaction).to include_event(
+          "name" => "request.http_rb",
+          "title" => "GET http://www.example.com"
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
When Appsignal is enabled, it hooks into HTTP request method. It uses `URI.parse` when uri is a string, but `URI.parse` doesn't support non-ascii characters:
```ruby
HTTP.get("http://www.example.com/áéíóúãÔù") # it works when appsignal is disabled
```

With Appsignal enabled, the code above raises this error:
```
URI::InvalidURIError:
       URI must be ascii only "http://www.example.com/\u00E1\u00E9\u00ED\u00F3\u00FA\u00E3\u00D4\u00F9"
```

The solution I found was using Addressable::URI.parse since it handles non-ascii characters.

ps.: Addressable is a HTTP's runtime dependency since 2015