### PR TITLE
Fix HTTP.rb when using non-ascii URIs

### DIFF
--- a/.changesets/fix-http-rb-integration-for-non--ascii-urls.md
+++ b/.changesets/fix-http-rb-integration-for-non--ascii-urls.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix an issue where the HTTP.rb gem integration would raise an error when a string containing non-ASCII characters is passed to the gem as the URL. 

--- a/lib/appsignal/integrations/http.rb
+++ b/lib/appsignal/integrations/http.rb
@@ -5,7 +5,8 @@ module Appsignal
     # @api private
     module HttpIntegration
       def request(verb, uri, opts = {})
-        parsed_request_uri = uri.is_a?(URI) ? uri : Addressable::URI.parse(uri.to_s)
+        uri_module = defined?(HTTP::URI) ? HTTP::URI : URI
+        parsed_request_uri = uri.is_a?(URI) ? uri : uri_module.parse(uri.to_s)
         request_uri = "#{parsed_request_uri.scheme}://#{parsed_request_uri.host}"
 
         Appsignal.instrument("request.http_rb", "#{verb.upcase} #{request_uri}") do

--- a/lib/appsignal/integrations/http.rb
+++ b/lib/appsignal/integrations/http.rb
@@ -5,7 +5,7 @@ module Appsignal
     # @api private
     module HttpIntegration
       def request(verb, uri, opts = {})
-        parsed_request_uri = uri.is_a?(URI) ? uri : URI.parse(uri.to_s)
+        parsed_request_uri = uri.is_a?(URI) ? uri : Addressable::URI.parse(uri.to_s)
         request_uri = "#{parsed_request_uri.scheme}://#{parsed_request_uri.host}"
 
         Appsignal.instrument("request.http_rb", "#{verb.upcase} #{request_uri}") do

--- a/spec/lib/appsignal/integrations/http_spec.rb
+++ b/spec/lib/appsignal/integrations/http_spec.rb
@@ -106,6 +106,17 @@ if DependencyHelper.http_present?
           "title" => "GET http://www.google.com"
         )
       end
+
+      it "parses a URI object with non ascii characters" do
+        stub_request(:get, "http://www.example.com/áéíóúãÔù")
+
+        HTTP.get("http://www.example.com/áéíóúãÔù")
+
+        expect(transaction).to include_event(
+          "name" => "request.http_rb",
+          "title" => "GET http://www.example.com"
+        )
+      end
     end
   end
 end

--- a/spec/lib/appsignal/integrations/http_spec.rb
+++ b/spec/lib/appsignal/integrations/http_spec.rb
@@ -96,7 +96,18 @@ if DependencyHelper.http_present?
         )
       end
 
-      it "parses a String object" do
+      it "parses an HTTP::URI object" do
+        stub_request(:get, "http://www.google.com")
+
+        HTTP.get(HTTP::URI.parse("http://www.google.com"))
+
+        expect(transaction).to include_event(
+          "name" => "request.http_rb",
+          "title" => "GET http://www.google.com"
+        )
+      end
+
+      it "parses a string" do
         stub_request(:get, "http://www.google.com")
 
         HTTP.get("http://www.google.com")
@@ -107,7 +118,7 @@ if DependencyHelper.http_present?
         )
       end
 
-      it "parses a URI object with non ascii characters" do
+      it "parses a string with non-ascii characters" do
         stub_request(:get, "http://www.example.com/áéíóúãÔù")
 
         HTTP.get("http://www.example.com/áéíóúãÔù")


### PR DESCRIPTION
Follow up to #1369 (thanks @stephannv!)

### [Fix HTTP.rb non-ascii URI](https://github.com/appsignal/appsignal-ruby/commit/3eba6738541380d536073f11c8746837588cb523)

When Appsignal is enabled, it hooks into HTTP request method. It
uses `URI.parse` when uri is a string, but `URI.parse` doesn't
support non-ascii characters:

```ruby
HTTP.get("http://www.example.com/áéíóúãÔù")
```

With Appsignal enabled, the code above raises this error:

```
URI::InvalidURIError:
       URI must be ascii only
```

The solution I found was using Addressable::URI.parse since it
handles non-ascii characters.

ps.: Addressable is a HTTP's runtime dependency since 2015

### [Use HTTP::URI if defined](https://github.com/appsignal/appsignal-ruby/commit/b1e64578588c0daa62d44ddcb6d1f96e8d1b19c8)

The `http` gem exposes the `HTTP::URI` module, which on different
versions of the gem either subclasses or includes `Addressable::URI`.

Use it instead of referring directly to `Addressable::URI`, avoiding
explicitly depending on the implementation detail that `HTTP::URI`
uses `Addressable::URI` internally.

When `HTTP::URI` is not defined (in `http` gem versions before 0.8.0)
fall back to using `URI` instead.