### PR TITLE
Fix JSON error assertions in diagnose specs

### DIFF
--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -490,12 +490,13 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
             "Agent diagnostics",
             "  Error while parsing agent diagnostics report:",
             "    Output: invalid agent\njson"
-          expect(output).to match(/Error:( \d+:)? unexpected token at 'invalid agent\njson'/)
+          expect(output)
+            .to match(/Error:( \d+:)? unexpected (token at|character:) 'invalid agent\njson'/)
         end
 
         it "adds the output to the report" do
           expect(received_report["agent"]["error"])
-            .to match(/unexpected token at 'invalid agent\njson'/)
+            .to match(/unexpected (token at|character:) 'invalid agent\njson'/)
           expect(received_report["agent"]["output"]).to eq(["invalid agent", "json"])
         end
       end


### PR DESCRIPTION
The json Ruby gem 2.10.0 changed the format of its error messages. Update the assertions to match.

[skip changeset]
[skip review]