### PR TITLE
Fix Capistrano 2 and 3 appsignal.rb config method

### DIFF
--- a/.changesets/fix-capistrano-support-when-using-an--appsignal-rb--config-file.md
+++ b/.changesets/fix-capistrano-support-when-using-an--appsignal-rb--config-file.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix Capistrano version 2 and 3 support when using an `appsignal.rb` config file. It will now pick up the config from `appsignal.rb` file.

--- a/.changesets/validate-app-environment-sources.md
+++ b/.changesets/validate-app-environment-sources.md
@@ -1,0 +1,13 @@
+---
+bump: patch
+type: fix
+---
+
+Validate application environment sources so nil values and empty strings are not valid app environments.
+Symbols are now always cast to a String before set as the application environment.
+
+```ruby
+# These will no longer be accepted as valid app environments
+Appsignal.configure("")
+Appsignal.configure(" ")
+```

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -192,6 +192,8 @@ module Appsignal
         # This will load the config/appsignal.yml file automatically
         @config ||= Config.new(context.root_path, context.env)
       end
+      # Allow a block to be given to customize the config and override any
+      # loaded config before it's validated.
       block.call(config) if block_given?
       # Validate the config, if present
       config&.validate

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -152,7 +152,12 @@ module Appsignal
     # @param env_var [String, NilClass] Used by diagnose CLI to pass through
     #   the environment CLI option value.
     # @api private
-    def _load_config!(env_param = nil)
+    def _load_config!(env_param = nil, &block)
+      # Ensure it's not an empty string if it's a value
+      proper_env_param = env_param&.to_s&.strip
+      # Unset it if it's an empty string
+      proper_env_param = nil if proper_env_param&.empty?
+
       context = Appsignal::Config::Context.new(
         :env => Config.determine_env(env_param),
         :root_path => Config.determine_root_path
@@ -171,13 +176,23 @@ module Appsignal
           Appsignal::Utils::StdoutAndLoggerMessage.warning(message)
         else
           # Load it when no config is present
-          load_dsl_config_file(context.dsl_config_file, env_param)
+          #
+          # We don't pass the `env_var` or `context.env` here so that the
+          # `Appsignal.configure` or `Appsignal.start` can figure out the
+          # environment themselves if it was not explicitly set.
+          # This way we prevent forcing an environment that's auto loaded on
+          # the to-be-loaded config file.
+          #
+          # The `(proper)_env_param` is only set when it's explicitly set,
+          # which means it needs to override any auto detected environment.
+          load_dsl_config_file(context.dsl_config_file, proper_env_param)
         end
       else
         # Load config if no config file was found and no config is present yet
         # This will load the config/appsignal.yml file automatically
         @config ||= Config.new(context.root_path, context.env)
       end
+      block.call(config) if block_given?
       # Validate the config, if present
       config&.validate
     end

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -39,8 +39,10 @@ module Appsignal
         ENV.fetch("APPSIGNAL_APP_ENV", nil),
         ENV.fetch("RAILS_ENV", nil),
         ENV.fetch("RACK_ENV", nil)
-      ].compact.each do |env|
-        return env if env
+      ].compact.each do |env_value|
+        value = env_value.to_s.strip
+        next if value.empty?
+        return value if value
       end
 
       loader_defaults.reverse.each do |loader_defaults|

--- a/lib/appsignal/integrations/capistrano/appsignal.cap
+++ b/lib/appsignal/integrations/capistrano/appsignal.cap
@@ -8,22 +8,18 @@ namespace :appsignal do
     user = fetch(:appsignal_user, ENV["USER"] || ENV.fetch("USERNAME", nil))
     revision = fetch(:appsignal_revision, fetch(:current_revision))
 
-    appsignal_config = Appsignal::Config.new(
-      Dir.pwd,
-      appsignal_env
-    ).tap do |c|
-      c.merge_dsl_options(fetch(:appsignal_config, {}))
-      c.validate
+    Appsignal._load_config!(appsignal_env) do |config|
+      config&.merge_dsl_options(fetch(:appsignal_config, {}))
     end
     Appsignal._start_logger
 
-    if appsignal_config&.active?
+    if Appsignal.config&.active?
       marker_data = {
         :revision => revision,
         :user => user
       }
 
-      marker = Appsignal::Marker.new(marker_data, appsignal_config)
+      marker = Appsignal::Marker.new(marker_data, Appsignal.config)
       # {#dry_run?} helper was added in Capistrano 3.5.0
       # https://github.com/capistrano/capistrano/commit/38d8d6d2c8485f1b5643857465b16ff01da57aff
       if respond_to?(:dry_run?) && dry_run?

--- a/lib/appsignal/integrations/capistrano/capistrano_2_tasks.rb
+++ b/lib/appsignal/integrations/capistrano/capistrano_2_tasks.rb
@@ -5,40 +5,37 @@ module Appsignal
     # @api private
     class Capistrano
       def self.tasks(config)
-        config.load do # rubocop:disable Metrics/BlockLength
+        config.load do
           after "deploy", "appsignal:deploy"
           after "deploy:migrations", "appsignal:deploy"
 
           namespace :appsignal do
             task :deploy do
-              env = fetch(:appsignal_env,
+              appsignal_env = fetch(:appsignal_env,
                 fetch(:stage, fetch(:rails_env, fetch(:rack_env, "production"))))
               user = fetch(:appsignal_user, ENV["USER"] || ENV.fetch("USERNAME", nil))
               revision = fetch(:appsignal_revision, fetch(:current_revision))
 
-              appsignal_config = Appsignal::Config.new(
-                ENV.fetch("PWD", nil),
-                env
-              ).tap do |c|
-                c.merge_dsl_options(fetch(:appsignal_config, {}))
-                c.validate
+              Appsignal._load_config!(appsignal_env) do |conf|
+                conf&.merge_dsl_options(fetch(:appsignal_config, {}))
               end
               Appsignal._start_logger
 
-              if appsignal_config&.active?
+              if Appsignal.config&.active?
                 marker_data = {
                   :revision => revision,
                   :user => user
                 }
 
-                marker = Marker.new(marker_data, appsignal_config)
+                marker = Marker.new(marker_data, Appsignal.config)
                 if config.dry_run
                   puts "Dry run: AppSignal deploy marker not actually sent."
                 else
                   marker.transmit
                 end
               else
-                puts "Not notifying of deploy, config is not active for environment: #{env}"
+                puts "Not notifying of deploy, config is not active for " \
+                  "environment: #{appsignal_env}"
               end
             end
           end

--- a/lib/appsignal/marker.rb
+++ b/lib/appsignal/marker.rb
@@ -49,7 +49,7 @@ module Appsignal
     # @return [void]
     def transmit
       transmitter = Transmitter.new(ACTION, config)
-      puts "Notifying AppSignal of deploy with: " \
+      puts "Notifying AppSignal of '#{config.env}' deploy with " \
         "revision: #{marker_data[:revision]}, user: #{marker_data[:user]}"
 
       response = transmitter.transmit(marker_data)

--- a/spec/lib/appsignal/capistrano2_spec.rb
+++ b/spec/lib/appsignal/capistrano2_spec.rb
@@ -47,6 +47,174 @@ if DependencyHelper.capistrano2_present?
         ENV["USER"] = "batman"
       end
 
+      context "with appsignal.rb config file" do
+        def write_appsignal_rb_config_file(config_contents)
+          test_path = File.join(tmp_dir, "config_file_test_#{SecureRandom.uuid}")
+          FileUtils.mkdir_p(test_path)
+          Dir.chdir(test_path) do
+            write_file(File.join(test_path, "config", "appsignal.rb"), config_contents)
+          end
+          test_path
+        end
+
+        around do |example|
+          tmp_config_dir = write_appsignal_rb_config_file(
+            <<~CONFIG
+              Appsignal.configure do |config|
+                config.active = true
+                config.name = "CapDSLapp"
+                config.push_api_key = "cap_push_api_key"
+              end
+            CONFIG
+          )
+          Dir.chdir(tmp_config_dir) { example.run }
+        end
+
+        it "reads the base config from the config file" do
+          marker_request = stub_marker_request(
+            {
+              :environment => "production",
+              :name => "CapDSLapp",
+              :push_api_key => "cap_push_api_key"
+            },
+            marker_data
+          ).to_return(:status => 200)
+
+          run
+
+          expect(marker_request).to have_been_made
+        end
+
+        context "when rack_env is the only env set" do
+          let(:env) { "rack_production" }
+          before do
+            capistrano_config.unset(:rails_env)
+            capistrano_config.set(:rack_env, env)
+          end
+
+          it "uses the rack_env as the env" do
+            marker_request = stub_marker_request(
+              {
+                :environment => env.to_s,
+                :name => "CapDSLapp",
+                :push_api_key => "cap_push_api_key"
+              },
+              marker_data
+            ).to_return(:status => 200)
+
+            run
+
+            expect(marker_request).to have_been_made
+          end
+        end
+
+        context "when stage is set" do
+          let(:env) { "stage_production" }
+          before do
+            capistrano_config.set(:rack_env, "rack_production")
+            capistrano_config.set(:stage, env)
+          end
+
+          it "prefers the Capistrano stage rather than rails_env and rack_env" do
+            marker_request = stub_marker_request(
+              {
+                :environment => env.to_s,
+                :name => "CapDSLapp",
+                :push_api_key => "cap_push_api_key"
+              },
+              marker_data
+            ).to_return(:status => 200)
+
+            run
+
+            expect(marker_request).to have_been_made
+          end
+        end
+
+        context "when `appsignal_config` is set" do
+          before do
+            ENV["APPSIGNAL_APP_NAME"] = "EnvName"
+            capistrano_config.set(:appsignal_config, :name => "CapName")
+          end
+
+          it "overrides the default config with the custom appsignal_config" do
+            marker_request = stub_marker_request(
+              {
+                :environment => env.to_s,
+                :name => "CapName",
+                :push_api_key => "cap_push_api_key"
+              },
+              marker_data
+            ).to_return(:status => 200)
+
+            run
+
+            expect(marker_request).to have_been_made
+          end
+
+          context "with invalid config" do
+            before do
+              capistrano_config.set(:appsignal_config, :push_api_key => nil)
+            end
+
+            it "does not continue with invalid config" do
+              run
+              expect(output).to include \
+                "Not notifying of deploy, config is not active for environment: production"
+              expect(logs).to contains_log(:error, "Push API key not set after loading config")
+            end
+          end
+        end
+
+        context "when `appsignal_env` is set as a string" do
+          let(:env) { "appsignal_production" }
+          before do
+            capistrano_config.set(:rack_env, "rack_production")
+            capistrano_config.set(:stage, "stage_production")
+            capistrano_config.set(:appsignal_env, env)
+          end
+
+          it "prefers the appsignal_env rather than stage, rails_env and rack_env" do
+            marker_request = stub_marker_request(
+              {
+                :environment => env.to_s,
+                :name => "CapDSLapp",
+                :push_api_key => "cap_push_api_key"
+              },
+              marker_data
+            ).to_return(:status => 200)
+
+            run
+
+            expect(marker_request).to have_been_made
+          end
+        end
+
+        context "when `appsignal_env` is set as a symbol" do
+          let(:env) { :appsignal_production }
+          before do
+            capistrano_config.set(:rack_env, "rack_production")
+            capistrano_config.set(:stage, "stage_production")
+            capistrano_config.set(:appsignal_env, env)
+          end
+
+          it "prefers the appsignal_env rather than stage, rails_env and rack_env" do
+            marker_request = stub_marker_request(
+              {
+                :environment => env.to_s,
+                :name => "CapDSLapp",
+                :push_api_key => "cap_push_api_key"
+              },
+              marker_data
+            ).to_return(:status => 200)
+
+            run
+
+            expect(marker_request).to have_been_made
+          end
+        end
+      end
+
       context "with appsignal.yml config file" do
         around do |example|
           Dir.chdir project_fixture_path do

--- a/spec/lib/appsignal/capistrano2_spec.rb
+++ b/spec/lib/appsignal/capistrano2_spec.rb
@@ -154,8 +154,9 @@ if DependencyHelper.capistrano2_present?
             run
 
             expect(output).to include \
-              "Notifying AppSignal of deploy with: revision: 503ce0923ed177a3ce000005," \
-                " user: batman",
+              "Notifying AppSignal of 'production' deploy with " \
+                "revision: 503ce0923ed177a3ce000005, " \
+                "user: batman",
               "AppSignal has been notified of this deploy!"
           end
 
@@ -168,7 +169,7 @@ if DependencyHelper.capistrano2_present?
 
             it "transmits the overridden revision" do
               expect(output).to include \
-                "Notifying AppSignal of deploy with: revision: abc123, user: batman",
+                "Notifying AppSignal of 'production' deploy with revision: abc123, user: batman",
                 "AppSignal has been notified of this deploy!"
             end
           end
@@ -182,8 +183,9 @@ if DependencyHelper.capistrano2_present?
 
             it "transmits the overridden deploy user" do
               expect(output).to include \
-                "Notifying AppSignal of deploy with: revision: 503ce0923ed177a3ce000005," \
-                  " user: robin",
+                "Notifying AppSignal of 'production' deploy with " \
+                  "revision: 503ce0923ed177a3ce000005, " \
+                  "user: robin",
                 "AppSignal has been notified of this deploy!"
             end
           end
@@ -196,8 +198,9 @@ if DependencyHelper.capistrano2_present?
 
             it "does not transmit marker" do
               expect(output).to include \
-                "Notifying AppSignal of deploy with: revision: 503ce0923ed177a3ce000005," \
-                  " user: batman",
+                "Notifying AppSignal of 'production' deploy with " \
+                  "revision: 503ce0923ed177a3ce000005, " \
+                  "user: batman",
                 "Something went wrong while trying to notify AppSignal:"
               expect(output).to_not include "AppSignal has been notified of this deploy!"
             end

--- a/spec/lib/appsignal/capistrano3_spec.rb
+++ b/spec/lib/appsignal/capistrano3_spec.rb
@@ -48,9 +48,172 @@ if DependencyHelper.capistrano3_present?
       before do
         ENV["USER"] = "batman"
       end
-      around do |example|
-        Dir.chdir project_fixture_path do
-          example.run
+
+      context "with appsignal.rb config file" do
+        def write_appsignal_rb_config_file(config_contents)
+          test_path = File.join(tmp_dir, "config_file_test_#{SecureRandom.uuid}")
+          FileUtils.mkdir_p(test_path)
+          Dir.chdir(test_path) do
+            write_file(File.join(test_path, "config", "appsignal.rb"), config_contents)
+          end
+          test_path
+        end
+
+        around do |example|
+          tmp_config_dir = write_appsignal_rb_config_file(
+            <<~CONFIG
+              Appsignal.configure do |config|
+                config.active = true
+                config.name = "CapDSLapp"
+                config.push_api_key = "cap_push_api_key"
+              end
+            CONFIG
+          )
+          Dir.chdir(tmp_config_dir) { example.run }
+        end
+
+        it "reads the base config from the config file" do
+          marker_request = stub_marker_request(
+            {
+              :environment => "production",
+              :name => "CapDSLapp",
+              :push_api_key => "cap_push_api_key"
+            },
+            marker_data
+          ).to_return(:status => 200)
+
+          run
+
+          expect(marker_request).to have_been_made
+        end
+
+        context "when rack_env is the only env set" do
+          let(:env) { "rack_production" }
+          before do
+            capistrano_config.delete(:rails_env)
+            capistrano_config.set(:rack_env, env)
+          end
+
+          it "uses the rack_env as the env" do
+            marker_request = stub_marker_request(
+              {
+                :environment => "rack_production",
+                :name => "CapDSLapp",
+                :push_api_key => "cap_push_api_key"
+              },
+              marker_data
+            ).to_return(:status => 200)
+
+            run
+
+            expect(marker_request).to have_been_made
+          end
+        end
+
+        context "when stage is set" do
+          let(:env) { "stage_production" }
+          before do
+            capistrano_config.set(:rack_env, "rack_production")
+            capistrano_config.set(:stage, env)
+          end
+
+          it "prefers the Capistrano stage rather than rails_env and rack_env" do
+            marker_request = stub_marker_request(
+              {
+                :environment => env.to_s,
+                :name => "CapDSLapp",
+                :push_api_key => "cap_push_api_key"
+              },
+              marker_data
+            ).to_return(:status => 200)
+
+            run
+
+            expect(marker_request).to have_been_made
+          end
+        end
+
+        context "when `appsignal_config` is set" do
+          before do
+            ENV["APPSIGNAL_APP_NAME"] = "EnvName"
+            capistrano_config.set(:appsignal_config, :name => "CapName")
+          end
+
+          it "overrides the default config with the custom appsignal_config" do
+            marker_request = stub_marker_request(
+              {
+                :environment => env.to_s,
+                :name => "CapName",
+                :push_api_key => "cap_push_api_key"
+              },
+              marker_data
+            ).to_return(:status => 200)
+
+            run
+
+            expect(marker_request).to have_been_made
+          end
+
+          context "with invalid config" do
+            before do
+              capistrano_config.set(:appsignal_config, :push_api_key => nil)
+            end
+
+            it "does not continue with invalid config" do
+              run
+              expect(output).to include \
+                "Not notifying of deploy, config is not active for environment: production"
+              expect(logs).to contains_log(:error, "Push API key not set after loading config")
+            end
+          end
+        end
+
+        context "when `appsignal_env` is set as a string" do
+          let(:env) { "appsignal_production" }
+          before do
+            capistrano_config.set(:rack_env, "rack_production")
+            capistrano_config.set(:stage, "stage_production")
+            capistrano_config.set(:appsignal_env, env)
+          end
+
+          it "prefers the appsignal_env rather than stage, rails_env and rack_env" do
+            marker_request = stub_marker_request(
+              {
+                :environment => env.to_s,
+                :name => "CapDSLapp",
+                :push_api_key => "cap_push_api_key"
+              },
+              marker_data
+            ).to_return(:status => 200)
+
+            run
+
+            expect(marker_request).to have_been_made
+          end
+        end
+
+        context "when `appsignal_env` is set as a symbol" do
+          let(:env) { :appsignal_production }
+          before do
+            capistrano_config.set(:rack_env, "rack_production")
+            capistrano_config.set(:stage, "stage_production")
+            capistrano_config.set(:appsignal_env, env)
+          end
+
+          it "prefers the appsignal_env rather than stage, rails_env and rack_env" do
+            marker_request = stub_marker_request(
+              {
+                :environment => env.to_s,
+                :name => "CapDSLapp",
+                :push_api_key => "cap_push_api_key"
+              },
+              marker_data
+            ).to_return(:status => 200)
+
+            run
+
+            expect(marker_request).to have_been_made
+          end
         end
       end
 

--- a/spec/lib/appsignal/capistrano3_spec.rb
+++ b/spec/lib/appsignal/capistrano3_spec.rb
@@ -186,7 +186,7 @@ if DependencyHelper.capistrano3_present?
             run
 
             expect(output).to include \
-              "Notifying AppSignal of deploy with: revision: 503ce0923ed177a3ce000005, " \
+              "Notifying AppSignal of '#{env}' deploy with revision: 503ce0923ed177a3ce000005, " \
                 "user: batman",
               "AppSignal has been notified of this deploy!"
           end
@@ -207,7 +207,7 @@ if DependencyHelper.capistrano3_present?
 
             it "transmits the overridden revision" do
               expect(output).to include \
-                "Notifying AppSignal of deploy with: revision: abc123, user: batman",
+                "Notifying AppSignal of '#{env}' deploy with revision: abc123, user: batman",
                 "AppSignal has been notified of this deploy!"
             end
           end
@@ -228,7 +228,7 @@ if DependencyHelper.capistrano3_present?
 
             it "transmits the overridden deploy user" do
               expect(output).to include \
-                "Notifying AppSignal of deploy with: revision: 503ce0923ed177a3ce000005, " \
+                "Notifying AppSignal of '#{env}' deploy with revision: 503ce0923ed177a3ce000005, " \
                   "user: robin",
                 "AppSignal has been notified of this deploy!"
             end
@@ -259,7 +259,8 @@ if DependencyHelper.capistrano3_present?
 
             it "does not transmit marker" do
               expect(output).to include \
-                "Notifying AppSignal of deploy with: revision: 503ce0923ed177a3ce000005, " \
+                "Notifying AppSignal of '#{env}' deploy with " \
+                  "revision: 503ce0923ed177a3ce000005, " \
                   "user: batman",
                 "Something went wrong while trying to notify AppSignal:"
               expect(output).to_not include "AppSignal has been notified of this deploy!"

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -97,9 +97,23 @@ describe Appsignal::Config do
         expect(described_class.determine_env("given_env")).to eq("given_env")
       end
 
+      it "works with a symbol" do
+        expect(described_class.determine_env(:given_env)).to eq("given_env")
+      end
+
       it "considers the given env leading over APPSIGNAL_APP_ENV" do
         ENV["APPSIGNAL_APP_ENV"] = "env_env"
         expect(described_class.determine_env("given_env")).to eq("given_env")
+      end
+
+      it "ignores empty strings" do
+        ENV["APPSIGNAL_APP_ENV"] = "env_env"
+        expect(described_class.determine_env("")).to eq("env_env")
+      end
+
+      it "ignores nil values" do
+        ENV["APPSIGNAL_APP_ENV"] = "env_env"
+        expect(described_class.determine_env(nil)).to eq("env_env")
       end
 
       it "considers the given env leading over other env vars" do

--- a/spec/lib/appsignal/marker_spec.rb
+++ b/spec/lib/appsignal/marker_spec.rb
@@ -29,7 +29,8 @@ describe Appsignal::Marker do
       it "outputs success" do
         run
         expect(output).to include \
-          "Notifying AppSignal of deploy with: revision: 503ce0923ed177a3ce000005, user: batman",
+          "Notifying AppSignal of 'production' deploy with revision: 503ce0923ed177a3ce000005, " \
+            "user: batman",
           "AppSignal has been notified of this deploy!"
       end
     end
@@ -40,7 +41,8 @@ describe Appsignal::Marker do
       it "outputs failure" do
         run
         expect(output).to include \
-          "Notifying AppSignal of deploy with: revision: 503ce0923ed177a3ce000005, user: batman",
+          "Notifying AppSignal of 'production' deploy with revision: 503ce0923ed177a3ce000005, " \
+            "user: batman",
           "Something went wrong while trying to notify AppSignal: 500 at " \
             "#{config[:endpoint]}/1/markers"
         expect(output).to_not include \

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -370,6 +370,7 @@ describe Appsignal do
       end
       expect(called).to be(true)
       expect(Appsignal.config.valid?).to be(true)
+      expect(Appsignal.config.config_hash).to include(:push_api_key => "abc")
     end
   end
 

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -340,6 +340,39 @@ describe Appsignal do
     end
   end
 
+  describe "._load_config!" do
+    it "works with envs as symbols" do
+      ENV["APPSIGNAL_APP_ENV"] = "_load_config_env"
+      Appsignal._load_config!(:production)
+      expect(Appsignal.config.env).to eq("production")
+    end
+
+    it "ignores zero length string values" do
+      ENV["APPSIGNAL_APP_ENV"] = "_load_config_env"
+      Appsignal._load_config!("")
+      expect(Appsignal.config.env).to eq("_load_config_env")
+    end
+
+    it "ignores empty string values" do
+      ENV["APPSIGNAL_APP_ENV"] = "_load_config_env"
+      Appsignal._load_config!("  ")
+      expect(Appsignal.config.env).to eq("_load_config_env")
+    end
+
+    it "calls the blocks before validation" do
+      called = false
+      Appsignal._load_config! do |config|
+        # Not yet validated here
+        expect(Appsignal.config.valid?).to be(false)
+
+        config.merge_dsl_options(:push_api_key => "abc")
+        called = true
+      end
+      expect(called).to be(true)
+      expect(Appsignal.config.valid?).to be(true)
+    end
+  end
+
   describe ".start" do
     context "with no config set beforehand" do
       let(:stdout_stream) { std_stream }

--- a/spec/support/helpers/api_request_helper.rb
+++ b/spec/support/helpers/api_request_helper.rb
@@ -30,6 +30,10 @@ module ApiRequestHelper
     stub_request(:post, "#{endpoint}/1/#{path}").with(options)
   end
 
+  def stub_marker_request(config = {}, data = {})
+    stub_api_request(config, "markers", data)
+  end
+
   def stub_public_endpoint_markers_request(marker_data:)
     config = Appsignal.config
     options = {


### PR DESCRIPTION
## Validate app environment sources better

Do not accept nil values, empty strings, symbols, etc.

Symbols are internally cast to a String so the app environment is always a string. Solving problems with symbols trying to be set on env vars, which Ruby will raise an error for.

## Print app env in Capistrano output

Help debug the app env for us and confirm the app env for our users when a deploy marker is sent with out Capistrano integration.

## Rename config_file helper to YAML specific one

Don't confuse the config file value with _the loaded config file_. It's just a helper for the YAML config file.

## Improve _load_config! helper

Do not accept any empty or blank app environment strings. It also casts symbols to strings. This prevents any errors or weird behavior due to unexpected input.

Accept a block so that we can use this for the Capistrano config update.

Also document why we don't pass `context.env` to the `load_dsl_config_file` helper, because I forgot again.

## Refactor Capistrano specs

Standardize the Capistrano 2 and 3 specs a bit with each other.

I found that we don't assertion if we actually make marker requests to the API. This change will make sure we do.

Move the `stub_marker_request` helper to the shared helpers, so we have one helper for this, instead of one per spec file.

## Fix Capistrano 2 and 3 appsignal.rb config method

When using an `appsignal.rb` config file, we wouldn't pick up the config from the config file.

This changes fixes that by relying on the private `_load_config!` helper instead of initializing a Config class directly.

---

- [ ] [Inform customer](https://app.intercom.com/a/inbox/yzor8gyw/inbox/conversation/16410700399164)