### PR TITLE
Require Rack 2+ for Rack::Events module

### DIFF
--- a/.changesets/rack-version-requirement.md
+++ b/.changesets/rack-version-requirement.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Specify stricter Rack version requirement. The Ruby gem relies on the `Rack::Events` constant which was introduced in Rack 2. Update our version requirement to require Rack 2 or newer.

--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -57,7 +57,8 @@ Gem::Specification.new do |gem| # rubocop:disable Metrics/BlockLength
   }
 
   gem.add_dependency "logger"
-  gem.add_dependency "rack"
+  # Needs 2.0+ because we rely on Rack::Events
+  gem.add_dependency "rack", ">= 2.0.0"
 
   gem.add_development_dependency "pry"
   gem.add_development_dependency "rake", ">= 12"


### PR DESCRIPTION
We now rely on the Rack::Events module, which was added in Rack 2.0.0. https://github.com/rack/rack/commit/c393176b0edf3e5d06cabbb6eb9d9c7a07b2afa7

To avoid people running into issues with Rack 1 apps, specify our Rack version requirement.

Then people shouldn't run into the issue below, but instead Bundler will install a compatible version.

(That would be anything between 4.5.2 and 3.8 even though it also doesn't work, but the next best time to specify a version lock is now.

[Related support conversation](https://app.intercom.com/a/inbox/yzor8gyw/inbox/shared/all/conversation/16410700399815#part_id=initial-part-16410700399815-2720403779)