### PR TITLE
Support Sidekiq 8

### DIFF
--- a/.changesets/fix-queue-time-reporting-for-sidekiq-8.md
+++ b/.changesets/fix-queue-time-reporting-for-sidekiq-8.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix the queue time reporting for Sidekiq 8 jobs. It would report high negative values for the queue time with Sidekiq 8.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 # This is a generated file by the `rake build_matrix:github:generate` task.
 # See `build_matrix.yml` for the build matrix.
 # Generate this file with `rake build_matrix:github:generate`.
-# Generated job count: 157
+# Generated job count: 159
 ---
 name: Ruby gem CI
 'on':
@@ -723,6 +723,60 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/redis-5.gemfile
+  ruby_3-4-1__sidekiq-7_ubuntu-latest:
+    name: Ruby 3.4.1 - sidekiq-7
+    needs: ruby_3-4-1_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.1
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/sidekiq-7.gemfile
+  ruby_3-4-1__sidekiq-8_ubuntu-latest:
+    name: Ruby 3.4.1 - sidekiq-8
+    needs: ruby_3-4-1_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.1
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/sidekiq-8.gemfile
   ruby_3-4-1_macos-14:
     name: Ruby 3.4.1 (macos-14)
     needs: validation

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -208,3 +208,11 @@ matrix:
     - gem: "webmachine2"
     - gem: "redis-4"
     - gem: "redis-5"
+    - gem: "sidekiq-7"
+      only:
+        ruby:
+          - "3.4.1"
+    - gem: "sidekiq-8"
+      only:
+        ruby:
+          - "3.4.1"

--- a/gemfiles/sidekiq-7.gemfile
+++ b/gemfiles/sidekiq-7.gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gem "rails"
+gem "rake"
+gem "sidekiq", "~> 7.0"
+
+gemspec :path => "../"

--- a/gemfiles/sidekiq-8.gemfile
+++ b/gemfiles/sidekiq-8.gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gem "rails"
+gem "rake"
+gem "sidekiq", "~> 8.0"
+
+gemspec :path => "../"

--- a/lib/appsignal/integrations/sidekiq.rb
+++ b/lib/appsignal/integrations/sidekiq.rb
@@ -156,8 +156,6 @@ module Appsignal
           safe_load(args[0], args) do |_, _, arg|
             arg
           end
-        when "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper"
-          nil # Set in the ActiveJob integration
         else
           # Sidekiq Enterprise argument encryption.
           # More information: https://github.com/mperham/sidekiq/wiki/Ent-Encryption

--- a/lib/appsignal/integrations/sidekiq.rb
+++ b/lib/appsignal/integrations/sidekiq.rb
@@ -58,6 +58,12 @@ module Appsignal
         error_message failed_at jid retried_at retry wrapped
       ].freeze
 
+      def self.sidekiq8?
+        return false unless ::Sidekiq.respond_to?(:gem_version)
+
+        @sidekiq8 ||= ::Sidekiq.gem_version >= Gem::Version.new("8.0.0")
+      end
+
       def call(_worker, item, _queue, &block)
         job_status = nil
         transaction = Appsignal::Transaction.create(Appsignal::Transaction::BACKGROUND_JOB)
@@ -74,7 +80,14 @@ module Appsignal
       ensure
         if transaction
           transaction.add_params_if_nil { parse_arguments(item) }
-          queue_start = (item["enqueued_at"].to_f * 1000.0).to_i # Convert seconds to milliseconds
+          enqueued_at = item["enqueued_at"]
+          queue_start =
+            if self.class.sidekiq8?
+              enqueued_at.to_i # Sidekiq 8 stores it as epoc milliseconds
+            else
+              # Convert seconds to milliseconds for Sidekiq 7 and older
+              (enqueued_at.to_f * 1000.0).to_i
+            end
           transaction.set_queue_start(queue_start)
           transaction.add_tags(:request_id => item["jid"])
           Appsignal::Transaction.complete_current! unless exception

--- a/spec/lib/appsignal/integrations/sidekiq_spec.rb
+++ b/spec/lib/appsignal/integrations/sidekiq_spec.rb
@@ -202,13 +202,19 @@ describe Appsignal::Integrations::SidekiqMiddleware do
   let(:job_class) { "TestClass" }
   let(:jid) { "b4a577edbccf1d805744efa9" }
   let(:item) do
+    time =
+      if DependencyHelper.sidekiq8_present?
+        Time.parse("2001-01-01 10:00:00UTC").to_f * 1000
+      else
+        Time.parse("2001-01-01 10:00:00UTC").to_f
+      end
     {
       "jid" => jid,
       "class" => job_class,
       "retry_count" => 0,
       "queue" => "default",
-      "created_at" => Time.parse("2001-01-01 10:00:00UTC").to_f,
-      "enqueued_at" => Time.parse("2001-01-01 10:00:00UTC").to_f,
+      "created_at" => time,
+      "enqueued_at" => time,
       "args" => given_args,
       "extra" => "data"
     }

--- a/spec/lib/appsignal/integrations/sidekiq_spec.rb
+++ b/spec/lib/appsignal/integrations/sidekiq_spec.rb
@@ -1,135 +1,26 @@
-require "appsignal/integrations/sidekiq"
+if DependencyHelper.sidekiq_present?
+  require "appsignal/integrations/sidekiq"
 
-describe Appsignal::Integrations::SidekiqDeathHandler do
-  let(:options) { {} }
-  before do
-    stub_const("Sidekiq::VERSION", "7.1.0")
-    start_agent(:options => options)
-  end
-  around { |example| keep_transactions { example.run } }
-
-  let(:exception) do
-    raise ExampleStandardError, "uh oh"
-  rescue => error
-    error
-  end
-  let(:job_context) { {} }
-  let(:transaction) { http_request_transaction }
-  before { set_current_transaction(transaction) }
-
-  def call_handler
-    expect do
-      described_class.new.call(job_context, exception)
-    end.to_not(change { created_transactions.count })
-  end
-
-  def expect_error_on_transaction
-    expect(last_transaction).to have_error("ExampleStandardError", "uh oh")
-  end
-
-  def expect_no_error_on_transaction
-    expect(last_transaction).to_not have_error
-  end
-
-  context "when sidekiq_report_errors = none" do
-    let(:options) { { :sidekiq_report_errors => "none" } }
-    before { call_handler }
-
-    it "doesn't track the error on the transaction" do
-      expect_no_error_on_transaction
-    end
-  end
-
-  context "when sidekiq_report_errors = all" do
-    let(:options) { { :sidekiq_report_errors => "all" } }
-    before { call_handler }
-
-    it "doesn't track the error on the transaction" do
-      expect_no_error_on_transaction
-    end
-  end
-
-  context "when sidekiq_report_errors = discard" do
-    let(:options) { { :sidekiq_report_errors => "discard" } }
-    before { call_handler }
-
-    it "records each occurrence of the error on the transaction" do
-      expect_error_on_transaction
-    end
-  end
-end
-
-describe Appsignal::Integrations::SidekiqErrorHandler do
-  let(:options) { {} }
-  before { start_agent(:options => options) }
-  around { |example| keep_transactions { example.run } }
-
-  let(:exception) do
-    raise ExampleStandardError, "uh oh"
-  rescue => error
-    error
-  end
-
-  context "when error is an internal error" do
-    let(:job_context) do
-      {
-        :context => "Sidekiq internal error!",
-        :jobstr => "{ bad json }"
-      }
-    end
-
-    def expect_report_internal_error
-      expect do
-        described_class.new.call(exception, job_context)
-      end.to(change { created_transactions.count }.by(1))
-
-      transaction = last_transaction
-      expect(transaction).to have_action("SidekiqInternal")
-      expect(transaction).to have_error("ExampleStandardError", "uh oh")
-      expect(transaction).to include_params(
-        "jobstr" => "{ bad json }"
-      )
-      expect(transaction).to include_metadata(
-        "sidekiq_error" => "Sidekiq internal error!"
-      )
-    end
-
-    context "when sidekiq_report_errors = none" do
-      let(:options) { { :sidekiq_report_errors => "none" } }
-
-      it "tracks the error on a new transaction" do
-        expect_report_internal_error
-      end
-    end
-
-    context "when sidekiq_report_errors = all" do
-      let(:options) { { :sidekiq_report_errors => "all" } }
-
-      it "tracks the error on a new transaction" do
-        expect_report_internal_error
-      end
-    end
-
-    context "when sidekiq_report_errors = discard" do
-      let(:options) { { :sidekiq_report_errors => "discard" } }
-
-      it "tracks the error on a new transaction" do
-        expect_report_internal_error
-      end
-    end
-  end
-
-  context "when error is a job error" do
-    let(:sidekiq_context) { { :job => {} } }
-    let(:transaction) { http_request_transaction }
+  describe Appsignal::Integrations::SidekiqDeathHandler do
+    let(:options) { {} }
     before do
-      transaction.set_action("existing transaction action")
-      set_current_transaction(transaction)
+      stub_const("Sidekiq::VERSION", "7.1.0")
+      start_agent(:options => options)
     end
+    around { |example| keep_transactions { example.run } }
+
+    let(:exception) do
+      raise ExampleStandardError, "uh oh"
+    rescue => error
+      error
+    end
+    let(:job_context) { {} }
+    let(:transaction) { http_request_transaction }
+    before { set_current_transaction(transaction) }
 
     def call_handler
       expect do
-        described_class.new.call(exception, sidekiq_context)
+        described_class.new.call(job_context, exception)
       end.to_not(change { created_transactions.count })
     end
 
@@ -147,7 +38,6 @@ describe Appsignal::Integrations::SidekiqErrorHandler do
 
       it "doesn't track the error on the transaction" do
         expect_no_error_on_transaction
-        expect(last_transaction).to be_completed
       end
     end
 
@@ -155,9 +45,8 @@ describe Appsignal::Integrations::SidekiqErrorHandler do
       let(:options) { { :sidekiq_report_errors => "all" } }
       before { call_handler }
 
-      it "records each occurrence of the error on the transaction" do
-        expect_error_on_transaction
-        expect(last_transaction).to be_completed
+      it "doesn't track the error on the transaction" do
+        expect_no_error_on_transaction
       end
     end
 
@@ -165,317 +54,139 @@ describe Appsignal::Integrations::SidekiqErrorHandler do
       let(:options) { { :sidekiq_report_errors => "discard" } }
       before { call_handler }
 
-      it "doesn't track the error on the transaction" do
-        expect_no_error_on_transaction
-        expect(last_transaction).to be_completed
-      end
-    end
-  end
-end
-
-describe Appsignal::Integrations::SidekiqMiddleware do
-  class DelayedTestClass; end
-
-  let(:namespace) { Appsignal::Transaction::BACKGROUND_JOB }
-  let(:worker) { anything }
-  let(:queue) { anything }
-  let(:given_args) do
-    [
-      "foo",
-      {
-        :foo => "Foo",
-        :bar => "Bar",
-        "baz" => { 1 => :foo }
-      }
-    ]
-  end
-  let(:expected_args) do
-    [
-      "foo",
-      {
-        "foo" => "Foo",
-        "bar" => "Bar",
-        "baz" => { "1" => "foo" }
-      }
-    ]
-  end
-  let(:job_class) { "TestClass" }
-  let(:jid) { "b4a577edbccf1d805744efa9" }
-  let(:item) do
-    time =
-      if DependencyHelper.sidekiq8_present?
-        Time.parse("2001-01-01 10:00:00UTC").to_f * 1000
-      else
-        Time.parse("2001-01-01 10:00:00UTC").to_f
-      end
-    {
-      "jid" => jid,
-      "class" => job_class,
-      "retry_count" => 0,
-      "queue" => "default",
-      "created_at" => time,
-      "enqueued_at" => time,
-      "args" => given_args,
-      "extra" => "data"
-    }
-  end
-  let(:plugin) { Appsignal::Integrations::SidekiqMiddleware.new }
-  let(:options) { {} }
-  before do
-    start_agent(:options => options)
-  end
-  around { |example| keep_transactions { example.run } }
-
-  def expect_no_yaml_parse_error(logs)
-    expect(logs).to_not contains_log(:warn, "Unable to load YAML")
-  end
-
-  describe "internal Sidekiq job values" do
-    it "does not save internal Sidekiq values as metadata on transaction" do
-      perform_sidekiq_job
-
-      transaction_hash = transaction.to_h
-      expect(transaction_hash["metadata"].keys)
-        .to_not include(*Appsignal::Integrations::SidekiqMiddleware::EXCLUDED_JOB_KEYS)
-    end
-  end
-
-  context "with parameter filtering" do
-    let(:options) { { :filter_parameters => ["foo"] } }
-
-    it "filters selected arguments" do
-      perform_sidekiq_job
-
-      expect(transaction).to include_params(
-        [
-          "foo",
-          {
-            "foo" => "[FILTERED]",
-            "bar" => "Bar",
-            "baz" => { "1" => "foo" }
-          }
-        ]
-      )
-    end
-  end
-
-  context "with encrypted arguments" do
-    before do
-      item["encrypt"] = true
-      item["args"] << "super secret value" # Last argument will be replaced
-    end
-
-    it "replaces the last argument (the secret bag) with an [encrypted data] string" do
-      perform_sidekiq_job
-
-      expect(transaction).to include_params(expected_args << "[encrypted data]")
-    end
-  end
-
-  context "when using the Sidekiq delayed extension" do
-    let(:item) do
-      {
-        "jid" => jid,
-        "class" => "Sidekiq::Extensions::DelayedClass",
-        "queue" => "default",
-        "args" => [
-          "---\n- !ruby/class 'DelayedTestClass'\n- :foo_method\n- - :bar: baz\n"
-        ],
-        "retry" => true,
-        "created_at" => Time.parse("2001-01-01 10:00:00UTC").to_f,
-        "enqueued_at" => Time.parse("2001-01-01 10:00:00UTC").to_f,
-        "extra" => "data"
-      }
-    end
-
-    it "uses the delayed class and method name for the action" do
-      perform_sidekiq_job
-
-      expect(transaction).to have_action("DelayedTestClass.foo_method")
-      expect(transaction).to include_params(["bar" => "baz"])
-    end
-
-    context "when job arguments is a malformed YAML object" do
-      before { item["args"] = [] }
-
-      it "logs a warning and uses the default argument" do
-        logs = capture_logs { perform_sidekiq_job }
-
-        expect(transaction).to have_action("Sidekiq::Extensions::DelayedClass#perform")
-        expect(transaction).to include_params([])
-        expect(logs).to contains_log(:warn, "Unable to load YAML")
+      it "records each occurrence of the error on the transaction" do
+        expect_error_on_transaction
       end
     end
   end
 
-  context "when using the Sidekiq ActiveRecord instance delayed extension" do
-    let(:item) do
-      {
-        "jid" => jid,
-        "class" => "Sidekiq::Extensions::DelayedModel",
-        "queue" => "default",
-        "args" => [
-          "---\n- !ruby/object:DelayedTestClass {}\n- :foo_method\n- - :bar: :baz\n"
-        ],
-        "retry" => true,
-        "created_at" => Time.parse("2001-01-01 10:00:00UTC").to_f,
-        "enqueued_at" => Time.parse("2001-01-01 10:00:00UTC").to_f,
-        "extra" => "data"
-      }
+  describe Appsignal::Integrations::SidekiqErrorHandler do
+    let(:options) { {} }
+    before { start_agent(:options => options) }
+    around { |example| keep_transactions { example.run } }
+
+    let(:exception) do
+      raise ExampleStandardError, "uh oh"
+    rescue => error
+      error
     end
 
-    it "uses the delayed class and method name for the action" do
-      perform_sidekiq_job
-
-      expect(transaction).to have_action("DelayedTestClass#foo_method")
-      expect(transaction).to include_params(["bar" => "baz"])
-    end
-
-    context "when job arguments is a malformed YAML object" do
-      before { item["args"] = [] }
-
-      it "logs a warning and uses the default argument" do
-        logs = capture_logs { perform_sidekiq_job }
-
-        expect(transaction).to have_action("Sidekiq::Extensions::DelayedModel#perform")
-        expect(transaction).to include_params([])
-        expect(logs).to contains_log(:warn, "Unable to load YAML")
+    context "when error is an internal error" do
+      let(:job_context) do
+        {
+          :context => "Sidekiq internal error!",
+          :jobstr => "{ bad json }"
+        }
       end
-    end
-  end
 
-  context "with an error" do
-    let(:error) { ExampleException }
-
-    it "creates a transaction and adds the error" do
-      # TODO: additional curly brackets required for issue
-      # https://github.com/rspec/rspec-mocks/issues/1460
-      expect(Appsignal).to receive(:increment_counter)
-        .with("sidekiq_queue_job_count", 1, { :queue => "default", :status => :failed })
-      expect(Appsignal).to receive(:increment_counter)
-        .with("sidekiq_queue_job_count", 1, { :queue => "default", :status => :processed })
-      expect do
-        perform_sidekiq_job { raise error, "uh oh" }
-      end.to raise_error(error)
-
-      expect(transaction).to have_id
-      expect(transaction).to have_namespace(namespace)
-      expect(transaction).to have_action("TestClass#perform")
-      expect(transaction).to have_error("ExampleException", "uh oh")
-      expect(transaction).to include_metadata(
-        "extra" => "data",
-        "queue" => "default",
-        "retry_count" => "0"
-      )
-      expect(transaction).to_not include_environment
-      expect(transaction).to include_params(expected_args)
-      expect(transaction).to include_tags("request_id" => jid)
-      expect(transaction).to_not include_breadcrumbs
-      expect_transaction_to_have_sidekiq_event(transaction)
-    end
-  end
-
-  if DependencyHelper.rails7_present?
-    context "with Rails error reporter" do
-      include RailsHelper
-
-      it "reports the worker name as the action, copies the namespace and tags" do
+      def expect_report_internal_error
         expect do
-          with_rails_error_reporter do
-            perform_sidekiq_job do
-              Appsignal.tag_job("test_tag" => "value")
-              Rails.error.handle do
-                raise ExampleStandardError, "error message"
-              end
-            end
-          end
-        end.to change { created_transactions.count }.by(1)
+          described_class.new.call(exception, job_context)
+        end.to(change { created_transactions.count }.by(1))
 
-        tags = { "test_tag" => "value" }
         transaction = last_transaction
+        expect(transaction).to have_action("SidekiqInternal")
+        expect(transaction).to have_error("ExampleStandardError", "uh oh")
+        expect(transaction).to include_params(
+          "jobstr" => "{ bad json }"
+        )
+        expect(transaction).to include_metadata(
+          "sidekiq_error" => "Sidekiq internal error!"
+        )
+      end
 
-        expect(transaction).to have_namespace("background_job")
-        expect(transaction).to have_action("TestClass#perform")
-        expect(transaction).to have_error("ExampleStandardError", "error message")
-        expect(transaction).to include_tags(tags)
+      context "when sidekiq_report_errors = none" do
+        let(:options) { { :sidekiq_report_errors => "none" } }
+
+        it "tracks the error on a new transaction" do
+          expect_report_internal_error
+        end
+      end
+
+      context "when sidekiq_report_errors = all" do
+        let(:options) { { :sidekiq_report_errors => "all" } }
+
+        it "tracks the error on a new transaction" do
+          expect_report_internal_error
+        end
+      end
+
+      context "when sidekiq_report_errors = discard" do
+        let(:options) { { :sidekiq_report_errors => "discard" } }
+
+        it "tracks the error on a new transaction" do
+          expect_report_internal_error
+        end
+      end
+    end
+
+    context "when error is a job error" do
+      let(:sidekiq_context) { { :job => {} } }
+      let(:transaction) { http_request_transaction }
+      before do
+        transaction.set_action("existing transaction action")
+        set_current_transaction(transaction)
+      end
+
+      def call_handler
+        expect do
+          described_class.new.call(exception, sidekiq_context)
+        end.to_not(change { created_transactions.count })
+      end
+
+      def expect_error_on_transaction
+        expect(last_transaction).to have_error("ExampleStandardError", "uh oh")
+      end
+
+      def expect_no_error_on_transaction
+        expect(last_transaction).to_not have_error
+      end
+
+      context "when sidekiq_report_errors = none" do
+        let(:options) { { :sidekiq_report_errors => "none" } }
+        before { call_handler }
+
+        it "doesn't track the error on the transaction" do
+          expect_no_error_on_transaction
+          expect(last_transaction).to be_completed
+        end
+      end
+
+      context "when sidekiq_report_errors = all" do
+        let(:options) { { :sidekiq_report_errors => "all" } }
+        before { call_handler }
+
+        it "records each occurrence of the error on the transaction" do
+          expect_error_on_transaction
+          expect(last_transaction).to be_completed
+        end
+      end
+
+      context "when sidekiq_report_errors = discard" do
+        let(:options) { { :sidekiq_report_errors => "discard" } }
+        before { call_handler }
+
+        it "doesn't track the error on the transaction" do
+          expect_no_error_on_transaction
+          expect(last_transaction).to be_completed
+        end
       end
     end
   end
 
-  context "without an error" do
-    it "creates a transaction with events" do
-      # TODO: additional curly brackets required for issue
-      # https://github.com/rspec/rspec-mocks/issues/1460
-      expect(Appsignal).to receive(:increment_counter)
-        .with("sidekiq_queue_job_count", 1, { :queue => "default", :status => :processed })
-      perform_sidekiq_job
-
-      expect(transaction).to have_id
-      expect(transaction).to have_namespace(namespace)
-      expect(transaction).to have_action("TestClass#perform")
-      expect(transaction).to_not have_error
-      expect(transaction).to include_tags("request_id" => jid)
-      expect(transaction).to_not include_environment
-      expect(transaction).to_not include_breadcrumbs
-      expect(transaction).to_not include_params(expected_args)
-      expect(transaction).to include_metadata(
-        "extra" => "data",
-        "queue" => "default",
-        "retry_count" => "0"
-      )
-      expect(transaction).to have_queue_start(Time.parse("2001-01-01 10:00:00UTC").to_i * 1000)
-      expect_transaction_to_have_sidekiq_event(transaction)
-    end
-  end
-
-  def perform_sidekiq_job
-    Timecop.freeze(Time.parse("2001-01-01 10:01:00UTC")) do
-      exception = nil
-      plugin.call(worker, item, queue) do
-        yield if block_given?
-      end
-    rescue Exception => exception # rubocop:disable Lint/RescueException
-      raise exception
-    ensure
-      Appsignal::Integrations::SidekiqErrorHandler.new.call(exception, :job => item) if exception
-    end
-  end
-
-  def transaction
-    last_transaction
-  end
-
-  def expect_transaction_to_have_sidekiq_event(transaction)
-    expect(transaction.to_h["events"].count).to eq(1)
-    expect(transaction).to include_event(
-      "name"        => "perform_job.sidekiq",
-      "title"       => "",
-      "count"       => 1,
-      "body"        => "",
-      "body_format" => Appsignal::EventFormatter::DEFAULT
-    )
-  end
-end
-
-if DependencyHelper.active_job_present?
-  require "active_job"
-  require "action_mailer"
-  require "sidekiq/testing"
-
-  describe "Sidekiq ActiveJob integration" do
-    include RailsHelper
-    include ActiveJobHelpers
+  describe Appsignal::Integrations::SidekiqMiddleware do
+    class DelayedTestClass; end
 
     let(:namespace) { Appsignal::Transaction::BACKGROUND_JOB }
-    let(:time) { Time.parse("2001-01-01 10:00:00UTC") }
-    let(:log) { StringIO.new }
+    let(:worker) { anything }
+    let(:queue) { anything }
     let(:given_args) do
       [
         "foo",
         {
           :foo => "Foo",
-          "bar" => "Bar",
-          "baz" => { "1" => "foo" }
+          :bar => "Bar",
+          "baz" => { 1 => :foo }
         }
       ]
     end
@@ -483,106 +194,366 @@ if DependencyHelper.active_job_present?
       [
         "foo",
         {
-          "_aj_symbol_keys" => ["foo"],
           "foo" => "Foo",
           "bar" => "Bar",
-          "baz" => {
-            "_aj_symbol_keys" => [],
-            "1" => "foo"
-          }
+          "baz" => { "1" => "foo" }
         }
       ]
     end
-    let(:expected_wrapped_args) do
-      if DependencyHelper.active_job_wraps_args?
-        [{
-          "_aj_ruby2_keywords" => ["args"],
-          "args" => expected_args
-        }]
-      else
-        expected_args
+    let(:job_class) { "TestClass" }
+    let(:jid) { "b4a577edbccf1d805744efa9" }
+    let(:item) do
+      time =
+        if DependencyHelper.sidekiq8_present?
+          Time.parse("2001-01-01 10:00:00UTC").to_f * 1000
+        else
+          Time.parse("2001-01-01 10:00:00UTC").to_f
+        end
+      {
+        "jid" => jid,
+        "class" => job_class,
+        "retry_count" => 0,
+        "queue" => "default",
+        "created_at" => time,
+        "enqueued_at" => time,
+        "args" => given_args,
+        "extra" => "data"
+      }
+    end
+    let(:plugin) { Appsignal::Integrations::SidekiqMiddleware.new }
+    let(:options) { {} }
+    before do
+      start_agent(:options => options)
+    end
+    around { |example| keep_transactions { example.run } }
+
+    def expect_no_yaml_parse_error(logs)
+      expect(logs).to_not contains_log(:warn, "Unable to load YAML")
+    end
+
+    describe "internal Sidekiq job values" do
+      it "does not save internal Sidekiq values as metadata on transaction" do
+        perform_sidekiq_job
+
+        transaction_hash = transaction.to_h
+        expect(transaction_hash["metadata"].keys)
+          .to_not include(*Appsignal::Integrations::SidekiqMiddleware::EXCLUDED_JOB_KEYS)
       end
     end
-    let(:expected_tags) do
-      { "executions" => 1 }.tap do |hash|
-        hash["active_job_id"] = kind_of(String)
-        if DependencyHelper.rails_version >= Gem::Version.new("5.0.0")
-          hash["provider_job_id"] = kind_of(String)
+
+    context "with parameter filtering" do
+      let(:options) { { :filter_parameters => ["foo"] } }
+
+      it "filters selected arguments" do
+        perform_sidekiq_job
+
+        expect(transaction).to include_params(
+          [
+            "foo",
+            {
+              "foo" => "[FILTERED]",
+              "bar" => "Bar",
+              "baz" => { "1" => "foo" }
+            }
+          ]
+        )
+      end
+    end
+
+    context "with encrypted arguments" do
+      before do
+        item["encrypt"] = true
+        item["args"] << "super secret value" # Last argument will be replaced
+      end
+
+      it "replaces the last argument (the secret bag) with an [encrypted data] string" do
+        perform_sidekiq_job
+
+        expect(transaction).to include_params(expected_args << "[encrypted data]")
+      end
+    end
+
+    context "when using the Sidekiq delayed extension" do
+      let(:item) do
+        {
+          "jid" => jid,
+          "class" => "Sidekiq::Extensions::DelayedClass",
+          "queue" => "default",
+          "args" => [
+            "---\n- !ruby/class 'DelayedTestClass'\n- :foo_method\n- - :bar: baz\n"
+          ],
+          "retry" => true,
+          "created_at" => Time.parse("2001-01-01 10:00:00UTC").to_f,
+          "enqueued_at" => Time.parse("2001-01-01 10:00:00UTC").to_f,
+          "extra" => "data"
+        }
+      end
+
+      it "uses the delayed class and method name for the action" do
+        perform_sidekiq_job
+
+        expect(transaction).to have_action("DelayedTestClass.foo_method")
+        expect(transaction).to include_params(["bar" => "baz"])
+      end
+
+      context "when job arguments is a malformed YAML object" do
+        before { item["args"] = [] }
+
+        it "logs a warning and uses the default argument" do
+          logs = capture_logs { perform_sidekiq_job }
+
+          expect(transaction).to have_action("Sidekiq::Extensions::DelayedClass#perform")
+          expect(transaction).to include_params([])
+          expect(logs).to contains_log(:warn, "Unable to load YAML")
         end
       end
     end
-    let(:expected_perform_events) do
-      if DependencyHelper.rails7_present?
-        ["perform_job.sidekiq", "perform.active_job", "perform_start.active_job"]
-      else
-        ["perform_job.sidekiq", "perform_start.active_job", "perform.active_job"]
+
+    context "when using the Sidekiq ActiveRecord instance delayed extension" do
+      let(:item) do
+        {
+          "jid" => jid,
+          "class" => "Sidekiq::Extensions::DelayedModel",
+          "queue" => "default",
+          "args" => [
+            "---\n- !ruby/object:DelayedTestClass {}\n- :foo_method\n- - :bar: :baz\n"
+          ],
+          "retry" => true,
+          "created_at" => Time.parse("2001-01-01 10:00:00UTC").to_f,
+          "enqueued_at" => Time.parse("2001-01-01 10:00:00UTC").to_f,
+          "extra" => "data"
+        }
+      end
+
+      it "uses the delayed class and method name for the action" do
+        perform_sidekiq_job
+
+        expect(transaction).to have_action("DelayedTestClass#foo_method")
+        expect(transaction).to include_params(["bar" => "baz"])
+      end
+
+      context "when job arguments is a malformed YAML object" do
+        before { item["args"] = [] }
+
+        it "logs a warning and uses the default argument" do
+          logs = capture_logs { perform_sidekiq_job }
+
+          expect(transaction).to have_action("Sidekiq::Extensions::DelayedModel#perform")
+          expect(transaction).to include_params([])
+          expect(logs).to contains_log(:warn, "Unable to load YAML")
+        end
       end
     end
-    around do |example|
-      with_rails_error_reporter do
-        keep_transactions do
-          Sidekiq::Testing.fake! do
-            example.run
+
+    context "with an error" do
+      let(:error) { ExampleException }
+
+      it "creates a transaction and adds the error" do
+        # TODO: additional curly brackets required for issue
+        # https://github.com/rspec/rspec-mocks/issues/1460
+        expect(Appsignal).to receive(:increment_counter)
+          .with("sidekiq_queue_job_count", 1, { :queue => "default", :status => :failed })
+        expect(Appsignal).to receive(:increment_counter)
+          .with("sidekiq_queue_job_count", 1, { :queue => "default", :status => :processed })
+        expect do
+          perform_sidekiq_job { raise error, "uh oh" }
+        end.to raise_error(error)
+
+        expect(transaction).to have_id
+        expect(transaction).to have_namespace(namespace)
+        expect(transaction).to have_action("TestClass#perform")
+        expect(transaction).to have_error("ExampleException", "uh oh")
+        expect(transaction).to include_metadata(
+          "extra" => "data",
+          "queue" => "default",
+          "retry_count" => "0"
+        )
+        expect(transaction).to_not include_environment
+        expect(transaction).to include_params(expected_args)
+        expect(transaction).to include_tags("request_id" => jid)
+        expect(transaction).to_not include_breadcrumbs
+        expect_transaction_to_have_sidekiq_event(transaction)
+      end
+    end
+
+    if DependencyHelper.rails7_present?
+      context "with Rails error reporter" do
+        include RailsHelper
+
+        it "reports the worker name as the action, copies the namespace and tags" do
+          expect do
+            with_rails_error_reporter do
+              perform_sidekiq_job do
+                Appsignal.tag_job("test_tag" => "value")
+                Rails.error.handle do
+                  raise ExampleStandardError, "error message"
+                end
+              end
+            end
+          end.to change { created_transactions.count }.by(1)
+
+          tags = { "test_tag" => "value" }
+          transaction = last_transaction
+
+          expect(transaction).to have_namespace("background_job")
+          expect(transaction).to have_action("TestClass#perform")
+          expect(transaction).to have_error("ExampleStandardError", "error message")
+          expect(transaction).to include_tags(tags)
+        end
+      end
+    end
+
+    context "without an error" do
+      it "creates a transaction with events" do
+        # TODO: additional curly brackets required for issue
+        # https://github.com/rspec/rspec-mocks/issues/1460
+        expect(Appsignal).to receive(:increment_counter)
+          .with("sidekiq_queue_job_count", 1, { :queue => "default", :status => :processed })
+        perform_sidekiq_job
+
+        expect(transaction).to have_id
+        expect(transaction).to have_namespace(namespace)
+        expect(transaction).to have_action("TestClass#perform")
+        expect(transaction).to_not have_error
+        expect(transaction).to include_tags("request_id" => jid)
+        expect(transaction).to_not include_environment
+        expect(transaction).to_not include_breadcrumbs
+        expect(transaction).to_not include_params(expected_args)
+        expect(transaction).to include_metadata(
+          "extra" => "data",
+          "queue" => "default",
+          "retry_count" => "0"
+        )
+        expect(transaction).to have_queue_start(Time.parse("2001-01-01 10:00:00UTC").to_i * 1000)
+        expect_transaction_to_have_sidekiq_event(transaction)
+      end
+    end
+
+    def perform_sidekiq_job
+      Timecop.freeze(Time.parse("2001-01-01 10:01:00UTC")) do
+        exception = nil
+        plugin.call(worker, item, queue) do
+          yield if block_given?
+        end
+      rescue Exception => exception # rubocop:disable Lint/RescueException
+        raise exception
+      ensure
+        Appsignal::Integrations::SidekiqErrorHandler.new.call(exception, :job => item) if exception
+      end
+    end
+
+    def transaction
+      last_transaction
+    end
+
+    def expect_transaction_to_have_sidekiq_event(transaction)
+      expect(transaction.to_h["events"].count).to eq(1)
+      expect(transaction).to include_event(
+        "name"        => "perform_job.sidekiq",
+        "title"       => "",
+        "count"       => 1,
+        "body"        => "",
+        "body_format" => Appsignal::EventFormatter::DEFAULT
+      )
+    end
+  end
+
+  if DependencyHelper.active_job_present?
+    require "active_job"
+    require "action_mailer"
+    require "sidekiq/testing"
+
+    describe "Sidekiq ActiveJob integration" do
+      include RailsHelper
+      include ActiveJobHelpers
+
+      let(:namespace) { Appsignal::Transaction::BACKGROUND_JOB }
+      let(:time) { Time.parse("2001-01-01 10:00:00UTC") }
+      let(:log) { StringIO.new }
+      let(:given_args) do
+        [
+          "foo",
+          {
+            :foo => "Foo",
+            "bar" => "Bar",
+            "baz" => { "1" => "foo" }
+          }
+        ]
+      end
+      let(:expected_args) do
+        [
+          "foo",
+          {
+            "_aj_symbol_keys" => ["foo"],
+            "foo" => "Foo",
+            "bar" => "Bar",
+            "baz" => {
+              "_aj_symbol_keys" => [],
+              "1" => "foo"
+            }
+          }
+        ]
+      end
+      let(:expected_wrapped_args) do
+        if DependencyHelper.active_job_wraps_args?
+          [{
+            "_aj_ruby2_keywords" => ["args"],
+            "args" => expected_args
+          }]
+        else
+          expected_args
+        end
+      end
+      let(:expected_tags) do
+        { "executions" => 1 }.tap do |hash|
+          hash["active_job_id"] = kind_of(String)
+          if DependencyHelper.rails_version >= Gem::Version.new("5.0.0")
+            hash["provider_job_id"] = kind_of(String)
           end
         end
       end
-    end
-    before do
-      start_agent
-      Appsignal.internal_logger = test_logger(log)
-      ActiveJob::Base.queue_adapter = :sidekiq
-
-      stub_const("ActiveJobSidekiqTestJob", Class.new(ActiveJob::Base) do
-        self.queue_adapter = :sidekiq
-
-        def perform(*_args)
+      let(:expected_perform_events) do
+        if DependencyHelper.rails7_present?
+          ["perform_job.sidekiq", "perform.active_job", "perform_start.active_job"]
+        else
+          ["perform_job.sidekiq", "perform_start.active_job", "perform.active_job"]
         end
-      end)
-
-      stub_const("ActiveJobSidekiqErrorTestJob", Class.new(ActiveJob::Base) do
-        self.queue_adapter = :sidekiq
-
-        def perform(*_args)
-          raise "uh oh"
-        end
-      end)
-      # Manually add the AppSignal middleware for the Testing environment.
-      # It doesn't use configured middlewares by default looks like.
-      # We test somewhere else if the middleware is installed properly.
-      Sidekiq::Testing.server_middleware do |chain|
-        chain.add Appsignal::Integrations::SidekiqMiddleware
       end
-    end
+      around { |example| keep_transactions { example.run } }
+      before do
+        start_agent
+        Appsignal.internal_logger = test_logger(log)
+        ActiveJob::Base.queue_adapter = :sidekiq
 
-    it "reports the transaction from the ActiveJob integration" do
-      perform_sidekiq_job(ActiveJobSidekiqTestJob, given_args)
+        stub_const("ActiveJobSidekiqTestJob", Class.new(ActiveJob::Base) do
+          self.queue_adapter = :sidekiq
 
-      transaction = last_transaction
-      expect(transaction).to have_namespace(namespace)
-      expect(transaction).to have_action("ActiveJobSidekiqTestJob#perform")
-      expect(transaction).to_not have_error
-      expect(transaction).to include_metadata("queue" => "default")
-      expect(transaction).to_not include_environment
-      expect(transaction).to include_params([expected_args])
-      expect(transaction).to include_tags(expected_tags.merge("queue" => "default"))
-      expect(transaction).to have_queue_start(time.to_i * 1000)
+          def perform(*_args)
+          end
+        end)
 
-      events = transaction.to_h["events"]
-        .sort_by { |e| e["start"] }
-        .map { |event| event["name"] }
-      expect(events).to eq(expected_perform_events)
-    end
+        stub_const("ActiveJobSidekiqErrorTestJob", Class.new(ActiveJob::Base) do
+          self.queue_adapter = :sidekiq
 
-    context "with error" do
-      it "reports the error on the transaction from the ActiveRecord integration" do
-        expect do
-          perform_sidekiq_job(ActiveJobSidekiqErrorTestJob, given_args)
-        end.to raise_error(RuntimeError, "uh oh")
+          def perform(*_args)
+            raise "uh oh"
+          end
+        end)
+        # Manually add the AppSignal middleware for the Testing environment.
+        # It doesn't use configured middlewares by default looks like.
+        # We test somewhere else if the middleware is installed properly.
+        Sidekiq::Testing.server_middleware do |chain|
+          chain.add Appsignal::Integrations::SidekiqMiddleware
+        end
+      end
+
+      it "reports the transaction from the ActiveJob integration" do
+        perform_activejob_sidekiq_job(ActiveJobSidekiqTestJob, given_args)
 
         transaction = last_transaction
         expect(transaction).to have_namespace(namespace)
-        expect(transaction).to have_action("ActiveJobSidekiqErrorTestJob#perform")
-        expect(transaction).to have_error("RuntimeError", "uh oh")
+        expect(transaction).to have_action("ActiveJobSidekiqTestJob#perform")
+        expect(transaction).to_not have_error
         expect(transaction).to include_metadata("queue" => "default")
         expect(transaction).to_not include_environment
         expect(transaction).to include_params([expected_args])
@@ -594,49 +565,80 @@ if DependencyHelper.active_job_present?
           .map { |event| event["name"] }
         expect(events).to eq(expected_perform_events)
       end
-    end
 
-    context "with ActionMailer" do
-      include ActionMailerHelpers
+      context "with error" do
+        it "reports the error on the transaction from the ActiveRecord integration" do
+          expect do
+            perform_activejob_sidekiq_job(ActiveJobSidekiqErrorTestJob, given_args)
+          end.to raise_error(RuntimeError, "uh oh")
 
-      before do
-        class ActionMailerSidekiqTestJob < ActionMailer::Base
-          def welcome(*args)
+          transaction = last_transaction
+          expect(transaction).to have_namespace(namespace)
+          expect(transaction).to have_action("ActiveJobSidekiqErrorTestJob#perform")
+          expect(transaction).to have_error("RuntimeError", "uh oh")
+          expect(transaction).to include_metadata("queue" => "default")
+          expect(transaction).to_not include_environment
+          expect(transaction).to include_params([expected_args])
+          expect(transaction).to include_tags(expected_tags.merge("queue" => "default"))
+          expect(transaction).to have_queue_start(time.to_i * 1000)
+
+          events = transaction.to_h["events"]
+            .sort_by { |e| e["start"] }
+            .map { |event| event["name"] }
+          expect(events).to eq(expected_perform_events)
+        end
+      end
+
+      context "with ActionMailer" do
+        include ActionMailerHelpers
+
+        before do
+          class ActionMailerSidekiqTestJob < ActionMailer::Base
+            def welcome(*args)
+            end
+          end
+        end
+
+        it "reports ActionMailer data on the transaction" do
+          perform_mailer(ActionMailerSidekiqTestJob, :welcome, given_args)
+
+          transaction = last_transaction
+          expect(transaction).to have_action("ActionMailerSidekiqTestJob#welcome")
+          expect(transaction).to include_params(
+            ["ActionMailerSidekiqTestJob", "welcome",
+             "deliver_now"] + expected_wrapped_args
+          )
+        end
+      end
+
+      def perform_sidekiq
+        Timecop.freeze(time) do
+          yield
+          # Combined with Sidekiq::Testing.fake! and drain_all we get a
+          # enqueue_at in the job data.
+          Sidekiq::Worker.drain_all
+        rescue Exception => exception # rubocop:disable Lint/RescueException
+          raise exception
+        ensure
+          Appsignal::Integrations::SidekiqErrorHandler.new.call(exception, {}) if exception
+        end
+      end
+
+      def perform_activejob_sidekiq_job(job_class, args)
+        with_rails_error_reporter do
+          Sidekiq::Testing.fake! do
+            perform_sidekiq { job_class.perform_later(args) }
           end
         end
       end
 
-      it "reports ActionMailer data on the transaction" do
-        perform_mailer(ActionMailerSidekiqTestJob, :welcome, given_args)
-
-        transaction = last_transaction
-        expect(transaction).to have_action("ActionMailerSidekiqTestJob#welcome")
-        expect(transaction).to include_params(
-          ["ActionMailerSidekiqTestJob", "welcome",
-           "deliver_now"] + expected_wrapped_args
-        )
+      def perform_sidekiq_job(job_class, args)
+        perform_sidekiq { job_class.perform_later(args) }
       end
-    end
 
-    def perform_sidekiq
-      Timecop.freeze(time) do
-        yield
-        # Combined with Sidekiq::Testing.fake! and drain_all we get a
-        # enqueue_at in the job data.
-        Sidekiq::Worker.drain_all
-      rescue Exception => exception # rubocop:disable Lint/RescueException
-        raise exception
-      ensure
-        Appsignal::Integrations::SidekiqErrorHandler.new.call(exception, {}) if exception
+      def perform_mailer(mailer, method, args = nil)
+        perform_sidekiq { perform_action_mailer(mailer, method, args) }
       end
-    end
-
-    def perform_sidekiq_job(job_class, args)
-      perform_sidekiq { job_class.perform_later(args) }
-    end
-
-    def perform_mailer(mailer, method, args = nil)
-      perform_sidekiq { perform_action_mailer(mailer, method, args) }
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,10 @@ require "rspec"
 require "timecop"
 require "webmock/rspec"
 
+# Also mock the `Process.clock_gettime` method, which is not mocked by default by Timecop.
+# This is needed for Sidekiq 8 because it uses it for its time values.
+Timecop.mock_process_clock = true
+
 Dir[File.join(APPSIGNAL_SPEC_DIR, "support", "helpers", "*.rb")].sort.each do |f|
   require f
 end

--- a/spec/support/helpers/dependency_helper.rb
+++ b/spec/support/helpers/dependency_helper.rb
@@ -163,8 +163,12 @@ module DependencyHelper
     dependency_present? "dry-monitor"
   end
 
+  def sidekiq_present?
+    dependency_present?("sidekiq")
+  end
+
   def sidekiq8_present?
-    dependency_present?("sidekiq") &&
+    sidekiq_present? &&
       Gem::Version.new(::Sidekiq::VERSION) >= Gem::Version.new("8.0.0")
   end
 

--- a/spec/support/helpers/dependency_helper.rb
+++ b/spec/support/helpers/dependency_helper.rb
@@ -163,6 +163,11 @@ module DependencyHelper
     dependency_present? "dry-monitor"
   end
 
+  def sidekiq8_present?
+    dependency_present?("sidekiq") &&
+      Gem::Version.new(::Sidekiq::VERSION) >= Gem::Version.new("8.0.0")
+  end
+
   def dependency_present?(dependency_file)
     Gem.loaded_specs.key? dependency_file
   end


### PR DESCRIPTION
Closes #1372

## Add Sidekiq 8 to the CI

Make sure we test against both versions of Sidekiq by adding specific gemfiles for both versions.

Includes rails so that we can test the activejob and actionmailer integration for Sidekiq too.

## Fix Sidekiq 8 queue time reporting

Sidekiq 8 reports queue time as epoch milliseconds, so we don't need to do the conversion anymore. Check if Sidekiq is version 8 and if so, do not do any conversion.

https://github.com/sidekiq/sidekiq/blob/main/docs/8.0-Upgrade.md

## Only run Sidekiq specs when Sidekiq is in bundle

The CI fails on these specs because we now reference the Sidekiq constant and before we didn't. These specs should now only be run when Sidekiq is in the bundle.

## Fix Sidekiq ActiveJob specs

Enable Timecop's mock_process_clock behavior. This is disabled by default but needed for Sidekiq 8 because it changed how it fetches the values for `enqueued_at` and `created_at`.

## Remove Sidekiq ActiveJob case for job arguments

This case statement is never checked. The ActiveJob instrumentation is wrapped around the Sidekiq middleware. This sets the job arguments before Sidekiq can.

It's set with `add_params_if_nil` helper. Then when the Sidekiq middleware wants to set parameters, they're already set, and the check is skipped.

Remove it to avoid confusion about it. Sidekiq 8 renamed this class to `Sidekiq::ActiveJob::Wrapper`, but we don't need to check it.
