### PR TITLE
Log AppSignal stopping as info

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -216,9 +216,9 @@ module Appsignal
     def stop(called_by = nil)
       Thread.new do
         if called_by
-          internal_logger.debug("Stopping AppSignal (#{called_by})")
+          internal_logger.info("Stopping AppSignal (#{called_by})")
         else
-          internal_logger.debug("Stopping AppSignal")
+          internal_logger.info("Stopping AppSignal")
         end
         Appsignal::Extension.stop
         Appsignal::Probes.stop

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -880,7 +880,7 @@ describe Appsignal do
 
   describe ".stop" do
     it "calls stop on the extension" do
-      expect(Appsignal.internal_logger).to receive(:debug).with("Stopping AppSignal")
+      expect(Appsignal.internal_logger).to receive(:info).with("Stopping AppSignal")
       expect(Appsignal::Extension).to receive(:stop)
       Appsignal.stop
       expect(Appsignal.active?).to be_falsy
@@ -895,7 +895,7 @@ describe Appsignal do
 
     context "with context specified" do
       it "should log the context" do
-        expect(Appsignal.internal_logger).to receive(:debug).with("Stopping AppSignal (something)")
+        expect(Appsignal.internal_logger).to receive(:info).with("Stopping AppSignal (something)")
         expect(Appsignal::Extension).to receive(:stop)
         Appsignal.stop("something")
         expect(Appsignal.active?).to be_falsy


### PR DESCRIPTION
Inspired by the following [Slack conversation](https://appsignal.slack.com/archives/C7XHXQ7N0/p1741325230638539?thread_ts=1741086725.525029&cid=C7XHXQ7N0) and [Intercom conversation](https://app.intercom.com/a/inbox/yzor8gyw/inbox/shared/all/conversation/16410700410388#part_id=comment-16410700410388-21909589918).

---

AppSignal being told to stop is an uncommon event that has significant impact in the behaviour of the application past that point, and as such I think `info` level logging is warranted.

Specifically, this seeks to make it easier to debug a common-ish issue where customers interpret the `monitor_and_stop` method as meaning "stop monitoring this transaction" and not "stop monitoring AppSignal entirely".