### PR TITLE
Explicit method return values

### DIFF
--- a/.changesets/explicitly-return-nil-from-methods-with-no-usable-return-value.md
+++ b/.changesets/explicitly-return-nil-from-methods-with-no-usable-return-value.md
@@ -1,0 +1,14 @@
+---
+bump: patch
+type: change
+---
+
+Explicitly return `nil` from public methods with no usable return value. We want to avoid the situation where `Appsignal.start` happens to return `true` and it is thought to mean that the gem started successfully.
+
+Methods updated:
+
+- `Appsignal.start`
+- `Appsignal.stop`
+- `Appsignal.configure`
+- `Appsignal.forked`
+- `Appsignal.load`

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -145,6 +145,7 @@ module Appsignal
       else
         internal_logger.error("Not starting, no valid config for this environment")
       end
+      nil
     end
 
     # PRIVATE METHOD. DO NOT USE.
@@ -224,6 +225,7 @@ module Appsignal
         Appsignal::Probes.stop
         Appsignal::CheckIn.stop
       end.join
+      nil
     end
 
     # Configure the AppSignal Ruby gem using a DSL.
@@ -328,6 +330,7 @@ module Appsignal
 
       yield config_dsl
       config.merge_dsl_options(config_dsl.dsl_options)
+      nil
     end
 
     # @return [void]
@@ -337,6 +340,7 @@ module Appsignal
       Appsignal._start_logger
       internal_logger.debug("Forked process, resubscribing and restarting extension")
       Appsignal::Extension.start
+      nil
     end
 
     # Load an AppSignal integration.
@@ -369,6 +373,7 @@ module Appsignal
     # @since 3.12.0
     def load(integration_name)
       Loaders.load(integration_name)
+      nil
     end
 
     # @api private


### PR DESCRIPTION
In #1389 there's confusion about `Appsignal.start` returning `true` when it has not started.

It returns `true` because the last line in the method, `internal_logger.<level>` returns that value.

Avoid the confusion by returning a `nil` explicitly.