### PR TITLE
Add config_error method to fetch error on config

### DIFF
--- a/.changesets/add--appsignal-config_error--method.md
+++ b/.changesets/add--appsignal-config_error--method.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Add the `Appsignal.config_error` and `Appsignal.config_error?` methods. This method contains any error that may have occurred while loading the `config/appsignal.rb` file. If it is `nil` no error occurred or `Appsignal.start` hasn't been called yet. The `Appsignal.config_error?` method is an alias for syntax sugar.

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -62,6 +62,19 @@ module Appsignal
     #   @see start
     attr_writer :internal_logger
 
+    # Returns the error that was encountered while loading the `appsignal.rb`
+    # config file.
+    #
+    # It does not include any error that occurred while loading the
+    # `appsignal.yml` file.
+    #
+    # If the value is `nil`, no error was encountered or AppSignal wasn't
+    # started yet.
+    #
+    # @return [NilClass/Exception]
+    attr_reader :config_error
+    alias config_error? config_error
+
     # @api private
     def testing?
       false
@@ -508,7 +521,7 @@ module Appsignal
         @dsl_config_file_loaded = true
         require path
       rescue => error
-        @config_file_error = error
+        @config_error = error
         message = "Not starting AppSignal because an error occurred while " \
           "loading the AppSignal config file.\n" \
           "File: #{path.inspect}\n" \
@@ -527,7 +540,7 @@ module Appsignal
         end
 
         # Disable on config file error
-        config[:active] = false if defined?(@config_file_error)
+        config[:active] = false if defined?(@config_error)
 
         ENV.delete("_APPSIGNAL_CONFIG_FILE_CONTEXT")
         ENV.delete("_APPSIGNAL_CONFIG_FILE_ENV")

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -469,6 +469,8 @@ describe Appsignal do
         expect(Appsignal.config[:name]).to eq("DSL app")
         expect(Appsignal.config[:push_api_key]).to eq("config_file_push_api_key")
         expect(Appsignal.config[:ignore_actions]).to include("Test")
+        expect(Appsignal.config_error?).to be_falsey
+        expect(Appsignal.config_error).to be_nil
       ensure
         FileUtils.rm_rf(test_path)
       end
@@ -646,6 +648,8 @@ describe Appsignal do
         expect(Appsignal.config[:active]).to be(false) # Disables the config on error
         expect(Appsignal.config[:name]).to eq("DSL app")
         expect(Appsignal.config[:push_api_key]).to eq("config_file_push_api_key")
+        expect(Appsignal.config_error?).to be_truthy
+        expect(Appsignal.config_error).to be_kind_of(RuntimeError)
       ensure
         FileUtils.rm_rf(test_path)
       end

--- a/spec/support/testing.rb
+++ b/spec/support/testing.rb
@@ -25,7 +25,7 @@ module Appsignal
     # @api private
     def clear!
       remove_instance_variable(:@dsl_config_file_loaded) if defined?(@dsl_config_file_loaded)
-      remove_instance_variable(:@config_file_error) if defined?(@config_file_error)
+      remove_instance_variable(:@config_error) if defined?(@config_error)
       Appsignal.internal_logger = nil
 
       clear_started!


### PR DESCRIPTION
To help out with #1389, add a way to get the error that occurred on loading the config file available. This way people can check in the app if an error occurred and reraise it or exit the app if necessary.

We don't want to add the behavior of raising the config error on start by default, because the gem should never raise an error.

I decide not to put it behind a config option, because the only way to do that is with an environment variable. This also gives more flexibility for anyone who want to add any kind of custom behavior based on the presence of an error.