### PR TITLE
Add Logger `<<` method

### DIFF
--- a/.changesets/add-logger------method.md
+++ b/.changesets/add-logger------method.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Add the Logger `<<` method. This improves our compatibility with Ruby's Logger class implementation, making it usable in more scenarios.

--- a/lib/appsignal/logger.rb
+++ b/lib/appsignal/logger.rb
@@ -159,6 +159,17 @@ module Appsignal
       add_with_attributes(FATAL, message, @group, attributes)
     end
 
+    # Log an info level message
+    #
+    # Returns the number of characters written.
+    #
+    # @param message Message to log
+    # @return [Integer]
+    def <<(message)
+      add(Logger::INFO, message)
+      message.length
+    end
+
     # When using ActiveSupport::TaggedLogging without the broadcast feature,
     # the passed logger is required to respond to the `silence` method.
     #

--- a/spec/lib/appsignal/logger_spec.rb
+++ b/spec/lib/appsignal/logger_spec.rb
@@ -542,6 +542,23 @@ describe Appsignal::Logger do
     end
   end
 
+  describe "#<<" do
+    it "writes an info message and returns the number of characters written" do
+      expect(Appsignal::Extension).to receive(:log)
+        .with(
+          "group",
+          3,
+          0,
+          "hello there",
+          instance_of(Appsignal::Extension::Data)
+        )
+
+      message = "hello there"
+      result = logger << message
+      expect(result).to eq(message.length)
+    end
+  end
+
   if DependencyHelper.rails_present?
     describe "wrapped in ActiveSupport::TaggedLogging" do
       let(:logger) do


### PR DESCRIPTION
Adding this method improves our compatibility with Ruby's Logger class, allowing it to be used in scenarios we previously didn't support.

One such scenario is with Rack's CommonLogger which uses this method to write to the logger.

The method returns the character count, which is the same as the `<<` method on the Ruby class.

Normally no formatting is applied. I've chosen to ignore that for now, as we require a log severity, so that becomes 'info'. To apply no further formatting, one should not set a formatter on our logger.