### PR TITLE
Debug Rack event finish issue

### DIFF
--- a/.changesets/differentiate-between-process_request-rack-events.md
+++ b/.changesets/differentiate-between-process_request-rack-events.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Differentiate between `process_request.rack` events. Add the callback that triggered the event in the event title for debugging purposes.

--- a/lib/appsignal/rack/event_handler.rb
+++ b/lib/appsignal/rack/event_handler.rb
@@ -68,7 +68,7 @@ module Appsignal
 
             Appsignal::Rack::EventHandler
               .safe_execution("Appsignal::Rack::EventHandler's after_reply") do
-              transaction.finish_event("process_request.rack", "", "")
+              transaction.finish_event("process_request.rack", "callback: after_reply", "")
               queue_start = Appsignal::Rack::Utils.queue_start_from(request.env)
               transaction.set_queue_start(queue_start) if queue_start
             end
@@ -111,7 +111,7 @@ module Appsignal
         return unless transaction
 
         self.class.safe_execution("Appsignal::Rack::EventHandler#on_finish") do
-          transaction.finish_event("process_request.rack", "", "")
+          transaction.finish_event("process_request.rack", "callback: on_finish", "")
           transaction.add_params_if_nil { request.params }
           transaction.add_headers_if_nil { request.env }
           transaction.add_session_data_if_nil do

--- a/spec/lib/appsignal/rack/event_handler_spec.rb
+++ b/spec/lib/appsignal/rack/event_handler_spec.rb
@@ -78,6 +78,10 @@ describe Appsignal::Rack::EventHandler do
       expect(Appsignal::Transaction.current).to be_kind_of(Appsignal::Transaction::NilTransaction)
 
       expect(last_transaction.ext.queue_start).to eq(queue_start_time)
+      expect(last_transaction).to include_event(
+        "name" => "process_request.rack",
+        "title" => "callback: after_reply"
+      )
     end
 
     context "with error inside rack.after_reply handler" do
@@ -386,7 +390,10 @@ describe Appsignal::Rack::EventHandler do
       on_start
       on_finish
 
-      expect(last_transaction).to include_event("name" => "process_request.rack")
+      expect(last_transaction).to include_event(
+        "name" => "process_request.rack",
+        "title" => "callback: on_finish"
+      )
     end
 
     context "with response" do


### PR DESCRIPTION
Add a title to the rack `process_request.rack` event so it becomes easier to debug which event fails to close. That way I can continue debugging and see in which callback the problem originates.

Useful agent PR to go along with this:
https://github.com/appsignal/appsignal-agent/pull/1268