### PR TITLE
Add check_if_started! method (take 2)

### DIFF
--- a/.changesets/add-check_if_started--method.md
+++ b/.changesets/add-check_if_started--method.md
@@ -1,0 +1,16 @@
+---
+bump: patch
+type: add
+---
+
+Add the `check_if_started!` method. This method will raise an error if the AppSignal Ruby gem failed to start.
+
+Call this method in your CI or on app boot if you wish to verify that AppSignal has started when your application does, and want the application to fail to start if AppSignal hasn't started.
+
+For example, in this Rails initializer:
+
+```
+# config/initializers/appsignal.rb
+
+Appsignal.check_if_started!
+```

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -496,6 +496,31 @@ module Appsignal
       defined?(@dsl_config_file_loaded) ? true : false
     end
 
+    # Check if the AppSignal Ruby gem has started successfully.
+    #
+    # If it has not (yet) started or encountered an error in the
+    # `config/appsignal.rb` config file during start up that prevented it from
+    # starting, it will raise a {Appsignal::NotStartedError}.
+    #
+    # If there an error raised from the config file, it will include it as the
+    # error cause of the raised error.
+    #
+    # @raise [Appsignal::NotStartedError]
+    # @return [void]
+    def check_if_started!
+      return if started?
+
+      begin
+        raise config_error if config_error?
+      rescue
+        # Raise the NotStartedError and make the config error the error cause
+        raise NotStartedError, config_error
+      end
+
+      # Raise the NotStartedError as normal
+      raise NotStartedError
+    end
+
     private
 
     def params_match_loaded_config?(env_param, root_path_param)
@@ -582,6 +607,7 @@ module Appsignal
   end
 end
 
+require "appsignal/internal_errors"
 require "appsignal/loaders"
 require "appsignal/sample_data"
 require "appsignal/environment"

--- a/lib/appsignal/internal_errors.rb
+++ b/lib/appsignal/internal_errors.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Appsignal
+  # @api private
+  class InternalError < StandardError; end
+
+  # @api private
+  class NotStartedError < InternalError
+    MESSAGE = <<~MESSAGE
+      The AppSignal Ruby gem was not started!
+
+      This error was raised by calling `Appsignal.check_if_started!`
+    MESSAGE
+
+    def message
+      MESSAGE
+    end
+  end
+end


### PR DESCRIPTION
Reapply https://github.com/appsignal/appsignal-ruby/pull/1395 because GitHub didn't update the base branch after merging the parent PR.

---

This method will provide a convenience method to raise an error if AppSignal failed to start.

Some people prefer this behavior and this allows them to trigger that behavior.

As previously mentioned, I don't want to add this to an environment variable because the start up and config logic is complex enough. Last thing we need is another scenario to consider.
This method call makes it very explicit what happens, where and by whom.

[skip review]