### PR TITLE
Update at_exit hook to always call Appsignal.stop on containers

### DIFF
--- a/.changesets/add--enable_at_exit_hook--option-.md
+++ b/.changesets/add--enable_at_exit_hook--option-.md
@@ -5,4 +5,4 @@ type: add
 
 Add the `enable_at_exit_hook` option to configure if `Appsignal.stop` is called when the Ruby application exits. Calling `Appsignal.stop` will stop the application for a moment to flush all the data to our agent before shutting down.
 
-This behavior is enabled by default, but can be disabled by setting `enable_at_exit_hook` to `false` in your AppSignal configuration. We recommend leaving this on, especially if the `enable_at_exit_reporter` option is turned on, which reports errors that crash the application.
+This behavior is enabled by default on (Docker) containers, but can be disabled by setting `enable_at_exit_hook` to `false` in your AppSignal configuration. We recommend leaving this on, especially if the `enable_at_exit_reporter` option is turned on, which reports errors that crash the application.

--- a/.changesets/add--enable_at_exit_hook--option-.md
+++ b/.changesets/add--enable_at_exit_hook--option-.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+type: add
+---
+
+Add the `enable_at_exit_hook` option to configure if `Appsignal.stop` is called when the Ruby application exits. Calling `Appsignal.stop` will stop the application for a moment to flush all the data to our agent before shutting down.
+
+This behavior is enabled by default, but can be disabled by setting `enable_at_exit_hook` to `false` in your AppSignal configuration. We recommend leaving this on, especially if the `enable_at_exit_reporter` option is turned on, which reports errors that crash the application.

--- a/.changesets/add--enable_at_exit_hook--option-.md
+++ b/.changesets/add--enable_at_exit_hook--option-.md
@@ -5,4 +5,8 @@ type: add
 
 Add the `enable_at_exit_hook` option to configure if `Appsignal.stop` is called when the Ruby application exits. Calling `Appsignal.stop` will stop the application for a moment to flush all the data to our agent before shutting down.
 
-This behavior is enabled by default on (Docker) containers, but can be disabled by setting `enable_at_exit_hook` to `false` in your AppSignal configuration. We recommend leaving this on, especially if the `enable_at_exit_reporter` option is turned on, which reports errors that crash the application.
+This option has three possible values:
+
+- `always`: Always call `Appsignal.stop` when the program exits. On (Docker) containers it's automatically set to this value.
+- `never`: Never call `Appsignal.stop` when the program exits. The default value when the program doesn't run on a (Docker) container.
+- `on_error`: Call `Appsignal.stop` when the program exits with an error.

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -93,7 +93,6 @@ module Appsignal
       :ca_file_path => File.expand_path(File.join("../../../resources/cacert.pem"), __FILE__),
       :dns_servers => [],
       :enable_allocation_tracking => true,
-      :enable_at_exit_hook => true,
       :enable_at_exit_reporter => true,
       :enable_host_metrics => true,
       :enable_minutely_probes => true,
@@ -509,6 +508,8 @@ module Appsignal
         # environment variable is present and not empty.
         env_push_api_key = ENV["APPSIGNAL_PUSH_API_KEY"] || ""
         hash[:active] = true unless env_push_api_key.strip.empty?
+
+        hash[:enable_at_exit_hook] = true if Appsignal::Extension.running_in_container?
       end
     end
 

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -93,6 +93,7 @@ module Appsignal
       :ca_file_path => File.expand_path(File.join("../../../resources/cacert.pem"), __FILE__),
       :dns_servers => [],
       :enable_allocation_tracking => true,
+      :enable_at_exit_hook => "on_error",
       :enable_at_exit_reporter => true,
       :enable_host_metrics => true,
       :enable_minutely_probes => true,
@@ -153,6 +154,7 @@ module Appsignal
       :name => "APPSIGNAL_APP_NAME",
       :bind_address => "APPSIGNAL_BIND_ADDRESS",
       :ca_file_path => "APPSIGNAL_CA_FILE_PATH",
+      :enable_at_exit_hook => "APPSIGNAL_ENABLE_AT_EXIT_HOOK",
       :hostname => "APPSIGNAL_HOSTNAME",
       :host_role => "APPSIGNAL_HOST_ROLE",
       :http_proxy => "APPSIGNAL_HTTP_PROXY",
@@ -172,7 +174,6 @@ module Appsignal
     BOOLEAN_OPTIONS = {
       :active => "APPSIGNAL_ACTIVE",
       :enable_allocation_tracking => "APPSIGNAL_ENABLE_ALLOCATION_TRACKING",
-      :enable_at_exit_hook => "APPSIGNAL_ENABLE_AT_EXIT_HOOK",
       :enable_at_exit_reporter => "APPSIGNAL_ENABLE_AT_EXIT_REPORTER",
       :enable_host_metrics => "APPSIGNAL_ENABLE_HOST_METRICS",
       :enable_minutely_probes => "APPSIGNAL_ENABLE_MINUTELY_PROBES",
@@ -509,7 +510,7 @@ module Appsignal
         env_push_api_key = ENV["APPSIGNAL_PUSH_API_KEY"] || ""
         hash[:active] = true unless env_push_api_key.strip.empty?
 
-        hash[:enable_at_exit_hook] = true if Appsignal::Extension.running_in_container?
+        hash[:enable_at_exit_hook] = "always" if Appsignal::Extension.running_in_container?
       end
     end
 

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -93,6 +93,7 @@ module Appsignal
       :ca_file_path => File.expand_path(File.join("../../../resources/cacert.pem"), __FILE__),
       :dns_servers => [],
       :enable_allocation_tracking => true,
+      :enable_at_exit_hook => true,
       :enable_at_exit_reporter => true,
       :enable_host_metrics => true,
       :enable_minutely_probes => true,
@@ -172,6 +173,7 @@ module Appsignal
     BOOLEAN_OPTIONS = {
       :active => "APPSIGNAL_ACTIVE",
       :enable_allocation_tracking => "APPSIGNAL_ENABLE_ALLOCATION_TRACKING",
+      :enable_at_exit_hook => "APPSIGNAL_ENABLE_AT_EXIT_HOOK",
       :enable_at_exit_reporter => "APPSIGNAL_ENABLE_AT_EXIT_REPORTER",
       :enable_host_metrics => "APPSIGNAL_ENABLE_HOST_METRICS",
       :enable_minutely_probes => "APPSIGNAL_ENABLE_MINUTELY_PROBES",

--- a/lib/appsignal/hooks/at_exit.rb
+++ b/lib/appsignal/hooks/at_exit.rb
@@ -11,18 +11,25 @@ module Appsignal
       end
 
       def install
-        return unless Appsignal.config[:enable_at_exit_reporter]
-
         Kernel.at_exit(&AtExitCallback.method(:call))
       end
 
-      # Report any unhandled errors and will crash the Ruby process.
+      # Stop AppSignal before the app exists.
+      #
+      # This is the default behavior and can be customized with the
+      # `enable_at_exit_hook` option.
+      #
+      # When the `enable_at_exit_reporter` option is set to `true` (the
+      # default), it will report any unhandled errors that will crash the Ruby
+      # process.
       #
       # If this error was previously reported by any of our instrumentation,
       # the error will not also be reported here. This way we don't report an
       # error from a Rake task or instrumented script twice.
       class AtExitCallback
         def self.call
+          return unless Appsignal.config&.[](:enable_at_exit_reporter)
+
           error = $! # rubocop:disable Style/SpecialGlobalVars
           return unless error
           return if ignored_error?(error)
@@ -31,7 +38,8 @@ module Appsignal
           Appsignal.report_error(error) do |transaction|
             transaction.set_namespace("unhandled")
           end
-          Appsignal.stop("at_exit")
+        ensure
+          Appsignal.stop("at_exit") if Appsignal.config&.[](:enable_at_exit_hook)
         end
 
         IGNORED_ERRORS = [

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -786,20 +786,27 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
 
         it "outputs config defaults" do
           expect(output).to include("Configuration")
-          expect_config_to_be_printed(Appsignal::Config::DEFAULT_CONFIG)
+          options = Appsignal::Config::DEFAULT_CONFIG
+          if Appsignal::Extension.running_in_container?
+            options = options.merge(:enable_at_exit_hook => "always")
+          end
+          expect_config_to_be_printed(options)
         end
 
         it "transmits validation in report" do
           default_config = hash_with_string_keys(Appsignal::Config::DEFAULT_CONFIG)
-          # Tested elsewhere so remove it here
-          received_report["config"]["options"].delete("enable_at_exit_hook")
-          received_report["config"]["sources"]["system"].delete("enable_at_exit_hook")
+          options = default_config.merge("env" => "", "send_session_data" => true)
 
+          system_options = {}
+          if Appsignal::Extension.running_in_container?
+            options["enable_at_exit_hook"] = "always"
+            system_options["enable_at_exit_hook"] = "always"
+          end
           expect(received_report["config"]).to eq(
-            "options" => default_config.merge("env" => "", "send_session_data" => true),
+            "options" => options,
             "sources" => {
               "default" => default_config,
-              "system" => {},
+              "system" => system_options,
               "loaders" => {},
               "initial" => { "env" => "" },
               "file" => {},
@@ -1096,13 +1103,16 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
           final_config = Appsignal.config.config_hash
             .merge(:env => "production")
 
-          # Tested elsewhere so remove it here
-          received_report["config"]["sources"]["system"].delete("enable_at_exit_hook")
+          system_options = {}
+          if Appsignal::Extension.running_in_container?
+            final_config["enable_at_exit_hook"] = "always"
+            system_options["enable_at_exit_hook"] = "always"
+          end
           expect(received_report["config"]).to match(
             "options" => hash_with_string_keys(final_config),
             "sources" => {
               "default" => hash_with_string_keys(Appsignal::Config::DEFAULT_CONFIG),
-              "system" => {},
+              "system" => system_options,
               "loaders" => {},
               "initial" => hash_with_string_keys(Appsignal.config.initial_config),
               "file" => hash_with_string_keys(Appsignal.config.file_config),
@@ -1126,19 +1136,27 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
 
         it "outputs config defaults" do
           expect(output).to include("Configuration")
-          expect_config_to_be_printed(Appsignal::Config::DEFAULT_CONFIG)
+          options = Appsignal::Config::DEFAULT_CONFIG
+          if Appsignal::Extension.running_in_container?
+            options = options.merge(:enable_at_exit_hook => "always")
+          end
+          expect_config_to_be_printed(options)
         end
 
         it "transmits config in report" do
-          # Tested elsewhere so remove it here
-          received_report["config"]["sources"]["system"].delete("enable_at_exit_hook")
+          options = Appsignal.config.config_hash.merge("env" => "foobar")
+          if Appsignal::Extension.running_in_container?
+            options = options.merge("enable_at_exit_hook" => "always")
+          end
+          system_options = {}
+          if Appsignal::Extension.running_in_container?
+            system_options["enable_at_exit_hook"] = "always"
+          end
           expect(received_report["config"]).to match(
-            "options" => hash_with_string_keys(
-              Appsignal.config.config_hash.merge("env" => "foobar")
-            ),
+            "options" => hash_with_string_keys(options),
             "sources" => {
               "default" => hash_with_string_keys(Appsignal::Config::DEFAULT_CONFIG),
-              "system" => {},
+              "system" => system_options,
               "loaders" => {},
               "initial" => hash_with_string_keys(Appsignal.config.initial_config),
               "file" => hash_with_string_keys(Appsignal.config.file_config),

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -791,6 +791,10 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
 
         it "transmits validation in report" do
           default_config = hash_with_string_keys(Appsignal::Config::DEFAULT_CONFIG)
+          # Tested elsewhere so remove it here
+          received_report["config"]["options"].delete("enable_at_exit_hook")
+          received_report["config"]["sources"]["system"].delete("enable_at_exit_hook")
+
           expect(received_report["config"]).to eq(
             "options" => default_config.merge("env" => "", "send_session_data" => true),
             "sources" => {
@@ -1091,6 +1095,9 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
           run
           final_config = Appsignal.config.config_hash
             .merge(:env => "production")
+
+          # Tested elsewhere so remove it here
+          received_report["config"]["sources"]["system"].delete("enable_at_exit_hook")
           expect(received_report["config"]).to match(
             "options" => hash_with_string_keys(final_config),
             "sources" => {
@@ -1123,6 +1130,8 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
         end
 
         it "transmits config in report" do
+          # Tested elsewhere so remove it here
+          received_report["config"]["sources"]["system"].delete("enable_at_exit_hook")
           expect(received_report["config"]).to match(
             "options" => hash_with_string_keys(
               Appsignal.config.config_hash.merge("env" => "foobar")

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -317,6 +317,36 @@ describe Appsignal::Config do
         end
       end
     end
+
+    describe ":enable_at_exit_hook" do
+      context "when running on a container" do
+        before do
+          allow(Appsignal::Extension).to receive(:running_in_container?).and_return(true)
+        end
+
+        it "is enabled" do
+          expect(config[:enable_at_exit_hook]).to be(true)
+        end
+
+        it "sets the option as loaded through the system" do
+          expect(config.system_config).to include(:enable_at_exit_hook => true)
+        end
+      end
+
+      context "when not running on Heroku" do
+        before do
+          allow(Appsignal::Extension).to receive(:running_in_container?).and_return(false)
+        end
+
+        it "is not enabled" do
+          expect(config[:enable_at_exit_hook]).to be_nil
+        end
+
+        it "does not set option as loaded through the system" do
+          expect(config.system_config).to_not have_key(:enable_at_exit_hook)
+        end
+      end
+    end
   end
 
   describe "loader default config" do
@@ -544,6 +574,7 @@ describe Appsignal::Config do
         :cpu_count => 1.5,
         :dns_servers => ["8.8.8.8", "8.8.4.4"],
         :enable_allocation_tracking => false,
+        :enable_at_exit_hook => false,
         :enable_at_exit_reporter => false,
         :enable_gvl_global_timer => false,
         :enable_gvl_waiting_threads => false,
@@ -612,6 +643,7 @@ describe Appsignal::Config do
         # Booleans
         "APPSIGNAL_ACTIVE" => "true",
         "APPSIGNAL_ENABLE_ALLOCATION_TRACKING" => "false",
+        "APPSIGNAL_ENABLE_AT_EXIT_HOOK" => "false",
         "APPSIGNAL_ENABLE_AT_EXIT_REPORTER" => "false",
         "APPSIGNAL_ENABLE_GVL_GLOBAL_TIMER" => "false",
         "APPSIGNAL_ENABLE_GVL_WAITING_THREADS" => "false",

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -762,6 +762,11 @@ describe Appsignal::Config do
         :options => dsl_config
       )
     end
+    before do
+      # Mock this to false in case it is tested in a container.
+      # We're asserting like it's not.
+      allow(Appsignal::Extension).to receive(:running_in_container?).and_return(false)
+    end
 
     it "merges with the default config" do
       expect(config.config_hash).to eq(

--- a/spec/lib/appsignal/hooks/at_exit_spec.rb
+++ b/spec/lib/appsignal/hooks/at_exit_spec.rb
@@ -28,7 +28,7 @@ end
 
 describe Appsignal::Hooks::AtExit::AtExitCallback do
   around { |example| keep_transactions { example.run } }
-  before { start_agent(:options => { :enable_at_exit_reporter => true }) }
+  before { start_agent(:options => options) }
 
   def with_error(error_class, error_message)
     raise error_class, error_message
@@ -40,66 +40,114 @@ describe Appsignal::Hooks::AtExit::AtExitCallback do
     Appsignal::Hooks::AtExit::AtExitCallback.call
   end
 
-  it "reports no transaction if the process didn't exit with an error" do
-    logs =
-      capture_logs do
+  context "when enable_at_exit_reporter is true" do
+    let(:options) do
+      {
+        :enable_at_exit_reporter => true,
+        :enable_at_exit_hook => false # Turned off to speed up the tests
+      }
+    end
+
+    it "reports no transaction if the process didn't exit with an error" do
+      logs =
+        capture_logs do
+          expect do
+            call_callback
+          end.to_not(change { created_transactions.count })
+        end
+
+      expect(logs).to_not contains_log(:error, "Appsignal.report_error: Cannot add error.")
+    end
+
+    it "reports an error if there's an unhandled error" do
+      expect do
+        with_error(ExampleException, "error message") do
+          call_callback
+        end
+      end.to change { created_transactions.count }.by(1)
+
+      transaction = last_transaction
+      expect(transaction).to have_namespace("unhandled")
+      expect(transaction).to have_error("ExampleException", "error message")
+    end
+
+    it "doesn't report the error if it is also the last error reported" do
+      with_error(ExampleException, "error message") do |error|
+        Appsignal.report_error(error)
+        expect(created_transactions.count).to eq(1)
+
         expect do
           call_callback
-        end.to_not(change { created_transactions.count })
+        end.to_not change { created_transactions.count }.from(1)
       end
+    end
 
-    expect(logs).to_not contains_log(:error, "Appsignal.report_error: Cannot add error.")
+    it "doesn't report the error if it is a SystemExit exception" do
+      with_error(SystemExit, "error message") do |error|
+        Appsignal.report_error(error)
+        expect(created_transactions.count).to eq(1)
+
+        expect do
+          call_callback
+        end.to_not change { created_transactions.count }.from(1)
+      end
+    end
+
+    it "doesn't report the error if it is a SignalException exception" do
+      with_error(SignalException, "TERM") do |error|
+        Appsignal.report_error(error)
+        expect(created_transactions.count).to eq(1)
+
+        expect do
+          call_callback
+        end.to_not change { created_transactions.count }.from(1)
+      end
+    end
   end
 
-  it "reports an error if there's an unhandled error" do
-    expect do
-      with_error(ExampleException, "error message") do
-        call_callback
-      end
-    end.to change { created_transactions.count }.by(1)
+  context "when enable_at_exit_reporter is false" do
+    let(:options) { { :enable_at_exit_reporter => false } }
 
-    transaction = last_transaction
-    expect(transaction).to have_namespace("unhandled")
-    expect(transaction).to have_error("ExampleException", "error message")
+    it "reports no error if the process didn't exit with an error" do
+      logs =
+        capture_logs do
+          expect do
+            call_callback
+          end.to_not(change { created_transactions.count })
+        end
+
+      expect(logs).to_not contains_log(:error, "Appsignal.report_error: Cannot add error.")
+    end
+
+    it "reports no error if there's an unhandled error" do
+      logs =
+        capture_logs do
+          expect do
+            with_error(ExampleException, "error message") do
+              call_callback
+            end
+          end.to_not(change { created_transactions.count })
+        end
+
+      expect(logs).to_not contains_log(:error, "Appsignal.report_error: Cannot add error.")
+    end
   end
 
-  it "calls Appsignal.stop" do
-    expect(Appsignal).to receive(:stop).with("at_exit")
-    with_error(ExampleException, "error message") do
+  context "when enable_at_exit_hook is true" do
+    let(:options) { { :enable_at_exit_hook => true } }
+
+    it "calls Appsignal.stop" do
+      expect(Appsignal).to receive(:stop).with("at_exit")
       call_callback
     end
   end
 
-  it "doesn't report the error if it is also the last error reported" do
-    with_error(ExampleException, "error message") do |error|
-      Appsignal.report_error(error)
-      expect(created_transactions.count).to eq(1)
+  context "when enable_at_exit_hook is false" do
+    let(:options) { { :enable_at_exit_hook => false } }
 
-      expect do
-        call_callback
-      end.to_not change { created_transactions.count }.from(1)
-    end
-  end
-
-  it "doesn't report the error if it is a SystemExit exception" do
-    with_error(SystemExit, "error message") do |error|
-      Appsignal.report_error(error)
-      expect(created_transactions.count).to eq(1)
-
-      expect do
-        call_callback
-      end.to_not change { created_transactions.count }.from(1)
-    end
-  end
-
-  it "doesn't report the error if it is a SignalException exception" do
-    with_error(SignalException, "TERM") do |error|
-      Appsignal.report_error(error)
-      expect(created_transactions.count).to eq(1)
-
-      expect do
-        call_callback
-      end.to_not change { created_transactions.count }.from(1)
+    it "does not call Appsignal.stop" do
+      expect(Appsignal).to_not receive(:stop).with("at_exit")
+      call_callback
     end
   end
 end

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -227,8 +227,12 @@ describe Appsignal do
       end
 
       it "loads the default config" do
+        options = Appsignal::Config::DEFAULT_CONFIG
+        if Appsignal::Extension.running_in_container?
+          options = options.merge(:enable_at_exit_hook => "always")
+        end
         Appsignal.configure do |config|
-          Appsignal::Config::DEFAULT_CONFIG.each do |option, value|
+          options.each do |option, value|
             expect(config.send(option)).to eq(value)
           end
         end


### PR DESCRIPTION
## Update at_exit hook to always call Appsignal.stop

The `Appsignal.stop` method was only called from our `at_exit` hook when an error occurred, but it could be a good default. It does slow down the app shut down by half a second on my machine.

This behavior can be turned off with `enable_at_exit_hook = false`.

When `enable_at_exit_hook` == `false`:
```
bundle exec rake test_me  0.24s user 0.08s system 42% cpu 0.735 total
```

When `enable_at_exit_hook` == `true`:
```
bundle exec rake test_me  0.23s user 0.07s system 95% cpu 0.318 total
```

Part of #1387

## Only enable at_exit hook on containers

The reason we call `Appsignal.stop` is to flush data to our extension before the app exits and hopefully before the container does. It gives our extension and agent a bit more time to send the data before they are shut down along with the container.

For VMs (non-container hosts or bare metal), this additional `Appsignal.stop` call adds a half second delay to the shut down process (see previous commit message), so it's not great to have it always add that delay, even when there's no data to flush.

Part of #1387
