### PR TITLE
Deprecate monitor_and_stop helper

### DIFF
--- a/.changesets/deprecate-monitor_and_stop-helper.md
+++ b/.changesets/deprecate-monitor_and_stop-helper.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+type: deprecate
+---
+
+Deprecate the `Appsignal.monitor_and_stop` helper.
+
+We instead recommend using the `Appsignal.monitor` helper and configuring the `enable_at_exit_hook` config option to `always`.

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -154,6 +154,11 @@ module Appsignal
       #
       # @see monitor
       def monitor_and_stop(action:, namespace: nil, &block)
+        Appsignal::Utils::StdoutAndLoggerMessage.warning \
+          "The `Appsignal.monitor_and_stop` helper is deprecated. " \
+            "Use the `Appsignal.monitor` along with our `enable_at_exit_hook` " \
+            "option instead."
+
         monitor(:namespace => namespace, :action => action, &block)
       ensure
         Appsignal.stop("monitor_and_stop")


### PR DESCRIPTION
Deprecate this helper. It causes confusion in use, so let's recommend using the new `enable_at_exit_hook` config option instead.

Closes #1387