### PR TITLE
Close known transactions in EventHandler

### DIFF
--- a/.changesets/ensure-request-transactions-are-always-closed.md
+++ b/.changesets/ensure-request-transactions-are-always-closed.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Ensure request transactions are always closed in the `Rack::EventHandler`. A problem with Fibers changing during a request would cause transactions transactions to be left open and the data from requests to not be sent to our servers.

--- a/lib/appsignal/rack/event_handler.rb
+++ b/lib/appsignal/rack/event_handler.rb
@@ -82,7 +82,8 @@ module Appsignal
             # just a fallback if that doesn't get called.
             #
             # One such scenario is when a Puma "lowlevel_error" occurs.
-            Appsignal::Transaction.complete_current!
+            transaction.complete
+            Appsignal::Transaction.clear_current_transaction!
           end
         end
       end
@@ -138,7 +139,8 @@ module Appsignal
 
         # Make sure the current transaction is always closed when the request
         # is finished
-        Appsignal::Transaction.complete_current!
+        transaction.complete
+        Appsignal::Transaction.clear_current_transaction!
       end
 
       private


### PR DESCRIPTION
There's an issue in a Hanami app where transactions for web request aren't completed, kept open and never flushed to our servers.

This is because it's using a gem dependency that uses the Dry::Effect gem, which has changed the Ruby Fiber by the time it gets to the `on_finish` callback.

With `Thread.current[:appsignal_transaction]`, which we use to fetch the 'current transaction', we fetch a Fiber-local variable, not a Thread-local variable, set with `Thread.current.thread_variable_set`. This Fiber-local variable does not move across Fibers if it changes.

https://docs.ruby-lang.org/en/3.4/Thread.html#class-Thread-label-Thread+variables+and+scope

We can't simply move to use `Thread.current.thread_variable_set`, because that will not work with web servers like Falcon, which handles requests in Fibers.

This is a quick fix to complete transactions using the `transaction` variable we know in the EventHandler and then _try_ to clear the current transaction. This is not perfect, but at least we complete the transaction we know exists, when fetched from the request environment. The `clear_current_transaction!` call will fail, but I haven't seen it prevent new transactions to be created.

This change doesn't break it for the Falcon server as far as I can tell.

Internal Slack thread:
https://appsignal.slack.com/archives/C7XHXQ7N0/p1740725725929659