### PR TITLE
Remove redundant cron check-in pairs

### DIFF
--- a/lib/appsignal/check_in/event.rb
+++ b/lib/appsignal/check_in/event.rb
@@ -66,6 +66,61 @@ module Appsignal
             end
           end
         end
+
+        def deduplicate_cron!(events) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity
+          # Remove redundant cron check-in events from the given list of events.
+          # This is done by removing redundant *pairs* of events -- that is,
+          # for each identifier, only send one complete pair of start and
+          # finish events. Remove all other complete pairs of start and finish
+          # events for that identifier, but keep any other start or finish events
+          # that don't have a matching pair.
+          #
+          # Note that this method assumes that the events in this list have already
+          # been rejected based on `Event.redundant?`, so we don't check to remove
+          # check-in events that are functionally identical.
+          start_digests = Hash.new { |h, k| h[k] = Set.new }
+          finish_digests = Hash.new { |h, k| h[k] = Set.new }
+          complete_digests = Hash.new { |h, k| h[k] = Set.new }
+          keep_digest = {}
+
+          # Compute a list of complete digests for each identifier, that is, digests
+          # for which both a start and finish cron check-in event exist. Store the
+          # last seen digest for each identifier as the one to keep.
+          events.each do |event|
+            if event[:check_in_type] == "cron"
+              if event[:kind] == "start"
+                start_digests[event[:identifier]] << event[:digest]
+                if finish_digests[event[:identifier]].include?(event[:digest])
+                  complete_digests[event[:identifier]] << event[:digest]
+                  keep_digest[event[:identifier]] = event[:digest]
+                end
+              elsif event[:kind] == "finish"
+                finish_digests[event[:identifier]] << event[:digest]
+                if start_digests[event[:identifier]].include?(event[:digest])
+                  complete_digests[event[:identifier]] << event[:digest]
+                  keep_digest[event[:identifier]] = event[:digest]
+                end
+              end
+            end
+          end
+
+          start_digests = nil
+          finish_digests = nil
+
+          events.reject! do |event|
+            # Do not remove events that are not cron check-in events or that
+            # have an unknown kind.
+            return false unless
+              event[:check_in_type] == "cron" && (
+                event[:kind] == "start" ||
+                event[:kind] == "finish")
+
+            # Remove any event that is part of a complete digest pair, except
+            # for the one digest that should be kept.
+            keep_digest[event[:identifier]] != event[:digest] &&
+              complete_digests[event[:identifier]].include?(event[:digest])
+          end
+        end
       end
     end
   end

--- a/lib/appsignal/check_in/scheduler.rb
+++ b/lib/appsignal/check_in/scheduler.rb
@@ -161,7 +161,9 @@ module Appsignal
         # Push a copy of the events to the queue, and clear the events array.
         # This ensures that `@events` always contains events that have not
         # yet been pushed to the queue.
-        @queue.push(@events.dup)
+        events = @events.dup
+        Event.deduplicate_cron!(events)
+        @queue.push(events)
         @events.clear
 
         start_waker(BETWEEN_TRANSMISSIONS_DEBOUNCE_SECONDS)

--- a/spec/lib/appsignal/check_in/event_spec.rb
+++ b/spec/lib/appsignal/check_in/event_spec.rb
@@ -166,4 +166,99 @@ describe Appsignal::CheckIn::Event do
       ).to be(false)
     end
   end
+
+  describe "#deduplicate_cron!" do
+    it "removes redundant pairs of cron events" do
+      first_start = described_class.cron(
+        :identifier => "checkin-name",
+        :digest => "first",
+        :kind => "start"
+      )
+      first_finish = described_class.cron(
+        :identifier => "checkin-name",
+        :digest => "first",
+        :kind => "finish"
+      )
+      second_start = described_class.cron(
+        :identifier => "checkin-name",
+        :digest => "second",
+        :kind => "start"
+      )
+      second_finish = described_class.cron(
+        :identifier => "checkin-name",
+        :digest => "second",
+        :kind => "finish"
+      )
+
+      [first_start, first_finish, second_start, second_finish].permutation(4) do |events|
+        described_class.deduplicate_cron!(events)
+
+        expect(events.count).to eq(2)
+        expect(events[0][:digest]).to eq(events[1][:digest])
+        expect(Set.new(events.map { |event| event[:kind] })).to eq(Set.new(["start", "finish"]))
+      end
+    end
+
+    it "does not remove pairs with different identifiers" do
+      first_start = described_class.cron(
+        :identifier => "checkin-name",
+        :digest => "first",
+        :kind => "start"
+      )
+      first_finish = described_class.cron(
+        :identifier => "checkin-name",
+        :digest => "first",
+        :kind => "finish"
+      )
+      second_start = described_class.cron(
+        :identifier => "other-checkin-name",
+        :digest => "second",
+        :kind => "start"
+      )
+      second_finish = described_class.cron(
+        :identifier => "other-checkin-name",
+        :digest => "second",
+        :kind => "finish"
+      )
+
+      [first_start, first_finish, second_start, second_finish].permutation(4) do |events|
+        described_class.deduplicate_cron!(events)
+
+        expect(Set.new(events)).to eq(
+          Set.new([first_start, first_finish, second_start, second_finish])
+        )
+      end
+    end
+
+    it "does not remove unmatched pairs" do
+      first_start = described_class.cron(
+        :identifier => "checkin-name",
+        :digest => "first",
+        :kind => "start"
+      )
+      second_start = described_class.cron(
+        :identifier => "checkin-name",
+        :digest => "second",
+        :kind => "start"
+      )
+      second_finish = described_class.cron(
+        :identifier => "checkin-name",
+        :digest => "second",
+        :kind => "finish"
+      )
+      third_finish = described_class.cron(
+        :identifier => "checkin-name",
+        :digest => "third",
+        :kind => "finish"
+      )
+
+      [first_start, second_start, second_finish, third_finish].permutation(4) do |events|
+        described_class.deduplicate_cron!(events)
+
+        expect(Set.new(events)).to eq(
+          Set.new([first_start, second_start, second_finish, third_finish])
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
See [Slack conversation](https://appsignal.slack.com/archives/C7XHXQ7N0/p1744823975975979?thread_ts=1744809152.531019&cid=C7XHXQ7N0) for context.

Before submitting a batch of check-in events, check for any pairs of events that are redundant with other pairs of check-in events. This would happen, for example, when running a `cron` block for a given identifier many times in quick succession.

A redundant pair of cron check-in events is a pair of start and finish cron check-in events for a given identifier, given that another pair of start and finish check-in events exists for that identifier.

Unfortunately the same kind of check is not possible for calls to `.cron` that do not use a block, which only send a finish check-in event. This is because, when analyzing the list of check-in events, it is not possible to know whether the finish event is meant to close a check-in occurrence by itself (in which case it would be redundant with other un-paired finish check-in events in the same timeframe) or whether it is meant to close a start cron check-in event that was sent in a previous batch.