### PR TITLE
Fix C extension function definition warnings

### DIFF
--- a/.changesets/fix-c-extension-function-definitions.md
+++ b/.changesets/fix-c-extension-function-definitions.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix the C extension function definitions. On install, the Ruby gem extension would print warnings or fail to compile.

--- a/ext/appsignal_extension.c
+++ b/ext/appsignal_extension.c
@@ -838,7 +838,7 @@ static void track_allocation(rb_event_flag_t flag, VALUE arg1, VALUE arg2, ID ar
   appsignal_track_allocation();
 }
 
-static VALUE install_allocation_event_hook() {
+static VALUE install_allocation_event_hook(VALUE self) {
   // This event hook is only available on Ruby 2.1 and 2.2
   #if defined(RUBY_INTERNAL_EVENT_NEWOBJ)
   rb_add_event_hook(
@@ -851,7 +851,7 @@ static VALUE install_allocation_event_hook() {
   return Qnil;
 }
 
-static VALUE running_in_container() {
+static VALUE running_in_container(VALUE self) {
   return appsignal_running_in_container() == 1 ? Qtrue : Qfalse;
 }
 


### PR DESCRIPTION
We got warnings in the C extension installation `rake extension:install` in the CI and on Linux.

I see this on CI or in a Docker container.

```
compiling appsignal_extension.c
appsignal_extension.c: In function ‘install_allocation_event_hook’:
appsignal_extension.c:841:14: warning: old-style function definition [-Wold-style-definition]
  841 | static VALUE install_allocation_event_hook() {
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
appsignal_extension.c: In function ‘running_in_container’:
appsignal_extension.c:854:14: warning: old-style function definition [-Wold-style-definition]
  854 | static VALUE running_in_container() {
      |              ^~~~~~~~~~~~~~~~~~~~
At top level:
cc1: note: unrecognized command-line option ‘-Wno-self-assign’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-parentheses-equality’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-constant-logical-operand’ may have been intended to silence earlier diagnostics
```

Update the function definitions to include `VALUE self` as the first argument, even if they don't use it.
This seems like what the `old-style-definition` warning is warning about.

This change is based on the Ruby 3.4 C extension docs and updating these function definition to match how we define other functions with `rb_define_singleton_method`.
https://docs.ruby-lang.org/en/3.4/extension_rdoc.html

In #1410, it's reported a similar error fails the extension installation.
I was not able to reproduce that scenario, but this at least fixes the warnings, which I hope also fixes the same issue in that issue.

Closes #1410