### PR TITLE
Report the Active Job queue time

### DIFF
--- a/.changesets/report-active-job-queue-time-as--active_job_queue_time--metric-.md
+++ b/.changesets/report-active-job-queue-time-as--active_job_queue_time--metric-.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Report the Active Job queue time as the `active_job_queue_time` metric. This metric can be used to track the queue time per Active Job queue.


### PR DESCRIPTION
When we instrument a job, record the queue time: the time from when it was inserted into the queue until when it was picked up for execution.

This is the only way I found to report this metric, because Active Job doesn't have a stats module like Sidekiq does.

The value itself needs to be reported as milliseconds, which is why it performs a `* 1_000` calculation, because our metrics require durations (time) to be sent in milliseconds.

I've updated the test implementation `enqueued_at` format to match the actual format used by Active Job 8.

[Internal Slack thread](https://appsignal.slack.com/archives/C7XHXQ7N0/p1746715203918389)