### PR TITLE
Clear completed transactions if still in Thread

### DIFF
--- a/.changesets/fix-fiber-transaction-reuse.md
+++ b/.changesets/fix-fiber-transaction-reuse.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Resolve problems with transactions not being properly closed when using libraries that change Fibers during the transactions. Previously, completed transactions would be attempted to be reused when creating a transaction, when the Fiber would be switched during a transaction.


### PR DESCRIPTION
When a request changes the Ruby Fiber during a request, like when used with Dry::Effect as reported in #1403, make sure the Ruby doesn't try to reuse the completed transaction. This would make it report no data from subsequent requests.

The completed transaction could stay in the
`Thread.current[:appsignal_transaction]` value store when this happens. Check if the transaction is actually closed when we find an existing transaction in memory.