### PR TITLE
Fix JSON parse errors in test suite

### DIFF
--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -491,12 +491,12 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
             "  Error while parsing agent diagnostics report:",
             "    Output: invalid agent\njson"
           expect(output)
-            .to match(/Error:( \d+:)? unexpected (token at|character:) 'invalid agent\njson'/)
+            .to match(/Error:( \d+:)? unexpected (token at|character:) 'invalid/)
         end
 
         it "adds the output to the report" do
           expect(received_report["agent"]["error"])
-            .to match(/unexpected (token at|character:) 'invalid agent\njson'/)
+            .to match(/unexpected (token at|character:) 'invalid/)
           expect(received_report["agent"]["output"]).to eq(["invalid agent", "json"])
         end
       end


### PR DESCRIPTION
I think the newer version of the Ruby JSON gem has slightly different errors. Update the test to pass with the new error message. I've updated the assertions to match the common parts of the error message for different versions.

[skip changeset]
[skip review]