### PR TITLE
Ignore `Errno::ECONNRESET` in Rack wrapper

### DIFF
--- a/.changesets/ignore--errno--econnreset--errors-in-the-rack-wrapper.md
+++ b/.changesets/ignore--errno--econnreset--errors-in-the-rack-wrapper.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Ignore `Errno::ECONNRESET` errors in the Rack wrapper.

--- a/lib/appsignal/rack/body_wrapper.rb
+++ b/lib/appsignal/rack/body_wrapper.rb
@@ -4,7 +4,7 @@ module Appsignal
   module Rack
     # @api private
     class BodyWrapper
-      IGNORED_ERRORS = [Errno::EPIPE].freeze
+      IGNORED_ERRORS = [Errno::EPIPE, Errno::ECONNRESET].freeze
 
       def self.wrap(original_body, appsignal_transaction)
         # The logic of how Rack treats a response body differs based on which methods


### PR DESCRIPTION
Pending customer feedback ([see internal Slack conversation](https://appsignal.slack.com/archives/C7XHXQ7N0/p1749765575610609?thread_ts=1749739111.556319&cid=C7XHXQ7N0)) to see if we actually want this.