### PR TITLE
Logger improvements

### DIFF
--- a/lib/appsignal/logger.rb
+++ b/lib/appsignal/logger.rb
@@ -124,14 +124,6 @@ module Appsignal
       return if message.nil?
 
       message = "#{message.class}: #{message.message}" if message.is_a?(Exception)
-      message = message.to_s if message.respond_to?(:to_s)
-
-      unless message.is_a?(String)
-        Appsignal.internal_logger.warn(
-          "Logger message was ignored, because it was not a String: #{message.inspect}"
-        )
-        return
-      end
 
       message = formatter.call(severity, Time.now, group, message) if formatter
 
@@ -139,7 +131,7 @@ module Appsignal
         group,
         SEVERITY_MAP.fetch(severity, 0),
         @format,
-        message,
+        message.to_s,
         Appsignal::Utils::Data.generate(appsignal_attributes)
       )
 

--- a/lib/appsignal/logger.rb
+++ b/lib/appsignal/logger.rb
@@ -73,6 +73,8 @@ module Appsignal
         nil
       end
 
+      message = message.to_s if message.respond_to?(:to_s)
+
       unless message.is_a?(String)
         Appsignal.internal_logger.warn(
           "Logger message was ignored, because it was not a String: #{message.inspect}"

--- a/lib/appsignal/logger.rb
+++ b/lib/appsignal/logger.rb
@@ -123,7 +123,9 @@ module Appsignal
 
       return if message.nil?
 
-      message = "#{message.class}: #{message.message}" if message.is_a?(Exception)
+      if message.is_a?(Exception)
+        message = "#{message.class}: #{message.message} (#{message.backtrace[0]})"
+      end
 
       message = formatter.call(severity, Time.now, group, message) if formatter
 

--- a/lib/appsignal/logger.rb
+++ b/lib/appsignal/logger.rb
@@ -166,7 +166,7 @@ module Appsignal
     # @param message Message to log
     # @return [Integer]
     def <<(message)
-      add(Logger::INFO, message)
+      info(message)
       message.length
     end
 

--- a/lib/appsignal/logger.rb
+++ b/lib/appsignal/logger.rb
@@ -37,7 +37,7 @@ module Appsignal
       @format = format
       @mutex = Mutex.new
       @default_attributes = attributes
-      @appsignal_attributes = {}
+      @appsignal_attributes = attributes
       @loggers = []
     end
 
@@ -197,7 +197,7 @@ module Appsignal
       @appsignal_attributes = default_attributes.merge(attributes)
       add(severity, message, group)
     ensure
-      @appsignal_attributes = {}
+      @appsignal_attributes = default_attributes
     end
   end
 end

--- a/spec/lib/appsignal/logger_spec.rb
+++ b/spec/lib/appsignal/logger_spec.rb
@@ -584,7 +584,8 @@ describe Appsignal::Logger do
         begin
           raise ExampleStandardError, "oh no!"
         rescue => e
-          # This makes the exception include a backtrace, so we can assert it's NOT included
+          # This makes the exception include a backtrace, so we can assert its
+          # first line is included
           e
         end
       expect(Appsignal::Extension).to receive(:log)
@@ -592,7 +593,7 @@ describe Appsignal::Logger do
           "group",
           6,
           0,
-          "ExampleStandardError: oh no!",
+          a_string_matching(/ExampleStandardError: oh no! \(.*logger_spec.rb.*\)/),
           instance_of(Appsignal::Extension::Data)
         )
       logger.error(error)

--- a/spec/lib/appsignal/logger_spec.rb
+++ b/spec/lib/appsignal/logger_spec.rb
@@ -456,16 +456,18 @@ describe Appsignal::Logger do
     ["warn", 5, ::Logger::ERROR],
     ["error", 6, ::Logger::FATAL],
     ["fatal", 7, nil]
-  ].each do |method|
-    describe "##{method[0]}" do
+  ].each do |permutation|
+    method, extension_level, higher_level = permutation
+
+    describe "##{method}" do
       it "should log with a message" do
         expect(Appsignal::Utils::Data).to receive(:generate)
           .with({ :attribute => "value" })
           .and_call_original
         expect(Appsignal::Extension).to receive(:log)
-          .with("group", method[1], 0, "Log message", instance_of(Appsignal::Extension::Data))
+          .with("group", extension_level, 0, "Log message", instance_of(Appsignal::Extension::Data))
 
-        logger.send(method[0], "Log message", :attribute => "value")
+        logger.send(method, "Log message", :attribute => "value")
       end
 
       it "should log with a block" do
@@ -473,25 +475,25 @@ describe Appsignal::Logger do
           .with({})
           .and_call_original
         expect(Appsignal::Extension).to receive(:log)
-          .with("group", method[1], 0, "Log message", instance_of(Appsignal::Extension::Data))
+          .with("group", extension_level, 0, "Log message", instance_of(Appsignal::Extension::Data))
 
-        logger.send(method[0]) do
+        logger.send(method) do
           "Log message"
         end
       end
 
       it "should return with a nil message" do
         expect(Appsignal::Extension).not_to receive(:log)
-        logger.send(method[0])
+        logger.send(method)
       end
 
-      if method[2]
+      if higher_level
         context "with a lower log level" do
-          let(:logger) { Appsignal::Logger.new("group", :level => method[2]) }
+          let(:logger) { Appsignal::Logger.new("group", :level => higher_level) }
 
           it "should skip logging if the level is too low" do
             expect(Appsignal::Extension).not_to receive(:log)
-            logger.send(method[0], "Log message")
+            logger.send(method, "Log message")
           end
         end
       end
@@ -516,12 +518,12 @@ describe Appsignal::Logger do
           expect(Appsignal::Extension).to receive(:log)
             .with(
               "group",
-              method[1],
+              extension_level,
               0,
               "formatted: 2023-01-01T00:00:00.000000 'Log message'",
               instance_of(Appsignal::Extension::Data)
             )
-          logger.send(method[0], "Log message")
+          logger.send(method, "Log message")
         end
       end
     end

--- a/spec/lib/appsignal/logger_spec.rb
+++ b/spec/lib/appsignal/logger_spec.rb
@@ -519,6 +519,14 @@ describe Appsignal::Logger do
 
       logger.error("Some message", { :some_key => "other_value" })
     end
+
+    it "adds the default attributes when #add is called" do
+      logger = Appsignal::Logger.new("group", :attributes => { :some_key => "some_value" })
+
+      expect(Appsignal::Extension).to receive(:log).with("group", 3, 0, "Log message",
+        Appsignal::Utils::Data.generate({ :some_key => "some_value" }))
+      logger.add(::Logger::INFO, "Log message")
+    end
   end
 
   describe "#error with exception object" do


### PR DESCRIPTION
### [Have #<< and #info use the same implementation](https://github.com/appsignal/appsignal-ruby/commit/a68cb365b006e417093cd477ca8cffc0142be8f7)

The `#<<` method is meant to use the `INFO` log level. Since we do
some extra transformations on `add_with_attributes` when the `#info`
method is called, we can use the same code path and make it easier
to understand that it's just an alias.

### [Log default attributes when #add is used](https://github.com/appsignal/appsignal-ruby/commit/d266270696367698fd3c31686df77a4de48b5180)

When the `#add` method is used instead of the level-specific helper
methods, log the default attributes as well.

### [Call #to_s on the message](https://github.com/appsignal/appsignal-ruby/commit/5f1a0491f4b7f43910433ffa1d8ac0d635a3cf43)

Before refusing to log a message because it is not a string, attempt
to call `#to_s` on the message.

Fixes https://github.com/appsignal/appsignal-ruby/issues/1418.

### [Broadcast log messages regardless of level](https://github.com/appsignal/appsignal-ruby/commit/5d58a287c8571cb06c8d8b759df44843c8d8d670)

When broadcasting log messages, do so regardless of the log level
of the AppSignal broadcaster. This allows loggers with less strict
levels to log messages according to their own level thresholds.

To avoid executing the block passed as a message several times, which
would run into the same issues as `ActiveSupport::BroadcastLogger`,
wrap the given message block with an object that can be cast into a
proc and be called more than once, but that only call the underlying
block once, with the same return value each time. This also ensures
that we don't call the underlying block if the message is not logged
by any of the broadcasted loggers.

When the logger is silenced, however, do not broadcast any logs over
the silenced log threshold. This makes sense because silencing is
about the application code that performs the logging, not about its
destination.

Move the `Exception` formatting to the `#add` method so that all
error levels, not just `#error`, can format exceptions.

Fixes https://github.com/appsignal/appsignal-ruby/issues/1422.

### [Improve readability of logger method tests](https://github.com/appsignal/appsignal-ruby/commit/3d5922e3fed6159e7142e33376fe727e2b6c0574)

Name the members of the permutations.