### PR TITLE
Fix non-canonical rendering events paths

### DIFF
--- a/.changesets/fix-non-canonical-rendering-events.md
+++ b/.changesets/fix-non-canonical-rendering-events.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix non-canonical rendering event paths for Capistrano deployments

--- a/lib/appsignal/event_formatter/action_view/render_formatter.rb
+++ b/lib/appsignal/event_formatter/action_view/render_formatter.rb
@@ -7,16 +7,14 @@ module Appsignal
       class RenderFormatter
         BLANK = ""
 
-        attr_reader :root_path
-
-        def initialize
-          @root_path = "#{Rails.root}/"
-        end
-
         def format(payload)
           return nil unless payload[:identifier]
 
           [payload[:identifier].sub(root_path, BLANK), nil]
+        end
+
+        def root_path
+          @root_path ||= "#{Rails.root}/"
         end
       end
     end

--- a/lib/appsignal/event_formatter/view_component/render_formatter.rb
+++ b/lib/appsignal/event_formatter/view_component/render_formatter.rb
@@ -7,14 +7,12 @@ module Appsignal
       class RenderFormatter
         BLANK = ""
 
-        attr_reader :root_path
-
-        def initialize
-          @root_path = "#{Rails.root}/"
+        def format(payload)
+          [payload[:name], payload[:identifier].sub(root_path, BLANK)]
         end
 
-        def format(payload)
-          [payload[:name], payload[:identifier].sub(@root_path, BLANK)]
+        def root_path
+          @root_path ||= "#{Rails.root}/"
         end
       end
     end


### PR DESCRIPTION
I noticed that the ActionView events are not canonical for our Rails app.
They are shown in Appsignal as e.g: `path/to/our/app/releases/20250625094847/app/views/my/partial.html.haml`, which is actually the full path only missing the leading `/`.

We are deploying with Capistrano which includes the deployment timestamp in the path. Thus the events are not canonical and we cannot measure the events' performance over different releases.

As far as I could debug this, the `Rails.root` path is only `/` when the formatters are getting initialized. Probably because the formatter is initialized before the whole Rails app is fully initialized.

Let's fix this by determining the root path lazily when the first event is sent.