### PR TITLE
Track error backtrace in install.report file

### DIFF
--- a/.changesets/log-error-backtrace-on-extension-download-failure.md
+++ b/.changesets/log-error-backtrace-on-extension-download-failure.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Log the error's backtrace on extension download failure. This will help us debug issues related to downloading the extension.

--- a/ext/base.rb
+++ b/ext/base.rb
@@ -145,7 +145,9 @@ def download_archive(type)
         return open(*args)
       end
     rescue => error
-      download_errors << "- URL: #{download_url}\n  Error: #{error.class}: #{error.message}"
+      backtrace = error.backtrace.join("\n")
+      download_errors <<
+        "- URL: #{download_url}\n  Error: #{error.class}: #{error.message}\n#{backtrace}"
       next
     end
   end


### PR DESCRIPTION
When an error occurs during the extension download script, log the backtrace so we can find the original location of the error.