### PR TITLE
Lock sidekiq version to 8.0.4

### DIFF
--- a/gemfiles/rails-7.1.gemfile
+++ b/gemfiles/rails-7.1.gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "rails", "~> 7.1.0"
 gem "rake", "> 12.2"
-gem "sidekiq"
+gem "sidekiq", "<= 8.0.4"
 
 if RUBY_PLATFORM == "java"
   # Fix install issue for jruby on gem 3.1.8.


### PR DESCRIPTION
It breaks the CI to upgrade to 8.0.5.
See issue https://github.com/sidekiq/sidekiq/issues/6746

[skip review]
[skip changeset]