### PR TITLE
Update YARD documentation

### DIFF
--- a/.changesets/improve-yard-documentation-for-public-apis-.md
+++ b/.changesets/improve-yard-documentation-for-public-apis-.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Improve the YARD documentation for public APIs. This will make the documentation clearer and more useful for developers using the Ruby gem.

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -71,7 +71,7 @@ module Appsignal
     # If the value is `nil`, no error was encountered or AppSignal wasn't
     # started yet.
     #
-    # @return [NilClass/Exception]
+    # @return [nil, Exception]
     attr_reader :config_error
     alias config_error? config_error
 
@@ -163,8 +163,10 @@ module Appsignal
 
     # PRIVATE METHOD. DO NOT USE.
     #
-    # @param env_param [String, NilClass] Used by diagnose CLI to pass through
-    #   the environment CLI option value.
+    # @param env_param [String, nil] Used by diagnose CLI to pass through
+    #   the environment CLI option value. If nil, the environment will be
+    #   auto-detected.
+    # @param block [Proc] Optional block to configure the config object.
     # @api private
     def _load_config!(env_param = nil, &block) # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
       # Ensure it's not an empty string if it's a value

--- a/lib/appsignal/auth_check.rb
+++ b/lib/appsignal/auth_check.rb
@@ -37,7 +37,7 @@ module Appsignal
     # Perform push api validation request and return a descriptive response
     # tuple.
     #
-    # @return [Array<String/nil, String>] response tuple.
+    # @return [Array<String, String>] response tuple.
     #   - First value is the response status code.
     #   - Second value is a description of the response and the exception error
     #     message if an exception occurred.
@@ -57,7 +57,7 @@ module Appsignal
     rescue => e
       result = "Something went wrong while trying to " \
         "authenticate with AppSignal: #{e}"
-      [nil, result]
+      ["error", result]
     end
   end
 end

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -230,13 +230,15 @@ module Appsignal
     attr_reader :system_config, :loaders_config, :initial_config, :file_config,
       :env_config, :override_config, :dsl_config
 
-    # Initialize a new configuration object for AppSignal.
+    # Initialize a new AppSignal configuration object.
     #
-    # @param root_path [String] Root path of the app.
+    # @param root_path [String] Path to the root of the application.
     # @param env [String] The environment to load when AppSignal is started. It
     #   will look for an environment with this name in the `config/appsignal.yml`
     #   config file.
-    #
+    # @param load_yaml_file [Boolean] Whether to load configuration from
+    #   the YAML config file. Defaults to true.
+    # @return [Config] The initialized configuration object.
     # @api private
     # @see https://docs.appsignal.com/ruby/configuration/
     #   Configuration documentation
@@ -337,6 +339,10 @@ module Appsignal
       end
     end
 
+    # Fetch a configuration value by key.
+    #
+    # @param key [Symbol, String] The configuration option key to fetch.
+    # @return [Object] The configuration value.
     # @api private
     def [](key)
       config_hash[key]
@@ -347,6 +353,9 @@ module Appsignal
     # This method does not update the config in the extension and agent. It
     # should not be used to update the config after AppSignal has started.
     #
+    # @param key [Symbol, String] The configuration option key to set.
+    # @param value [Object] The configuration value to set.
+    # @return [void]
     # @api private
     def []=(key, value)
       config_hash[key] = value
@@ -390,14 +399,23 @@ module Appsignal
       @log_file_path
     end
 
+    # Check if the configuration is valid.
+    #
+    # @return [Boolean] True if the configuration is valid, false otherwise.
     def valid?
       @valid
     end
 
+    # Check if AppSignal is active for the current environment.
+    #
+    # @return [Boolean] True if active for the current environment.
     def active_for_env?
       config_hash[:active]
     end
 
+    # Check if AppSignal is active.
+    #
+    # @return [Boolean] True if valid and active for the current environment.
     def active?
       valid? && active_for_env?
     end

--- a/lib/appsignal/custom_marker.rb
+++ b/lib/appsignal/custom_marker.rb
@@ -15,7 +15,7 @@ module Appsignal
     # @param icon [String] icon to use for the marker, like an emoji.
     # @param message [String] name of the user that is creating the
     #   marker.
-    # @param created_at [Time/String] A Ruby time object or a valid ISO8601
+    # @param created_at [Time, String] A Ruby time object or a valid ISO8601
     #   timestamp.
     # @return [Boolean]
     def self.report(

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -89,7 +89,7 @@ module Appsignal
       #   end
       #
       # @since 3.11.0
-      # @param namespace [String/Symbol] The namespace to set on the new
+      # @param namespace [String, Symbol] The namespace to set on the new
       #   transaction.
       #   Defaults to the 'web' namespace.
       #   This will not update the active transaction's namespace if
@@ -459,7 +459,7 @@ module Appsignal
       #   # The custom data is: [1, 2, 3]
       #
       # @since 4.0.0
-      # @param data [Hash/Array] Custom data to add to the transaction.
+      # @param data [Hash, Array] Custom data to add to the transaction.
       # @return [void]
       #
       # @see https://docs.appsignal.com/guides/custom-data/sample-data.html
@@ -668,7 +668,7 @@ module Appsignal
       # Add breadcrumbs to the transaction.
       #
       # Breadcrumbs can be used to trace what path a user has taken
-      # before encounterin an error.
+      # before encountering an error.
       #
       # Only the last 20 added breadcrumbs will be saved.
       #

--- a/lib/appsignal/helpers/metrics.rb
+++ b/lib/appsignal/helpers/metrics.rb
@@ -11,6 +11,7 @@ module Appsignal
       # @param tags [Hash] The tags for the metric. The Hash keys can be either
       #   a String or a Symbol. The tag values can be a String, Symbol,
       #   Integer, Float, TrueClass or FalseClass.
+      # @return [void]
       #
       # @see https://docs.appsignal.com/metrics/custom.html
       #   Metrics documentation
@@ -33,6 +34,7 @@ module Appsignal
       # @param tags [Hash] The tags for the metric. The Hash keys can be either
       #   a String or a Symbol. The tag values can be a String, Symbol,
       #   Integer, Float, TrueClass or FalseClass.
+      # @return [void]
       #
       # @see https://docs.appsignal.com/metrics/custom.html
       #   Metrics documentation
@@ -55,6 +57,7 @@ module Appsignal
       # @param tags [Hash] The tags for the metric. The Hash keys can be either
       #   a String or a Symbol. The tag values can be a String, Symbol,
       #   Integer, Float, TrueClass or FalseClass.
+      # @return [void]
       #
       # @see https://docs.appsignal.com/metrics/custom.html
       #   Metrics documentation

--- a/lib/appsignal/probes.rb
+++ b/lib/appsignal/probes.rb
@@ -23,7 +23,7 @@ module Appsignal
       end
 
       # Fetch a probe using its name.
-      # @param key [Symbol/String] The name of the probe to fetch.
+      # @param key [Symbol, String] The name of the probe to fetch.
       # @return [Object] Returns the registered probe.
       def [](key)
         probes[key]
@@ -129,7 +129,7 @@ module Appsignal
       #   # "started" # Printed on Appsignal::Probes.start
       #   # "called" # Repeated every minute
       #
-      # @param name [Symbol/String] Name of the probe. Can be used with
+      # @param name [Symbol, String] Name of the probe. Can be used with
       #   {ProbeCollection#[]}. This name will be used in errors in the log and
       #   allows overwriting of probes by registering new ones with the same
       #   name.
@@ -153,7 +153,7 @@ module Appsignal
       #   # Then unregister a probe if needed
       #   Appsignal::Probes.unregister :my_probe
       #
-      # @param name [Symbol/String] Name of the probe used to {register} the
+      # @param name [Symbol, String] Name of the probe used to {register} the
       #   probe.
       # @return [void]
       def unregister(name)

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -429,7 +429,7 @@ module Appsignal
     # Add custom data to the transaction.
     #
     # @since 4.0.0
-    # @param data [Hash/Array]
+    # @param data [Hash, Array]
     # @return [void]
     #
     # @see Helpers::Instrumentation#add_custom_data

--- a/spec/lib/appsignal/auth_check_spec.rb
+++ b/spec/lib/appsignal/auth_check_spec.rb
@@ -75,7 +75,7 @@ describe Appsignal::AuthCheck do
 
       it "returns an error tuple" do
         is_expected.to eq [
-          nil,
+          "error",
           "Something went wrong while trying to authenticate with AppSignal: execution expired"
         ]
       end


### PR DESCRIPTION
## Update YARD documentation

Have Claude check the YARD documentation and suggest improvements. I manually checked them myself so they're accurate.

## Update auth check return value

Instead of returning `nil` for an error, return the string `error`. This will help with defining the return value in the YARD documentation and makes it more clear from the return value what the result of the request was. I haven't found a way to define a tuple in YARD where one value is either String or Nil.
