### PR TITLE
Read revision from the REVISION file

### DIFF
--- a/.changesets/when-a-deployment-tool-provides-the-revision-file--appsignal-will-now-use-that-to-set-the-revision-config.md
+++ b/.changesets/when-a-deployment-tool-provides-the-revision-file--appsignal-will-now-use-that-to-set-the-revision-config.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+type: add
+---
+
+When a deployment tool (Capistrano, Hatchbox.io) provides the REVISION file in the deployed application, AppSignal will now use that to set the revision config


### PR DESCRIPTION
Deployment tools, like Capistrano and Hatchbox.io, put a `REVISION` file in the root of a deployed directory. This PR reads that file to set `revision`.

- [x]  Read `revision` from the `REVISION` fille.

Closes #1381 