### PR TITLE
Revert Sidekiq version lock

### DIFF
--- a/gemfiles/rails-7.1.gemfile
+++ b/gemfiles/rails-7.1.gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "rails", "~> 7.1.0"
 gem "rake", "> 12.2"
-gem "sidekiq", "<= 8.0.4"
+gem "sidekiq"
 
 if RUBY_PLATFORM == "java"
   # Fix install issue for jruby on gem 3.1.8.


### PR DESCRIPTION
In commit ed008876b176ea0c5811f1b27291af33fc400154 I locked the Sidekiq version to 8.0.4 because 8.0.5 contained an issue for this Rails 7.1 build.

This was resolved in Sidekiq 8.0.6.
See this issue:
https://github.com/sidekiq/sidekiq/issues/6746

[skip changeset]
[skip review]