### PR TITLE
Change backtrace logging from debug to error level

### DIFF
--- a/.changesets/updates-to-error-level-instead-of-debug-level-for-better-visibility-of-critical-failures-.md
+++ b/.changesets/updates-to-error-level-instead-of-debug-level-for-better-visibility-of-critical-failures-.md
@@ -1,6 +1,6 @@
 ---
-bump: minor
+bump: patch
 type: change
 ---
 
-Updates to error level instead of debug level for better visibility of critical failures.
+Use error level for displaying backtraces instead for better visibility of critical failures.

--- a/.changesets/updates-to-error-level-instead-of-debug-level-for-better-visibility-of-critical-failures-.md
+++ b/.changesets/updates-to-error-level-instead-of-debug-level-for-better-visibility-of-critical-failures-.md
@@ -3,4 +3,4 @@ bump: patch
 type: change
 ---
 
-Use error level for displaying backtraces instead for better visibility of critical failures.
+When an error occurs while initializing AppSignal or when running a probe, use the error log level to log the error's backtrace.

--- a/.changesets/updates-to-error-level-instead-of-debug-level-for-better-visibility-of-critical-failures-.md
+++ b/.changesets/updates-to-error-level-instead-of-debug-level-for-better-visibility-of-critical-failures-.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+type: change
+---
+
+Updates to error level instead of debug level for better visibility of critical failures.

--- a/lib/appsignal/hooks.rb
+++ b/lib/appsignal/hooks.rb
@@ -39,7 +39,7 @@ module Appsignal
         rescue => ex
           logger = Appsignal.internal_logger
           logger.error("Error while installing #{name} hook: #{ex}")
-          logger.debug ex.backtrace.join("\n")
+          logger.error ex.backtrace.join("\n")
         end
       end
 

--- a/lib/appsignal/hooks.rb
+++ b/lib/appsignal/hooks.rb
@@ -38,8 +38,10 @@ module Appsignal
           @installed = true
         rescue => ex
           logger = Appsignal.internal_logger
-          logger.error("Error while installing #{name} hook: #{ex}")
-          logger.error ex.backtrace.join("\n")
+          logger.error(
+            "Error while installing #{name} hook: #{ex.class}: #{ex.message}\n" \
+              "#{ex.backtrace.join("\n")}"
+          )
         end
       end
 

--- a/lib/appsignal/probes.rb
+++ b/lib/appsignal/probes.rb
@@ -185,7 +185,7 @@ module Appsignal
                 probe.call
               rescue => ex
                 logger.error "Error in minutely probe '#{name}': #{ex}"
-                logger.debug ex.backtrace.join("\n")
+                logger.error ex.backtrace.join("\n")
               end
             end
             end_time = Time.now
@@ -257,7 +257,7 @@ module Appsignal
       rescue => error
         logger = Appsignal.internal_logger
         logger.error "Error while initializing minutely probe '#{name}': #{error}"
-        logger.debug error.backtrace.join("\n")
+        logger.error error.backtrace.join("\n")
       end
 
       def uninitialize_probe(name)

--- a/lib/appsignal/probes.rb
+++ b/lib/appsignal/probes.rb
@@ -184,8 +184,10 @@ module Appsignal
                 logger.debug("Gathering minutely metrics with '#{name}' probe")
                 probe.call
               rescue => ex
-                logger.error "Error in minutely probe '#{name}': #{ex}"
-                logger.error ex.backtrace.join("\n")
+                logger.error(
+                  "Error in minutely probe '#{name}': #{ex.class}: #{ex.message}\n" \
+                    "#{ex.backtrace.join("\n")}"
+                )
               end
             end
             end_time = Time.now
@@ -256,8 +258,10 @@ module Appsignal
         end
       rescue => error
         logger = Appsignal.internal_logger
-        logger.error "Error while initializing minutely probe '#{name}': #{error}"
-        logger.error error.backtrace.join("\n")
+        logger.error(
+          "Error while initializing minutely probe '#{name}': #{error.class}: #{error.message}\n" \
+            "#{error.backtrace.join("\n")}"
+        )
       end
 
       def uninitialize_probe(name)

--- a/spec/lib/appsignal/hooks_spec.rb
+++ b/spec/lib/appsignal/hooks_spec.rb
@@ -67,14 +67,15 @@ describe Appsignal::Hooks do
     expect(Appsignal::Hooks.hooks[:mock_error_hook]).to be_instance_of(MockErrorHook)
     expect(Appsignal::Hooks.hooks[:mock_error_hook].installed?).to be_falsy
 
-    expect(Appsignal.internal_logger).to receive(:error)
-      .with("Error while installing mock_error_hook hook: error").once
     expect(Appsignal.internal_logger).to receive(:debug).ordered do |message|
       expect(message).to eq("Installing mock_error_hook hook")
     end
     expect(Appsignal.internal_logger).to receive(:error).ordered do |message|
-      # Start of the error backtrace as error log
-      expect(message).to start_with(File.expand_path("../../..", __dir__))
+      # Error message with class, message and backtrace in single line
+      expect(message).to start_with(
+        "Error while installing mock_error_hook hook: RuntimeError: error\n"
+      )
+      expect(message).to include(project_dir)
     end
 
     Appsignal::Hooks.load_hooks

--- a/spec/lib/appsignal/hooks_spec.rb
+++ b/spec/lib/appsignal/hooks_spec.rb
@@ -72,8 +72,8 @@ describe Appsignal::Hooks do
     expect(Appsignal.internal_logger).to receive(:debug).ordered do |message|
       expect(message).to eq("Installing mock_error_hook hook")
     end
-    expect(Appsignal.internal_logger).to receive(:debug).ordered do |message|
-      # Start of the error backtrace as debug log
+    expect(Appsignal.internal_logger).to receive(:error).ordered do |message|
+      # Start of the error backtrace as error log
       expect(message).to start_with(File.expand_path("../../..", __dir__))
     end
 

--- a/spec/lib/appsignal/probes_spec.rb
+++ b/spec/lib/appsignal/probes_spec.rb
@@ -138,14 +138,14 @@ describe Appsignal::Probes do
           wait_for("enough probe calls") { Appsignal::Testing.store[:mock_probe_call] >= 2 }
           # Only counts initialized probes
           expect(log).to contains_log(:debug, "Gathering minutely metrics with 1 probe")
-          # Logs error
+          # Logs error with class, message and backtrace in single line
           expect(log).to contains_log(
             :error,
             "Error while initializing minutely probe 'broken_probe_on_initialize': " \
-              "oh no initialize!"
+              "RuntimeError: oh no initialize!\n"
           )
-          # Start of the error backtrace as error log
-          expect(log).to contains_log :error, File.expand_path("../../..", __dir__)
+          # Backtrace is included in the same log entry - just check it contains the file path
+          expect(log).to include(project_dir)
         end
       end
     end
@@ -177,9 +177,10 @@ describe Appsignal::Probes do
         expect(log).to contains_log(:debug, "Gathering minutely metrics with 2 probes")
         expect(log).to contains_log(:debug, "Gathering minutely metrics with 'my_probe' probe")
         expect(log).to contains_log(:debug, "Gathering minutely metrics with 'broken_probe' probe")
-        expect(log).to contains_log(:error, "Error in minutely probe 'broken_probe': oh no!")
+
         gem_path = File.expand_path("../../..", __dir__) # Start of backtrace
-        expect(log).to contains_log(:error, gem_path)
+        expect(log).to contains_log(:error,
+          "Error in minutely probe 'broken_probe': RuntimeError: oh no!\n#{gem_path}")
       end
     end
 

--- a/spec/lib/appsignal/probes_spec.rb
+++ b/spec/lib/appsignal/probes_spec.rb
@@ -144,8 +144,8 @@ describe Appsignal::Probes do
             "Error while initializing minutely probe 'broken_probe_on_initialize': " \
               "oh no initialize!"
           )
-          # Start of the error backtrace as debug log
-          expect(log).to contains_log :debug, File.expand_path("../../..", __dir__)
+          # Start of the error backtrace as error log
+          expect(log).to contains_log :error, File.expand_path("../../..", __dir__)
         end
       end
     end
@@ -179,7 +179,7 @@ describe Appsignal::Probes do
         expect(log).to contains_log(:debug, "Gathering minutely metrics with 'broken_probe' probe")
         expect(log).to contains_log(:error, "Error in minutely probe 'broken_probe': oh no!")
         gem_path = File.expand_path("../../..", __dir__) # Start of backtrace
-        expect(log).to contains_log(:debug, gem_path)
+        expect(log).to contains_log(:error, gem_path)
       end
     end
 


### PR DESCRIPTION
Updates to error level instead of debug level for better visibility of critical failures.