### PR TITLE
Merge Hash-like values in sample data

### DIFF
--- a/.changesets/merge-metadata-when-comparing-hash-like-values-.md
+++ b/.changesets/merge-metadata-when-comparing-hash-like-values-.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+type: fix
+---
+
+When using the transaction helpers to set metadata like `add_params`, `add_sesion_data`, etc.), we will now merge Hash-like values, value types that are subclasses of the Ruby Hash class.
+Now, if a `ActiveSupport::HashWithIndifferentAccess` or `Sinatra::IndifferentHash` value is given, it will be merged with the existing Hash-like value instead of replacing the original value.

--- a/.changesets/merge-metadata-when-comparing-hash-like-values-.md
+++ b/.changesets/merge-metadata-when-comparing-hash-like-values-.md
@@ -3,5 +3,17 @@ bump: patch
 type: fix
 ---
 
-When using the transaction helpers to set metadata like `add_params`, `add_sesion_data`, etc.), we will now merge Hash-like values, value types that are subclasses of the Ruby Hash class.
-Now, if a `ActiveSupport::HashWithIndifferentAccess` or `Sinatra::IndifferentHash` value is given, it will be merged with the existing Hash-like value instead of replacing the original value.
+When a Hash-like value (such as `ActiveSupport::HashWithIndifferentAccess` or `Sinatra::IndifferentHash`) is passed to a transaction helper (such as `add_params`, `add_session_data`, ...) it is now converted to a Ruby `Hash` before setting it as the value or merging it with the existing value. This allows Hash-like objects to be merged, instead of logging a warning and only storing the new value.
+
+```ruby
+# Example scenario
+Appsignal.add_params(:key1 => { :abc => "value" })
+Appsignal.add_params(ActiveSupport::HashWithIndifferentAccess.new(:key2 => { :def => "value" }))
+
+# Params
+{
+  :key1 => { :abc => "value" },
+  # Keys from HashWithIndifferentAccess are stored as Strings
+  "key2" => { "def" => "value" }
+}
+```

--- a/lib/appsignal/sample_data.rb
+++ b/lib/appsignal/sample_data.rb
@@ -79,15 +79,21 @@ module Appsignal
       end
     end
 
+    def mergable?(value_original, value_new)
+      return true if value_new.instance_of?(value_original.class)
+
+      value_original.is_a?(Hash) && value_new.is_a?(Hash)
+    end
+
     def merge_values(value_original, value_new)
-      unless value_new.instance_of?(value_original.class)
-        unless value_original == UNSET_VALUE
-          Appsignal.internal_logger.warn(
-            "The sample data '#{@key}' changed type from " \
-              "'#{value_original.class}' to '#{value_new.class}'. " \
-              "These types can not be merged. Using new '#{value_new.class}' type."
-          )
-        end
+      return value_new if value_original == UNSET_VALUE
+
+      unless mergable?(value_original, value_new)
+        Appsignal.internal_logger.warn(
+          "The sample data '#{@key}' changed type from " \
+            "'#{value_original.class}' to '#{value_new.class}'. " \
+            "These types can not be merged. Using new '#{value_new.class}' type."
+        )
         return value_new
       end
 

--- a/spec/lib/appsignal/sample_data_spec.rb
+++ b/spec/lib/appsignal/sample_data_spec.rb
@@ -145,13 +145,14 @@ describe Appsignal::SampleData do
     end
 
     if DependencyHelper.rails_present?
-      context "with ActiveSupport::HashWithIndifferentAccess" do
+      context "when merging a ActiveSupport::HashWithIndifferentAccess into a Hash" do
         it "merges the HashWithIndifferentAccess value into the existing Hash value" do
           logs = capture_logs do
             data.add(:key1 => { :abc => "value" })
             data.add(HashWithIndifferentAccess.new(:key2 => { :def => "value" }))
             data.value # Precalculate values so they show up in the logs
           end
+          expect(data.value).to be_instance_of(Hash)
           expect(data.value).to eq(
             :key1 => { :abc => "value" },
             # String keys because that's what HashWithIndifferentAccess returns
@@ -167,6 +168,40 @@ describe Appsignal::SampleData do
             data.add(HashWithIndifferentAccess.new(:key2 => { :def => "value" }))
             data.value # Precalculate values so they show up in the logs
           end
+          expect(data.value).to be_instance_of(Hash)
+          expect(data.value).to eq(
+            :key1 => { :abc => "value" },
+            # String keys because that's what HashWithIndifferentAccess returns
+            "key2" => { "def" => "value" }
+          )
+          expect(logs).to_not contains_log(:warn, "The sample data")
+        end
+      end
+
+      context "when merging a Hash into a ActiveSupport::HashWithIndifferentAccess" do
+        it "merges the HashWithIndifferentAccess value into the existing Hash value" do
+          logs = capture_logs do
+            data.add(HashWithIndifferentAccess.new(:key2 => { :def => "value" }))
+            data.add(:key1 => { :abc => "value" })
+            data.value # Precalculate values so they show up in the logs
+          end
+          expect(data.value).to be_instance_of(Hash)
+          expect(data.value).to eq(
+            :key1 => { :abc => "value" },
+            # String keys because that's what HashWithIndifferentAccess returns
+            "key2" => { "def" => "value" }
+          )
+          expect(logs).to_not contains_log(:warn, "The sample data")
+        end
+
+        it "works with accepted_type set to Hash" do
+          data = described_class.new(:data_key, Hash)
+          logs = capture_logs do
+            data.add(HashWithIndifferentAccess.new(:key2 => { :def => "value" }))
+            data.add(:key1 => { :abc => "value" })
+            data.value # Precalculate values so they show up in the logs
+          end
+          expect(data.value).to be_instance_of(Hash)
           expect(data.value).to eq(
             :key1 => { :abc => "value" },
             # String keys because that's what HashWithIndifferentAccess returns
@@ -178,7 +213,7 @@ describe Appsignal::SampleData do
     end
 
     if DependencyHelper.sinatra_present?
-      context "with Sinatra::IndifferentHash" do
+      context "when merging a Sinatra::IndifferentHash into a Hash" do
         it "merges the Sinatra::IndifferentHash value into the existing Hash value" do
           logs = capture_logs do
             data.add(:key1 => { :abc => "value" })
@@ -187,6 +222,7 @@ describe Appsignal::SampleData do
             data.add(indifferent_hash)
             data.value # Precalculate values so they show up in the logs
           end
+          expect(data.value).to be_instance_of(Hash)
           expect(data.value).to eq(
             :key1 => { :abc => "value" },
             # String keys because that's what Sinatra::IndifferentHash returns
@@ -204,6 +240,44 @@ describe Appsignal::SampleData do
             data.add(indifferent_hash)
             data.value # Precalculate values so they show up in the logs
           end
+          expect(data.value).to be_instance_of(Hash)
+          expect(data.value).to eq(
+            :key1 => { :abc => "value" },
+            # String keys because that's what Sinatra::IndifferentHash returns
+            "key2" => { "def" => "value" }
+          )
+          expect(logs).to_not contains_log(:warn, "The sample data")
+        end
+      end
+
+      context "when merging a Hash into a Sinatra::IndifferentHash" do
+        it "merges the Sinatra::IndifferentHash value into the existing Hash value" do
+          logs = capture_logs do
+            indifferent_hash = Sinatra::IndifferentHash.new
+            indifferent_hash[:key2] = { :def => "value" }
+            data.add(indifferent_hash)
+            data.add(:key1 => { :abc => "value" })
+            data.value # Precalculate values so they show up in the logs
+          end
+          expect(data.value).to be_instance_of(Hash)
+          expect(data.value).to eq(
+            :key1 => { :abc => "value" },
+            # String keys because that's what Sinatra::IndifferentHash returns
+            "key2" => { "def" => "value" }
+          )
+          expect(logs).to_not contains_log(:warn, "The sample data")
+        end
+
+        it "works with accepted_type set to Hash" do
+          data = described_class.new(:data_key, Hash)
+          logs = capture_logs do
+            indifferent_hash = Sinatra::IndifferentHash.new
+            indifferent_hash[:key2] = { :def => "value" }
+            data.add(indifferent_hash)
+            data.add(:key1 => { :abc => "value" })
+            data.value # Precalculate values so they show up in the logs
+          end
+          expect(data.value).to be_instance_of(Hash)
           expect(data.value).to eq(
             :key1 => { :abc => "value" },
             # String keys because that's what Sinatra::IndifferentHash returns


### PR DESCRIPTION
Fix the issue reported in #1431 where first adding a Hash value and then adding a ActiveSupport::HashWithIndifferentAccess value logs a warning.

Look if the values are not just the same class, but also if both values are subclasses of the Hash, which makes them mergable.

I also added a test case for Sinatra's IndifferentHash, because it's a very similar scenario.

Fix #1431