### PR TITLE
Improve YARD docs and signatures

### DIFF
--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -308,7 +308,8 @@ module Appsignal
     # @param env_param [String, Symbol] The environment to load.
     # @param root_path [String] The path to look the `config/appsignal.yml` config file in.
     #   Defaults to the current working directory.
-    # @yield [Config] Gives the {Config} instance to the block.
+    # @yield [config_dsl] Gives the configuration DSL instance to the block.
+    # @yieldparam config_dsl [Appsignal::Config::ConfigDSL] The configuration DSL object
     # @return [void]
     # @see config
     # @see Config

--- a/lib/appsignal/check_in.rb
+++ b/lib/appsignal/check_in.rb
@@ -38,8 +38,9 @@ module Appsignal
       #   end
       #
       # @param identifier [String] identifier of the cron check-in to report.
-      # @yield the block to monitor.
-      # @return [void]
+      # @yield [] the block to monitor.
+      # @yieldreturn [Object] The return value of the block
+      # @return [Object] returns the block value.
       # @since 3.13.0
       # @see https://docs.appsignal.com/check-ins/cron
       def cron(identifier)

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -666,19 +666,43 @@ module Appsignal
       end
     end
 
-    # @!visibility private
+    # Configuration DSL for use in configuration blocks.
+    #
+    # This class provides a Domain Specific Language for configuring AppSignal
+    # within the `Appsignal.configure` block. It provides getter and setter
+    # methods for all configuration options.
+    #
+    # @example Using the configuration DSL
+    #   Appsignal.configure do |config|
+    #     config.name = "My App"
+    #     config.active = true
+    #     config.push_api_key = "your-api-key"
+    #     config.ignore_actions = ["StatusController#health"]
+    #   end
+    #
+    # @see AppSignal Ruby gem configuration
+    #   https://docs.appsignal.com/ruby/configuration.html
     class ConfigDSL
+      # @!visibility private
+      # @return [Hash] Hash containing the DSL option values
       attr_reader :dsl_options
 
+      # @!visibility private
       def initialize(config)
         @config = config
         @dsl_options = {}
       end
 
+      # Returns the application's root path.
+      #
+      # @return [String] The root path of the application
       def app_path
         @config.root_path
       end
 
+      # Returns the current environment name.
+      #
+      # @return [String] The environment name (e.g., "production", "development")
       def env
         @config.env
       end
@@ -692,10 +716,58 @@ module Appsignal
         env == given_env.to_s
       end
 
+      # Activates AppSignal if the current environment matches any of the given environments.
+      #
+      # @param envs [Array<String, Symbol>] List of environment names to activate for
+      # @return [Boolean] true if AppSignal was activated, false otherwise
+      #
+      # @example Activate for production and staging
+      #   config.activate_if_environment(:production, :staging)
       def activate_if_environment(*envs)
         self.active = envs.map(&:to_s).include?(env)
       end
 
+      # @!group String Configuration Options
+
+      # @!attribute [rw] activejob_report_errors
+      #   @return [String] Error reporting mode for ActiveJob ("all", "discard" or "none")
+      # @!attribute [rw] name
+      #   @return [String] The application name
+      # @!attribute [rw] bind_address
+      #   @return [String] The host to the agent binds to for its HTTP server
+      # @!attribute [rw] ca_file_path
+      #   @return [String] Path to the CA certificate file
+      # @!attribute [rw] hostname
+      #   @return [String] Override for the detected hostname
+      # @!attribute [rw] host_role
+      #   @return [String] Role of the host for grouping in metrics
+      # @!attribute [rw] http_proxy
+      #   @return [String] HTTP proxy URL
+      # @!attribute [rw] log
+      #   @return [String] Log destination ("file" or "stdout")
+      # @!attribute [rw] log_level
+      #   @return [String] AppSignal internal logger
+      #     log level ("error", "warn", "info", "debug", "trace")
+      # @!attribute [rw] log_path
+      #   @return [String] Path to the log directory
+      # @!attribute [rw] logging_endpoint
+      #   @return [String] Endpoint for log transmission
+      # @!attribute [rw] endpoint
+      #   @return [String] Push API endpoint URL
+      # @!attribute [rw] push_api_key
+      #   @return [String] AppSignal Push API key
+      # @!attribute [rw] sidekiq_report_errors
+      #   @return [String] Error reporting mode for Sidekiq ("all", "discard" or "none")
+      # @!attribute [rw] statsd_port
+      #   @return [String] Port for StatsD metrics
+      # @!attribute [rw] nginx_port
+      #   @return [String] Port for Nginx metrics collection
+      # @!attribute [rw] working_directory_path
+      #   @return [String] Override for the agent working directory
+      # @!attribute [rw] revision
+      #   @return [String] Application revision identifier
+
+      # @!endgroup
       Appsignal::Config::STRING_OPTIONS.each_key do |option|
         define_method(option) do
           fetch_option(option)
@@ -706,6 +778,54 @@ module Appsignal
         end
       end
 
+      # @!group Boolean Configuration Options
+
+      # @!attribute [rw] active
+      #   @return [Boolean] Activate AppSignal for the loaded environment
+      # @!attribute [rw] enable_allocation_tracking
+      #   @return [Boolean] Configure whether allocation tracking is enabled
+      # @!attribute [rw] enable_at_exit_reporter
+      #   @return [Boolean] Configure whether the at_exit reporter is enabled
+      # @!attribute [rw] enable_host_metrics
+      #   @return [Boolean] Configure whether host metrics collection is enabled
+      # @!attribute [rw] enable_minutely_probes
+      #   @return [Boolean] Configure whether minutely probes are enabled
+      # @!attribute [rw] enable_statsd
+      #   @return [Boolean] Configure whether the StatsD metrics endpoint on the agent is enabled
+      # @!attribute [rw] enable_nginx_metrics
+      #   @return [Boolean] Configure whether the agent's NGINX metrics endpoint is enabled
+      # @!attribute [rw] enable_gvl_global_timer
+      #   @return [Boolean] Configure whether the GVL global timer instrumentationis enabled
+      # @!attribute [rw] enable_gvl_waiting_threads
+      #   @return [Boolean] Configure whether GVL waiting threads instrumentation is enabled
+      # @!attribute [rw] enable_rails_error_reporter
+      #   @return [Boolean] Configure whether Rails error reporter integration is enabled
+      # @!attribute [rw] enable_rake_performance_instrumentation
+      #   @return [Boolean] Configure whether Rake performance instrumentation is enabled
+      # @!attribute [rw] files_world_accessible
+      #   @return [Boolean] Configure whether files created by AppSignal should be world accessible
+      # @!attribute [rw] instrument_http_rb
+      #   @return [Boolean] Configure whether to instrument requests made with the http.rb gem
+      # @!attribute [rw] instrument_net_http
+      #   @return [Boolean] Configure whether to instrument requests made with Net::HTTP
+      # @!attribute [rw] instrument_ownership
+      #   @return [Boolean] Configure whether to instrument the Ownership gem
+      # @!attribute [rw] instrument_redis
+      #   @return [Boolean] Configure whether to instrument Redis queries
+      # @!attribute [rw] instrument_sequel
+      #   @return [Boolean] Configure whether to instrument Sequel queries
+      # @!attribute [rw] ownership_set_namespace
+      #   @return [Boolean] Configure whether the Ownership gem instrumentation should set namespace
+      # @!attribute [rw] running_in_container
+      #   @return [Boolean] Configure whether the application is running in a container
+      # @!attribute [rw] send_environment_metadata
+      #   @return [Boolean] Configure whether to send environment metadata
+      # @!attribute [rw] send_params
+      #   @return [Boolean] Configure whether to send request parameters
+      # @!attribute [rw] send_session_data
+      #   @return [Boolean] Configure whether to send request session data
+
+      # @!endgroup
       Appsignal::Config::BOOLEAN_OPTIONS.each_key do |option|
         define_method(option) do
           fetch_option(option)
@@ -716,6 +836,28 @@ module Appsignal
         end
       end
 
+      # @!group Array Configuration Options
+
+      # @!attribute [rw] dns_servers
+      #   @return [Array<String>] Custom DNS servers to use
+      # @!attribute [rw] filter_metadata
+      #   @return [Array<String>] Metadata keys to filter from trace data
+      # @!attribute [rw] filter_parameters
+      #   @return [Array<String>] Keys of parameter to filter
+      # @!attribute [rw] filter_session_data
+      #   @return [Array<String>] Request session data keys to filter
+      # @!attribute [rw] ignore_actions
+      #   @return [Array<String>] Ignore traces by action names
+      # @!attribute [rw] ignore_errors
+      #   @return [Array<String>] List of errors to not report
+      # @!attribute [rw] ignore_logs
+      #   @return [Array<String>] Ignore log messages by substrings
+      # @!attribute [rw] ignore_namespaces
+      #   @return [Array<String>] Ignore traces by namespaces
+      # @!attribute [rw] request_headers
+      #   @return [Array<String>] HTTP request headers to include in error reports
+
+      # @!endgroup
       Appsignal::Config::ARRAY_OPTIONS.each_key do |option|
         define_method(option) do
           fetch_option(option)
@@ -726,6 +868,12 @@ module Appsignal
         end
       end
 
+      # @!group Float Configuration Options
+
+      # @!attribute [rw] cpu_count
+      #   @return [Float] CPU count override for metrics collection
+
+      # @!endgroup
       Appsignal::Config::FLOAT_OPTIONS.each_key do |option|
         define_method(option) do
           fetch_option(option)

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -113,7 +113,7 @@ module Appsignal
       # @see https://docs.appsignal.com/ruby/instrumentation/background-jobs.html
       #   Monitor guide
       def monitor(action:, namespace: nil)
-        return yield unless active?
+        return yield unless Appsignal.active?
 
         has_parent_transaction = Appsignal::Transaction.current?
         if has_parent_transaction
@@ -227,10 +227,11 @@ module Appsignal
       # @see https://docs.appsignal.com/ruby/instrumentation/exception-handling.html
       #   Exception handling guide
       def send_error(error, &block)
-        return unless active?
+        return unless Appsignal.active?
 
         unless error.is_a?(Exception)
-          internal_logger.error "Appsignal.send_error: Cannot send error. " \
+          Appsignal.internal_logger.error "Appsignal.send_error: " \
+            "Cannot send error. " \
             "The given value is not an exception: #{error.inspect}"
           return
         end
@@ -293,11 +294,12 @@ module Appsignal
       #   Exception handling guide
       def set_error(exception)
         unless exception.is_a?(Exception)
-          internal_logger.error "Appsignal.set_error: Cannot set error. " \
+          Appsignal.internal_logger.error "Appsignal.set_error: " \
+            "Cannot set error. " \
             "The given value is not an exception: #{exception.inspect}"
           return
         end
-        return if !active? || !Appsignal::Transaction.current?
+        return if !Appsignal.active? || !Appsignal::Transaction.current?
 
         transaction = Appsignal::Transaction.current
         transaction.set_error(exception)
@@ -356,11 +358,12 @@ module Appsignal
       #   Exception handling guide
       def report_error(exception, &block)
         unless exception.is_a?(Exception)
-          internal_logger.error "Appsignal.report_error: Cannot add error. " \
+          Appsignal.internal_logger.error "Appsignal.report_error: " \
+            "Cannot add error. " \
             "The given value is not an exception: #{exception.inspect}"
           return
         end
-        return unless active?
+        return unless Appsignal.active?
 
         has_parent_transaction = Appsignal::Transaction.current?
         transaction =
@@ -398,7 +401,7 @@ module Appsignal
       # @param action [String]
       # @return [void]
       def set_action(action)
-        return if !active? ||
+        return if !Appsignal.active? ||
           !Appsignal::Transaction.current? ||
           action.nil?
 
@@ -440,7 +443,7 @@ module Appsignal
       # @see https://docs.appsignal.com/guides/namespaces.html
       #   Grouping with namespaces guide
       def set_namespace(namespace)
-        return if !active? ||
+        return if !Appsignal.active? ||
           !Appsignal::Transaction.current? ||
           namespace.nil?
 
@@ -488,7 +491,7 @@ module Appsignal
       # @see https://docs.appsignal.com/guides/custom-data/sample-data.html
       #   Sample data guide
       def add_custom_data(data)
-        return unless active?
+        return unless Appsignal.active?
         return unless Appsignal::Transaction.current?
 
         transaction = Appsignal::Transaction.current
@@ -533,7 +536,7 @@ module Appsignal
       # @see https://docs.appsignal.com/ruby/instrumentation/tagging.html
       #   Tagging guide
       def add_tags(tags = {})
-        return unless active?
+        return unless Appsignal.active?
         return unless Appsignal::Transaction.current?
 
         transaction = Appsignal::Transaction.current
@@ -591,7 +594,7 @@ module Appsignal
       # @see https://docs.appsignal.com/guides/filter-data/filter-parameters.html
       #   Parameter filtering guide
       def add_params(params = nil, &block)
-        return unless active?
+        return unless Appsignal.active?
         return unless Appsignal::Transaction.current?
 
         transaction = Appsignal::Transaction.current
@@ -616,7 +619,7 @@ module Appsignal
       # @see Transaction#set_empty_params!
       # @see Transaction#set_params_if_nil
       def set_empty_params!
-        return unless active?
+        return unless Appsignal.active?
         return unless Appsignal::Transaction.current?
 
         transaction = Appsignal::Transaction.current
@@ -657,7 +660,7 @@ module Appsignal
       # @see https://docs.appsignal.com/guides/filter-data/filter-session-data.html
       #   Session data filtering guide
       def add_session_data(session_data = nil, &block)
-        return unless active?
+        return unless Appsignal.active?
         return unless Appsignal::Transaction.current?
 
         transaction = Appsignal::Transaction.current
@@ -699,7 +702,7 @@ module Appsignal
       # @see https://docs.appsignal.com/guides/filter-data/filter-headers.html
       #   Request headers filtering guide
       def add_headers(headers = nil, &block)
-        return unless active?
+        return unless Appsignal.active?
         return unless Appsignal::Transaction.current?
 
         transaction = Appsignal::Transaction.current
@@ -747,7 +750,7 @@ module Appsignal
       # @see https://docs.appsignal.com/ruby/instrumentation/breadcrumbs.html
       #   Breadcrumb reference
       def add_breadcrumb(category, action, message = "", metadata = {}, time = Time.now.utc)
-        return unless active?
+        return unless Appsignal.active?
         return unless Appsignal::Transaction.current?
 
         transaction = Appsignal::Transaction.current
@@ -875,7 +878,7 @@ module Appsignal
       #   Ignore instrumentation guide
       def ignore_instrumentation_events
         Appsignal::Transaction.current&.pause!
-        yield
+        yield if block_given?
       ensure
         Appsignal::Transaction.current&.resume!
       end

--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -102,10 +102,13 @@ module Appsignal
       #   within the block with {#set_action}.
       #   This will not update the active transaction's action if
       #   {.monitor} is called when another transaction is already active.
-      # @yield The block to monitor.
+      # @yield [] The block to monitor.
+      # @yieldreturn [Object] The return value of the block
       # @raise [Exception] Any exception that occurs within the given block is
       #   re-raised by this method.
-      # @return [Object] The value of the given block is returned.
+      # @return [Object, nil] The value of the given block is returned.
+      #   Returns `nil` if there already is a transaction active and no block
+      #   was given.
       #
       # @see https://docs.appsignal.com/ruby/instrumentation/background-jobs.html
       #   Monitor guide
@@ -165,10 +168,11 @@ module Appsignal
       #   within the block with {#set_action}.
       #   This will not update the active transaction's action if
       #   {.monitor} is called when another transaction is already active.
-      # @yield The block to monitor.
+      # @yield [] The block to monitor.
+      # @yieldreturn [Object] The return value of the block
       # @raise [Exception] Any exception that occurs within the given block is
       #   re-raised by this method.
-      # @return [Object] The value of the given block is returned.
+      # @return [Object, nil] The value of the given block is returned.
       #
       # @see monitor
       def monitor_and_stop(action:, namespace: nil, &block)
@@ -862,8 +866,10 @@ module Appsignal
       #   # Only the "my_event.my_group" instrumentation event is reported.
       #
       # @since 3.10.0
-      # @yield block of code that shouldn't be instrumented.
-      # @return [Object] Returns the return value of the block.
+      # @yield [] block of code that shouldn't be instrumented.
+      # @yieldreturn [Object] The return value of the block
+      # @return [Object, nil] Returns the return value of the block.
+      #   Return nil if the block returns nil or no block is given.
       #
       # @see https://docs.appsignal.com/ruby/instrumentation/ignore-instrumentation.html
       #   Ignore instrumentation guide

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -109,7 +109,7 @@ module Appsignal
       # active.
       #
       # @see .current?
-      # @return [Boolean]
+      # @return [Appsignal::Transaction, Appsignal::Transaction::NilTransaction]
       def current
         Thread.current[:appsignal_transaction] || NilTransaction.new
       end

--- a/sig/appsignal.rbi
+++ b/sig/appsignal.rbi
@@ -156,8 +156,8 @@ module Appsignal
   # _@see_ `https://docs.appsignal.com/ruby/configuration.html` — Configuration guide
   # 
   # _@see_ `https://docs.appsignal.com/ruby/configuration/options.html` — Configuration options
-  sig { params(env_param: T.nilable(T.any(String, Symbol)), root_path: T.nilable(String)).void }
-  def self.configure(env_param = nil, root_path: nil); end
+  sig { params(env_param: T.nilable(T.any(String, Symbol)), root_path: T.nilable(String), blk: T.proc.params(config_dsl: Appsignal::Config::ConfigDSL).void).void }
+  def self.configure(env_param = nil, root_path: nil, &blk); end
 
   sig { void }
   def self.forked; end
@@ -302,6 +302,8 @@ module Appsignal
   # _@param_ `action` — The action name for the transaction. The action name is required to be set for the transaction to be reported. The argument can be set to `nil` or `:set_later` if the action is set within the block with {#set_action}. This will not update the active transaction's action if {.monitor} is called when another transaction is already active.
   # 
   # _@return_ — The value of the given block is returned.
+  # Returns `nil` if there already is a transaction active and no block
+  # was given.
   # 
   # Instrument a block of code
   # ```ruby
@@ -389,8 +391,8 @@ module Appsignal
   # ```
   # 
   # _@see_ `https://docs.appsignal.com/ruby/instrumentation/background-jobs.html` — Monitor guide
-  sig { params(action: T.any(String, Symbol, NilClass), namespace: T.nilable(T.any(String, Symbol))).returns(Object) }
-  def self.monitor(action:, namespace: nil); end
+  sig { params(action: T.any(String, Symbol, NilClass), namespace: T.nilable(T.any(String, Symbol)), blk: T.proc.returns(Object)).returns(T.nilable(Object)) }
+  def self.monitor(action:, namespace: nil, &blk); end
 
   # Instrument a block of code and stop AppSignal.
   # 
@@ -407,7 +409,7 @@ module Appsignal
   # _@return_ — The value of the given block is returned.
   # 
   # _@see_ `monitor`
-  sig { params(action: T.any(String, Symbol, NilClass), namespace: T.nilable(T.any(String, Symbol)), block: T.untyped).returns(Object) }
+  sig { params(action: T.any(String, Symbol, NilClass), namespace: T.nilable(T.any(String, Symbol)), block: T.proc.returns(Object)).returns(T.nilable(Object)) }
   def self.monitor_and_stop(action:, namespace: nil, &block); end
 
   # Send an error to AppSignal regardless of the context.
@@ -979,6 +981,7 @@ module Appsignal
   # - Errors and metrics are reported from within this block.
   # 
   # _@return_ — Returns the return value of the block.
+  # Return nil if the block returns nil or no block is given.
   # 
   # ```ruby
   # Appsignal.instrument "my_event.my_group" do
@@ -994,8 +997,8 @@ module Appsignal
   # ```
   # 
   # _@see_ `https://docs.appsignal.com/ruby/instrumentation/ignore-instrumentation.html` — Ignore instrumentation guide
-  sig { returns(Object) }
-  def self.ignore_instrumentation_events; end
+  sig { params(blk: T.proc.returns(Object)).returns(T.nilable(Object)) }
+  def self.ignore_instrumentation_events(&blk); end
 
   # {Appsignal::Demo} is a way to send demonstration / test samples for a
   # exception and a performance issue.
@@ -1268,6 +1271,8 @@ module Appsignal
     # 
     # _@param_ `identifier` — identifier of the cron check-in to report.
     # 
+    # _@return_ — returns the block value.
+    # 
     # Send a cron check-in
     # ```ruby
     # Appsignal::CheckIn.cron("send_invoices")
@@ -1281,8 +1286,8 @@ module Appsignal
     # ```
     # 
     # _@see_ `https://docs.appsignal.com/check-ins/cron`
-    sig { params(identifier: String).void }
-    def self.cron(identifier); end
+    sig { params(identifier: String, blk: T.proc.returns(Object)).returns(Object) }
+    def self.cron(identifier, &blk); end
 
     # Track heartbeat check-ins.
     # 
@@ -1607,6 +1612,8 @@ module Appsignal
       # _@param_ `action` — The action name for the transaction. The action name is required to be set for the transaction to be reported. The argument can be set to `nil` or `:set_later` if the action is set within the block with {#set_action}. This will not update the active transaction's action if {.monitor} is called when another transaction is already active.
       # 
       # _@return_ — The value of the given block is returned.
+      # Returns `nil` if there already is a transaction active and no block
+      # was given.
       # 
       # Instrument a block of code
       # ```ruby
@@ -1694,8 +1701,8 @@ module Appsignal
       # ```
       # 
       # _@see_ `https://docs.appsignal.com/ruby/instrumentation/background-jobs.html` — Monitor guide
-      sig { params(action: T.any(String, Symbol, NilClass), namespace: T.nilable(T.any(String, Symbol))).returns(Object) }
-      def monitor(action:, namespace: nil); end
+      sig { params(action: T.any(String, Symbol, NilClass), namespace: T.nilable(T.any(String, Symbol)), blk: T.proc.returns(Object)).returns(T.nilable(Object)) }
+      def monitor(action:, namespace: nil, &blk); end
 
       # Instrument a block of code and stop AppSignal.
       # 
@@ -1712,7 +1719,7 @@ module Appsignal
       # _@return_ — The value of the given block is returned.
       # 
       # _@see_ `monitor`
-      sig { params(action: T.any(String, Symbol, NilClass), namespace: T.nilable(T.any(String, Symbol)), block: T.untyped).returns(Object) }
+      sig { params(action: T.any(String, Symbol, NilClass), namespace: T.nilable(T.any(String, Symbol)), block: T.proc.returns(Object)).returns(T.nilable(Object)) }
       def monitor_and_stop(action:, namespace: nil, &block); end
 
       # Send an error to AppSignal regardless of the context.
@@ -2284,6 +2291,7 @@ module Appsignal
       # - Errors and metrics are reported from within this block.
       # 
       # _@return_ — Returns the return value of the block.
+      # Return nil if the block returns nil or no block is given.
       # 
       # ```ruby
       # Appsignal.instrument "my_event.my_group" do
@@ -2299,8 +2307,8 @@ module Appsignal
       # ```
       # 
       # _@see_ `https://docs.appsignal.com/ruby/instrumentation/ignore-instrumentation.html` — Ignore instrumentation guide
-      sig { returns(Object) }
-      def ignore_instrumentation_events; end
+      sig { params(blk: T.proc.returns(Object)).returns(T.nilable(Object)) }
+      def ignore_instrumentation_events(&blk); end
     end
   end
 

--- a/sig/appsignal.rbi
+++ b/sig/appsignal.rbi
@@ -1323,7 +1323,7 @@ module Appsignal
     # active.
     # 
     # _@see_ `.current?`
-    sig { returns(T::Boolean) }
+    sig { returns(T.any(Appsignal::Transaction, Appsignal::Transaction::NilTransaction)) }
     def self.current; end
 
     # Returns if any transaction is currently active or not. A

--- a/sig/appsignal.rbi
+++ b/sig/appsignal.rbi
@@ -1043,6 +1043,257 @@ module Appsignal
 
     sig { returns(T::Boolean) }
     def yml_config_file?; end
+
+    # Configuration DSL for use in configuration blocks.
+    # 
+    # This class provides a Domain Specific Language for configuring AppSignal
+    # within the `Appsignal.configure` block. It provides getter and setter
+    # methods for all configuration options.
+    # 
+    # @example Using the configuration DSL
+    #   Appsignal.configure do |config|
+    #     config.name = "My App"
+    #     config.active = true
+    #     config.push_api_key = "your-api-key"
+    #     config.ignore_actions = ["StatusController#health"]
+    #   end
+    # 
+    # @see AppSignal Ruby gem configuration
+    #   https://docs.appsignal.com/ruby/configuration.html
+    class ConfigDSL
+      # Returns the application's root path.
+      # 
+      # _@return_ — The root path of the application
+      sig { returns(String) }
+      def app_path; end
+
+      # Returns the current environment name.
+      # 
+      # _@return_ — The environment name (e.g., "production", "development")
+      sig { returns(String) }
+      def env; end
+
+      # Returns true if the given environment name matches the loaded
+      # environment name.
+      # 
+      # _@param_ `given_env`
+      sig { params(given_env: T.any(String, Symbol)).returns(T.any(TrueClass, FalseClass)) }
+      def env?(given_env); end
+
+      # Activates AppSignal if the current environment matches any of the given environments.
+      # 
+      # _@param_ `envs` — List of environment names to activate for
+      # 
+      # _@return_ — true if AppSignal was activated, false otherwise
+      # 
+      # Activate for production and staging
+      # ```ruby
+      # config.activate_if_environment(:production, :staging)
+      # ```
+      sig { params(envs: T::Array[T.any(String, Symbol)]).returns(T::Boolean) }
+      def activate_if_environment(*envs); end
+
+      # _@return_ — Error reporting mode for ActiveJob ("all", "discard" or "none")
+      sig { returns(String) }
+      attr_accessor :activejob_report_errors
+
+      # _@return_ — The application name
+      sig { returns(String) }
+      attr_accessor :name
+
+      # _@return_ — The host to the agent binds to for its HTTP server
+      sig { returns(String) }
+      attr_accessor :bind_address
+
+      # _@return_ — Path to the CA certificate file
+      sig { returns(String) }
+      attr_accessor :ca_file_path
+
+      # _@return_ — Override for the detected hostname
+      sig { returns(String) }
+      attr_accessor :hostname
+
+      # _@return_ — Role of the host for grouping in metrics
+      sig { returns(String) }
+      attr_accessor :host_role
+
+      # _@return_ — HTTP proxy URL
+      sig { returns(String) }
+      attr_accessor :http_proxy
+
+      # _@return_ — Log destination ("file" or "stdout")
+      sig { returns(String) }
+      attr_accessor :log
+
+      # _@return_ — AppSignal internal logger
+      # log level ("error", "warn", "info", "debug", "trace")
+      sig { returns(String) }
+      attr_accessor :log_level
+
+      # _@return_ — Path to the log directory
+      sig { returns(String) }
+      attr_accessor :log_path
+
+      # _@return_ — Endpoint for log transmission
+      sig { returns(String) }
+      attr_accessor :logging_endpoint
+
+      # _@return_ — Push API endpoint URL
+      sig { returns(String) }
+      attr_accessor :endpoint
+
+      # _@return_ — AppSignal Push API key
+      sig { returns(String) }
+      attr_accessor :push_api_key
+
+      # _@return_ — Error reporting mode for Sidekiq ("all", "discard" or "none")
+      sig { returns(String) }
+      attr_accessor :sidekiq_report_errors
+
+      # _@return_ — Port for StatsD metrics
+      sig { returns(String) }
+      attr_accessor :statsd_port
+
+      # _@return_ — Port for Nginx metrics collection
+      sig { returns(String) }
+      attr_accessor :nginx_port
+
+      # _@return_ — Override for the agent working directory
+      sig { returns(String) }
+      attr_accessor :working_directory_path
+
+      # _@return_ — Application revision identifier
+      sig { returns(String) }
+      attr_accessor :revision
+
+      # _@return_ — Activate AppSignal for the loaded environment
+      sig { returns(T::Boolean) }
+      attr_accessor :active
+
+      # _@return_ — Configure whether allocation tracking is enabled
+      sig { returns(T::Boolean) }
+      attr_accessor :enable_allocation_tracking
+
+      # _@return_ — Configure whether the at_exit reporter is enabled
+      sig { returns(T::Boolean) }
+      attr_accessor :enable_at_exit_reporter
+
+      # _@return_ — Configure whether host metrics collection is enabled
+      sig { returns(T::Boolean) }
+      attr_accessor :enable_host_metrics
+
+      # _@return_ — Configure whether minutely probes are enabled
+      sig { returns(T::Boolean) }
+      attr_accessor :enable_minutely_probes
+
+      # _@return_ — Configure whether the StatsD metrics endpoint on the agent is enabled
+      sig { returns(T::Boolean) }
+      attr_accessor :enable_statsd
+
+      # _@return_ — Configure whether the agent's NGINX metrics endpoint is enabled
+      sig { returns(T::Boolean) }
+      attr_accessor :enable_nginx_metrics
+
+      # _@return_ — Configure whether the GVL global timer instrumentationis enabled
+      sig { returns(T::Boolean) }
+      attr_accessor :enable_gvl_global_timer
+
+      # _@return_ — Configure whether GVL waiting threads instrumentation is enabled
+      sig { returns(T::Boolean) }
+      attr_accessor :enable_gvl_waiting_threads
+
+      # _@return_ — Configure whether Rails error reporter integration is enabled
+      sig { returns(T::Boolean) }
+      attr_accessor :enable_rails_error_reporter
+
+      # _@return_ — Configure whether Rake performance instrumentation is enabled
+      sig { returns(T::Boolean) }
+      attr_accessor :enable_rake_performance_instrumentation
+
+      # _@return_ — Configure whether files created by AppSignal should be world accessible
+      sig { returns(T::Boolean) }
+      attr_accessor :files_world_accessible
+
+      # _@return_ — Configure whether to instrument requests made with the http.rb gem
+      sig { returns(T::Boolean) }
+      attr_accessor :instrument_http_rb
+
+      # _@return_ — Configure whether to instrument requests made with Net::HTTP
+      sig { returns(T::Boolean) }
+      attr_accessor :instrument_net_http
+
+      # _@return_ — Configure whether to instrument the Ownership gem
+      sig { returns(T::Boolean) }
+      attr_accessor :instrument_ownership
+
+      # _@return_ — Configure whether to instrument Redis queries
+      sig { returns(T::Boolean) }
+      attr_accessor :instrument_redis
+
+      # _@return_ — Configure whether to instrument Sequel queries
+      sig { returns(T::Boolean) }
+      attr_accessor :instrument_sequel
+
+      # _@return_ — Configure whether the Ownership gem instrumentation should set namespace
+      sig { returns(T::Boolean) }
+      attr_accessor :ownership_set_namespace
+
+      # _@return_ — Configure whether the application is running in a container
+      sig { returns(T::Boolean) }
+      attr_accessor :running_in_container
+
+      # _@return_ — Configure whether to send environment metadata
+      sig { returns(T::Boolean) }
+      attr_accessor :send_environment_metadata
+
+      # _@return_ — Configure whether to send request parameters
+      sig { returns(T::Boolean) }
+      attr_accessor :send_params
+
+      # _@return_ — Configure whether to send request session data
+      sig { returns(T::Boolean) }
+      attr_accessor :send_session_data
+
+      # _@return_ — Custom DNS servers to use
+      sig { returns(T::Array[String]) }
+      attr_accessor :dns_servers
+
+      # _@return_ — Metadata keys to filter from trace data
+      sig { returns(T::Array[String]) }
+      attr_accessor :filter_metadata
+
+      # _@return_ — Keys of parameter to filter
+      sig { returns(T::Array[String]) }
+      attr_accessor :filter_parameters
+
+      # _@return_ — Request session data keys to filter
+      sig { returns(T::Array[String]) }
+      attr_accessor :filter_session_data
+
+      # _@return_ — Ignore traces by action names
+      sig { returns(T::Array[String]) }
+      attr_accessor :ignore_actions
+
+      # _@return_ — List of errors to not report
+      sig { returns(T::Array[String]) }
+      attr_accessor :ignore_errors
+
+      # _@return_ — Ignore log messages by substrings
+      sig { returns(T::Array[String]) }
+      attr_accessor :ignore_logs
+
+      # _@return_ — Ignore traces by namespaces
+      sig { returns(T::Array[String]) }
+      attr_accessor :ignore_namespaces
+
+      # _@return_ — HTTP request headers to include in error reports
+      sig { returns(T::Array[String]) }
+      attr_accessor :request_headers
+
+      # _@return_ — CPU count override for metrics collection
+      sig { returns(Float) }
+      attr_accessor :cpu_count
+    end
   end
 
   # Logger that flushes logs to the AppSignal logging service.

--- a/sig/appsignal.rbs
+++ b/sig/appsignal.rbs
@@ -1251,7 +1251,7 @@ module Appsignal
     # active.
     # 
     # _@see_ `.current?`
-    def self.current: () -> bool
+    def self.current: () -> (Appsignal::Transaction | Appsignal::Transaction::NilTransaction)
 
     # Returns if any transaction is currently active or not. A
     # {NilTransaction} is not considered an active transaction.

--- a/sig/appsignal.rbs
+++ b/sig/appsignal.rbs
@@ -124,7 +124,7 @@ module Appsignal
   # _@see_ `https://docs.appsignal.com/ruby/configuration.html` — Configuration guide
   # 
   # _@see_ `https://docs.appsignal.com/ruby/configuration/options.html` — Configuration options
-  def self.configure: (?(String | Symbol)? env_param, ?root_path: String?) -> void
+  def self.configure: (?(String | Symbol)? env_param, ?root_path: String?) ?{ (Appsignal::Config::ConfigDSL config_dsl) -> void } -> void
 
   def self.forked: () -> void
 
@@ -260,6 +260,8 @@ module Appsignal
   # _@param_ `action` — The action name for the transaction. The action name is required to be set for the transaction to be reported. The argument can be set to `nil` or `:set_later` if the action is set within the block with {#set_action}. This will not update the active transaction's action if {.monitor} is called when another transaction is already active.
   # 
   # _@return_ — The value of the given block is returned.
+  # Returns `nil` if there already is a transaction active and no block
+  # was given.
   # 
   # Instrument a block of code
   # ```ruby
@@ -347,7 +349,7 @@ module Appsignal
   # ```
   # 
   # _@see_ `https://docs.appsignal.com/ruby/instrumentation/background-jobs.html` — Monitor guide
-  def self.monitor: (action: (String | Symbol | NilClass), ?namespace: (String | Symbol)?) -> Object
+  def self.monitor: (action: (String | Symbol | NilClass), ?namespace: (String | Symbol)?) ?{ () -> Object } -> Object?
 
   # Instrument a block of code and stop AppSignal.
   # 
@@ -364,7 +366,7 @@ module Appsignal
   # _@return_ — The value of the given block is returned.
   # 
   # _@see_ `monitor`
-  def self.monitor_and_stop: (action: (String | Symbol | NilClass), ?namespace: (String | Symbol)?) -> Object
+  def self.monitor_and_stop: (action: (String | Symbol | NilClass), ?namespace: (String | Symbol)?) ?{ () -> Object } -> Object?
 
   # Send an error to AppSignal regardless of the context.
   # 
@@ -909,6 +911,7 @@ module Appsignal
   # - Errors and metrics are reported from within this block.
   # 
   # _@return_ — Returns the return value of the block.
+  # Return nil if the block returns nil or no block is given.
   # 
   # ```ruby
   # Appsignal.instrument "my_event.my_group" do
@@ -924,7 +927,7 @@ module Appsignal
   # ```
   # 
   # _@see_ `https://docs.appsignal.com/ruby/instrumentation/ignore-instrumentation.html` — Ignore instrumentation guide
-  def self.ignore_instrumentation_events: () -> Object
+  def self.ignore_instrumentation_events: () ?{ () -> Object } -> Object?
 
   # The loaded AppSignal configuration.
   # Returns the current AppSignal configuration.
@@ -1199,6 +1202,8 @@ module Appsignal
     # 
     # _@param_ `identifier` — identifier of the cron check-in to report.
     # 
+    # _@return_ — returns the block value.
+    # 
     # Send a cron check-in
     # ```ruby
     # Appsignal::CheckIn.cron("send_invoices")
@@ -1212,7 +1217,7 @@ module Appsignal
     # ```
     # 
     # _@see_ `https://docs.appsignal.com/check-ins/cron`
-    def self.cron: (String identifier) -> void
+    def self.cron: (String identifier) ?{ () -> Object } -> Object
 
     # Track heartbeat check-ins.
     # 
@@ -1514,6 +1519,8 @@ module Appsignal
       # _@param_ `action` — The action name for the transaction. The action name is required to be set for the transaction to be reported. The argument can be set to `nil` or `:set_later` if the action is set within the block with {#set_action}. This will not update the active transaction's action if {.monitor} is called when another transaction is already active.
       # 
       # _@return_ — The value of the given block is returned.
+      # Returns `nil` if there already is a transaction active and no block
+      # was given.
       # 
       # Instrument a block of code
       # ```ruby
@@ -1601,7 +1608,7 @@ module Appsignal
       # ```
       # 
       # _@see_ `https://docs.appsignal.com/ruby/instrumentation/background-jobs.html` — Monitor guide
-      def monitor: (action: (String | Symbol | NilClass), ?namespace: (String | Symbol)?) -> Object
+      def monitor: (action: (String | Symbol | NilClass), ?namespace: (String | Symbol)?) ?{ () -> Object } -> Object?
 
       # Instrument a block of code and stop AppSignal.
       # 
@@ -1618,7 +1625,7 @@ module Appsignal
       # _@return_ — The value of the given block is returned.
       # 
       # _@see_ `monitor`
-      def monitor_and_stop: (action: (String | Symbol | NilClass), ?namespace: (String | Symbol)?) -> Object
+      def monitor_and_stop: (action: (String | Symbol | NilClass), ?namespace: (String | Symbol)?) ?{ () -> Object } -> Object?
 
       # Send an error to AppSignal regardless of the context.
       # 
@@ -2163,6 +2170,7 @@ module Appsignal
       # - Errors and metrics are reported from within this block.
       # 
       # _@return_ — Returns the return value of the block.
+      # Return nil if the block returns nil or no block is given.
       # 
       # ```ruby
       # Appsignal.instrument "my_event.my_group" do
@@ -2178,7 +2186,7 @@ module Appsignal
       # ```
       # 
       # _@see_ `https://docs.appsignal.com/ruby/instrumentation/ignore-instrumentation.html` — Ignore instrumentation guide
-      def ignore_instrumentation_events: () -> Object
+      def ignore_instrumentation_events: () ?{ () -> Object } -> Object?
     end
   end
 

--- a/sig/appsignal.rbs
+++ b/sig/appsignal.rbs
@@ -992,6 +992,203 @@ module Appsignal
     def active?: () -> bool
 
     def yml_config_file?: () -> bool
+
+    # Configuration DSL for use in configuration blocks.
+    # 
+    # This class provides a Domain Specific Language for configuring AppSignal
+    # within the `Appsignal.configure` block. It provides getter and setter
+    # methods for all configuration options.
+    # 
+    # @example Using the configuration DSL
+    #   Appsignal.configure do |config|
+    #     config.name = "My App"
+    #     config.active = true
+    #     config.push_api_key = "your-api-key"
+    #     config.ignore_actions = ["StatusController#health"]
+    #   end
+    # 
+    # @see AppSignal Ruby gem configuration
+    #   https://docs.appsignal.com/ruby/configuration.html
+    class ConfigDSL
+      # Returns the application's root path.
+      # 
+      # _@return_ — The root path of the application
+      def app_path: () -> String
+
+      # Returns the current environment name.
+      # 
+      # _@return_ — The environment name (e.g., "production", "development")
+      def env: () -> String
+
+      # Returns true if the given environment name matches the loaded
+      # environment name.
+      # 
+      # _@param_ `given_env`
+      def env?: ((String | Symbol) given_env) -> (TrueClass | FalseClass)
+
+      # Activates AppSignal if the current environment matches any of the given environments.
+      # 
+      # _@param_ `envs` — List of environment names to activate for
+      # 
+      # _@return_ — true if AppSignal was activated, false otherwise
+      # 
+      # Activate for production and staging
+      # ```ruby
+      # config.activate_if_environment(:production, :staging)
+      # ```
+      def activate_if_environment: (*::Array[(String | Symbol)] envs) -> bool
+
+      # _@return_ — Error reporting mode for ActiveJob ("all", "discard" or "none")
+      attr_accessor activejob_report_errors: String
+
+      # _@return_ — The application name
+      attr_accessor name: String
+
+      # _@return_ — The host to the agent binds to for its HTTP server
+      attr_accessor bind_address: String
+
+      # _@return_ — Path to the CA certificate file
+      attr_accessor ca_file_path: String
+
+      # _@return_ — Override for the detected hostname
+      attr_accessor hostname: String
+
+      # _@return_ — Role of the host for grouping in metrics
+      attr_accessor host_role: String
+
+      # _@return_ — HTTP proxy URL
+      attr_accessor http_proxy: String
+
+      # _@return_ — Log destination ("file" or "stdout")
+      attr_accessor log: String
+
+      # _@return_ — AppSignal internal logger
+      # log level ("error", "warn", "info", "debug", "trace")
+      attr_accessor log_level: String
+
+      # _@return_ — Path to the log directory
+      attr_accessor log_path: String
+
+      # _@return_ — Endpoint for log transmission
+      attr_accessor logging_endpoint: String
+
+      # _@return_ — Push API endpoint URL
+      attr_accessor endpoint: String
+
+      # _@return_ — AppSignal Push API key
+      attr_accessor push_api_key: String
+
+      # _@return_ — Error reporting mode for Sidekiq ("all", "discard" or "none")
+      attr_accessor sidekiq_report_errors: String
+
+      # _@return_ — Port for StatsD metrics
+      attr_accessor statsd_port: String
+
+      # _@return_ — Port for Nginx metrics collection
+      attr_accessor nginx_port: String
+
+      # _@return_ — Override for the agent working directory
+      attr_accessor working_directory_path: String
+
+      # _@return_ — Application revision identifier
+      attr_accessor revision: String
+
+      # _@return_ — Activate AppSignal for the loaded environment
+      attr_accessor active: bool
+
+      # _@return_ — Configure whether allocation tracking is enabled
+      attr_accessor enable_allocation_tracking: bool
+
+      # _@return_ — Configure whether the at_exit reporter is enabled
+      attr_accessor enable_at_exit_reporter: bool
+
+      # _@return_ — Configure whether host metrics collection is enabled
+      attr_accessor enable_host_metrics: bool
+
+      # _@return_ — Configure whether minutely probes are enabled
+      attr_accessor enable_minutely_probes: bool
+
+      # _@return_ — Configure whether the StatsD metrics endpoint on the agent is enabled
+      attr_accessor enable_statsd: bool
+
+      # _@return_ — Configure whether the agent's NGINX metrics endpoint is enabled
+      attr_accessor enable_nginx_metrics: bool
+
+      # _@return_ — Configure whether the GVL global timer instrumentationis enabled
+      attr_accessor enable_gvl_global_timer: bool
+
+      # _@return_ — Configure whether GVL waiting threads instrumentation is enabled
+      attr_accessor enable_gvl_waiting_threads: bool
+
+      # _@return_ — Configure whether Rails error reporter integration is enabled
+      attr_accessor enable_rails_error_reporter: bool
+
+      # _@return_ — Configure whether Rake performance instrumentation is enabled
+      attr_accessor enable_rake_performance_instrumentation: bool
+
+      # _@return_ — Configure whether files created by AppSignal should be world accessible
+      attr_accessor files_world_accessible: bool
+
+      # _@return_ — Configure whether to instrument requests made with the http.rb gem
+      attr_accessor instrument_http_rb: bool
+
+      # _@return_ — Configure whether to instrument requests made with Net::HTTP
+      attr_accessor instrument_net_http: bool
+
+      # _@return_ — Configure whether to instrument the Ownership gem
+      attr_accessor instrument_ownership: bool
+
+      # _@return_ — Configure whether to instrument Redis queries
+      attr_accessor instrument_redis: bool
+
+      # _@return_ — Configure whether to instrument Sequel queries
+      attr_accessor instrument_sequel: bool
+
+      # _@return_ — Configure whether the Ownership gem instrumentation should set namespace
+      attr_accessor ownership_set_namespace: bool
+
+      # _@return_ — Configure whether the application is running in a container
+      attr_accessor running_in_container: bool
+
+      # _@return_ — Configure whether to send environment metadata
+      attr_accessor send_environment_metadata: bool
+
+      # _@return_ — Configure whether to send request parameters
+      attr_accessor send_params: bool
+
+      # _@return_ — Configure whether to send request session data
+      attr_accessor send_session_data: bool
+
+      # _@return_ — Custom DNS servers to use
+      attr_accessor dns_servers: ::Array[String]
+
+      # _@return_ — Metadata keys to filter from trace data
+      attr_accessor filter_metadata: ::Array[String]
+
+      # _@return_ — Keys of parameter to filter
+      attr_accessor filter_parameters: ::Array[String]
+
+      # _@return_ — Request session data keys to filter
+      attr_accessor filter_session_data: ::Array[String]
+
+      # _@return_ — Ignore traces by action names
+      attr_accessor ignore_actions: ::Array[String]
+
+      # _@return_ — List of errors to not report
+      attr_accessor ignore_errors: ::Array[String]
+
+      # _@return_ — Ignore log messages by substrings
+      attr_accessor ignore_logs: ::Array[String]
+
+      # _@return_ — Ignore traces by namespaces
+      attr_accessor ignore_namespaces: ::Array[String]
+
+      # _@return_ — HTTP request headers to include in error reports
+      attr_accessor request_headers: ::Array[String]
+
+      # _@return_ — CPU count override for metrics collection
+      attr_accessor cpu_count: Float
+    end
   end
 
   # Logger that flushes logs to the AppSignal logging service.


### PR DESCRIPTION
## Improve documentation for yields

When a method is yielding a block, document this better so it shows up in the generated signatures.

[skip changeset] because the other updates on this aren't published yet.

## Fix Transaction current return value API docs

It doesn't return a boolean, that's the `current?` method. Update the return value documentation to the actual return value types.

## Make Appsignal calls more explicit for helpers

The instrumentation helper module calls methods that do not exist on the module itself. They instead exist on the `Appsignal` module. Make the calls more explicit so it's easier to follow the code paths. This helps resolves some errors flagged by Steep.

## Document ConfigDSL with YARD and signatures

This is a part of the Ruby gem our customers will interact with, so help usability by providing documentation and signatures.

[skip review]
