### PR TITLE
Include updated signatures in releases

### DIFF
--- a/mono.yml
+++ b/mono.yml
@@ -9,6 +9,9 @@ clean:
     - "bundle exec rake extension:clean"
     - "rm -rf pkg"
 build:
+  pre: |
+    script/generate_signatures
+    git add sig/*
   command: "bundle exec rake build:all"
 publish:
   gem_files_dir: pkg/

--- a/sig/appsignal.rbi
+++ b/sig/appsignal.rbi
@@ -8,7 +8,7 @@
 module Appsignal
   extend Appsignal::Helpers::Metrics
   extend Appsignal::Helpers::Instrumentation
-  VERSION = T.let("4.5.17", T.untyped)
+  VERSION = T.let("4.6.0", T.untyped)
 
   class << self
     # The loaded AppSignal configuration.


### PR DESCRIPTION
## Regenerate signatures after release

This change should be included in the release, but we need to update the workflow for that first.

## Include updated signatures in releases

See previous commit, when we release a new version the signatures aren't generated with the updated version number, leaving it behind one version all the time. Generate the signatures as part of the build process so it is included in the released Ruby gem.

[skip review]
[skip changeset]