### PR TITLE
Fix Rails detection to check for Railtie presence

### DIFF
--- a/.changesets/fix-rails-detection-to-check-for-rails--railtie-presence.md
+++ b/.changesets/fix-rails-detection-to-check-for-rails--railtie-presence.md
@@ -1,0 +1,10 @@
+---
+bump: patch
+type: fix
+---
+
+Fix Rails detection to check for Rails::Railtie presence
+
+Improves Rails detection by checking for Rails::Railtie instead of just the Rails module. 
+
+This prevents loading errors when non-Rails code defines a Rails constant without the full Rails framework.

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -643,7 +643,7 @@ require "appsignal/rack/body_wrapper"
 require "appsignal/rack/abstract_middleware"
 require "appsignal/rack/instrumentation_middleware"
 require "appsignal/rack/event_handler"
-require "appsignal/integrations/railtie" if defined?(::Rails)
+require "appsignal/integrations/railtie" if defined?(::Rails::Railtie)
 require "appsignal/transaction"
 require "appsignal/version"
 require "appsignal/transmitter"

--- a/lib/appsignal/integrations/railtie.rb
+++ b/lib/appsignal/integrations/railtie.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
-Appsignal.internal_logger.debug("Loading Rails (#{Rails.version}) integration")
-
 require "appsignal/utils/rails_helper"
 require "appsignal/rack/rails_instrumentation"
 
 module Appsignal
   module Integrations
+    rails_version = Rails.respond_to?(:version) ? Rails.version : "unknown"
+    Appsignal.internal_logger.debug("Loading Rails (#{rails_version}) integration")
+
     # @!visibility private
     class Railtie < ::Rails::Railtie
       config.appsignal = ActiveSupport::OrderedOptions.new

--- a/spec/lib/appsignal/rails_detection_spec.rb
+++ b/spec/lib/appsignal/rails_detection_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+describe "Rails detection" do
+  context "when Rails module exists without Railtie" do
+    before do
+      stub_const("Rails", Module.new)
+    end
+
+    it "does not trigger Rails integration loading" do
+      expect(defined?(::Rails::Railtie)).to be_falsy
+    end
+
+    context "even with version method" do
+      before do
+        rails_module = Module.new do
+          def self.version
+            "8.0.0"
+          end
+        end
+        stub_const("Rails", rails_module)
+      end
+
+      it "still does not trigger loading without Railtie" do
+        expect(Rails.respond_to?(:version)).to be_truthy
+        expect(defined?(::Rails::Railtie)).to be_falsy
+      end
+    end
+  end
+
+  context "when Rails::Railtie is present" do
+    before do
+      rails_module = Module.new do
+        def self.version
+          "8.0.0"
+        end
+      end
+      stub_const("Rails", rails_module)
+      stub_const("Rails::Railtie", Class.new)
+    end
+
+    it "triggers Rails integration loading" do
+      expect(defined?(::Rails::Railtie)).to be_truthy
+    end
+
+    it "safely handles Rails.version" do
+      expect(Rails.version).to eq("8.0.0")
+    end
+  end
+end


### PR DESCRIPTION
Improve Rails detection by checking for Rails::Railtie instead of just the Rails module. This prevents loading errors when non-Rails code defines a Rails constant without the full Rails framework.

Some applications may define a Rails module/constant without actually using the Rails framework. By specifically checking for Rails::Railtie, we ensure the Rails framework is actually present before attempting integration.