### PR TITLE
Only instrument Rails if AppSignal started

### DIFF
--- a/.changesets/avoid-instrumenting-rails-when-appsignal-is-not-active.md
+++ b/.changesets/avoid-instrumenting-rails-when-appsignal-is-not-active.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Avoid instrumenting Rails when AppSignal is not active. If AppSignal is configured to start when the Rails application loads, rather than after it has initialised, only add Rails' instrumentation middlewares if AppSignal was actually started.


### PR DESCRIPTION
Issue #1442 can be reproduced without AppSignal starting or being active in the current environment, because the Railtie will add Rails instrumentation even if AppSignal is not active.

This should not happen -- no instrumentation should be added to the customer's application if AppSignal is not active.

Unfortunately, it is not possible to modify the middleware chain at `after_initialize`, so this only fixes the issue for `on_load`.

Note that this does not fix the issue described in #1442.