### PR TITLE
Fix streaming responses with Rack middleware

### DIFF
--- a/.changesets/fix-streaming-bodies-with-rack-middleware.md
+++ b/.changesets/fix-streaming-bodies-with-rack-middleware.md
@@ -1,0 +1,20 @@
+---
+bump: minor
+type: fix
+---
+
+Support streaming bodies. AppSignal's Rack instrumentation now supports streaming bodies in responses, such as those produced by `Async::Cable`. This fixes an issue where AppSignal's Rack instrumentation would cause requests with streaming bodies to crash.
+
+If you use our Rack instrumentation through a framework that is automatically instrumented by AppSignal, such as Rails, Hanami, Padrino or Sinatra, this fix is applied automatically.
+
+If your application instruments Rack manually, you must remove the following line from your application's initial setup:
+
+```ruby
+use Rack::Events, [Appsignal::Rack::EventHandler.new]
+```
+
+And replace it with the following line:
+
+```ruby
+use Appsignal::Rack::EventMiddleware
+```

--- a/lib/appsignal.rb
+++ b/lib/appsignal.rb
@@ -643,6 +643,7 @@ require "appsignal/rack/body_wrapper"
 require "appsignal/rack/abstract_middleware"
 require "appsignal/rack/instrumentation_middleware"
 require "appsignal/rack/event_handler"
+require "appsignal/rack/event_middleware"
 require "appsignal/integrations/railtie" if defined?(::Rails)
 require "appsignal/transaction"
 require "appsignal/version"

--- a/lib/appsignal/integrations/railtie.rb
+++ b/lib/appsignal/integrations/railtie.rb
@@ -68,8 +68,7 @@ module Appsignal
       def self.add_instrumentation_middleware(app)
         app.middleware.insert(
           0,
-          ::Rack::Events,
-          [Appsignal::Rack::EventHandler.new]
+          ::Appsignal::Rack::EventMiddleware
         )
         app.middleware.insert_after(
           ActionDispatch::DebugExceptions,

--- a/lib/appsignal/loaders/hanami.rb
+++ b/lib/appsignal/loaders/hanami.rb
@@ -21,10 +21,7 @@ module Appsignal
         require "appsignal/rack/hanami_middleware"
 
         hanami_app_config = ::Hanami.app.config
-        hanami_app_config.middleware.use(
-          ::Rack::Events,
-          [Appsignal::Rack::EventHandler.new]
-        )
+        hanami_app_config.middleware.use(Appsignal::Rack::EventMiddleware)
         hanami_app_config.middleware.use(Appsignal::Rack::HanamiMiddleware)
 
         return unless Gem::Version.new(Hanami::VERSION) < Gem::Version.new("2.2.0")

--- a/lib/appsignal/loaders/padrino.rb
+++ b/lib/appsignal/loaders/padrino.rb
@@ -18,7 +18,7 @@ module Appsignal
         Padrino::Application.prepend(Appsignal::Loaders::PadrinoLoader::PadrinoIntegration)
 
         Padrino.before_load do
-          Padrino.use ::Rack::Events, [Appsignal::Rack::EventHandler.new]
+          Padrino.use Appsignal::Rack::EventMiddleware
           Padrino.use Appsignal::Rack::SinatraBaseInstrumentation,
             :instrument_event_name => "process_action.padrino"
         end

--- a/lib/appsignal/loaders/sinatra.rb
+++ b/lib/appsignal/loaders/sinatra.rb
@@ -16,7 +16,7 @@ module Appsignal
       def on_start
         require "appsignal/rack/sinatra_instrumentation"
 
-        ::Sinatra::Base.use(::Rack::Events, [Appsignal::Rack::EventHandler.new])
+        ::Sinatra::Base.use(Appsignal::Rack::EventMiddleware)
         ::Sinatra::Base.use(Appsignal::Rack::SinatraBaseInstrumentation)
       end
     end

--- a/lib/appsignal/rack/event_middleware.rb
+++ b/lib/appsignal/rack/event_middleware.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module Appsignal
+  module Rack
+    # Modified version of the {::Rack::Events} instrumentation
+    # middleware.
+    #
+    # We recommend using this instead of {::Rack::Events}, as it
+    # is compatible with streaming bodies.
+    #
+    # We do not recommend using this middleware directly, instead
+    # recommending the use of {EventMiddleware}, which is a
+    # convenience wrapper around this middleware that includes
+    # AppSignal's {EventHandler}.
+    #
+    # See the original implementation at:
+    # https://github.com/rack/rack/blob/8d3d7857fcd9e5df057a6c22458bab35b3a19c12/lib/rack/events.rb
+    class Events < ::Rack::Events
+      # A stub for {::Rack::Events::EventedBodyProxy}. It
+      # allows the same initialization arguments, but
+      # otherwise behaves identically to {::Rack::BodyProxy}.
+      #
+      # It does not implement `#each`, fixing an issue
+      # where the evented body proxy would break
+      # streaming responses by always responding to `#each`
+      # even if the proxied body did not implement it.
+      #
+      # Because it ignores the handlers passed to it and
+      # behaves like a normal body proxy, the `on_send`
+      # event on the handlers is never called.
+      class EventedBodyProxy < ::Rack::BodyProxy
+        def initialize(body, _request, _response, _handlers, &block)
+          super(body, &block)
+        end
+      end
+
+      # Notifies the AppSignal event handler that it's being
+      # used with the modified middleware, suppressing a
+      # deprecation warning.
+      def initialize(app, handlers = [])
+        super
+        handlers.each do |handler|
+          if handler.respond_to?(:using_appsignal_rack_events_middleware=)
+            handler.using_appsignal_rack_events_middleware = true
+          end
+        end
+      end
+
+      # The `call` method, exactly as implemented by {::Rack::Events},
+      # but redefined here so that it uses our {EventedBodyProxy}
+      # instead of the original {::Rack::Events::EventedBodyProxy}.
+      #
+      # This fixes streaming bodies, but it also means that the
+      # `on_send` event on the handlers is never called.
+      #
+      # See the original implementation at:
+      # https://github.com/rack/rack/blob/8d3d7857fcd9e5df057a6c22458bab35b3a19c12/lib/rack/events.rb#L111-L129
+      def call(env)
+        request = make_request env
+        on_start request, nil
+
+        begin
+          status, headers, body = @app.call request.env
+          response = make_response status, headers, body
+          on_commit request, response
+        rescue StandardError => e
+          on_error request, response, e
+          on_finish request, response
+          raise
+        end
+
+        body = EventedBodyProxy.new(body, request, response, @handlers) do
+          on_finish request, response
+        end
+        [response.status, response.headers, body]
+      end
+    end
+
+    # Instrumentation middleware using Rack's Events module.
+    #
+    # A convenience wrapper around our {Events} middleware,
+    # modified to be compatible with streaming bodies,
+    # that automatically includes AppSignal's {EventHandler}.
+    #
+    # We recommend using this in combination with the
+    # {InstrumentationMiddleware}.
+    #
+    # This middleware will report the response status code as the
+    # `response_status` tag on the sample. It will also report the response
+    # status as the `response_status` metric.
+    #
+    # This middleware will ensure the AppSignal transaction is always completed
+    # for every request.
+    #
+    # @example Add EventMiddleware to a Rack app
+    #   # Add this middleware as the first middleware of an app
+    #   use Appsignal::Rack::EventMiddleware
+    #
+    #   # Then add the InstrumentationMiddleware
+    #   use Appsignal::Rack::InstrumentationMiddleware
+    #
+    # @see https://docs.appsignal.com/ruby/integrations/rack.html
+    #   Rack integration documentation.
+    # @api public
+    class EventMiddleware < Events
+      def initialize(app)
+        super(app, [Appsignal::Rack::EventHandler.new])
+      end
+    end
+  end
+end

--- a/lib/appsignal/rack/instrumentation_middleware.rb
+++ b/lib/appsignal/rack/instrumentation_middleware.rb
@@ -27,8 +27,8 @@ module Appsignal
     #   require "appsignal"
     #   # Configure and start AppSignal
     #
-    #   # Add the EventHandler first
-    #   use ::Rack::Events, [Appsignal::Rack::EventHandler.new]
+    #   # Add the EventMiddleware first
+    #   use Appsignal::Rack::EventMiddleware
     #   # Add the instrumentation middleware second
     #   use Appsignal::Rack::InstrumentationMiddleware
     #

--- a/spec/lib/appsignal/integrations/railtie_spec.rb
+++ b/spec/lib/appsignal/integrations/railtie_spec.rb
@@ -119,9 +119,9 @@ if DependencyHelper.rails_present?
 
           middleware_stack = resolve_middleware(app)
           expect_middleware_to_match(
-            middleware_stack.find { |m| m.klass == ::Rack::Events },
-            ::Rack::Events,
-            [[instance_of(Appsignal::Rack::EventHandler)]]
+            middleware_stack.find { |m| m.klass == Appsignal::Rack::EventMiddleware },
+            Appsignal::Rack::EventMiddleware,
+            []
           )
           expect_middleware_to_match(
             middleware_stack.find { |m| m.klass == Appsignal::Rack::RailsInstrumentation },
@@ -199,7 +199,9 @@ if DependencyHelper.rails_present?
           initialize_railtie(event)
 
           middleware_stack = resolve_middleware(app)
-          expect(middleware_stack.find { |m| m.klass == ::Rack::Events }).to be_nil
+          expect(middleware_stack.find do |m|
+                   m.klass == Appsignal::Rack::EventMiddleware
+                 end).to be_nil
           expect(middleware_stack.find { |m| m.klass == Appsignal::Rack::RailsInstrumentation })
             .to be_nil
         end
@@ -237,9 +239,9 @@ if DependencyHelper.rails_present?
 
           middleware_stack = resolve_middleware(app)
           expect_middleware_to_match(
-            middleware_stack.find { |m| m.klass == ::Rack::Events },
-            ::Rack::Events,
-            [[instance_of(Appsignal::Rack::EventHandler)]]
+            middleware_stack.find { |m| m.klass == Appsignal::Rack::EventMiddleware },
+            Appsignal::Rack::EventMiddleware,
+            []
           )
           expect_middleware_to_match(
             middleware_stack.find { |m| m.klass == Appsignal::Rack::RailsInstrumentation },

--- a/spec/lib/appsignal/loaders/hanami_spec.rb
+++ b/spec/lib/appsignal/loaders/hanami_spec.rb
@@ -30,14 +30,15 @@ if DependencyHelper.hanami_present?
         middleware_stack = ::Hanami.app.config.middleware.stack[::Hanami::Router::DEFAULT_PREFIX]
         middleware_stack.delete_if do |middleware|
           middleware.first == Appsignal::Rack::HanamiMiddleware ||
-            middleware.first == Rack::Events
+            middleware.first == Appsignal::Rack::EventMiddleware
         end
       end
 
       it "adds the instrumentation middleware to Sinatra::Base" do
         expect(::Hanami.app.config.middleware.stack[::Hanami::Router::DEFAULT_PREFIX])
           .to include(
-            [Rack::Events, [[kind_of(Appsignal::Rack::EventHandler)]], *hanami_middleware_options],
+            [Appsignal::Rack::EventMiddleware, [],
+             *hanami_middleware_options],
             [Appsignal::Rack::HanamiMiddleware, [], *hanami_middleware_options]
           )
       end

--- a/spec/lib/appsignal/loaders/padrino_spec.rb
+++ b/spec/lib/appsignal/loaders/padrino_spec.rb
@@ -26,7 +26,7 @@ if DependencyHelper.padrino_present?
 
       def uninstall_padrino_integration
         expected_middleware = [
-          Rack::Events,
+          Appsignal::Rack::EventMiddleware,
           Appsignal::Rack::SinatraBaseInstrumentation
         ]
         Padrino.middleware.delete_if do |middleware|
@@ -42,7 +42,7 @@ if DependencyHelper.padrino_present?
 
         middlewares = Padrino.middleware
         expect(middlewares).to include(
-          [Rack::Events, [[instance_of(Appsignal::Rack::EventHandler)]], nil]
+          [Appsignal::Rack::EventMiddleware, [], nil]
         )
         expect(middlewares).to include(
           [

--- a/spec/lib/appsignal/loaders/sinatra_spec.rb
+++ b/spec/lib/appsignal/loaders/sinatra_spec.rb
@@ -19,7 +19,7 @@ if DependencyHelper.sinatra_present?
 
       def uninstall_sinatra_integration
         expected_middleware = [
-          Rack::Events,
+          Appsignal::Rack::EventMiddleware,
           Appsignal::Rack::SinatraBaseInstrumentation
         ]
         Sinatra::Base.instance_variable_get(:@middleware).delete_if do |middleware|
@@ -33,7 +33,7 @@ if DependencyHelper.sinatra_present?
 
         middlewares = Sinatra::Base.middleware.to_a
         expect(middlewares).to include(
-          [Rack::Events, [[instance_of(Appsignal::Rack::EventHandler)]], nil]
+          [Appsignal::Rack::EventMiddleware, [], nil]
         )
         expect(middlewares).to include(
           [Appsignal::Rack::SinatraBaseInstrumentation, [], nil]


### PR DESCRIPTION
The `Rack::Events` middleware is not compatible with streaming bodies. It wraps the body in a `Rack::Events::EventedBodyProxy`, which unlike a `Rack::BodyProxy`, always responds to `#each`, even if the body it is proxying does not respond to `#each`.

According to the Rack spec, when a body responds to both `#each` and `#call`, the former is preferred, ultimately causing a `NoMethodError` on the original body.

Deprecate the use of `Rack::Events` for our event-based Rack instrumentation. Implement a modified `Appsignal::Rack::Events` which wraps the body in a `Rack::BodyProxy`, ensuring it does not respond to `#each` when the body it's proxying does not respond to `#each`.

Since `Appsignal::Rack::Events`' modifications break the `on_send` event, we do not recommend its direct usage. Instead, we provide a convenience `Appsignal::Rack::EventMiddleware` wrapper, which uses our modified events middleware with our event handler.

A deprecation warning is emitted when `Appsignal::Rack::EventMiddleware` is used with `Rack::Events`.

Fixes #1442.