### PR TITLE
Fix return type of `finish_transaction` for jRuby

### DIFF
--- a/.changesets/fix-jruby-extension-return-type.md
+++ b/.changesets/fix-jruby-extension-return-type.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+type: fix
+---
+
+Fix sample data not being reported for JRuby applications. Data like tags, parameters, session data, etc. would not be set if a transaction was sampled.
+

--- a/lib/appsignal/extension/jruby.rb
+++ b/lib/appsignal/extension/jruby.rb
@@ -128,7 +128,7 @@ module Appsignal
           :void
         attach_function :appsignal_finish_transaction,
           [:pointer, :long],
-          :void
+          :bool
         attach_function :appsignal_complete_transaction,
           [:pointer],
           :void


### PR DESCRIPTION
The current binding specifies `:void` as return type for `:appsignal_finish_transaction`, which means that `should_sample` returns `nil` for apps using jRuby.