### PR TITLE
Handle unowned files for `code_ownership`

### DIFF
--- a/lib/appsignal/integrations/code_ownership.rb
+++ b/lib/appsignal/integrations/code_ownership.rb
@@ -7,7 +7,7 @@ module Appsignal
       class << self
         def before_complete(transaction, error)
           team = ::CodeOwnership.for_backtrace(error.backtrace)
-          transaction.add_tags(:owner => team.name)
+          transaction.add_tags(:owner => team.name) if team
         rescue => ex
           logger = Appsignal.internal_logger
           logger.error(

--- a/spec/lib/appsignal/integrations/code_ownership_spec.rb
+++ b/spec/lib/appsignal/integrations/code_ownership_spec.rb
@@ -109,6 +109,21 @@ if DependencyHelper.code_ownership_present?
 
           expect(transaction).to include_tags("owner" => "GlobTeam")
         end
+
+        it "handles files without owners" do
+          transaction = create_transaction
+
+          logs = capture_logs do
+            load File.join(support_dir, "code_ownership", "no_owner.rb")
+          rescue => error
+            transaction.add_error(error)
+          ensure
+            transaction.complete
+          end
+
+          expect(transaction).to_not include_tags("owner" => anything)
+          expect(logs).to be_empty
+        end
       end
     end
 

--- a/spec/support/code_ownership/no_owner.rb
+++ b/spec/support/code_ownership/no_owner.rb
@@ -1,0 +1,1 @@
+raise "no ownership"


### PR DESCRIPTION
Follow up to #1443.

It is perfectly fine to have unowned files, but appsignal currently produces log lines for this case, which look like some errors and can be confusing 

```
INFO -- : ║ [2025-09-30T18:13:32 (process) #8][ERROR] appsignal: Error while looking up CodeOwnership team: NoMethodError: undefined method `name' for nil
```