### PR TITLE
Fix code_ownership for transactions without errors

### DIFF
--- a/lib/appsignal/integrations/code_ownership.rb
+++ b/lib/appsignal/integrations/code_ownership.rb
@@ -6,6 +6,8 @@ module Appsignal
     module CodeOwnershipIntegration
       class << self
         def before_complete(transaction, error)
+          return unless error
+
           team = ::CodeOwnership.for_backtrace(error.backtrace)
           transaction.add_tags(:owner => team.name) if team
         rescue => ex

--- a/spec/lib/appsignal/integrations/code_ownership_spec.rb
+++ b/spec/lib/appsignal/integrations/code_ownership_spec.rb
@@ -124,6 +124,17 @@ if DependencyHelper.code_ownership_present?
           expect(transaction).to_not include_tags("owner" => anything)
           expect(logs).to be_empty
         end
+
+        it "handles transactions without errors" do
+          transaction = create_transaction
+
+          logs = capture_logs do
+            transaction.complete
+          end
+
+          expect(transaction).to_not include_tags("owner" => anything)
+          expect(logs).to be_empty
+        end
       end
     end
 


### PR DESCRIPTION
Found another case after #1463 was merged.

AppSignal currently produces log lines if transaction has no errors:
```
#125][ERROR] appsignal: Error while looking up CodeOwnership team: NoMethodError: undefined method `backtrace' for nil
```

Follow-up to #1443.