### PR TITLE
Fix issue with logger config on Rails boot

### DIFF
--- a/.changesets/fix-issue-with-logger-not-supporting-a-formatter.md
+++ b/.changesets/fix-issue-with-logger-not-supporting-a-formatter.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix an issue with loggers not supporting a formatter on Rails boot. This will prevent the AppSignal logger config from running into an error if the logger configuration is added to `config/application.rb` or one of the environments in `config/environments/`.

--- a/lib/appsignal/logger.rb
+++ b/lib/appsignal/logger.rb
@@ -93,7 +93,9 @@ module Appsignal
     # @return [Proc]
     def formatter=(formatter)
       super
-      @loggers.each { |logger| logger.formatter = formatter }
+      @loggers.each do |logger|
+        logger.formatter = formatter if logger.respond_to?(:formatter=)
+      end
     end
 
     # We support the various methods in the Ruby


### PR DESCRIPTION
I'm looking into an issue with the AppSignal logger not logging all the same logs as the Rails logger does itself.

It seems to work better by adding the AppSignal logger config to `config/application.rb` or one of the environment files, but not without running into the error error first.

Make a quick fix by checking if we can set a formatter on the loggers before configuring one.
This could cause issues with different formats, but at least it won't cause the Rails app to fail to start.

```
`block in formatter=': undefined method `formatter=' for nil (NoMethodError)

        logger.formatter = formatter
              ^^^^^^^^^^^^
	from /integration/lib/appsignal/logger.rb:96:in `each'
	from /integration/lib/appsignal/logger.rb:96:in `formatter='
	from /app/vendor/bundle/ruby/3.3.0/gems/activesupport-8.0.2/lib/active_support/tagged_logging.rb:132:in `new'
	from /app/config/application.rb:42:in `<class:Application>'
	from /app/config/application.rb:10:in `<module:ExampleApp>'
	from /app/config/application.rb:9:in `<main>'
	from /usr/local/lib/ruby/3.3.0/bundled_gems.rb:69:in `require'
	from /usr/local/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
	from /app/vendor/bundle/ruby/3.3.0/gems/bootsnap-1.18.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /app/vendor/bundle/ruby/3.3.0/gems/railties-8.0.2/lib/rails/commands/server/server_command.rb:139:in `block in perform'
	from <internal:kernel>:90:in `tap'
	from /app/vendor/bundle/ruby/3.3.0/gems/railties-8.0.2/lib/rails/commands/server/server_command.rb:136:in `perform'
	from /app/vendor/bundle/ruby/3.3.0/gems/thor-1.3.2/lib/thor/command.rb:28:in `run'
	from /app/vendor/bundle/ruby/3.3.0/gems/thor-1.3.2/lib/thor/invocation.rb:127:in `invoke_command'
	from /app/vendor/bundle/ruby/3.3.0/gems/railties-8.0.2/lib/rails/command/base.rb:178:in `invoke_command'
	from /app/vendor/bundle/ruby/3.3.0/gems/thor-1.3.2/lib/thor.rb:538:in `dispatch'
	from /app/vendor/bundle/ruby/3.3.0/gems/railties-8.0.2/lib/rails/command/base.rb:73:in `perform'
	from /app/vendor/bundle/ruby/3.3.0/gems/railties-8.0.2/lib/rails/command.rb:65:in `block in invoke'
	from /app/vendor/bundle/ruby/3.3.0/gems/railties-8.0.2/lib/rails/command.rb:143:in `with_argv'
	from /app/vendor/bundle/ruby/3.3.0/gems/railties-8.0.2/lib/rails/command.rb:63:in `invoke'
	from /app/vendor/bundle/ruby/3.3.0/gems/railties-8.0.2/lib/rails/commands.rb:18:in `<main>'
	from /usr/local/lib/ruby/3.3.0/bundled_gems.rb:69:in `require'
	from /usr/local/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
	from /app/vendor/bundle/ruby/3.3.0/gems/bootsnap-1.18.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from bin/rails:4:in `<main>'
```