### PR TITLE
Disable Rails 8.1 CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 # This is a generated file by the `rake build_matrix:github:generate` task.
 # See `build_matrix.yml` for the build matrix.
 # Generate this file with `rake build_matrix:github:generate`.
-# Generated job count: 198
+# Generated job count: 194
 ---
 name: Ruby gem CI
 'on':
@@ -643,33 +643,6 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/rails-8.0.gemfile
-  ruby_3-5-0-preview1__rails-8-1_ubuntu-latest:
-    name: Ruby 3.5.0-preview1 - rails-8.1
-    needs: ruby_3-5-0-preview1_ubuntu-latest
-    runs-on: ubuntu-latest
-    steps:
-    - name: Check out repository
-      uses: actions/checkout@v4
-    - name: Install Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 3.5.0-preview1
-        bundler-cache: true
-    - name: Install gem extension
-      run: "./script/bundler_wrapper exec rake extension:install"
-    - name: Print extension install report
-      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
-        file found'"
-    - name: Print Makefile log file
-      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
-        found'"
-    - name: Run tests
-      run: "./script/bundler_wrapper exec rake test"
-    env:
-      RAILS_ENV: test
-      JRUBY_OPTS: ''
-      COV: '1'
-      BUNDLE_GEMFILE: gemfiles/rails-8.1.gemfile
   ruby_3-5-0-preview1__sequel_ubuntu-latest:
     name: Ruby 3.5.0-preview1 - sequel
     needs: ruby_3-5-0-preview1_ubuntu-latest
@@ -1430,33 +1403,6 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/rails-8.0.gemfile
-  ruby_3-4-1__rails-8-1_ubuntu-latest:
-    name: Ruby 3.4.1 - rails-8.1
-    needs: ruby_3-4-1_ubuntu-latest
-    runs-on: ubuntu-latest
-    steps:
-    - name: Check out repository
-      uses: actions/checkout@v4
-    - name: Install Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 3.4.1
-        bundler-cache: true
-    - name: Install gem extension
-      run: "./script/bundler_wrapper exec rake extension:install"
-    - name: Print extension install report
-      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
-        file found'"
-    - name: Print Makefile log file
-      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
-        found'"
-    - name: Run tests
-      run: "./script/bundler_wrapper exec rake test"
-    env:
-      RAILS_ENV: test
-      JRUBY_OPTS: ''
-      COV: '1'
-      BUNDLE_GEMFILE: gemfiles/rails-8.1.gemfile
   ruby_3-4-1__sequel_ubuntu-latest:
     name: Ruby 3.4.1 - sequel
     needs: ruby_3-4-1_ubuntu-latest
@@ -2244,33 +2190,6 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/rails-8.0.gemfile
-  ruby_3-3-4__rails-8-1_ubuntu-latest:
-    name: Ruby 3.3.4 - rails-8.1
-    needs: ruby_3-3-4_ubuntu-latest
-    runs-on: ubuntu-latest
-    steps:
-    - name: Check out repository
-      uses: actions/checkout@v4
-    - name: Install Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 3.3.4
-        bundler-cache: true
-    - name: Install gem extension
-      run: "./script/bundler_wrapper exec rake extension:install"
-    - name: Print extension install report
-      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
-        file found'"
-    - name: Print Makefile log file
-      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
-        found'"
-    - name: Run tests
-      run: "./script/bundler_wrapper exec rake test"
-    env:
-      RAILS_ENV: test
-      JRUBY_OPTS: ''
-      COV: '1'
-      BUNDLE_GEMFILE: gemfiles/rails-8.1.gemfile
   ruby_3-3-4__sequel_ubuntu-latest:
     name: Ruby 3.3.4 - sequel
     needs: ruby_3-3-4_ubuntu-latest
@@ -3004,33 +2923,6 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/rails-8.0.gemfile
-  ruby_3-2-5__rails-8-1_ubuntu-latest:
-    name: Ruby 3.2.5 - rails-8.1
-    needs: ruby_3-2-5_ubuntu-latest
-    runs-on: ubuntu-latest
-    steps:
-    - name: Check out repository
-      uses: actions/checkout@v4
-    - name: Install Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 3.2.5
-        bundler-cache: true
-    - name: Install gem extension
-      run: "./script/bundler_wrapper exec rake extension:install"
-    - name: Print extension install report
-      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
-        file found'"
-    - name: Print Makefile log file
-      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
-        found'"
-    - name: Run tests
-      run: "./script/bundler_wrapper exec rake test"
-    env:
-      RAILS_ENV: test
-      JRUBY_OPTS: ''
-      COV: '1'
-      BUNDLE_GEMFILE: gemfiles/rails-8.1.gemfile
   ruby_3-2-5__sequel_ubuntu-latest:
     name: Ruby 3.2.5 - sequel
     needs: ruby_3-2-5_ubuntu-latest

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -115,7 +115,7 @@ matrix:
       - "rails-7.1"
       - "rails-7.2"
       - "rails-8.0"
-      - "rails-8.1"
+      # - "rails-8.1"
 
   ruby:
     - ruby: "3.5.0-preview1"
@@ -245,13 +245,13 @@ matrix:
           - "3.4.1"
           - "3.3.4"
           - "3.2.5"
-    - gem: "rails-8.1"
-      only:
-        ruby:
-          - "3.5.0-preview1"
-          - "3.4.1"
-          - "3.3.4"
-          - "3.2.5"
+    # - gem: "rails-8.1"
+    #   only:
+    #     ruby:
+    #       - "3.5.0-preview1"
+    #       - "3.4.1"
+    #       - "3.3.4"
+    #       - "3.2.5"
     - gem: "sequel"
     - gem: "sinatra"
     - gem: "webmachine2"


### PR DESCRIPTION
Something broke and it's not an easy fix so I'm disabling the builds and creating an issue to reenable it. I want to have a passing build before a release.

[skip changeset]
[skip review]