### PR TITLE
Fix JSON parse errors in test suite

### DIFF
--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -490,13 +490,14 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
             "Agent diagnostics",
             "  Error while parsing agent diagnostics report:",
             "    Output: invalid agent\njson"
-          expect(output)
-            .to match(/Error:( \d+:)? unexpected (token at|character:) 'invalid/)
+          expect(output).to match(
+            /Error:( \d+:)? (unexpected (token at|character:) 'invalid|source is not valid JSON)/
+          )
         end
 
         it "adds the output to the report" do
           expect(received_report["agent"]["error"])
-            .to match(/unexpected (token at|character:) 'invalid/)
+            .to match(/(unexpected (token at|character:) 'invalid|source is not valid JSON)/)
           expect(received_report["agent"]["output"]).to eq(["invalid agent", "json"])
         end
       end


### PR DESCRIPTION
The newer version of the Ruby JSON gem (2.16.0) has different error messages. Update the test to pass with the new error message.

The assertions now match both the old error message format ("unexpected token at" or "unexpected character:") and the new format ("source is not valid JSON").

[skip changeset]