### PR TITLE
Listen to Active Job queue time on AJ retries

### DIFF
--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -173,6 +173,7 @@ module Appsignal
       @error_blocks = Hash.new { |hash, key| hash[key] = [] }
       @is_duplicate = false
       @error_set = nil
+      @queue_start = nil
 
       @params = Appsignal::SampleData.new(:params)
       @session_data = Appsignal::SampleData.new(:session_data, Hash)
@@ -564,8 +565,17 @@ module Appsignal
       return unless start
 
       @ext.set_queue_start(start)
+      @queue_start = start
     rescue RangeError
       Appsignal.internal_logger.warn("Queue start value #{start} is too big")
+    end
+
+    # Check if queue start time is set.
+    #
+    # @return [Boolean] true if queue start time is set, false otherwise.
+    # @!visibility private
+    def queue_start?
+      !@queue_start.nil?
     end
 
     # @!visibility private

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -1404,6 +1404,24 @@ describe Appsignal::Transaction do
     end
   end
 
+  describe "#queue_start?" do
+    let(:transaction) { new_transaction }
+
+    context "when the queue start is not set" do
+      it "returns false" do
+        expect(transaction.queue_start?).to be(false)
+      end
+    end
+
+    context "when the queue start is set" do
+      it "returns true" do
+        transaction.set_queue_start(10)
+
+        expect(transaction.queue_start?).to be(true)
+      end
+    end
+  end
+
   describe "#set_metadata" do
     let(:transaction) { new_transaction }
 


### PR DESCRIPTION
Active Job has its own retry system using `retry_on`. Most background job libraries (Active Job adapters) have their own retry system too.

If an app uses Active Job but relies on the worker library's retry mechanism, the `enqueued_at` field on the Active Job payload does not update.
Neither does the `executions` field update, which keeps track of Active Job powered retries.
Only when `retry_on` is configured on the Active Job job class does the `enqueued_at` field update, along with the `executions` field.

The problem was that when Sidekiq retries a job, the Active Job payload with the queue time would not update to the retried job queue time. We would consider Active Job's reported `enqueued_at` leading, which lead to reporting the original job's `enqueued_at` time, leading to very high queue times the more the job is retried.

This change only listens to the Active Job `enqueued_at` time if the job is a retried job, retried by Active Job, or when the `enqueued_at` time is not set (using the app is using a worker library we don't have our own instrumentation for).

On the first execution of the job we don't know if the worker is using the Active Job or worker library's retry mechanism, so we follow the worker library's `enqueued_at` time value. There should be little to no difference to the enqueue time values for the first execution.

Fixes #1488

Use the Rails 8 Delayed Job test app here to test it: https://github.com/appsignal/test-setups/tree/main/ruby/rails8-delayed-job
See also this commit for testing customization: https://github.com/appsignal/test-setups/commit/2eecf7c64cd05bab0abc1f0c82096a934709b7ed