### PR TITLE
Fix Delayed Job queue time

### DIFF
--- a/.changesets/fix-delayed-job-queue-time.md
+++ b/.changesets/fix-delayed-job-queue-time.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix the queue time reported for the Delayed Job gem. It would report too low values, not taking into account when a job was created/enqueued.

--- a/lib/appsignal/integrations/delayed_job_plugin.rb
+++ b/lib/appsignal/integrations/delayed_job_plugin.rb
@@ -46,7 +46,9 @@ module Appsignal
           :attempts => extract_value(job, :attempts, 0)
         )
 
-        transaction.set_queue_start(extract_value(job, :run_at)&.to_i&.* 1_000)
+        # Use updated_at, as it's the time the first job iteration was enqueued
+        # or when a failed job was updated and enqueued for a retry
+        transaction.set_queue_start(extract_value(job, :updated_at)&.to_i&.* 1_000)
 
         Appsignal::Transaction.complete_current!
       end

--- a/spec/lib/appsignal/integrations/delayed_job_plugin_spec.rb
+++ b/spec/lib/appsignal/integrations/delayed_job_plugin_spec.rb
@@ -19,9 +19,8 @@ describe "Appsignal::Integrations::DelayedJobHook" do
 
   describe ".invoke_with_instrumentation" do
     let(:plugin) { Appsignal::Integrations::DelayedJobPlugin }
-    let(:time) { Time.parse("01-01-2001 10:01:00UTC") }
-    let(:created_at) { time - 3600 }
-    let(:run_at) { time - 3600 }
+    let(:time) { Time.parse("01-01-2001 10:05:00UTC") }
+    let(:updated_at) { Time.parse("01-01-2001 10:00:00UTC") }
     let(:payload_object) { double(:args => args) }
     let(:job_data) do
       {
@@ -30,8 +29,7 @@ describe "Appsignal::Integrations::DelayedJobHook" do
         :priority => 1,
         :attempts => 1,
         :queue => "default",
-        :created_at => created_at,
-        :run_at => run_at,
+        :updated_at => updated_at,
         :payload_object => payload_object
       }
     end
@@ -90,13 +88,11 @@ describe "Appsignal::Integrations::DelayedJobHook" do
         end
       end
 
-      context "with run_at in the future" do
-        let(:run_at) { Time.parse("2017-01-01 10:01:00UTC") }
-
-        it "reports queue_start with run_at time" do
+      context "with updated_at in the past" do
+        it "reports queue_start" do
           perform
 
-          expect(last_transaction).to have_queue_start(run_at.to_i * 1000)
+          expect(last_transaction).to have_queue_start(updated_at.to_i * 1000)
         end
       end
 
@@ -223,8 +219,7 @@ describe "Appsignal::Integrations::DelayedJobHook" do
               :priority       => 1,
               :attempts       => 1,
               :queue          => "default",
-              :created_at     => created_at,
-              :run_at         => run_at,
+              :updated_at     => updated_at,
               :payload_object => payload_object
             )
           end
@@ -280,13 +275,11 @@ describe "Appsignal::Integrations::DelayedJobHook" do
             end
           end
 
-          context "with run_at in the future" do
-            let(:run_at) { Time.parse("2017-01-01 10:01:00UTC") }
-
-            it "reports queue_start with run_at time" do
+          context "with updated_at in the past" do
+            it "reports queue_start" do
               perform
 
-              expect(last_transaction).to have_queue_start(run_at.to_i * 1000)
+              expect(last_transaction).to have_queue_start(updated_at.to_i * 1000)
             end
           end
         end


### PR DESCRIPTION
We listened to the `run_at` field, which is the time the job is supposed
to run at. This is not when it was enqueued. That's what `updated_at`
can be used for.

This `updated_at` value updates when the job gets retried, to the time
of the previous job's execution time. The difference of which is the
queue time, as the job gets immediately enqueued for a retry, just with
a delayed execution time.

Related to #1488, and seems to work for Delayed Job with Active Job retries, but the linked issue still remains for when Delayed Job handles the retries and the `active_job_queue_time` metric is wrong. Will pick up in another PR.