### PR TITLE
Update changelog PR dispatch URL

### DIFF
--- a/.github/workflows/create_release_from_tag.yml
+++ b/.github/workflows/create_release_from_tag.yml
@@ -58,5 +58,5 @@ jobs:
             -H "Authorization: token ${{ secrets.INTEGRATIONS_CHANGELOG_TOKEN }}" \
             -H "Accept: application/vnd.github+json" \
             --fail-with-body \
-            https://api.github.com/repos/appsignal/appsignal.com/actions/workflows/102125282/dispatches \
+            https://api.github.com/repos/appsignal/appsignal-web/actions/workflows/create_integrations_changelog_entry.yml/dispatches \
             -d "$payload"


### PR DESCRIPTION
The repo changed, so update the location of the workflow. Use the filename as the workflow ID, this should work and is easier to find than the workflow ID.

[skip changeset]
[skip review]