### PR TITLE
Validate mono changesets in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 # This is a generated file by the `rake build_matrix:github:generate` task.
 # See `build_matrix.yml` for the build matrix.
 # Generate this file with `rake build_matrix:github:generate`.
-# Generated job count: 195
+# Generated job count: 196
 ---
 name: Ruby gem CI
 'on':
@@ -21,6 +21,8 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: "${{ !contains(github.ref, 'main')}}"
 jobs:
+  validate-changesets:
+    uses: "./.github/workflows/validate_changesets.yml"
   lint-git:
     name: Git linter (Lintje)
     runs-on: ubuntu-latest

--- a/.github/workflows/validate_changesets.yml
+++ b/.github/workflows/validate_changesets.yml
@@ -1,0 +1,24 @@
+name: Validate changesets
+
+on:
+  workflow_call:
+
+jobs:
+  validate-changesets:
+    name: Validate changesets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+      - name: Checkout Mono
+        uses: actions/checkout@v4
+        with:
+          repository: appsignal/mono
+          path: tmp/mono
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+      - name: Validate changesets
+        run: tmp/mono/bin/mono changeset validate
+

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -13,6 +13,9 @@ github:
     cancel-in-progress: ${{ !contains(github.ref, 'main')}}
 
   jobs:
+    validate-changesets:
+      uses: ./.github/workflows/validate_changesets.yml
+
     lint-git:
       name: "Git linter (Lintje)"
       runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Extract the inline `validate-changesets` job into a reusable workflow (`.github/workflows/validate_changesets`)
- Reference the reusable workflow from CI and publish release workflows using `uses:`

## Context
Follows the pattern established in appsignal-wrap for reusable workflows (e.g. `build_release`). See appsignal/appsignal-kubernetes#71 review comment.