### PR TITLE
Pin YARD/RBS versions for signature generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.3'
+        ruby-version: '4.0'
         bundler-cache: true
     - name: Generate fresh signatures and check sync
       run: |

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "benchmark-ips"
+gem "rbs", "4.0.2" if RUBY_VERSION.start_with?("4.0")
 # Fix install issue for jruby on gem 3.1.8.
 # No java stub is published.
 gem "bigdecimal", "3.1.7" if RUBY_PLATFORM == "java"

--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -67,5 +67,5 @@ Gem::Specification.new do |gem| # rubocop:disable Metrics/BlockLength
   gem.add_development_dependency("sord") unless RUBY_PLATFORM == "java"
   gem.add_development_dependency "timecop"
   gem.add_development_dependency "webmock"
-  gem.add_development_dependency "yard", ">= 0.9.20"
+  gem.add_development_dependency "yard", "0.9.40"
 end

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -46,7 +46,7 @@ github:
         - uses: actions/checkout@v4
         - uses: ruby/setup-ruby@v1
           with:
-            ruby-version: "3.3"
+            ruby-version: "4.0"
             bundler-cache: true
         - name: "Generate fresh signatures and check sync"
           run: |

--- a/script/generate_signatures
+++ b/script/generate_signatures
@@ -3,6 +3,7 @@
 set -eu
 
 rm -rf .yardoc
+rm -f sig/appsignal.rbs
 bundle exec sord gen sig/appsignal.rbi --rbi --hide-private --exclude-untyped --regenerate --no-sord-comments
 # Don't regenerate YARD docs in the following command because the command just above this generates it already
 bundle exec sord gen sig/appsignal.rbs --rbs --hide-private --exclude-untyped --no-regenerate --no-sord-comments


### PR DESCRIPTION
It currently breaks on CI because it automatically upgraded the versions, but lock them to those specific versions and see if it works.

[skip changeset]
[skip review]