### PR TITLE
Exclude more Sidekiq internal attributes from tags

### DIFF
--- a/lib/appsignal/integrations/sidekiq.rb
+++ b/lib/appsignal/integrations/sidekiq.rb
@@ -55,7 +55,8 @@ module Appsignal
 
       EXCLUDED_JOB_KEYS = %w[
         args backtrace class created_at enqueued_at error_backtrace error_class
-        error_message failed_at jid retried_at retry wrapped
+        error_message failed_at jid retried_at retry wrapped cattr tags retry_for
+        unique_for
       ].freeze
 
       def self.sidekiq8?


### PR DESCRIPTION
`cattr` is added by sidekiq saving and restoring CurrentAttributes - https://github.com/sidekiq/sidekiq/blob/6bdf6903e93eeaf9b96fcbbe66f503fe758ee4b2/lib/sidekiq/middleware/current_attributes.rb#L111

`tags` is used to add custom tags to sidekiq dashboard to improve its UX https://github.com/sidekiq/sidekiq/wiki/Advanced-Options#jobs

`retry_for` is used by sidekiq to allow retrying for a specific amount of time https://github.com/sidekiq/sidekiq/wiki/Error-Handling#configuration

`unique_for` is used by Sidekiq Ent to add uniqueness to jobs - https://github.com/sidekiq/sidekiq/wiki/Ent-Unique-Jobs