### PR TITLE
Move post-spawn wait into the spec that needs it

### DIFF
--- a/spec/integration/runner.rb
+++ b/spec/integration/runner.rb
@@ -7,7 +7,6 @@ class Runner
     @pid = nil
     @output = nil
     @status = nil
-    @post_spawn_wait = jruby? ? 10 : 1 # seconds
     @finish_timeout = jruby? ? 10 : 5 # seconds
     @read_timeout = 1 # seconds
     @read, @write = IO.pipe
@@ -36,7 +35,6 @@ class Runner
         :chdir => directory
       }
     )
-    sleep @post_spawn_wait # Let the app boot
 
     yield if block_given?
 

--- a/spec/integration/stop_spec.rb
+++ b/spec/integration/stop_spec.rb
@@ -2,6 +2,10 @@ describe "AppSignal stop" do
   it "doesn't exit the process with a ThreadError when receiving a signal trap" do
     runner = Runner.new("stop_with_trap")
     runner.run do
+      # Let the child fully boot and install its USR1 trap before signalling
+      # it. Without this, the signal can arrive before `Signal.trap` and the
+      # default handler terminates the child.
+      sleep(DependencyHelper.running_jruby? ? 10 : 1) # seconds
       # Send a problematic signal
       # "USR1" has no special meaning for this test, it's just a signal
       Process.kill("USR1", runner.pid)


### PR DESCRIPTION
The unconditional sleep in the test runner exists so a spec can interact with a still-booting child (sending USR1 in stop_spec). Other specs that only wait for the child to exit pay the wait for no reason. Move it into stop_spec where the signal is sent, so the runner stays minimal.