### PR TITLE
Skip set_error when Active Job transaction is nil

### DIFF
--- a/.changesets/fix-active-job-nil-transaction-set-error.md
+++ b/.changesets/fix-active-job-nil-transaction-set-error.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Prevent a `NoMethodError` in the Active Job hook when a job is interrupted by `SIGTERM`.

--- a/lib/appsignal/hooks/active_job.rb
+++ b/lib/appsignal/hooks/active_job.rb
@@ -119,7 +119,7 @@ module Appsignal
           # To report errors on discard, see the `after_discard` callback.
           return unless Appsignal.config[:activejob_report_errors] == "all"
 
-          transaction.set_error(exception)
+          transaction&.set_error(exception)
         end
       end
 

--- a/spec/lib/appsignal/hooks/activejob_spec.rb
+++ b/spec/lib/appsignal/hooks/activejob_spec.rb
@@ -285,6 +285,19 @@ if DependencyHelper.active_job_present?
           end
         end
       end
+
+      context "when the local transaction was never assigned" do
+        # Reproduce a nil `transaction` local in the rescue, as can happen
+        # when an async signal raises before the assignment completes.
+        it "does not raise NoMethodError and re-raises the original error" do
+          allow(Appsignal).to receive(:increment_counter)
+          allow(Appsignal::Transaction).to receive(:create).and_return(nil)
+
+          expect do
+            queue_job(ActiveJobErrorTestJob)
+          end.to raise_error(RuntimeError, "uh oh")
+        end
+      end
     end
 
     context "with retries" do


### PR DESCRIPTION
We hit this in production when stopping Resque workers: AppSignal reported `NoMethodError: undefined method 'set_error' for nil` from `Appsignal::Hooks::ActiveJobHook::ActiveJobClassInstrumentation#execute`, masking the underlying `Resque::TermException: SIGTERM` that triggered worker shutdown.

The cause: when an async signal unwinds through `execute` before its `transaction = …` assignment completes, the local `transaction` stays at its parser-default `nil`. The `rescue Exception` clause then calls `nil.set_error(exception)`, raising the `NoMethodError` on top of the original `SignalException`.