### PR TITLE
Avoid transactions being nil in instrumentations

### DIFF
--- a/.changesets/transaction-nil-error.md
+++ b/.changesets/transaction-nil-error.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Prevent a `NoMethodError` in the Active Job, Rake, Sidekiq, Delayed Job, and WebMachine instrumentations when the creation of an AppSignal transaction is interrupted by process shutdown signals.

--- a/lib/appsignal/hooks/active_job.rb
+++ b/lib/appsignal/hooks/active_job.rb
@@ -66,49 +66,51 @@ module Appsignal
               Appsignal::Transaction.create(Appsignal::Transaction::BACKGROUND_JOB)
             end
 
-          if transaction
-            transaction.add_params_if_nil(job["arguments"])
+          begin
+            if transaction
+              transaction.add_params_if_nil(job["arguments"])
 
-            transaction_tags = ActiveJobHelpers.transaction_tags_for(job)
-            transaction.add_tags(transaction_tags)
+              transaction_tags = ActiveJobHelpers.transaction_tags_for(job)
+              transaction.add_tags(transaction_tags)
 
-            transaction.set_action(ActiveJobHelpers.action_name(job))
-          end
-
-          super
-        rescue Exception => exception # rubocop:disable Lint/RescueException
-          job_status = :failed
-          transaction_set_error(transaction, exception)
-          raise exception
-        ensure
-          if transaction
-            # Present in Rails 6 and up
-            transaction.set_queue_start((queue_start.to_f * 1_000).to_i) if queue_start
-
-            unless has_wrapper_transaction
-              # Only complete transaction if ActiveJob is not wrapped in
-              # another supported integration, such as Sidekiq.
-              Appsignal::Transaction.complete_current!
+              transaction.set_action(ActiveJobHelpers.action_name(job))
             end
-          end
 
-          metrics = ActiveJobHelpers.metrics_for(job)
-          metrics.each do |(metric_name, tags)|
-            if job_status
+            super
+          rescue Exception => exception # rubocop:disable Lint/RescueException
+            job_status = :failed
+            transaction_set_error(transaction, exception)
+            raise exception
+          ensure
+            if transaction
+              # Present in Rails 6 and up
+              transaction.set_queue_start((queue_start.to_f * 1_000).to_i) if queue_start
+
+              unless has_wrapper_transaction
+                # Only complete transaction if ActiveJob is not wrapped in
+                # another supported integration, such as Sidekiq.
+                Appsignal::Transaction.complete_current!
+              end
+            end
+
+            metrics = ActiveJobHelpers.metrics_for(job)
+            metrics.each do |(metric_name, tags)|
+              if job_status
+                ActiveJobHelpers.increment_counter metric_name, 1,
+                  tags.merge(:status => job_status)
+              end
               ActiveJobHelpers.increment_counter metric_name, 1,
-                tags.merge(:status => job_status)
+                tags.merge(:status => :processed)
             end
-            ActiveJobHelpers.increment_counter metric_name, 1,
-              tags.merge(:status => :processed)
-          end
 
-          queue_name = job["queue_name"]
-          if queue_time && queue_name
-            ActiveJobHelpers.add_distribution_value(
-              "queue_time",
-              queue_time,
-              :queue => queue_name
-            )
+            queue_name = job["queue_name"]
+            if queue_time && queue_name
+              ActiveJobHelpers.add_distribution_value(
+                "queue_time",
+                queue_time,
+                :queue => queue_name
+              )
+            end
           end
         end
 

--- a/lib/appsignal/hooks/active_job.rb
+++ b/lib/appsignal/hooks/active_job.rb
@@ -42,7 +42,7 @@ module Appsignal
       end
 
       module ActiveJobClassInstrumentation
-        def execute(job) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        def execute(job) # rubocop:disable Metrics/CyclomaticComplexity
           enqueued_at = job["enqueued_at"]
           queue_start = Time.parse(enqueued_at) if enqueued_at
           queue_time =
@@ -67,14 +67,12 @@ module Appsignal
             end
 
           begin
-            if transaction
-              transaction.add_params_if_nil(job["arguments"])
+            transaction.add_params_if_nil(job["arguments"])
 
-              transaction_tags = ActiveJobHelpers.transaction_tags_for(job)
-              transaction.add_tags(transaction_tags)
+            transaction_tags = ActiveJobHelpers.transaction_tags_for(job)
+            transaction.add_tags(transaction_tags)
 
-              transaction.set_action(ActiveJobHelpers.action_name(job))
-            end
+            transaction.set_action(ActiveJobHelpers.action_name(job))
 
             super
           rescue Exception => exception # rubocop:disable Lint/RescueException

--- a/lib/appsignal/integrations/delayed_job_plugin.rb
+++ b/lib/appsignal/integrations/delayed_job_plugin.rb
@@ -20,35 +20,37 @@ module Appsignal
         transaction =
           Appsignal::Transaction.create(Appsignal::Transaction::BACKGROUND_JOB)
 
-        Appsignal.instrument("perform_job.delayed_job") do
-          block.call(job)
+        begin
+          Appsignal.instrument("perform_job.delayed_job") do
+            block.call(job)
+          end
+        rescue Exception => error # rubocop:disable Lint/RescueException
+          transaction.set_error(error)
+          raise
+        ensure
+          payload = job.payload_object
+          if payload.respond_to? :job_data
+            # ActiveJob
+            job_data = payload.job_data
+            transaction.set_action_if_nil("#{job_data["job_class"]}#perform")
+            transaction.add_params_if_nil(job_data.fetch("arguments", {}))
+          else
+            # Delayed Job
+            transaction.set_action_if_nil(action_name_from_payload(payload, job.name))
+            transaction.add_params_if_nil(extract_value(payload, :args, {}))
+          end
+
+          transaction.add_tags(
+            :id => extract_value(job, :id, nil, true),
+            :queue => extract_value(job, :queue),
+            :priority => extract_value(job, :priority, 0),
+            :attempts => extract_value(job, :attempts, 0)
+          )
+
+          transaction.set_queue_start(extract_value(job, :run_at)&.to_i&.* 1_000)
+
+          Appsignal::Transaction.complete_current!
         end
-      rescue Exception => error # rubocop:disable Lint/RescueException
-        transaction.set_error(error)
-        raise
-      ensure
-        payload = job.payload_object
-        if payload.respond_to? :job_data
-          # ActiveJob
-          job_data = payload.job_data
-          transaction.set_action_if_nil("#{job_data["job_class"]}#perform")
-          transaction.add_params_if_nil(job_data.fetch("arguments", {}))
-        else
-          # Delayed Job
-          transaction.set_action_if_nil(action_name_from_payload(payload, job.name))
-          transaction.add_params_if_nil(extract_value(payload, :args, {}))
-        end
-
-        transaction.add_tags(
-          :id => extract_value(job, :id, nil, true),
-          :queue => extract_value(job, :queue),
-          :priority => extract_value(job, :priority, 0),
-          :attempts => extract_value(job, :attempts, 0)
-        )
-
-        transaction.set_queue_start(extract_value(job, :run_at)&.to_i&.* 1_000)
-
-        Appsignal::Transaction.complete_current!
       end
 
       def self.action_name_from_payload(payload, default_name)

--- a/lib/appsignal/integrations/rake.rb
+++ b/lib/appsignal/integrations/rake.rb
@@ -21,24 +21,26 @@ module Appsignal
             _appsignal_create_transaction
           end
 
-        Appsignal.instrument "task.rake" do
-          super
-        end
-      rescue Exception => error # rubocop:disable Lint/RescueException
-        Appsignal::Integrations::RakeIntegrationHelper.register_at_exit_hook
-        unless RakeIntegration.ignored_error?(error)
-          transaction ||= _appsignal_create_transaction
-          transaction.set_error(error)
-        end
-        raise error
-      ensure
-        if transaction
-          # Format given arguments and cast to hash if possible
-          params, _ = args
-          params = params.to_hash if params.respond_to?(:to_hash)
-          transaction.set_action(name)
-          transaction.add_params_if_nil(params)
-          transaction.complete
+        begin
+          Appsignal.instrument "task.rake" do
+            super
+          end
+        rescue Exception => error # rubocop:disable Lint/RescueException
+          Appsignal::Integrations::RakeIntegrationHelper.register_at_exit_hook
+          unless RakeIntegration.ignored_error?(error)
+            transaction ||= _appsignal_create_transaction
+            transaction.set_error(error)
+          end
+          raise error
+        ensure
+          if transaction
+            # Format given arguments and cast to hash if possible
+            params, _ = args
+            params = params.to_hash if params.respond_to?(:to_hash)
+            transaction.set_action(name)
+            transaction.add_params_if_nil(params)
+            transaction.complete
+          end
         end
       end
 

--- a/lib/appsignal/integrations/sidekiq.rb
+++ b/lib/appsignal/integrations/sidekiq.rb
@@ -75,44 +75,45 @@ module Appsignal
           transaction.set_metadata key, value
         end
 
-        Appsignal.instrument "perform_job.sidekiq", &block
-      rescue Exception => exception # rubocop:disable Lint/RescueException
-        job_status = :failed
-        raise exception
-      ensure
-        if transaction
-          transaction.add_params_if_nil { parse_arguments(item) }
-          enqueued_at = item["enqueued_at"]
-          queue_start =
-            if self.class.sidekiq8?
-              enqueued_at.to_i # Sidekiq 8 stores it as epoc milliseconds
-            else
-              # Convert seconds to milliseconds for Sidekiq 7 and older
-              (enqueued_at.to_f * 1000.0).to_i
+        begin
+          Appsignal.instrument "perform_job.sidekiq", &block
+        rescue Exception => exception # rubocop:disable Lint/RescueException
+          job_status = :failed
+          raise exception
+        ensure
+          if transaction
+            transaction.add_params_if_nil { parse_arguments(item) }
+            enqueued_at = item["enqueued_at"]
+            queue_start =
+              if self.class.sidekiq8?
+                enqueued_at.to_i # Sidekiq 8 stores it as epoc milliseconds
+              else
+                # Convert seconds to milliseconds for Sidekiq 7 and older
+                (enqueued_at.to_f * 1000.0).to_i
+              end
+            transaction.set_queue_start(queue_start)
+            transaction.add_tags(:request_id => item["jid"])
+            Appsignal::Transaction.complete_current! unless exception
+
+            queue = item["queue"] || "unknown"
+
+            if job_status
+              increment_counter "queue_job_count", 1,
+                :queue => queue,
+                :status => job_status
+              increment_counter "worker_job_count", 1,
+                :worker => action_name,
+                :queue => queue,
+                :status => job_status
             end
-          transaction.set_queue_start(queue_start)
-          transaction.add_tags(:request_id => item["jid"])
-          Appsignal::Transaction.complete_current! unless exception
-
-          queue = item["queue"] || "unknown"
-
-          if job_status
             increment_counter "queue_job_count", 1,
               :queue => queue,
-              :status => job_status
+              :status => :processed
             increment_counter "worker_job_count", 1,
               :worker => action_name,
               :queue => queue,
-              :status => job_status
+              :status => :processed
           end
-          increment_counter "queue_job_count", 1,
-            :queue => queue,
-            :status => :processed
-          increment_counter "worker_job_count", 1,
-            :worker => action_name,
-            :queue => queue,
-            :status => :processed
-
         end
       end
 

--- a/lib/appsignal/integrations/webmachine.rb
+++ b/lib/appsignal/integrations/webmachine.rb
@@ -12,16 +12,19 @@ module Appsignal
           else
             Appsignal::Transaction.create(Appsignal::Transaction::HTTP_REQUEST)
           end
-        transaction.add_params_if_nil { request.query }
-        transaction.add_headers_if_nil { request.headers if request.respond_to?(:headers) }
 
-        Appsignal.instrument("process_action.webmachine") do
-          super
+        begin
+          transaction.add_params_if_nil { request.query }
+          transaction.add_headers_if_nil { request.headers if request.respond_to?(:headers) }
+
+          Appsignal.instrument("process_action.webmachine") do
+            super
+          end
+        ensure
+          transaction.set_action_if_nil("#{resource.class.name}##{request.method}")
+
+          Appsignal::Transaction.complete_current! unless has_parent_transaction
         end
-      ensure
-        transaction.set_action_if_nil("#{resource.class.name}##{request.method}")
-
-        Appsignal::Transaction.complete_current! unless has_parent_transaction
       end
 
       private


### PR DESCRIPTION
Fix the instrumentations that use a rescue and/or ensure block for the entire method when we instrument other libraries by ensuring that the transaction variable is always assigned before those blocks can be called. Which means defining the variable outside of the begin-block.

This avoids the situation where the Ruby process is told to shut down before the transaction is being created in the instrumentation method. Which is the only point when the transaction variable can be `nil` and then raise a `NoMethodError`.

We can guarantee the transaction is then never `nil` because even if the extension is not installed/active, and the transaction can't be created, we return a `NilTransaction` class which doesn't cause the `NoMethodError` to be raised.

Closes #1516