### PR TITLE
Instrument Shoryuken job enqueues

### DIFF
--- a/.changesets/add-shoryuken-enqueue-instrumentation.md
+++ b/.changesets/add-shoryuken-enqueue-instrumentation.md
@@ -1,0 +1,8 @@
+---
+bump: minor
+type: add
+---
+
+Instrument Shoryuken job enqueues. Enqueuing a job now records an
+`enqueue.shoryuken` event on the active transaction, so enqueues made from
+within a web request or another job show up in the event timeline.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 # This is a generated file by the `rake build_matrix:github:generate` task.
 # See `build_matrix.yml` for the build matrix.
 # Generate this file with `rake build_matrix:github:generate`.
-# Generated job count: 227
+# Generated job count: 234
 ---
 name: Ruby gem CI
 'on':
@@ -726,6 +726,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/sequel.gemfile
+  ruby_4-0-0__shoryuken_ubuntu-latest:
+    name: Ruby 4.0.0 - shoryuken
+    needs: ruby_4-0-0_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 4.0.0
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/shoryuken.gemfile
   ruby_4-0-0__sinatra_ubuntu-latest:
     name: Ruby 4.0.0 - sinatra
     needs: ruby_4-0-0_ubuntu-latest
@@ -1675,6 +1702,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/sequel.gemfile
+  ruby_3-4-1__shoryuken_ubuntu-latest:
+    name: Ruby 3.4.1 - shoryuken
+    needs: ruby_3-4-1_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.1
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/shoryuken.gemfile
   ruby_3-4-1__sinatra_ubuntu-latest:
     name: Ruby 3.4.1 - sinatra
     needs: ruby_3-4-1_ubuntu-latest
@@ -2651,6 +2705,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/sequel.gemfile
+  ruby_3-3-4__shoryuken_ubuntu-latest:
+    name: Ruby 3.3.4 - shoryuken
+    needs: ruby_3-3-4_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.3.4
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/shoryuken.gemfile
   ruby_3-3-4__sinatra_ubuntu-latest:
     name: Ruby 3.3.4 - sinatra
     needs: ruby_3-3-4_ubuntu-latest
@@ -3546,6 +3627,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/sequel.gemfile
+  ruby_3-2-5__shoryuken_ubuntu-latest:
+    name: Ruby 3.2.5 - shoryuken
+    needs: ruby_3-2-5_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.2.5
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/shoryuken.gemfile
   ruby_3-2-5__sinatra_ubuntu-latest:
     name: Ruby 3.2.5 - sinatra
     needs: ruby_3-2-5_ubuntu-latest
@@ -4360,6 +4468,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/sequel.gemfile
+  ruby_3-1-6__shoryuken_ubuntu-latest:
+    name: Ruby 3.1.6 - shoryuken
+    needs: ruby_3-1-6_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.1.6
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/shoryuken.gemfile
   ruby_3-1-6__sinatra_ubuntu-latest:
     name: Ruby 3.1.6 - sinatra
     needs: ruby_3-1-6_ubuntu-latest
@@ -5147,6 +5282,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/sequel.gemfile
+  ruby_3-0-7__shoryuken_ubuntu-latest:
+    name: Ruby 3.0.7 - shoryuken
+    needs: ruby_3-0-7_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.0.7
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/shoryuken.gemfile
   ruby_3-0-7__sinatra_ubuntu-latest:
     name: Ruby 3.0.7 - sinatra
     needs: ruby_3-0-7_ubuntu-latest
@@ -5772,6 +5934,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/sequel.gemfile
+  ruby_2-7-8__shoryuken_ubuntu-latest:
+    name: Ruby 2.7.8 - shoryuken
+    needs: ruby_2-7-8_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7.8
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/shoryuken.gemfile
   ruby_2-7-8__sinatra_ubuntu-latest:
     name: Ruby 2.7.8 - sinatra
     needs: ruby_2-7-8_ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 # This is a generated file by the `rake build_matrix:github:generate` task.
 # See `build_matrix.yml` for the build matrix.
 # Generate this file with `rake build_matrix:github:generate`.
-# Generated job count: 231
+# Generated job count: 234
 ---
 name: Ruby gem CI
 'on':
@@ -726,8 +726,8 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/sequel.gemfile
-  ruby_4-0-0__shoryuken_ubuntu-latest:
-    name: Ruby 4.0.0 - shoryuken
+  ruby_4-0-0__shoryuken-7_ubuntu-latest:
+    name: Ruby 4.0.0 - shoryuken-7
     needs: ruby_4-0-0_ubuntu-latest
     runs-on: ubuntu-latest
     steps:
@@ -752,7 +752,7 @@ jobs:
       RAILS_ENV: test
       JRUBY_OPTS: ''
       COV: '1'
-      BUNDLE_GEMFILE: gemfiles/shoryuken.gemfile
+      BUNDLE_GEMFILE: gemfiles/shoryuken-7.gemfile
   ruby_4-0-0__sinatra_ubuntu-latest:
     name: Ruby 4.0.0 - sinatra
     needs: ruby_4-0-0_ubuntu-latest
@@ -1702,8 +1702,8 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/sequel.gemfile
-  ruby_3-4-1__shoryuken_ubuntu-latest:
-    name: Ruby 3.4.1 - shoryuken
+  ruby_3-4-1__shoryuken-7_ubuntu-latest:
+    name: Ruby 3.4.1 - shoryuken-7
     needs: ruby_3-4-1_ubuntu-latest
     runs-on: ubuntu-latest
     steps:
@@ -1728,7 +1728,7 @@ jobs:
       RAILS_ENV: test
       JRUBY_OPTS: ''
       COV: '1'
-      BUNDLE_GEMFILE: gemfiles/shoryuken.gemfile
+      BUNDLE_GEMFILE: gemfiles/shoryuken-7.gemfile
   ruby_3-4-1__sinatra_ubuntu-latest:
     name: Ruby 3.4.1 - sinatra
     needs: ruby_3-4-1_ubuntu-latest
@@ -2705,8 +2705,8 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/sequel.gemfile
-  ruby_3-3-4__shoryuken_ubuntu-latest:
-    name: Ruby 3.3.4 - shoryuken
+  ruby_3-3-4__shoryuken-7_ubuntu-latest:
+    name: Ruby 3.3.4 - shoryuken-7
     needs: ruby_3-3-4_ubuntu-latest
     runs-on: ubuntu-latest
     steps:
@@ -2731,7 +2731,7 @@ jobs:
       RAILS_ENV: test
       JRUBY_OPTS: ''
       COV: '1'
-      BUNDLE_GEMFILE: gemfiles/shoryuken.gemfile
+      BUNDLE_GEMFILE: gemfiles/shoryuken-7.gemfile
   ruby_3-3-4__sinatra_ubuntu-latest:
     name: Ruby 3.3.4 - sinatra
     needs: ruby_3-3-4_ubuntu-latest
@@ -3627,8 +3627,8 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/sequel.gemfile
-  ruby_3-2-5__shoryuken_ubuntu-latest:
-    name: Ruby 3.2.5 - shoryuken
+  ruby_3-2-5__shoryuken-7_ubuntu-latest:
+    name: Ruby 3.2.5 - shoryuken-7
     needs: ruby_3-2-5_ubuntu-latest
     runs-on: ubuntu-latest
     steps:
@@ -3653,7 +3653,7 @@ jobs:
       RAILS_ENV: test
       JRUBY_OPTS: ''
       COV: '1'
-      BUNDLE_GEMFILE: gemfiles/shoryuken.gemfile
+      BUNDLE_GEMFILE: gemfiles/shoryuken-7.gemfile
   ruby_3-2-5__sinatra_ubuntu-latest:
     name: Ruby 3.2.5 - sinatra
     needs: ruby_3-2-5_ubuntu-latest
@@ -4468,6 +4468,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/sequel.gemfile
+  ruby_3-1-6__shoryuken-6_ubuntu-latest:
+    name: Ruby 3.1.6 - shoryuken-6
+    needs: ruby_3-1-6_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.1.6
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/shoryuken-6.gemfile
   ruby_3-1-6__sinatra_ubuntu-latest:
     name: Ruby 3.1.6 - sinatra
     needs: ruby_3-1-6_ubuntu-latest
@@ -5255,6 +5282,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/sequel.gemfile
+  ruby_3-0-7__shoryuken-6_ubuntu-latest:
+    name: Ruby 3.0.7 - shoryuken-6
+    needs: ruby_3-0-7_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.0.7
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/shoryuken-6.gemfile
   ruby_3-0-7__sinatra_ubuntu-latest:
     name: Ruby 3.0.7 - sinatra
     needs: ruby_3-0-7_ubuntu-latest
@@ -5880,6 +5934,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/sequel.gemfile
+  ruby_2-7-8__shoryuken-6_ubuntu-latest:
+    name: Ruby 2.7.8 - shoryuken-6
+    needs: ruby_2-7-8_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7.8
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/shoryuken-6.gemfile
   ruby_2-7-8__sinatra_ubuntu-latest:
     name: Ruby 2.7.8 - sinatra
     needs: ruby_2-7-8_ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 # This is a generated file by the `rake build_matrix:github:generate` task.
 # See `build_matrix.yml` for the build matrix.
 # Generate this file with `rake build_matrix:github:generate`.
-# Generated job count: 234
+# Generated job count: 231
 ---
 name: Ruby gem CI
 'on':
@@ -4468,33 +4468,6 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/sequel.gemfile
-  ruby_3-1-6__shoryuken_ubuntu-latest:
-    name: Ruby 3.1.6 - shoryuken
-    needs: ruby_3-1-6_ubuntu-latest
-    runs-on: ubuntu-latest
-    steps:
-    - name: Check out repository
-      uses: actions/checkout@v4
-    - name: Install Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 3.1.6
-        bundler-cache: true
-    - name: Install gem extension
-      run: "./script/bundler_wrapper exec rake extension:install"
-    - name: Print extension install report
-      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
-        file found'"
-    - name: Print Makefile log file
-      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
-        found'"
-    - name: Run tests
-      run: "./script/bundler_wrapper exec rake test"
-    env:
-      RAILS_ENV: test
-      JRUBY_OPTS: ''
-      COV: '1'
-      BUNDLE_GEMFILE: gemfiles/shoryuken.gemfile
   ruby_3-1-6__sinatra_ubuntu-latest:
     name: Ruby 3.1.6 - sinatra
     needs: ruby_3-1-6_ubuntu-latest
@@ -5282,33 +5255,6 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/sequel.gemfile
-  ruby_3-0-7__shoryuken_ubuntu-latest:
-    name: Ruby 3.0.7 - shoryuken
-    needs: ruby_3-0-7_ubuntu-latest
-    runs-on: ubuntu-latest
-    steps:
-    - name: Check out repository
-      uses: actions/checkout@v4
-    - name: Install Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 3.0.7
-        bundler-cache: true
-    - name: Install gem extension
-      run: "./script/bundler_wrapper exec rake extension:install"
-    - name: Print extension install report
-      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
-        file found'"
-    - name: Print Makefile log file
-      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
-        found'"
-    - name: Run tests
-      run: "./script/bundler_wrapper exec rake test"
-    env:
-      RAILS_ENV: test
-      JRUBY_OPTS: ''
-      COV: '1'
-      BUNDLE_GEMFILE: gemfiles/shoryuken.gemfile
   ruby_3-0-7__sinatra_ubuntu-latest:
     name: Ruby 3.0.7 - sinatra
     needs: ruby_3-0-7_ubuntu-latest
@@ -5934,33 +5880,6 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/sequel.gemfile
-  ruby_2-7-8__shoryuken_ubuntu-latest:
-    name: Ruby 2.7.8 - shoryuken
-    needs: ruby_2-7-8_ubuntu-latest
-    runs-on: ubuntu-latest
-    steps:
-    - name: Check out repository
-      uses: actions/checkout@v4
-    - name: Install Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.7.8
-        bundler-cache: true
-    - name: Install gem extension
-      run: "./script/bundler_wrapper exec rake extension:install"
-    - name: Print extension install report
-      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
-        file found'"
-    - name: Print Makefile log file
-      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
-        found'"
-    - name: Run tests
-      run: "./script/bundler_wrapper exec rake test"
-    env:
-      RAILS_ENV: test
-      JRUBY_OPTS: ''
-      COV: '1'
-      BUNDLE_GEMFILE: gemfiles/shoryuken.gemfile
   ruby_2-7-8__sinatra_ubuntu-latest:
     name: Ruby 2.7.8 - sinatra
     needs: ruby_2-7-8_ubuntu-latest

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -289,6 +289,7 @@ matrix:
           - "3.1.6"
           - "3.0.7"
     - gem: "sequel"
+    - gem: "shoryuken"
     - gem: "sinatra"
     - gem: "webmachine2"
     - gem: "redis-4"

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -290,6 +290,12 @@ matrix:
           - "3.0.7"
     - gem: "sequel"
     - gem: "shoryuken"
+      only:
+        ruby:
+          - "4.0.0"
+          - "3.4.1"
+          - "3.3.4"
+          - "3.2.5"
     - gem: "sinatra"
     - gem: "webmachine2"
     - gem: "redis-4"

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -289,7 +289,13 @@ matrix:
           - "3.1.6"
           - "3.0.7"
     - gem: "sequel"
-    - gem: "shoryuken"
+    - gem: "shoryuken-6"
+      only:
+        ruby:
+          - "3.1.6"
+          - "3.0.7"
+          - "2.7.8"
+    - gem: "shoryuken-7"
       only:
         ruby:
           - "4.0.0"

--- a/gemfiles/shoryuken-6.gemfile
+++ b/gemfiles/shoryuken-6.gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gem "shoryuken", "~> 6.0"
+# Shoryuken 6 depends on aws-sdk-core only and requires the SQS client to be
+# installed separately.
+gem "aws-sdk-sqs"
+
+gemspec :path => "../"

--- a/gemfiles/shoryuken-7.gemfile
+++ b/gemfiles/shoryuken-7.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "shoryuken", "~> 7.0"
+
+gemspec :path => "../"

--- a/gemfiles/shoryuken.gemfile
+++ b/gemfiles/shoryuken.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "shoryuken"
+
+gemspec :path => "../"

--- a/gemfiles/shoryuken.gemfile
+++ b/gemfiles/shoryuken.gemfile
@@ -1,5 +1,8 @@
 source "https://rubygems.org"
 
 gem "shoryuken"
+# Shoryuken uses AWS SDK 3, which requires the SQS client to be installed
+# separately.
+gem "aws-sdk-sqs"
 
 gemspec :path => "../"

--- a/gemfiles/shoryuken.gemfile
+++ b/gemfiles/shoryuken.gemfile
@@ -1,8 +1,0 @@
-source "https://rubygems.org"
-
-gem "shoryuken"
-# Shoryuken uses AWS SDK 3, which requires the SQS client to be installed
-# separately.
-gem "aws-sdk-sqs"
-
-gemspec :path => "../"

--- a/lib/appsignal/hooks/shoryuken.rb
+++ b/lib/appsignal/hooks/shoryuken.rb
@@ -17,6 +17,20 @@ module Appsignal
           config.server_middleware do |chain|
             chain.add Appsignal::Integrations::ShoryukenMiddleware
           end
+
+          # Servers enqueue jobs too, so they need the client middleware that
+          # records the enqueue event. Shoryuken only yields `configure_client`
+          # outside the server, so register it here as well for enqueues from
+          # within a worker.
+          config.client_middleware do |chain|
+            chain.add Appsignal::Integrations::ShoryukenClientMiddleware
+          end
+        end
+
+        ::Shoryuken.configure_client do |config|
+          config.client_middleware do |chain|
+            chain.add Appsignal::Integrations::ShoryukenClientMiddleware
+          end
         end
       end
     end

--- a/lib/appsignal/integrations/shoryuken.rb
+++ b/lib/appsignal/integrations/shoryuken.rb
@@ -71,5 +71,19 @@ module Appsignal
         end
       end
     end
+
+    # Shoryuken client middleware that records an `enqueue.shoryuken` event so
+    # the enqueue shows up under the active transaction.
+    #
+    # Like all AppSignal events, this only records when there's an active
+    # transaction (e.g. enqueuing from within a web request or another job). An
+    # enqueue with no transaction is a transparent pass-through.
+    #
+    # @!visibility private
+    class ShoryukenClientMiddleware
+      def call(_options, &block)
+        Appsignal.instrument("enqueue.shoryuken", &block)
+      end
+    end
   end
 end

--- a/lib/appsignal/integrations/shoryuken.rb
+++ b/lib/appsignal/integrations/shoryuken.rb
@@ -82,6 +82,11 @@ module Appsignal
     # @!visibility private
     class ShoryukenClientMiddleware
       def call(_options, &block)
+        # Under Active Job the enqueue is already recorded as an
+        # `enqueue.active_job` event, so skip recording it again here.
+        return yield if Appsignal::Transaction.current? &&
+          Appsignal::Transaction.current.job_enqueue_events_suppressed?
+
         Appsignal.instrument("enqueue.shoryuken", &block)
       end
     end

--- a/lib/appsignal/integrations/shoryuken.rb
+++ b/lib/appsignal/integrations/shoryuken.rb
@@ -81,13 +81,26 @@ module Appsignal
     #
     # @!visibility private
     class ShoryukenClientMiddleware
-      def call(_options, &block)
+      def call(options, &block)
         # Under Active Job the enqueue is already recorded as an
         # `enqueue.active_job` event, so skip recording it again here.
         return yield if Appsignal::Transaction.current? &&
           Appsignal::Transaction.current.job_enqueue_events_suppressed?
 
-        Appsignal.instrument("enqueue.shoryuken", &block)
+        Appsignal.instrument("enqueue.shoryuken", enqueue_title(options), &block)
+      end
+
+      private
+
+      # Enqueues through a Shoryuken worker carry the worker class in the
+      # `shoryuken_class` message attribute. Raw `send_message` enqueues don't,
+      # so there's no worker class to name -- fall back to the queue instead.
+      def enqueue_title(options)
+        worker_class = options.dig(:message_attributes, "shoryuken_class", :string_value)
+        return "enqueue #{worker_class} job" if worker_class
+
+        queue = options[:queue_url].to_s.split("/").last
+        "enqueue on #{queue}"
       end
     end
   end

--- a/spec/lib/appsignal/hooks/shoryuken_spec.rb
+++ b/spec/lib/appsignal/hooks/shoryuken_spec.rb
@@ -4,6 +4,9 @@ describe Appsignal::Hooks::ShoryukenHook do
       stub_const("Shoryuken", Module.new do
         def self.configure_server
         end
+
+        def self.configure_client
+        end
       end)
       Appsignal::Hooks::ShoryukenHook.new.install
     end
@@ -16,6 +19,8 @@ describe Appsignal::Hooks::ShoryukenHook do
   end
 
   context "without shoryuken" do
+    before { hide_const "Shoryuken" }
+
     describe "#dependencies_present?" do
       subject { described_class.new.dependencies_present? }
 

--- a/spec/lib/appsignal/integrations/shoryuken_client_spec.rb
+++ b/spec/lib/appsignal/integrations/shoryuken_client_spec.rb
@@ -1,0 +1,42 @@
+if DependencyHelper.shoryuken_present?
+  require "shoryuken"
+  require "appsignal/integrations/shoryuken"
+
+  # Integration test against the real Shoryuken gem and a stubbed AWS SQS client
+  # (the shoryuken_spec.rb suite drives the middleware with doubles). Verifies,
+  # end to end, that the hook registers the client middleware on the real send
+  # path and that an enqueue records an `enqueue.shoryuken` event -- the
+  # registration the doubled suite can't prove.
+  describe "Shoryuken client integration" do
+    before do
+      start_agent
+      Appsignal::Hooks::ShoryukenHook.new.install
+    end
+    around { |example| keep_transactions { example.run } }
+
+    after do
+      ::Shoryuken.client_middleware.remove(Appsignal::Integrations::ShoryukenClientMiddleware)
+      ::Shoryuken.server_middleware.remove(Appsignal::Integrations::ShoryukenMiddleware)
+    end
+
+    let(:sqs_client) do
+      client = Aws::SQS::Client.new(:stub_responses => true, :region => "us-east-1")
+      client.stub_responses(
+        :get_queue_url,
+        :queue_url => "https://sqs.us-east-1.amazonaws.com/0/test-queue"
+      )
+      client
+    end
+    let(:queue) { Shoryuken::Queue.new(sqs_client, "test-queue") }
+
+    it "records an enqueue event through the real send path" do
+      transaction = http_request_transaction
+      set_current_transaction(transaction)
+
+      queue.send_message(:message_body => "foo")
+
+      event_names = transaction.to_h["events"].map { |event| event["name"] }
+      expect(event_names).to include("enqueue.shoryuken")
+    end
+  end
+end

--- a/spec/lib/appsignal/integrations/shoryuken_spec.rb
+++ b/spec/lib/appsignal/integrations/shoryuken_spec.rb
@@ -175,14 +175,48 @@ describe Appsignal::Integrations::ShoryukenClientMiddleware do
   end
 
   context "with an active transaction" do
-    it "records the enqueue under the transaction" do
-      transaction = http_request_transaction
-      set_current_transaction(transaction)
+    # Enqueuing through a Shoryuken worker carries the worker class in the
+    # `shoryuken_class` message attribute, so the event is titled after it.
+    context "enqueued through a worker" do
+      let(:options) do
+        {
+          :message_body => "foo",
+          :queue_url => "https://sqs.us-east-1.amazonaws.com/0/my-queue",
+          :message_attributes => {
+            "shoryuken_class" => { :string_value => "MyShoryukenWorker", :data_type => "String" }
+          }
+        }
+      end
 
-      enqueue
+      it "records the enqueue under the transaction, titled after the worker" do
+        transaction = http_request_transaction
+        set_current_transaction(transaction)
 
-      event_names = transaction.to_h["events"].map { |event| event["name"] }
-      expect(event_names).to include("enqueue.shoryuken")
+        enqueue
+
+        event = transaction.to_h["events"].find { |e| e["name"] == "enqueue.shoryuken" }
+        expect(event).to_not be_nil
+        expect(event["title"]).to eq("enqueue MyShoryukenWorker job")
+      end
+    end
+
+    # A raw `send_message` enqueue has no worker class, so the event falls back
+    # to naming the queue it was sent to.
+    context "enqueued as a raw message" do
+      let(:options) do
+        { :message_body => "foo", :queue_url => "https://sqs.us-east-1.amazonaws.com/0/my-queue" }
+      end
+
+      it "records the enqueue under the transaction, titled after the queue" do
+        transaction = http_request_transaction
+        set_current_transaction(transaction)
+
+        enqueue
+
+        event = transaction.to_h["events"].find { |e| e["name"] == "enqueue.shoryuken" }
+        expect(event).to_not be_nil
+        expect(event["title"]).to eq("enqueue on my-queue")
+      end
     end
   end
 

--- a/spec/lib/appsignal/integrations/shoryuken_spec.rb
+++ b/spec/lib/appsignal/integrations/shoryuken_spec.rb
@@ -163,3 +163,32 @@ describe Appsignal::Integrations::ShoryukenMiddleware do
     end
   end
 end
+
+describe Appsignal::Integrations::ShoryukenClientMiddleware do
+  let(:options) { { :message_body => "foo" } }
+  before { start_agent }
+  around { |example| keep_transactions { example.run } }
+
+  def enqueue(&block)
+    block ||= lambda {}
+    described_class.new.call(options, &block)
+  end
+
+  context "with an active transaction" do
+    it "records the enqueue under the transaction" do
+      transaction = http_request_transaction
+      set_current_transaction(transaction)
+
+      enqueue
+
+      event_names = transaction.to_h["events"].map { |event| event["name"] }
+      expect(event_names).to include("enqueue.shoryuken")
+    end
+  end
+
+  context "without an active transaction" do
+    it "passes through without recording" do
+      expect { |block| enqueue(&block) }.to yield_control
+    end
+  end
+end

--- a/spec/lib/appsignal/integrations/shoryuken_spec.rb
+++ b/spec/lib/appsignal/integrations/shoryuken_spec.rb
@@ -191,4 +191,18 @@ describe Appsignal::Integrations::ShoryukenClientMiddleware do
       expect { |block| enqueue(&block) }.to yield_control
     end
   end
+
+  context "when job enqueue events are suppressed" do
+    # As happens under Active Job, which records the enqueue itself.
+    it "passes through without recording the enqueue" do
+      transaction = http_request_transaction
+      set_current_transaction(transaction)
+
+      transaction.suppress_job_enqueue_events { enqueue }
+
+      # The outer integration records the enqueue, so this one doesn't.
+      event_names = transaction.to_h["events"].map { |event| event["name"] }
+      expect(event_names).to_not include("enqueue.shoryuken")
+    end
+  end
 end

--- a/spec/support/helpers/dependency_helper.rb
+++ b/spec/support/helpers/dependency_helper.rb
@@ -191,6 +191,10 @@ module DependencyHelper
     dependency_present?("sidekiq")
   end
 
+  def shoryuken_present?
+    dependency_present?("shoryuken")
+  end
+
   def sidekiq8_present?
     sidekiq_present? &&
       Gem::Version.new(::Sidekiq::VERSION) >= Gem::Version.new("8.0.0")


### PR DESCRIPTION
Part of #1515, spun as a separate PR to make reviewing easier.

This work is part of ensuring that distributed tracing has a dedicated span to do context propagation from, following the OpenTelemetry semantic conventions for background jobs: a `PRODUCER` span is created when the job is enqueued, the trace context is propagated through the job data, and the server processing that job creates a new trace with a `CONSUMER` root span, which is linked to the `PRODUCER` span.

This PR does the preliminary changes to the Shoryuken integration needed in order to be able to support this behaviour. 

---

Add a client middleware that records an `enqueue.shoryuken` event so enqueues made from within a web request or another job show up on the active transaction. Register it on both the client and server configs, since Shoryuken only yields one of them per process and workers enqueue jobs too.

Backport of the enqueue instrumentation from the OpenTelemetry branch, without the trace-context propagation, which is collector-mode only.