### PR TITLE
Instrument Que job enqueues

### DIFF
--- a/.changesets/instrument-que-enqueues.md
+++ b/.changesets/instrument-que-enqueues.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+type: add
+---
+
+Instrument Que job enqueues. AppSignal now records an `enqueue.que` event when a Que job is enqueued, and a `bulk_enqueue.que` event for bulk enqueues on Que 2, so the enqueue shows up in the transaction timeline.

--- a/lib/appsignal/hooks/que.rb
+++ b/lib/appsignal/hooks/que.rb
@@ -13,6 +13,12 @@ module Appsignal
       def install
         require "appsignal/integrations/que"
         ::Que::Job.prepend Appsignal::Integrations::QuePlugin
+        ::Que::Job.singleton_class.prepend Appsignal::Integrations::QueClientPlugin
+
+        # `bulk_enqueue` exists only on Que 2+; don't define one where it's absent.
+        if ::Que::Job.respond_to?(:bulk_enqueue)
+          ::Que::Job.singleton_class.prepend Appsignal::Integrations::QueBulkClientPlugin
+        end
 
         ::Que.error_notifier = proc do |error, _job|
           Appsignal::Transaction.current.set_error(error)

--- a/lib/appsignal/integrations/que.rb
+++ b/lib/appsignal/integrations/que.rb
@@ -43,7 +43,7 @@ module Appsignal
     # from within a web request or another job); otherwise it's a transparent
     # pass-through.
     module QueClientPlugin
-      def enqueue(*_args, **_rest)
+      def enqueue(*_args, job_options: {}, **_rest)
         # Inside a Que 2 `bulk_enqueue` block the batch is recorded once by the
         # `bulk_enqueue` wrapper, so each inner enqueue is a pass-through to
         # avoid recording an event per job.
@@ -54,7 +54,10 @@ module Appsignal
         return super if Appsignal::Transaction.current? &&
           Appsignal::Transaction.current.job_enqueue_events_suppressed?
 
-        Appsignal.instrument("enqueue.que") { super }
+        # Resolve the job class the way Que does: an explicit `:job_class`, else
+        # the class `enqueue` was called on.
+        title = "enqueue #{job_options[:job_class] || name} job"
+        Appsignal.instrument("enqueue.que", title) { super }
       end
 
       private
@@ -71,13 +74,27 @@ module Appsignal
     # `bulk_enqueue` on Que versions that have none. The whole batch records a
     # single `bulk_enqueue.que` event; the inner enqueues are pass-throughs.
     module QueBulkClientPlugin
-      def bulk_enqueue(*_args, **_rest)
+      def bulk_enqueue(*_args, job_options: {}, **_rest)
         # Under Active Job the enqueue is already recorded as an
         # `enqueue.active_job` event, so skip recording it again here.
         return super if Appsignal::Transaction.current? &&
           Appsignal::Transaction.current.job_enqueue_events_suppressed?
 
-        Appsignal.instrument("bulk_enqueue.que") { super }
+        Appsignal.instrument("bulk_enqueue.que", bulk_enqueue_title(job_options)) { super }
+      end
+
+      private
+
+      # The batch's job class is known up front only from an explicit
+      # `:job_class` or when `bulk_enqueue` is called on a concrete subclass;
+      # called on `Que::Job` itself the class isn't known until the inner
+      # enqueues run, so the title is left class-less.
+      def bulk_enqueue_title(job_options)
+        job_class = job_options[:job_class]
+        job_class ||= name unless equal?(::Que::Job)
+        return "bulk enqueue jobs" unless job_class
+
+        "bulk enqueue #{job_class} jobs"
       end
     end
   end

--- a/lib/appsignal/integrations/que.rb
+++ b/lib/appsignal/integrations/que.rb
@@ -49,6 +49,11 @@ module Appsignal
         # avoid recording an event per job.
         return super if bulk_insert_in_progress?
 
+        # Under Active Job the enqueue is already recorded as an
+        # `enqueue.active_job` event, so skip recording it again here.
+        return super if Appsignal::Transaction.current? &&
+          Appsignal::Transaction.current.job_enqueue_events_suppressed?
+
         Appsignal.instrument("enqueue.que") { super }
       end
 
@@ -67,6 +72,11 @@ module Appsignal
     # single `bulk_enqueue.que` event; the inner enqueues are pass-throughs.
     module QueBulkClientPlugin
       def bulk_enqueue(*_args, **_rest)
+        # Under Active Job the enqueue is already recorded as an
+        # `enqueue.active_job` event, so skip recording it again here.
+        return super if Appsignal::Transaction.current? &&
+          Appsignal::Transaction.current.job_enqueue_events_suppressed?
+
         Appsignal.instrument("bulk_enqueue.que") { super }
       end
     end

--- a/lib/appsignal/integrations/que.rb
+++ b/lib/appsignal/integrations/que.rb
@@ -34,5 +34,41 @@ module Appsignal
         end
       end
     end
+
+    # @!visibility private
+    #
+    # Prepended to `Que::Job`'s singleton so it records each enqueue as an
+    # `enqueue.que` event under the active transaction. Like all AppSignal
+    # events, it only records when there's an active transaction (e.g. enqueuing
+    # from within a web request or another job); otherwise it's a transparent
+    # pass-through.
+    module QueClientPlugin
+      def enqueue(*_args, **_rest)
+        # Inside a Que 2 `bulk_enqueue` block the batch is recorded once by the
+        # `bulk_enqueue` wrapper, so each inner enqueue is a pass-through to
+        # avoid recording an event per job.
+        return super if bulk_insert_in_progress?
+
+        Appsignal.instrument("enqueue.que") { super }
+      end
+
+      private
+
+      def bulk_insert_in_progress?
+        !Thread.current[:que_jobs_to_bulk_insert].nil?
+      end
+    end
+
+    # @!visibility private
+    #
+    # `bulk_enqueue` exists only on Que 2+, so this lives in its own module that
+    # the hook prepends only when Que has the method -- otherwise we'd define a
+    # `bulk_enqueue` on Que versions that have none. The whole batch records a
+    # single `bulk_enqueue.que` event; the inner enqueues are pass-throughs.
+    module QueBulkClientPlugin
+      def bulk_enqueue(*_args, **_rest)
+        Appsignal.instrument("bulk_enqueue.que") { super }
+      end
+    end
   end
 end

--- a/lib/appsignal/integrations/que.rb
+++ b/lib/appsignal/integrations/que.rb
@@ -44,10 +44,10 @@ module Appsignal
     # pass-through.
     module QueClientPlugin
       def enqueue(*_args, job_options: {}, **_rest)
-        # Inside a Que 2 `bulk_enqueue` block the batch is recorded once by the
+        # Inside a `bulk_enqueue` block the batch is recorded once by the
         # `bulk_enqueue` wrapper, so each inner enqueue is a pass-through to
         # avoid recording an event per job.
-        return super if bulk_insert_in_progress?
+        return super if Thread.current[:appsignal_que_bulk_enqueue]
 
         # Under Active Job the enqueue is already recorded as an
         # `enqueue.active_job` event, so skip recording it again here.
@@ -58,12 +58,6 @@ module Appsignal
         # the class `enqueue` was called on.
         title = "enqueue #{job_options[:job_class] || name} job"
         Appsignal.instrument("enqueue.que", title) { super }
-      end
-
-      private
-
-      def bulk_insert_in_progress?
-        !Thread.current[:que_jobs_to_bulk_insert].nil?
       end
     end
 
@@ -80,7 +74,17 @@ module Appsignal
         return super if Appsignal::Transaction.current? &&
           Appsignal::Transaction.current.job_enqueue_events_suppressed?
 
-        Appsignal.instrument("bulk_enqueue.que", bulk_enqueue_title(job_options)) { super }
+        Appsignal.instrument("bulk_enqueue.que", bulk_enqueue_title(job_options)) do
+          # Flag the batch so the enqueues this block triggers pass through
+          # without recording, without reading Que's internal bulk state.
+          was_bulk = Thread.current[:appsignal_que_bulk_enqueue]
+          Thread.current[:appsignal_que_bulk_enqueue] = true
+          begin
+            super
+          ensure
+            Thread.current[:appsignal_que_bulk_enqueue] = was_bulk
+          end
+        end
       end
 
       private

--- a/spec/lib/appsignal/integrations/que_spec.rb
+++ b/spec/lib/appsignal/integrations/que_spec.rb
@@ -225,8 +225,10 @@ if DependencyHelper.que_present?
 
         enqueue
 
-        event_names = transaction.to_h["events"].map { |event| event["name"] }
-        expect(event_names).to include("enqueue.que")
+        # Records an enqueue event on the transaction, titled after the job.
+        event = transaction.to_h["events"].find { |e| e["name"] == "enqueue.que" }
+        expect(event).to_not be_nil
+        expect(event["title"]).to eq("enqueue MyQueJob job")
         expect(enqueued_tags).to eq(["user:42"])
       end
     end
@@ -280,9 +282,13 @@ if DependencyHelper.que_present?
 
         bulk_enqueue
 
+        # One event for the whole batch, titled after the job -- the inner
+        # enqueues don't add their own.
+        bulk_events =
+          transaction.to_h["events"].select { |e| e["name"] == "bulk_enqueue.que" }
+        expect(bulk_events.size).to eq(1)
+        expect(bulk_events.first["title"]).to eq("bulk enqueue MyQueJob jobs")
         event_names = transaction.to_h["events"].map { |event| event["name"] }
-        # One event for the whole batch -- the inner enqueues don't add their own.
-        expect(event_names.count { |name| name == "bulk_enqueue.que" }).to eq(1)
         expect(event_names).to_not include("enqueue.que")
         expect(enqueued_tags).to eq(["user:42"])
       end

--- a/spec/lib/appsignal/integrations/que_spec.rb
+++ b/spec/lib/appsignal/integrations/que_spec.rb
@@ -239,6 +239,20 @@ if DependencyHelper.que_present?
       end
     end
 
+    context "when job enqueue events are suppressed" do
+      # As happens under Active Job, which records the enqueue itself.
+      it "passes through without recording the enqueue" do
+        transaction = http_request_transaction
+        set_current_transaction(transaction)
+
+        transaction.suppress_job_enqueue_events { enqueue }
+
+        # The outer integration records the enqueue, so this one doesn't.
+        event_names = transaction.to_h["events"].map { |event| event["name"] }
+        expect(event_names).to_not include("enqueue.que")
+      end
+    end
+
     # `bulk_enqueue` is Que 2 only. The whole batch records a single
     # `bulk_enqueue.que` event; the inner enqueues are pass-throughs.
     describe "#bulk_enqueue", :if => DependencyHelper.que2_present? do
@@ -271,6 +285,20 @@ if DependencyHelper.que_present?
         expect(event_names.count { |name| name == "bulk_enqueue.que" }).to eq(1)
         expect(event_names).to_not include("enqueue.que")
         expect(enqueued_tags).to eq(["user:42"])
+      end
+
+      context "when job enqueue events are suppressed" do
+        # As happens under Active Job, which records the enqueue itself.
+        it "passes through without recording the enqueue" do
+          transaction = http_request_transaction
+          set_current_transaction(transaction)
+
+          transaction.suppress_job_enqueue_events { bulk_enqueue }
+
+          # The outer integration records the enqueue, so this one doesn't.
+          event_names = transaction.to_h["events"].map { |event| event["name"] }
+          expect(event_names).to_not include("bulk_enqueue.que")
+        end
       end
     end
   end

--- a/spec/lib/appsignal/integrations/que_spec.rb
+++ b/spec/lib/appsignal/integrations/que_spec.rb
@@ -184,4 +184,94 @@ if DependencyHelper.que_present?
       end
     end
   end
+
+  describe Appsignal::Integrations::QueClientPlugin do
+    let(:job) do
+      Class.new(::Que::Job) do
+        def self.name
+          "MyQueJob"
+        end
+      end
+    end
+
+    # Capture what Que would persist, without needing a database.
+    let(:captured) { {} }
+    before do
+      allow(Que).to receive(:execute) do |command, values|
+        captured[:values] = values if command == :insert_job
+        [{}]
+      end
+
+      start_agent
+    end
+    around { |example| keep_transactions { example.run } }
+
+    # `data` is the last value Que passes to its `:insert_job` query on both Que
+    # 1 and Que 2 (Que 2 inserts `kwargs` before it, shifting its index); the
+    # tags live under it as a JSON string.
+    def enqueued_tags
+      data = captured[:values]&.last
+      data ? JSON.parse(data)["tags"] : nil
+    end
+
+    def enqueue(tags: ["user:42"])
+      job.enqueue("post_id_123", :job_options => { :tags => tags })
+    end
+
+    context "with an active transaction" do
+      it "records an enqueue event and leaves the job's tags untouched" do
+        transaction = http_request_transaction
+        set_current_transaction(transaction)
+
+        enqueue
+
+        event_names = transaction.to_h["events"].map { |event| event["name"] }
+        expect(event_names).to include("enqueue.que")
+        expect(enqueued_tags).to eq(["user:42"])
+      end
+    end
+
+    context "without an active transaction" do
+      it "is a transparent pass-through" do
+        expect { enqueue }.to_not raise_error
+
+        expect(enqueued_tags).to eq(["user:42"])
+      end
+    end
+
+    # `bulk_enqueue` is Que 2 only. The whole batch records a single
+    # `bulk_enqueue.que` event; the inner enqueues are pass-throughs.
+    describe "#bulk_enqueue", :if => DependencyHelper.que2_present? do
+      before do
+        # Que's bulk path constantizes the job class by name, so it needs a real
+        # constant (the single-enqueue path uses `new` and doesn't).
+        stub_const("MyQueJob", job)
+        allow(Que).to receive(:transaction).and_yield
+        allow(Que).to receive(:execute) do |command, values|
+          captured[:values] = values if command == :bulk_insert_jobs
+          [{}]
+        end
+      end
+
+      def bulk_enqueue(tags: ["user:42"])
+        job.bulk_enqueue(:job_options => { :tags => tags }) do
+          job.enqueue("post_id_123")
+          job.enqueue("post_id_456")
+        end
+      end
+
+      it "records one bulk_enqueue event for the whole batch" do
+        transaction = http_request_transaction
+        set_current_transaction(transaction)
+
+        bulk_enqueue
+
+        event_names = transaction.to_h["events"].map { |event| event["name"] }
+        # One event for the whole batch -- the inner enqueues don't add their own.
+        expect(event_names.count { |name| name == "bulk_enqueue.que" }).to eq(1)
+        expect(event_names).to_not include("enqueue.que")
+        expect(enqueued_tags).to eq(["user:42"])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Part of #1515, spun as a separate PR to make reviewing easier.

This work is part of ensuring that distributed tracing has a dedicated span to do context propagation from, following the OpenTelemetry semantic conventions for background jobs: a `PRODUCER` span is created when the job is enqueued, the trace context is propagated through the job data, and the server processing that job creates a new trace with a `CONSUMER` root span, which is linked to the `PRODUCER` span.

This PR does the preliminary changes to the Que integration needed in order to be able to support this behaviour. 

---

Record an `enqueue.que` event when a Que job is enqueued, and a `bulk_enqueue.que` event for the whole batch on a bulk enqueue, so enqueues show up in the transaction timeline. The bulk wrapper records one event and its inner enqueues pass through.

The bulk module is only prepended on Que 2+, which has `bulk_enqueue`, so no phantom method is defined on Que 1.