### PR TITLE
Instrument Sidekiq job enqueues

### DIFF
--- a/.changesets/instrument-sidekiq-enqueues.md
+++ b/.changesets/instrument-sidekiq-enqueues.md
@@ -1,0 +1,8 @@
+---
+bump: minor
+type: add
+---
+
+Instrument Sidekiq job enqueues. Enqueuing a job now records an
+`enqueue.sidekiq` event on the active transaction, so enqueues made from within
+a web request or another job show up in the event timeline.

--- a/lib/appsignal/hooks/sidekiq.rb
+++ b/lib/appsignal/hooks/sidekiq.rb
@@ -42,6 +42,18 @@ module Appsignal
               chain.add Appsignal::Integrations::SidekiqMiddleware
             end
           end
+
+          # Servers enqueue jobs too, so they need the client middleware that
+          # records the enqueue event.
+          config.client_middleware do |chain|
+            chain.add Appsignal::Integrations::SidekiqClientMiddleware
+          end
+        end
+
+        ::Sidekiq.configure_client do |config|
+          config.client_middleware do |chain|
+            chain.add Appsignal::Integrations::SidekiqClientMiddleware
+          end
         end
       end
     end

--- a/lib/appsignal/integrations/sidekiq.rb
+++ b/lib/appsignal/integrations/sidekiq.rb
@@ -49,6 +49,21 @@ module Appsignal
       end
     end
 
+    # Sidekiq client middleware that runs on enqueue. Records an
+    # `enqueue.sidekiq` event so the enqueue shows up under the active
+    # transaction.
+    #
+    # Like all AppSignal events, this only records when there's an active
+    # transaction (e.g. enqueuing from within a web request or another job). An
+    # enqueue with no transaction is a transparent pass-through.
+    #
+    # @!visibility private
+    class SidekiqClientMiddleware
+      def call(_worker_class, _job, _queue, _redis_pool, &block)
+        Appsignal.instrument("enqueue.sidekiq", &block)
+      end
+    end
+
     # @!visibility private
     class SidekiqMiddleware
       include Appsignal::Hooks::Helpers

--- a/lib/appsignal/integrations/sidekiq.rb
+++ b/lib/appsignal/integrations/sidekiq.rb
@@ -60,6 +60,11 @@ module Appsignal
     # @!visibility private
     class SidekiqClientMiddleware
       def call(_worker_class, _job, _queue, _redis_pool, &block)
+        # Under Active Job the enqueue is already recorded as an
+        # `enqueue.active_job` event, so skip recording it again here.
+        return yield if Appsignal::Transaction.current? &&
+          Appsignal::Transaction.current.job_enqueue_events_suppressed?
+
         Appsignal.instrument("enqueue.sidekiq", &block)
       end
     end

--- a/lib/appsignal/integrations/sidekiq.rb
+++ b/lib/appsignal/integrations/sidekiq.rb
@@ -59,13 +59,13 @@ module Appsignal
     #
     # @!visibility private
     class SidekiqClientMiddleware
-      def call(_worker_class, _job, _queue, _redis_pool, &block)
+      def call(_worker_class, job, _queue, _redis_pool, &block)
         # Under Active Job the enqueue is already recorded as an
         # `enqueue.active_job` event, so skip recording it again here.
         return yield if Appsignal::Transaction.current? &&
           Appsignal::Transaction.current.job_enqueue_events_suppressed?
 
-        Appsignal.instrument("enqueue.sidekiq", &block)
+        Appsignal.instrument("enqueue.sidekiq", "enqueue #{job["class"]} job", &block)
       end
     end
 

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -53,6 +53,19 @@ describe Appsignal::Hooks::SidekiqHook do
         middlewares
       end
 
+      def self.client_middlewares
+        @client_middlewares ||= SidekiqMiddlewareMockWithPrepend.new
+      end
+
+      def self.configure_client
+        yield self
+      end
+
+      def self.client_middleware
+        yield client_middlewares if block_given?
+        client_middlewares
+      end
+
       def self.error_handlers
         @error_handlers ||= []
       end
@@ -73,6 +86,13 @@ describe Appsignal::Hooks::SidekiqHook do
       Sidekiq.middleware_mock = SidekiqMiddlewareMockWithPrepend
       described_class.new.install
       expect(Sidekiq.error_handlers).to include(Appsignal::Integrations::SidekiqErrorHandler)
+    end
+
+    it "adds the AppSignal client middleware to the client middleware chain" do
+      Sidekiq.middleware_mock = SidekiqMiddlewareMockWithPrepend
+      described_class.new.install
+      expect(Sidekiq.client_middleware)
+        .to include(Appsignal::Integrations::SidekiqClientMiddleware)
     end
 
     context "when Sidekiq middleware responds to prepend method" do # Sidekiq 3.3.0 and newer

--- a/spec/lib/appsignal/hooks/sidekiq_spec.rb
+++ b/spec/lib/appsignal/hooks/sidekiq_spec.rb
@@ -16,8 +16,14 @@ describe Appsignal::Hooks::SidekiqHook do
   end
 
   describe "#install" do
+    # Mirror Sidekiq's own middleware chain, which removes any existing entry
+    # for a class before adding it, so a class is only ever present once even
+    # if it's registered from more than one config block.
     class SidekiqMiddlewareMockWithPrepend < Array
-      alias add <<
+      def add(middleware)
+        delete(middleware)
+        push(middleware)
+      end
       alias exists? include?
 
       unless method_defined? :prepend
@@ -29,7 +35,10 @@ describe Appsignal::Hooks::SidekiqHook do
     end
 
     class SidekiqMiddlewareMockWithoutPrepend < Array
-      alias add <<
+      def add(middleware)
+        delete(middleware)
+        push(middleware)
+      end
       alias exists? include?
 
       undef_method :prepend if method_defined? :prepend # For Ruby >= 2.5
@@ -88,11 +97,17 @@ describe Appsignal::Hooks::SidekiqHook do
       expect(Sidekiq.error_handlers).to include(Appsignal::Integrations::SidekiqErrorHandler)
     end
 
-    it "adds the AppSignal client middleware to the client middleware chain" do
+    it "adds the AppSignal client middleware to the client middleware chain exactly once" do
       Sidekiq.middleware_mock = SidekiqMiddlewareMockWithPrepend
       described_class.new.install
-      expect(Sidekiq.client_middleware)
-        .to include(Appsignal::Integrations::SidekiqClientMiddleware)
+
+      # The client middleware is registered from both the server and client
+      # config blocks. Sidekiq only runs one of them per process and dedupes
+      # by class, so it must end up registered exactly once.
+      registrations = Sidekiq.client_middleware.count do |middleware|
+        middleware == Appsignal::Integrations::SidekiqClientMiddleware
+      end
+      expect(registrations).to eq(1)
     end
 
     context "when Sidekiq middleware responds to prepend method" do # Sidekiq 3.3.0 and newer

--- a/spec/lib/appsignal/integrations/sidekiq_spec.rb
+++ b/spec/lib/appsignal/integrations/sidekiq_spec.rb
@@ -191,8 +191,10 @@ if DependencyHelper.sidekiq_present?
 
         expect(enqueue).to eq(:enqueued)
 
-        event_names = transaction.to_h["events"].map { |event| event["name"] }
-        expect(event_names).to include("enqueue.sidekiq")
+        # Records an enqueue event on the transaction, titled after the job.
+        event = transaction.to_h["events"].find { |e| e["name"] == "enqueue.sidekiq" }
+        expect(event).to_not be_nil
+        expect(event["title"]).to eq("enqueue TestClass job")
       end
     end
 

--- a/spec/lib/appsignal/integrations/sidekiq_spec.rb
+++ b/spec/lib/appsignal/integrations/sidekiq_spec.rb
@@ -174,6 +174,36 @@ if DependencyHelper.sidekiq_present?
     end
   end
 
+  describe Appsignal::Integrations::SidekiqClientMiddleware do
+    let(:plugin) { described_class.new }
+    let(:job) { { "class" => "TestClass", "args" => [] } }
+    before { start_agent }
+    around { |example| keep_transactions { example.run } }
+
+    def enqueue
+      plugin.call("TestClass", job, "default", nil) { :enqueued }
+    end
+
+    context "with an active transaction" do
+      it "records the enqueue under the transaction" do
+        transaction = http_request_transaction
+        set_current_transaction(transaction)
+
+        expect(enqueue).to eq(:enqueued)
+
+        event_names = transaction.to_h["events"].map { |event| event["name"] }
+        expect(event_names).to include("enqueue.sidekiq")
+      end
+    end
+
+    context "without an active transaction" do
+      it "passes through without recording" do
+        expect { |block| plugin.call("TestClass", job, "default", nil, &block) }
+          .to yield_control
+      end
+    end
+  end
+
   describe Appsignal::Integrations::SidekiqMiddleware do
     class DelayedTestClass; end
 

--- a/spec/lib/appsignal/integrations/sidekiq_spec.rb
+++ b/spec/lib/appsignal/integrations/sidekiq_spec.rb
@@ -200,6 +200,8 @@ if DependencyHelper.sidekiq_present?
       it "passes through without recording" do
         expect { |block| plugin.call("TestClass", job, "default", nil, &block) }
           .to yield_control
+
+        expect(created_transactions).to be_empty
       end
     end
   end

--- a/spec/lib/appsignal/integrations/sidekiq_spec.rb
+++ b/spec/lib/appsignal/integrations/sidekiq_spec.rb
@@ -204,6 +204,21 @@ if DependencyHelper.sidekiq_present?
         expect(created_transactions).to be_empty
       end
     end
+
+    context "when job enqueue events are suppressed" do
+      # As happens under Active Job, which records the enqueue itself.
+      it "passes through without recording the enqueue" do
+        transaction = http_request_transaction
+        set_current_transaction(transaction)
+
+        result = transaction.suppress_job_enqueue_events { enqueue }
+        expect(result).to eq(:enqueued)
+
+        # The outer integration records the enqueue, so this one doesn't.
+        event_names = transaction.to_h["events"].map { |event| event["name"] }
+        expect(event_names).to_not include("enqueue.sidekiq")
+      end
+    end
   end
 
   describe Appsignal::Integrations::SidekiqMiddleware do


### PR DESCRIPTION
Part of #1515, spun as a separate PR to make reviewing easier.

This work is part of ensuring that distributed tracing has a dedicated span to do context propagation from, following the OpenTelemetry semantic conventions for background jobs: a `PRODUCER` span is created when the job is enqueued, the trace context is propagated through the job data, and the server processing that job creates a new trace with a `CONSUMER` root span, which is linked to the `PRODUCER` span.

This PR does the preliminary changes to the Sidekiq integration needed in order to be able to support this behaviour.

---

Add a client middleware that records an `enqueue.sidekiq` event so enqueues made from within a web request or another job show up on the active transaction. Register it on both the client and server configs, since workers enqueue jobs too.

Backport of the enqueue instrumentation from the OpenTelemetry branch, without the trace-context propagation, which is collector-mode only.