### PR TITLE
Instrument Resque job enqueues

### DIFF
--- a/.changesets/instrument-resque-enqueues.md
+++ b/.changesets/instrument-resque-enqueues.md
@@ -1,0 +1,8 @@
+---
+bump: minor
+type: add
+---
+
+Instrument Resque job enqueues. Enqueuing a job now records an `enqueue.resque`
+event on the active transaction, so enqueues made from within a web request or
+another job show up in the event timeline.

--- a/lib/appsignal/hooks/resque.rb
+++ b/lib/appsignal/hooks/resque.rb
@@ -13,6 +13,10 @@ module Appsignal
       def install
         require "appsignal/integrations/resque"
         Resque::Job.prepend Appsignal::Integrations::ResqueIntegration
+
+        # Resque enqueues through the `Resque.push` singleton method, so prepend
+        # onto its singleton class to record the enqueue event.
+        Resque.singleton_class.prepend Appsignal::Integrations::ResquePushIntegration
       end
     end
   end

--- a/lib/appsignal/integrations/resque.rb
+++ b/lib/appsignal/integrations/resque.rb
@@ -34,13 +34,13 @@ module Appsignal
     #
     # @!visibility private
     module ResquePushIntegration
-      def push(_queue, _item)
+      def push(_queue, item)
         # Under Active Job the enqueue is already recorded as an
         # `enqueue.active_job` event, so skip recording it again here.
         return super if Appsignal::Transaction.current? &&
           Appsignal::Transaction.current.job_enqueue_events_suppressed?
 
-        Appsignal.instrument("enqueue.resque") { super }
+        Appsignal.instrument("enqueue.resque", "enqueue #{item["class"]} job") { super }
       end
     end
 

--- a/lib/appsignal/integrations/resque.rb
+++ b/lib/appsignal/integrations/resque.rb
@@ -25,6 +25,20 @@ module Appsignal
       end
     end
 
+    # Wraps `Resque.push` to record an `enqueue.resque` event so the enqueue
+    # shows up under the active transaction.
+    #
+    # Like all AppSignal events, this only records when there's an active
+    # transaction (e.g. enqueuing from within a web request or another job).
+    # An enqueue with no transaction is a transparent pass-through.
+    #
+    # @!visibility private
+    module ResquePushIntegration
+      def push(_queue, _item)
+        Appsignal.instrument("enqueue.resque") { super }
+      end
+    end
+
     # @!visibility private
     class ResqueHelpers
       def self.arguments(payload)

--- a/lib/appsignal/integrations/resque.rb
+++ b/lib/appsignal/integrations/resque.rb
@@ -35,6 +35,11 @@ module Appsignal
     # @!visibility private
     module ResquePushIntegration
       def push(_queue, _item)
+        # Under Active Job the enqueue is already recorded as an
+        # `enqueue.active_job` event, so skip recording it again here.
+        return super if Appsignal::Transaction.current? &&
+          Appsignal::Transaction.current.job_enqueue_events_suppressed?
+
         Appsignal.instrument("enqueue.resque") { super }
       end
     end

--- a/spec/lib/appsignal/hooks/resque_spec.rb
+++ b/spec/lib/appsignal/hooks/resque_spec.rb
@@ -22,6 +22,11 @@ describe Appsignal::Hooks::ResqueHook do
       it "adds the ResqueIntegration module to Resque::Job" do
         expect(Resque::Job.included_modules).to include(Appsignal::Integrations::ResqueIntegration)
       end
+
+      it "adds the ResquePushIntegration module to the Resque singleton" do
+        expect(Resque.singleton_class.included_modules)
+          .to include(Appsignal::Integrations::ResquePushIntegration)
+      end
     end
   end
 end

--- a/spec/lib/appsignal/integrations/resque_spec.rb
+++ b/spec/lib/appsignal/integrations/resque_spec.rb
@@ -171,8 +171,10 @@ if DependencyHelper.resque_present?
 
         expect(enqueue).to eq(:pushed)
 
-        event_names = transaction.to_h["events"].map { |event| event["name"] }
-        expect(event_names).to include("enqueue.resque")
+        # Records an enqueue event on the transaction, titled after the job.
+        event = transaction.to_h["events"].find { |e| e["name"] == "enqueue.resque" }
+        expect(event).to_not be_nil
+        expect(event["title"]).to eq("enqueue ResqueTestJob job")
         expect(item).to eq("class" => "ResqueTestJob", "args" => [])
       end
     end

--- a/spec/lib/appsignal/integrations/resque_spec.rb
+++ b/spec/lib/appsignal/integrations/resque_spec.rb
@@ -183,5 +183,20 @@ if DependencyHelper.resque_present?
         expect(item).to eq("class" => "ResqueTestJob", "args" => [])
       end
     end
+
+    context "when job enqueue events are suppressed" do
+      # As happens under Active Job, which records the enqueue itself.
+      it "passes through without recording the enqueue" do
+        transaction = http_request_transaction
+        set_current_transaction(transaction)
+
+        result = transaction.suppress_job_enqueue_events { enqueue }
+        expect(result).to eq(:pushed)
+
+        # The outer integration records the enqueue, so this one doesn't.
+        event_names = transaction.to_h["events"].map { |event| event["name"] }
+        expect(event_names).to_not include("enqueue.resque")
+      end
+    end
   end
 end

--- a/spec/lib/appsignal/integrations/resque_spec.rb
+++ b/spec/lib/appsignal/integrations/resque_spec.rb
@@ -139,4 +139,49 @@ if DependencyHelper.resque_present?
       end
     end
   end
+
+  describe Appsignal::Integrations::ResquePushIntegration do
+    # A stand-in for the `Resque` singleton with the integration prepended.
+    # Its `push` records the pushed item so we can inspect what was written.
+    let(:resque) do
+      Class.new do
+        attr_reader :pushed
+
+        def push(queue, item)
+          @pushed = [queue, item]
+          :pushed
+        end
+
+        prepend Appsignal::Integrations::ResquePushIntegration
+      end.new
+    end
+    let(:item) { { "class" => "ResqueTestJob", "args" => [] } }
+
+    before { start_agent }
+    around { |example| keep_transactions { example.run } }
+
+    def enqueue
+      resque.push("default", item)
+    end
+
+    context "with an active transaction" do
+      it "records an enqueue event and leaves the job untouched" do
+        transaction = http_request_transaction
+        set_current_transaction(transaction)
+
+        expect(enqueue).to eq(:pushed)
+
+        event_names = transaction.to_h["events"].map { |event| event["name"] }
+        expect(event_names).to include("enqueue.resque")
+        expect(item).to eq("class" => "ResqueTestJob", "args" => [])
+      end
+    end
+
+    context "without an active transaction" do
+      it "is a transparent pass-through" do
+        expect(enqueue).to eq(:pushed)
+        expect(item).to eq("class" => "ResqueTestJob", "args" => [])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Part of #1515, spun as a separate PR to make reviewing easier.

This work is part of ensuring that distributed tracing has a dedicated span to do context propagation from, following the OpenTelemetry semantic conventions for background jobs: a `PRODUCER` span is created when the job is enqueued, the trace context is propagated through the job data, and the server processing that job creates a new trace with a `CONSUMER` root span, which is linked to the `PRODUCER` span.

This PR does the preliminary changes to the Resque integration needed in order to be able to support this behaviour.

---

Prepend onto the Resque singleton so each enqueue through `Resque.push` records an `enqueue.resque` event on the active transaction, so enqueues made from within a web request or another job show up in the event timeline. Mirrors the Sidekiq, Que and Shoryuken enqueue instrumentation.

Like any AppSignal event, it only records when a transaction is active; an enqueue with no transaction is a transparent pass-through.

Backport of the enqueue instrumentation from the OpenTelemetry branch, without the trace-context propagation, which is collector-mode only.