### PR TITLE
Emit MongoDB event body as a JSON string

### DIFF
--- a/.changesets/emit-mongodb-body-as-json-string.md
+++ b/.changesets/emit-mongodb-body-as-json-string.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Emit the MongoDB query event body as a JSON string instead of a structured data object. The recorded query body is unchanged.

--- a/lib/appsignal/integrations/mongo_ruby_driver.rb
+++ b/lib/appsignal/integrations/mongo_ruby_driver.rb
@@ -46,11 +46,13 @@ module Appsignal
         store   = transaction.store("mongo_driver")
         command = store.delete(event.request_id) || {}
 
-        # Finish the event in the extension.
+        # Finish the event. The sanitized command is a (nested) Hash; emit it
+        # as a JSON string. The agent serializes structured bodies to JSON
+        # anyway, so this is equivalent output.
         transaction.finish_event(
           "query.mongodb",
           "#{event.command_name} | #{event.database_name} | #{result}",
-          Appsignal::Utils::Data.generate(command),
+          Appsignal::Utils::JSON.generate(command),
           Appsignal::EventFormatter::DEFAULT
         )
 

--- a/spec/lib/appsignal/integrations/mongo_ruby_driver_spec.rb
+++ b/spec/lib/appsignal/integrations/mongo_ruby_driver_spec.rb
@@ -91,12 +91,12 @@ describe Appsignal::Hooks::MongoMonitorSubscriber do
         subscriber.finish("SUCCEEDED", event)
       end
 
-      it "should finish the transaction in the extension" do
+      it "should finish the event with the command as a JSON string" do
         expect(transaction).to receive(:finish_event).with(
           "query.mongodb",
           "find | test | SUCCEEDED",
-          Appsignal::Utils::Data.generate("foo" => "?"),
-          0
+          "{\"foo\":\"?\"}",
+          Appsignal::EventFormatter::DEFAULT
         )
 
         subscriber.finish("SUCCEEDED", event)


### PR DESCRIPTION
Part of #1515, spun as a separate PR to make reviewing easier.

The MongoDB integration was the only one to pass a structured `Appsignal::Utils::Data` object as an event body; every other integration passes a string. The agent serializes that data object to JSON before storing it, so the recorded query body is unchanged — this just makes the body a plain JSON string at the source.

On the OpenTelemetry branch this is a prerequisite for the OpenTelemetry transaction backend, which only takes scalar attribute values. Backported on its own since it stands alone and has no distributed-tracing content.