### PR TITLE
Refactor Active Job enqueues

### DIFF
--- a/.changesets/instrument-active-job-enqueues.md
+++ b/.changesets/instrument-active-job-enqueues.md
@@ -1,0 +1,10 @@
+---
+bump: patch
+type: change
+---
+
+Record the `enqueue.active_job` event from AppSignal's own Active Job
+instrumentation rather than from Rails' native `enqueue.active_job`
+notification, which is now suppressed so the enqueue is recorded once. The
+event still shows up on the active transaction when enqueuing from within a web
+request or another job; there is no change to what you see.

--- a/.changesets/instrument-active-job-enqueues.md
+++ b/.changesets/instrument-active-job-enqueues.md
@@ -7,4 +7,4 @@ Record the `enqueue.active_job` event from AppSignal's own Active Job
 instrumentation rather than from Rails' native `enqueue.active_job`
 notification, which is now suppressed so the enqueue is recorded once. The
 event still shows up on the active transaction when enqueuing from within a web
-request or another job; there is no change to what you see.
+request or another job, and is now titled after the job being enqueued.

--- a/lib/appsignal/hooks/active_job.rb
+++ b/lib/appsignal/hooks/active_job.rb
@@ -56,7 +56,7 @@ module Appsignal
       # @!visibility private
       module ActiveJobEnqueueInstrumentation
         def enqueue(*, **)
-          Appsignal.instrument("enqueue.active_job") do
+          Appsignal.instrument("enqueue.active_job", "enqueue #{self.class.name} job") do
             # Active Job enqueues through an adapter (Sidekiq, Resque, ...) that
             # has its own enqueue instrumentation. Suppress it so the enqueue is
             # recorded once, as this event, rather than as nested Active Job +

--- a/lib/appsignal/hooks/active_job.rb
+++ b/lib/appsignal/hooks/active_job.rb
@@ -29,6 +29,8 @@ module Appsignal
         ActiveSupport.on_load(:active_job) do
           ::ActiveJob::Base
             .extend ::Appsignal::Hooks::ActiveJobHook::ActiveJobClassInstrumentation
+          ::ActiveJob::Base
+            .prepend ::Appsignal::Hooks::ActiveJobHook::ActiveJobEnqueueInstrumentation
 
           next unless Appsignal::Hooks::ActiveJobHook.version_7_1_or_higher?
 
@@ -38,6 +40,23 @@ module Appsignal
 
             Appsignal::Transaction.current.set_error(exception)
           end
+        end
+      end
+
+      # Records an `enqueue.active_job` event when a job is enqueued, so the
+      # enqueue shows up on the active transaction's timeline (e.g. when
+      # enqueuing from within a web request or another job).
+      #
+      # Wrapping `enqueue` ourselves -- rather than relying on Rails' native
+      # `enqueue.active_job` notification, which the AppSignal notifications
+      # path now suppresses -- gives us a single event we own. Like all
+      # AppSignal events, this only records when there's an active transaction;
+      # an enqueue with no transaction is a transparent pass-through.
+      #
+      # @!visibility private
+      module ActiveJobEnqueueInstrumentation
+        def enqueue(*)
+          Appsignal.instrument("enqueue.active_job") { super }
         end
       end
 

--- a/lib/appsignal/hooks/active_job.rb
+++ b/lib/appsignal/hooks/active_job.rb
@@ -56,7 +56,17 @@ module Appsignal
       # @!visibility private
       module ActiveJobEnqueueInstrumentation
         def enqueue(*, **)
-          Appsignal.instrument("enqueue.active_job") { super }
+          Appsignal.instrument("enqueue.active_job") do
+            # Active Job enqueues through an adapter (Sidekiq, Resque, ...) that
+            # has its own enqueue instrumentation. Suppress it so the enqueue is
+            # recorded once, as this event, rather than as nested Active Job +
+            # adapter events.
+            if Appsignal::Transaction.current?
+              Appsignal::Transaction.current.suppress_job_enqueue_events { super }
+            else
+              super
+            end
+          end
         end
       end
 

--- a/lib/appsignal/hooks/active_job.rb
+++ b/lib/appsignal/hooks/active_job.rb
@@ -55,7 +55,7 @@ module Appsignal
       #
       # @!visibility private
       module ActiveJobEnqueueInstrumentation
-        def enqueue(*)
+        def enqueue(*, **)
           Appsignal.instrument("enqueue.active_job") { super }
         end
       end

--- a/lib/appsignal/integrations/active_support_notifications.rb
+++ b/lib/appsignal/integrations/active_support_notifications.rb
@@ -9,10 +9,10 @@ module Appsignal
 
         # Events a dedicated AppSignal integration already records, so the
         # generic notifications path must not record them a second time. The
-        # Faraday integration owns `request.faraday`: its middleware records the
-        # request itself, and Faraday's own instrumentation notification, if the
-        # user added that middleware, fires nested inside it.
-        SUPPRESSED_EVENT_NAMES = ["request.faraday"].freeze
+        # ActiveJob hook owns `enqueue.active_job` (it wraps the enqueue in its
+        # own event, with Rails' native notification nested inside), and the
+        # Faraday integration owns `request.faraday`.
+        SUPPRESSED_EVENT_NAMES = ["enqueue.active_job", "request.faraday"].freeze
 
         def start_event(name)
           return unless record_event?(name)

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -311,6 +311,27 @@ module Appsignal
       store("http_client")[:suppressed] == true
     end
 
+    # @!visibility private
+    #
+    # Run a block during which nested job enqueue integrations (Sidekiq, Resque,
+    # ...) skip recording their own enqueue event. Used when an outer integration
+    # (Active Job) already records the enqueue, so the same enqueue is not
+    # instrumented twice as nested enqueue events.
+    def suppress_job_enqueue_events
+      # Restore the previous value rather than forcing `false`, so nested calls
+      # don't unsuppress while an outer block is still active.
+      previously_suppressed = store("job_enqueue")[:suppressed]
+      store("job_enqueue")[:suppressed] = true
+      yield
+    ensure
+      store("job_enqueue")[:suppressed] = previously_suppressed
+    end
+
+    # @!visibility private
+    def job_enqueue_events_suppressed?
+      store("job_enqueue")[:suppressed] == true
+    end
+
     # Add parameters to the transaction.
     #
     # When this method is called multiple times, it will merge the request parameters.

--- a/spec/lib/appsignal/hooks/activejob_spec.rb
+++ b/spec/lib/appsignal/hooks/activejob_spec.rb
@@ -346,8 +346,11 @@ if DependencyHelper.active_job_present?
 
           # Exactly one enqueue event: ours. Rails' native `enqueue.active_job`
           # notification is suppressed so it isn't recorded a second time.
-          event_names = transaction.to_h["events"].map { |event| event["name"] }
-          expect(event_names.count("enqueue.active_job")).to eq(1)
+          enqueue_events =
+            transaction.to_h["events"].select { |event| event["name"] == "enqueue.active_job" }
+          expect(enqueue_events.size).to eq(1)
+          # The event is titled after the job being enqueued.
+          expect(enqueue_events.first["title"]).to eq("enqueue ActiveJobTestJob job")
         end
       end
 

--- a/spec/lib/appsignal/hooks/activejob_spec.rb
+++ b/spec/lib/appsignal/hooks/activejob_spec.rb
@@ -334,6 +334,34 @@ if DependencyHelper.active_job_present?
       end
     end
 
+    context "when enqueuing a job" do
+      before { ActiveJob::Base.queue_adapter = :test }
+
+      context "with an active transaction" do
+        it "records a single enqueue.active_job event on the transaction" do
+          transaction = http_request_transaction
+          set_current_transaction(transaction)
+
+          ActiveJobTestJob.perform_later
+
+          # Exactly one enqueue event: ours. Rails' native `enqueue.active_job`
+          # notification is suppressed so it isn't recorded a second time.
+          event_names = transaction.to_h["events"].map { |event| event["name"] }
+          expect(event_names.count("enqueue.active_job")).to eq(1)
+        end
+      end
+
+      context "without an active transaction" do
+        it "is a transparent pass-through that still enqueues the job" do
+          expect do
+            ActiveJobTestJob.perform_later
+          end.to_not(change { created_transactions.count })
+
+          expect(ActiveJob::Base.queue_adapter.enqueued_jobs.count).to eq(1)
+        end
+      end
+    end
+
     context "with params" do
       let(:options) { { :filter_parameters => ["foo"] } }
 

--- a/spec/lib/appsignal/hooks/activejob_spec.rb
+++ b/spec/lib/appsignal/hooks/activejob_spec.rb
@@ -360,6 +360,28 @@ if DependencyHelper.active_job_present?
           expect(ActiveJob::Base.queue_adapter.enqueued_jobs.count).to eq(1)
         end
       end
+
+      context "with an active transaction" do
+        it "suppresses nested adapter enqueue events while enqueuing" do
+          transaction = http_request_transaction
+          set_current_transaction(transaction)
+
+          # The window in which a nested adapter integration (Sidekiq, Resque,
+          # ...) would record its own event, which Active Job suppresses so the
+          # enqueue is recorded once.
+          suppressed_during_enqueue = nil
+          adapter = ActiveJob::Base.queue_adapter
+          allow(adapter).to receive(:enqueue).and_wrap_original do |method, *args|
+            suppressed_during_enqueue =
+              Appsignal::Transaction.current.job_enqueue_events_suppressed?
+            method.call(*args)
+          end
+
+          ActiveJobTestJob.perform_later
+
+          expect(suppressed_during_enqueue).to be(true)
+        end
+      end
     end
 
     context "with params" do

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -681,6 +681,41 @@ describe Appsignal::Transaction do
     end
   end
 
+  describe "#suppress_job_enqueue_events" do
+    let(:transaction) { new_transaction }
+
+    it "suppresses job enqueue events for the duration of the block" do
+      expect(transaction.job_enqueue_events_suppressed?).to be(false)
+
+      transaction.suppress_job_enqueue_events do
+        expect(transaction.job_enqueue_events_suppressed?).to be(true)
+      end
+
+      expect(transaction.job_enqueue_events_suppressed?).to be(false)
+    end
+
+    it "resets the suppression when the block raises" do
+      expect do
+        transaction.suppress_job_enqueue_events { raise "error" }
+      end.to raise_error("error")
+
+      expect(transaction.job_enqueue_events_suppressed?).to be(false)
+    end
+
+    it "stays suppressed in an outer block when a nested block returns" do
+      transaction.suppress_job_enqueue_events do
+        transaction.suppress_job_enqueue_events do
+          expect(transaction.job_enqueue_events_suppressed?).to be(true)
+        end
+
+        # The nested block must not unsuppress while the outer block is active.
+        expect(transaction.job_enqueue_events_suppressed?).to be(true)
+      end
+
+      expect(transaction.job_enqueue_events_suppressed?).to be(false)
+    end
+  end
+
   describe "#add_params" do
     let(:transaction) { new_transaction }
 


### PR DESCRIPTION
Part of #1515, spun as a separate PR to make reviewing easier.

This work is part of ensuring that distributed tracing has a dedicated span to do context propagation from, following the OpenTelemetry semantic conventions for background jobs: a `PRODUCER` span is created when the job is enqueued, the trace context is propagated through the job data, and the server processing that job creates a new trace with a `CONSUMER` root span, which is linked to the `PRODUCER` span.

This PR does the preliminary change to the Active Job integration needed in order to support this behaviour, without the trace-context propagation, which is collector-mode only.

---

Unlike the other job integrations, Active Job already records an `enqueue.active_job` event in agent mode: it rides on Rails' native `enqueue.active_job` notification, which the generic `ActiveSupport::Notifications` path picks up. This PR moves that recording into AppSignal's own instrumentation. A prepend on `ActiveJob::Base#enqueue` records the event, and the notifications path now suppresses the native one so the enqueue is recorded exactly once.

There is no user-facing change: the same single `enqueue.active_job` event still shows up on the active transaction when enqueuing from within a web request or another job. The point is to give AppSignal a single enqueue event it owns -- the seam the collector-mode work later hangs trace-context propagation off of -- and to land that instrumentation refactor on its own, so it can be reviewed and shipped independently of the OpenTelemetry changes.
