### PR TITLE
Instrument HTTP.rb chained requests on version 6

### DIFF
--- a/.changesets/instrument-http-rb-chained-requests.md
+++ b/.changesets/instrument-http-rb-chained-requests.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+type: fix
+---
+
+Instrument HTTP.rb chained requests on http 6. Requests made through a chained
+client -- `HTTP.follow.get(...)`, `HTTP.headers(...).get(...)`, and so on -- go
+through `HTTP::Session` rather than `HTTP::Client`, and were not being recorded.
+They now produce a `request.http_rb` event like any other request.

--- a/lib/appsignal/hooks/http.rb
+++ b/lib/appsignal/hooks/http.rb
@@ -16,6 +16,8 @@ module Appsignal
 
       def install
         require "appsignal/integrations/http"
+        # `Client#request` takes positional options in http5 and keyword options
+        # in http6.
         integration =
           if self.class.http6_or_higher?
             Appsignal::Integrations::HttpIntegration::KeywordOptions
@@ -23,6 +25,13 @@ module Appsignal
             Appsignal::Integrations::HttpIntegration::HashOptions
           end
         HTTP::Client.prepend integration
+        # In http6 a chained request (`.follow`, `.headers`, ...) goes through
+        # `HTTP::Session#request` instead of `HTTP::Client#request`, so
+        # instrument it too (keyword options). http5 has no Session; chained
+        # requests run through `Client#request` there.
+        if defined?(HTTP::Session)
+          HTTP::Session.prepend Appsignal::Integrations::HttpIntegration::KeywordOptions
+        end
 
         Appsignal::Environment.report_enabled("http_rb")
       end

--- a/lib/appsignal/integrations/http.rb
+++ b/lib/appsignal/integrations/http.rb
@@ -12,6 +12,15 @@ module Appsignal
         Appsignal.instrument("request.http_rb", "#{verb.upcase} #{request_uri}", &block)
       end
 
+      # The event is recorded at the request boundary, so a redirected request
+      # stays a single `request.http_rb` event spanning every hop. That boundary
+      # lives in more than one place: a bare request runs through
+      # `HTTP::Client#request`, but in http6 a chained request (`.follow`,
+      # `.headers`, `.timeout`, ...) runs through `HTTP::Session#request`
+      # instead, which never touches `Client#request`. The hook prepends one of
+      # these onto each. `Client#request` takes positional options in http5 and
+      # keyword options in http6; `Session#request` (http6 only) takes keyword
+      # options.
       module HashOptions
         def request(verb, uri, opts = {})
           HttpIntegration.instrument(verb, uri) { super }

--- a/spec/lib/appsignal/hooks/http_spec.rb
+++ b/spec/lib/appsignal/hooks/http_spec.rb
@@ -17,6 +17,11 @@ describe Appsignal::Hooks::HttpHook do
           expect(HTTP::Client.included_modules)
             .to include(Appsignal::Integrations::HttpIntegration::KeywordOptions)
         end
+
+        it "instruments chained requests through HTTP::Session" do
+          expect(HTTP::Session.included_modules)
+            .to include(Appsignal::Integrations::HttpIntegration::KeywordOptions)
+        end
       else
         it "installs the HTTP plugin with hash options" do
           expect(HTTP::Client.included_modules)

--- a/spec/lib/appsignal/integrations/http_spec.rb
+++ b/spec/lib/appsignal/integrations/http_spec.rb
@@ -67,6 +67,26 @@ if DependencyHelper.http_present?
       end
     end
 
+    describe "following redirects" do
+      # `HTTP.follow` chains through `HTTP::Session#request` in http6, which is
+      # instrumented separately from `HTTP::Client#request`. The event is
+      # recorded at the request boundary, so a redirected request is a single
+      # `request.http_rb` event spanning every hop.
+      it "records a single event spanning every hop" do
+        stub_request(:get, "http://www.google.com")
+          .to_return(:status => 301, :headers => { "Location" => "http://www.example.com" })
+        stub_request(:get, "http://www.example.com").to_return(:status => 200)
+
+        HTTP.follow.get("http://www.google.com")
+
+        events = transaction.to_h["events"]
+          .select { |event| event["name"] == "request.http_rb" }
+        expect(events.map { |event| event["title"] }).to eq(
+          ["GET http://www.google.com"]
+        )
+      end
+    end
+
     context "with various URI objects" do
       it "parses an object responding to #to_s" do
         request_uri = Struct.new(:uri) do


### PR DESCRIPTION
Part of #1515, spun as a separate PR to make reviewing easier.

While working on distributed tracing for HTTP clients we found a gap in the HTTP.rb integration that stands on its own, so it's split out here without any of the trace-context propagation (which is collector-mode only).

---

The HTTP.rb integration records its `request.http_rb` event by prepending onto `HTTP::Client#request`. In http 6, though, a *chained* request -- `HTTP.follow.get(...)`, `HTTP.headers(...).get(...)`, `HTTP.timeout(...).get(...)`, and so on -- runs through `HTTP::Session#request` instead, which never touches `HTTP::Client#request`. As a result those requests were not instrumented at all: no event was recorded for them.

This prepends the same request instrumentation onto `HTTP::Session` as well, so a chained request produces a `request.http_rb` event like any other request. http 5 has no `Session`; chained requests go through `Client#request` there, so it's unaffected.

The event is still recorded at the request boundary, so a redirected request stays a single event spanning every hop -- the added spec drives `HTTP.follow` through a redirect and asserts exactly one `request.http_rb` event, which fails on http 6 without this change.
