### PR TITLE
Test the Mongo integration with the real driver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 # This is a generated file by the `rake build_matrix:github:generate` task.
 # See `build_matrix.yml` for the build matrix.
 # Generate this file with `rake build_matrix:github:generate`.
-# Generated job count: 207
+# Generated job count: 214
 ---
 name: Ruby gem CI
 'on':
@@ -321,6 +321,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/http6.gemfile
+  ruby_4-0-0__mongo_ubuntu-latest:
+    name: Ruby 4.0.0 - mongo
+    needs: ruby_4-0-0_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 4.0.0
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/mongo.gemfile
   ruby_4-0-0__ownership_ubuntu-latest:
     name: Ruby 4.0.0 - ownership
     needs: ruby_4-0-0_ubuntu-latest
@@ -1135,6 +1162,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/http6.gemfile
+  ruby_3-4-1__mongo_ubuntu-latest:
+    name: Ruby 3.4.1 - mongo
+    needs: ruby_3-4-1_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.1
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/mongo.gemfile
   ruby_3-4-1__ownership_ubuntu-latest:
     name: Ruby 3.4.1 - ownership
     needs: ruby_3-4-1_ubuntu-latest
@@ -2003,6 +2057,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/http6.gemfile
+  ruby_3-3-4__mongo_ubuntu-latest:
+    name: Ruby 3.3.4 - mongo
+    needs: ruby_3-3-4_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.3.4
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/mongo.gemfile
   ruby_3-3-4__ownership_ubuntu-latest:
     name: Ruby 3.3.4 - ownership
     needs: ruby_3-3-4_ubuntu-latest
@@ -2817,6 +2898,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/http6.gemfile
+  ruby_3-2-5__mongo_ubuntu-latest:
+    name: Ruby 3.2.5 - mongo
+    needs: ruby_3-2-5_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.2.5
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/mongo.gemfile
   ruby_3-2-5__ownership_ubuntu-latest:
     name: Ruby 3.2.5 - ownership
     needs: ruby_3-2-5_ubuntu-latest
@@ -3604,6 +3712,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/http5.gemfile
+  ruby_3-1-6__mongo_ubuntu-latest:
+    name: Ruby 3.1.6 - mongo
+    needs: ruby_3-1-6_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.1.6
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/mongo.gemfile
   ruby_3-1-6__ownership_ubuntu-latest:
     name: Ruby 3.1.6 - ownership
     needs: ruby_3-1-6_ubuntu-latest
@@ -4310,6 +4445,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/http5.gemfile
+  ruby_3-0-7__mongo_ubuntu-latest:
+    name: Ruby 3.0.7 - mongo
+    needs: ruby_3-0-7_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.0.7
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/mongo.gemfile
   ruby_3-0-7__ownership_ubuntu-latest:
     name: Ruby 3.0.7 - ownership
     needs: ruby_3-0-7_ubuntu-latest
@@ -4935,6 +5097,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/http5.gemfile
+  ruby_2-7-8__mongo_ubuntu-latest:
+    name: Ruby 2.7.8 - mongo
+    needs: ruby_2-7-8_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7.8
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/mongo.gemfile
   ruby_2-7-8__ownership_ubuntu-latest:
     name: Ruby 2.7.8 - ownership
     needs: ruby_2-7-8_ubuntu-latest

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -182,6 +182,7 @@ matrix:
           - "3.4.1"
           - "3.3.4"
           - "3.2.5"
+    - gem: "mongo"
     - gem: "ownership"
     - gem: "padrino"
       exclude:

--- a/gemfiles/mongo.gemfile
+++ b/gemfiles/mongo.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "mongo"
+
+gemspec :path => "../"

--- a/spec/lib/appsignal/hooks/mongo_ruby_driver_spec.rb
+++ b/spec/lib/appsignal/hooks/mongo_ruby_driver_spec.rb
@@ -31,11 +31,16 @@ describe Appsignal::Hooks::MongoRubyDriverHook do
     end
   end
 
-  context "without mongo ruby driver" do
-    describe "#dependencies_present?" do
-      subject { described_class.new.dependencies_present? }
+  # Only meaningful when the real driver isn't loaded. Under `mongo.gemfile`
+  # the `Mongo::Monitoring::Global` constant is defined for real, so
+  # `dependencies_present?` is truthy and this expectation no longer holds.
+  unless DependencyHelper.mongo_present?
+    context "without mongo ruby driver" do
+      describe "#dependencies_present?" do
+        subject { described_class.new.dependencies_present? }
 
-      it { is_expected.to be_falsy }
+        it { is_expected.to be_falsy }
+      end
     end
   end
 end

--- a/spec/lib/appsignal/integrations/mongo_ruby_driver_spec.rb
+++ b/spec/lib/appsignal/integrations/mongo_ruby_driver_spec.rb
@@ -1,154 +1,146 @@
 require "appsignal/integrations/mongo_ruby_driver"
+
 describe Appsignal::Hooks::MongoMonitorSubscriber do
-  let(:subscriber) { Appsignal::Hooks::MongoMonitorSubscriber.new }
+  if DependencyHelper.mongo_present?
+    let(:subscriber) { Appsignal::Hooks::MongoMonitorSubscriber.new }
+    let(:address) { Mongo::Address.new("127.0.0.1:27017") }
 
-  context "with transaction" do
-    let(:transaction) { http_request_transaction }
-    before do
+    # Build real `Mongo::Monitoring::Event` objects so the subscriber is
+    # exercised against the driver's actual event API rather than doubles. The
+    # constructors don't open a connection, so no MongoDB server is needed.
+    def command_started_event(
+      request_id: 1, command_name: "find",
+      command: { "foo" => "bar" }, database_name: "test"
+    )
+      Mongo::Monitoring::Event::CommandStarted.new(
+        command_name, database_name, address, request_id, 1, command
+      )
+    end
+
+    def command_succeeded_event(
+      started_event, request_id: 1, command_name: "find",
+      database_name: "test", duration: 0.9919
+    )
+      Mongo::Monitoring::Event::CommandSucceeded.new(
+        command_name, database_name, address, request_id, 1, {}, duration,
+        :started_event => started_event
+      )
+    end
+
+    def command_failed_event(
+      started_event, request_id: 1, command_name: "find",
+      database_name: "test", duration: 0.9919
+    )
+      Mongo::Monitoring::Event::CommandFailed.new(
+        command_name, database_name, address, request_id, 1, "message", {}, duration,
+        :started_event => started_event
+      )
+    end
+
+    # `started` sanitizes the command and stores it on the transaction, keyed by
+    # request id, for the matching `succeeded`/`failed` to pick up.
+    it "stores the sanitized command on the transaction" do
       start_agent
+      transaction = http_request_transaction
       set_current_transaction(transaction)
+
+      subscriber.started(command_started_event(:request_id => 1))
+
+      expect(transaction.store("mongo_driver")).to eq(1 => { "foo" => "?" })
     end
 
-    describe "#started" do
-      let(:event) do
-        double(
-          :request_id   => 1,
-          :command_name => "find",
-          :command      => { "foo" => "bar" }
-        )
+    describe "instrumenting a successful query" do
+      let(:started_event) { command_started_event(:request_id => 2) }
+      let(:succeeded_event) { command_succeeded_event(started_event, :request_id => 2) }
+
+      def perform
+        subscriber.started(started_event)
+        subscriber.succeeded(succeeded_event)
       end
 
-      it "should sanitize command" do
-        # TODO: additional curly brackets required for issue
-        # https://github.com/rspec/rspec-mocks/issues/1460
-        expect(Appsignal::EventFormatter::MongoRubyDriver::QueryFormatter)
-          .to receive(:format).with("find", { "foo" => "bar" })
-        subscriber.started(event)
-      end
+      it "records the query as an event and emits a duration metric" do
+        start_agent
+        transaction = http_request_transaction
+        set_current_transaction(transaction)
 
-      it "should store command on the transaction" do
-        subscriber.started(event)
-
-        expect(transaction.store("mongo_driver")).to eq(1 => { "foo" => "?" })
-      end
-
-      it "should start an event in the extension" do
-        expect(transaction).to receive(:start_event)
-
-        subscriber.started(event)
-      end
-    end
-
-    describe "#succeeded" do
-      let(:event) { double }
-
-      it "should finish the event" do
-        expect(subscriber).to receive(:finish).with("SUCCEEDED", event)
-
-        subscriber.succeeded(event)
-      end
-    end
-
-    describe "#failed" do
-      let(:event) { double }
-
-      it "should finish the event" do
-        expect(subscriber).to receive(:finish).with("FAILED", event)
-
-        subscriber.failed(event)
-      end
-    end
-
-    describe "#finish" do
-      let(:command) { { "foo" => "?" } }
-      let(:event) do
-        double(
-          :request_id    => 2,
-          :command_name  => :find,
-          :database_name => "test",
-          :duration      => 0.9919
-        )
-      end
-
-      before do
-        store = transaction.store("mongo_driver")
-        store[2] = command
-      end
-
-      it "should emit a measurement" do
         expect(Appsignal).to receive(:add_distribution_value).with(
           "mongodb_query_duration",
           0.9919,
           :database => "test"
         ).and_call_original
 
-        subscriber.finish("SUCCEEDED", event)
-      end
+        perform
 
-      it "should get the query from the store" do
-        expect(transaction).to receive(:store).with("mongo_driver").and_return(command)
-
-        subscriber.finish("SUCCEEDED", event)
-      end
-
-      it "should finish the event with the command as a JSON string" do
-        expect(transaction).to receive(:finish_event).with(
-          "query.mongodb",
-          "find | test | SUCCEEDED",
-          "{\"foo\":\"?\"}",
-          Appsignal::EventFormatter::DEFAULT
+        expect(transaction).to include_event(
+          "name" => "query.mongodb",
+          "title" => "find | test | SUCCEEDED",
+          "body" => "{\"foo\":\"?\"}"
         )
-
-        subscriber.finish("SUCCEEDED", event)
       end
     end
-  end
 
-  context "without transaction" do
-    before do
-      allow(Appsignal::Transaction).to receive(:current)
-        .and_return(Appsignal::Transaction::NilTransaction.new)
+    describe "instrumenting a failed query" do
+      let(:started_event) { command_started_event(:request_id => 2) }
+      let(:failed_event) { command_failed_event(started_event, :request_id => 2) }
+
+      def perform
+        subscriber.started(started_event)
+        subscriber.failed(failed_event)
+      end
+
+      it "records the query as an event" do
+        start_agent
+        transaction = http_request_transaction
+        set_current_transaction(transaction)
+
+        perform
+
+        expect(transaction).to include_event(
+          "name" => "query.mongodb",
+          "title" => "find | test | FAILED",
+          "body" => "{\"foo\":\"?\"}"
+        )
+      end
     end
 
-    it "should not attempt to start an event" do
-      expect(Appsignal::Extension).to_not receive(:start_event)
+    # The subscriber guards on a current, unpaused transaction before touching
+    # the extension, so nothing is recorded otherwise.
+    describe "without an active transaction" do
+      def perform
+        started = command_started_event
+        subscriber.started(started)
+        subscriber.succeeded(command_succeeded_event(started))
+      end
 
-      subscriber.started(double)
+      it "does not record anything" do
+        start_agent
+        expect(Appsignal::Extension).to_not receive(:start_event)
+        expect(Appsignal::Extension).to_not receive(:finish_event)
+        expect(Appsignal).to_not receive(:add_distribution_value)
+
+        perform
+      end
     end
 
-    it "should not attempt to finish an event" do
-      expect(Appsignal::Extension).to_not receive(:finish_event)
+    describe "when the transaction is paused" do
+      def perform
+        started = command_started_event
+        subscriber.started(started)
+        subscriber.succeeded(command_succeeded_event(started))
+      end
 
-      subscriber.finish("SUCCEEDED", double)
-    end
+      it "does not record anything" do
+        start_agent
+        transaction = http_request_transaction
+        set_current_transaction(transaction)
+        transaction.pause!
 
-    it "should not attempt to send duration metrics" do
-      expect(Appsignal).to_not receive(:add_distribution_value)
+        expect(Appsignal::Extension).to_not receive(:start_event)
+        expect(Appsignal::Extension).to_not receive(:finish_event)
+        expect(Appsignal).to_not receive(:add_distribution_value)
 
-      subscriber.finish("SUCCEEDED", double)
-    end
-  end
-
-  context "when appsignal is paused" do
-    let(:transaction) { double(:paused? => true, :nil_transaction? => false) }
-    before { allow(Appsignal::Transaction).to receive(:current).and_return(transaction) }
-
-    it "should not attempt to start an event" do
-      expect(Appsignal::Extension).to_not receive(:start_event)
-
-      subscriber.started(double)
-    end
-
-    it "should not attempt to finish an event" do
-      expect(Appsignal::Extension).to_not receive(:finish_event)
-
-      subscriber.finish("SUCCEEDED", double)
-    end
-
-    it "should not attempt to send duration metrics" do
-      expect(Appsignal).to_not receive(:add_distribution_value)
-
-      subscriber.finish("SUCCEEDED", double)
+        perform
+      end
     end
   end
 end

--- a/spec/support/helpers/dependency_helper.rb
+++ b/spec/support/helpers/dependency_helper.rb
@@ -65,6 +65,10 @@ module DependencyHelper
     dependency_present? "sequel"
   end
 
+  def mongo_present?
+    dependency_present? "mongo"
+  end
+
   def resque_present?
     dependency_present? "resque"
   end


### PR DESCRIPTION
Part of #1515, spun as a separate PR to make reviewing easier. This extracts a test-quality improvement the OpenTelemetry work drags in, so it can be reviewed and validated independently of collector mode.

### Test the Mongo integration with the real driver

The subscriber specs fed the monitoring callbacks hand-built doubles, so the integration was never exercised against the driver's real event API. Build real `Mongo::Monitoring::Event` objects instead and drive the started/succeeded/failed callbacks; their constructors don't open a connection, so no MongoDB server is needed. Assert on the recorded event rather than on internal extension calls.

This needs the gem, so add a mongo gemfile and build matrix entry and gate the specs on it.