### PR TITLE
Report grape gem version in environment metadata

### DIFF
--- a/.changesets/report-grape-in-supported-gems.md
+++ b/.changesets/report-grape-in-supported-gems.md
@@ -3,4 +3,4 @@ bump: patch
 type: add
 ---
 
-Report the `grape` gem version in the environment metadata. Grape is a supported integration (loaded via `Appsignal.load(:grape)`), but it was missing from the list of supported gems used for environment reporting, so Grape applications did not appear in gem-version metadata. Adding it lets AppSignal track Grape adoption and version usage alongside the other supported frameworks.
+Report the `grape` gem version in the environment metadata. For more information, see [our environment metadata docs](https://docs.appsignal.com/application/environment-metadata).

--- a/.changesets/report-grape-in-supported-gems.md
+++ b/.changesets/report-grape-in-supported-gems.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Report the `grape` gem version in the environment metadata. Grape is a supported integration (loaded via `Appsignal.load(:grape)`), but it was missing from the list of supported gems used for environment reporting, so Grape applications did not appear in gem-version metadata. Adding it lets AppSignal track Grape adoption and version usage alongside the other supported frameworks.

--- a/lib/appsignal/environment.rb
+++ b/lib/appsignal/environment.rb
@@ -87,6 +87,7 @@ module Appsignal
       elasticsearch
       excon
       faraday
+      grape
       gvltools
       hanami
       hiredis


### PR DESCRIPTION
## Summary

Adds `grape` to the `SUPPORTED_GEMS` list in `lib/appsignal/environment.rb` so the agent reports `ruby_grape_version` in the environment metadata.

## Why

Grape is a supported integration — it has a loader (`lib/appsignal/loaders/grape.rb`, `Appsignal.load(:grape)`) and dedicated `Appsignal::Rack::GrapeMiddleware`. But `grape` was missing from `SUPPORTED_GEMS`, the allowlist that `report_supported_gems` iterates to emit `ruby_<gem>_version` environment metadata.

The practical effect: **Grape applications never report a `ruby_grape_version`, so Grape adoption and version usage are invisible in our telemetry** — even though the integration works. Its three sibling loader-based frameworks (`hanami`, `sinatra`, `padrino`) are all already in the list and report correctly; `grape` was simply left out.

This was surfaced while analyzing framework adoption across the customer base: Grape came back as "0" purely because of this omission, not because no one uses it.

## Change

One entry added to `SUPPORTED_GEMS` (alphabetical, between `faraday` and `gvltools`), plus a changeset. No behavior change beyond one additional gem version being reported when present in the bundle.

## Testing

`.report_supported_gems` is covered in `spec/lib/appsignal/environment_spec.rb`; it exercises the mechanism via `rack`/`rake` rather than asserting the full list, so no test changes are required.