### PR TITLE
Instrument Delayed Job enqueues

### DIFF
--- a/.changesets/add-delayed-job-enqueue-instrumentation.md
+++ b/.changesets/add-delayed-job-enqueue-instrumentation.md
@@ -1,0 +1,8 @@
+---
+bump: minor
+type: add
+---
+
+Instrument Delayed Job enqueues. Enqueuing a job now records an
+`enqueue.delayed_job` event on the active transaction, so enqueues made from
+within a web request or another job show up in the event timeline.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 # This is a generated file by the `rake build_matrix:github:generate` task.
 # See `build_matrix.yml` for the build matrix.
 # Generate this file with `rake build_matrix:github:generate`.
-# Generated job count: 234
+# Generated job count: 241
 ---
 name: Ruby gem CI
 'on':
@@ -213,6 +213,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/code_ownership.gemfile
+  ruby_4-0-0__delayed_job_ubuntu-latest:
+    name: Ruby 4.0.0 - delayed_job
+    needs: ruby_4-0-0_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 4.0.0
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/delayed_job.gemfile
   ruby_4-0-0__dry-monitor_ubuntu-latest:
     name: Ruby 4.0.0 - dry-monitor
     needs: ruby_4-0-0_ubuntu-latest
@@ -1054,6 +1081,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/code_ownership.gemfile
+  ruby_3-4-1__delayed_job_ubuntu-latest:
+    name: Ruby 3.4.1 - delayed_job
+    needs: ruby_3-4-1_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.1
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/delayed_job.gemfile
   ruby_3-4-1__dry-monitor_ubuntu-latest:
     name: Ruby 3.4.1 - dry-monitor
     needs: ruby_3-4-1_ubuntu-latest
@@ -2030,6 +2084,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/code_ownership.gemfile
+  ruby_3-3-4__delayed_job_ubuntu-latest:
+    name: Ruby 3.3.4 - delayed_job
+    needs: ruby_3-3-4_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.3.4
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/delayed_job.gemfile
   ruby_3-3-4__dry-monitor_ubuntu-latest:
     name: Ruby 3.3.4 - dry-monitor
     needs: ruby_3-3-4_ubuntu-latest
@@ -2952,6 +3033,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/capistrano3.gemfile
+  ruby_3-2-5__delayed_job_ubuntu-latest:
+    name: Ruby 3.2.5 - delayed_job
+    needs: ruby_3-2-5_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.2.5
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/delayed_job.gemfile
   ruby_3-2-5__dry-monitor_ubuntu-latest:
     name: Ruby 3.2.5 - dry-monitor
     needs: ruby_3-2-5_ubuntu-latest
@@ -3874,6 +3982,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/capistrano3.gemfile
+  ruby_3-1-6__delayed_job_ubuntu-latest:
+    name: Ruby 3.1.6 - delayed_job
+    needs: ruby_3-1-6_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.1.6
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/delayed_job.gemfile
   ruby_3-1-6__dry-monitor_ubuntu-latest:
     name: Ruby 3.1.6 - dry-monitor
     needs: ruby_3-1-6_ubuntu-latest
@@ -4715,6 +4850,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/capistrano3.gemfile
+  ruby_3-0-7__delayed_job_ubuntu-latest:
+    name: Ruby 3.0.7 - delayed_job
+    needs: ruby_3-0-7_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.0.7
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/delayed_job.gemfile
   ruby_3-0-7__dry-monitor_ubuntu-latest:
     name: Ruby 3.0.7 - dry-monitor
     needs: ruby_3-0-7_ubuntu-latest
@@ -5529,6 +5691,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/capistrano3.gemfile
+  ruby_2-7-8__delayed_job_ubuntu-latest:
+    name: Ruby 2.7.8 - delayed_job
+    needs: ruby_2-7-8_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7.8
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/delayed_job.gemfile
   ruby_2-7-8__faraday-1_ubuntu-latest:
     name: Ruby 2.7.8 - faraday-1
     needs: ruby_2-7-8_ubuntu-latest

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -141,6 +141,7 @@ matrix:
           - "3.4.1"
           - "3.3.4"
           - "jruby-9.4.7.0"
+    - gem: "delayed_job"
     - gem: "dry-monitor"
       only:
         ruby:

--- a/gemfiles/delayed_job.gemfile
+++ b/gemfiles/delayed_job.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "delayed_job"
+gem "ostruct"
+
+gemspec :path => "../"

--- a/lib/appsignal/integrations/delayed_job_plugin.rb
+++ b/lib/appsignal/integrations/delayed_job_plugin.rb
@@ -7,12 +7,33 @@ module Appsignal
       extend Appsignal::Hooks::Helpers
 
       callbacks do |lifecycle|
+        lifecycle.around(:enqueue) do |job, &block|
+          enqueue_with_instrumentation(job, block)
+        end
+
         lifecycle.around(:invoke_job) do |job, &block|
           invoke_with_instrumentation(job, block)
         end
 
         lifecycle.after(:execute) do |_execute|
           Appsignal.stop("delayed job")
+        end
+      end
+
+      # Records an `enqueue.delayed_job` event so the enqueue shows up under the
+      # active transaction (e.g. when enqueuing from within a web request or
+      # another job). An enqueue with no active transaction is a transparent
+      # pass-through.
+      def self.enqueue_with_instrumentation(job, block)
+        # Under Active Job the enqueue is already recorded as an
+        # `enqueue.active_job` event, so skip recording it again here.
+        if Appsignal::Transaction.current? &&
+            Appsignal::Transaction.current.job_enqueue_events_suppressed?
+          return block.call(job)
+        end
+
+        Appsignal.instrument("enqueue.delayed_job", "enqueue #{job.name} job") do
+          block.call(job)
         end
       end
 

--- a/lib/appsignal/integrations/delayed_job_plugin.rb
+++ b/lib/appsignal/integrations/delayed_job_plugin.rb
@@ -32,9 +32,23 @@ module Appsignal
           return block.call(job)
         end
 
-        Appsignal.instrument("enqueue.delayed_job", "enqueue #{job.name} job") do
+        Appsignal.instrument("enqueue.delayed_job", "enqueue #{enqueue_name(job)} job") do
           block.call(job)
         end
+      end
+
+      # Titles the enqueue event after the job. The `appsignal_name` override is
+      # honored verbatim, as it is when naming the perform action. That override
+      # is a full action name, so an enqueue that uses it reads as
+      # `enqueue Class#method job` rather than the bare `enqueue Class job`. We
+      # accept that inconsistency so the enqueue and perform events stay tied to
+      # the same name for the rare job that sets it.
+      def self.enqueue_name(job)
+        payload = job.payload_object
+        appsignal_name = extract_value(payload, :appsignal_name, nil)
+        return appsignal_name if appsignal_name.is_a?(String)
+
+        job.name
       end
 
       def self.invoke_with_instrumentation(job, block)

--- a/spec/lib/appsignal/hooks/delayed_job_spec.rb
+++ b/spec/lib/appsignal/hooks/delayed_job_spec.rb
@@ -31,6 +31,10 @@ describe Appsignal::Hooks::DelayedJobHook do
   end
 
   context "without delayed job" do
+    # Hide the constant so this passes whether or not the gem is loaded (it is
+    # under the `delayed_job` gemfile).
+    before { hide_const "Delayed::Plugin" }
+
     describe "#dependencies_present?" do
       subject { described_class.new.dependencies_present? }
 

--- a/spec/lib/appsignal/integrations/delayed_job_plugin_spec.rb
+++ b/spec/lib/appsignal/integrations/delayed_job_plugin_spec.rb
@@ -1,449 +1,222 @@
-describe "Appsignal::Integrations::DelayedJobHook" do
-  let(:options) { {} }
-  before do
-    stub_const("Delayed", Module.new)
-    stub_const("Delayed::Plugin", Class.new do
-      def self.callbacks
-      end
-    end)
-    stub_const("Delayed::Worker", Class.new do
-      def self.plugins
-        @plugins ||= []
-      end
-    end)
-    require "appsignal/integrations/delayed_job_plugin"
-    start_agent(:options => options)
-  end
+if DependencyHelper.delayed_job_present?
+  require "delayed_job"
+  require "appsignal/integrations/delayed_job_plugin"
+  # Delayed Job ships an in-memory test backend in its own `spec/` dir. Loading
+  # it lets us drive the real enqueue/perform lifecycle without a database.
+  require "#{Gem::Specification.find_by_name("delayed_job").gem_dir}/spec/delayed/backend/test"
 
-  # We haven't found a way to test the hooks, we'll have to do that manually
+  describe "Delayed Job integration" do
+    before do
+      Delayed::Worker.backend = Delayed::Backend::Test::Job
+      Delayed::Worker.delay_jobs = true
+      Delayed::Backend::Test::Job.delete_all
 
-  describe ".invoke_with_instrumentation" do
-    let(:plugin) { Appsignal::Integrations::DelayedJobPlugin }
-    let(:time) { Time.parse("01-01-2001 10:01:00UTC") }
-    let(:created_at) { time - 3600 }
-    let(:run_at) { time - 3600 }
-    let(:payload_object) { double(:args => args) }
-    let(:job_data) do
-      {
-        :id => 123,
-        :name => "TestClass#perform",
-        :priority => 1,
-        :attempts => 1,
-        :queue => "default",
-        :created_at => created_at,
-        :run_at => run_at,
-        :payload_object => payload_object
-      }
-    end
-    let(:args) { ["argument"] }
-    let(:job) { double(job_data) }
-    let(:invoked_block) { proc {} }
+      # Register our plugin exactly once on a fresh lifecycle. Delayed Job
+      # registers a plugin's callbacks when it instantiates the plugin (via
+      # `setup_lifecycle`); resetting the list and rebuilding per-example keeps
+      # the enqueue/perform from being instrumented more than once, whatever the
+      # AppSignal hook may have appended to the list.
+      Delayed::Worker.plugins.delete(Appsignal::Integrations::DelayedJobPlugin)
+      Delayed::Worker.plugins << Appsignal::Integrations::DelayedJobPlugin
+      Delayed::Worker.setup_lifecycle
 
-    def perform
-      Timecop.freeze(time) do
-        keep_transactions do
-          plugin.invoke_with_instrumentation(job, invoked_block)
+      stub_const("DelayedTestJob", Class.new do
+        def perform
         end
-      end
+      end)
     end
 
-    context "with a normal call" do
-      it "wraps it in a transaction" do
-        perform
+    # `invoke_job` runs the real `:invoke_job` lifecycle (and re-raises on
+    # error). Unlike `Delayed::Worker#run` it doesn't rebuild the lifecycle or
+    # swallow the job's exception, so it drives our instrumentation directly.
+    def perform_job(job)
+      job.invoke_job
+    end
 
-        transaction = last_transaction
-        expect(transaction).to have_namespace("background_job")
-        expect(transaction).to have_action("TestClass#perform")
-        expect(transaction).to_not have_error
-        expect(transaction).to include_event(:name => "perform_job.delayed_job")
-        expect(transaction).to include_tags(
-          "priority" => 1,
-          "attempts" => 1,
-          "queue" => "default",
-          "id" => "123"
-        )
-        expect(transaction).to include_params(["argument"])
-      end
+    describe "enqueueing a job" do
+      context "with an active transaction" do
+        it "records an enqueue event titled after the job" do
+          start_agent
+          transaction = http_request_transaction
+          set_current_transaction(transaction)
 
-      context "with more complex params" do
-        let(:args) do
-          {
-            :foo => "Foo",
-            :bar => "Bar"
-          }
-        end
+          Delayed::Job.enqueue(DelayedTestJob.new)
 
-        it "adds the more complex arguments" do
-          perform
-
-          expect(last_transaction).to include_params("foo" => "Foo", "bar" => "Bar")
-        end
-
-        context "with parameter filtering" do
-          let(:options) { { :filter_parameters => ["foo"] } }
-
-          it "filters selected arguments" do
-            perform
-
-            expect(last_transaction).to include_params("foo" => "[FILTERED]", "bar" => "Bar")
-          end
+          event = transaction.to_h["events"].find { |e| e["name"] == "enqueue.delayed_job" }
+          expect(event).to_not be_nil
+          expect(event["title"]).to eq("enqueue DelayedTestJob job")
         end
       end
 
-      context "with run_at in the future" do
-        let(:run_at) { Time.parse("2017-01-01 10:01:00UTC") }
+      context "without an active transaction" do
+        it "is a transparent pass-through" do
+          start_agent
 
-        it "reports queue_start with run_at time" do
-          perform
-
-          expect(last_transaction).to have_queue_start(run_at.to_i * 1000)
+          expect { Delayed::Job.enqueue(DelayedTestJob.new) }
+            .to change { Delayed::Backend::Test::Job.count }.by(1)
         end
       end
 
-      context "with class method job" do
-        let(:job_data) do
-          { :name => "CustomClassMethod.perform", :payload_object => payload_object }
-        end
+      if DependencyHelper.active_job_present?
+        context "when wrapped by Active Job" do
+          # Active Job records its own `enqueue.active_job` event and suppresses
+          # the backend's, so no duplicate is recorded here.
+          before do
+            require "active_job"
+            ActiveJob::Base.queue_adapter = :delayed_job
+            ActiveJob::Base.logger = nil
 
-        it "wraps it in a transaction using the class method job name" do
-          perform
-          expect(last_transaction).to have_action("CustomClassMethod.perform")
-        end
-      end
-
-      context "with custom name call" do
-        before { perform }
-
-        context "with appsignal_name defined" do
-          context "with payload_object being an object" do
-            context "with value" do
-              let(:payload_object) { double(:appsignal_name => "CustomClass#perform") }
-
-              it "wraps it in a transaction using the custom name" do
-                expect(last_transaction).to have_action("CustomClass#perform")
+            stub_const("DelayedActiveJob", Class.new(ActiveJob::Base) do
+              def perform(*)
               end
-            end
-
-            context "with non-String value" do
-              let(:payload_object) { double(:appsignal_name => Object.new) }
-
-              it "wraps it in a transaction using the original job name" do
-                expect(last_transaction).to have_action("TestClass#perform")
-              end
-            end
-
-            context "with class method name as job" do
-              let(:payload_object) { double(:appsignal_name => "CustomClassMethod.perform") }
-
-              it "wraps it in a transaction using the custom name" do
-                perform
-                expect(last_transaction).to have_action("CustomClassMethod.perform")
-              end
-            end
+            end)
           end
 
-          context "with payload_object being a Hash" do
-            context "with value" do
-              let(:payload_object) { double(:appsignal_name => "CustomClassHash#perform") }
+          it "does not record a second enqueue event" do
+            start_agent
+            transaction = http_request_transaction
+            set_current_transaction(transaction)
 
-              it "wraps it in a transaction using the custom name" do
-                expect(last_transaction).to have_action("CustomClassHash#perform")
-              end
-            end
+            DelayedActiveJob.perform_later
 
-            context "with non-String value" do
-              let(:payload_object) { double(:appsignal_name => Object.new) }
-
-              it "wraps it in a transaction using the original job name" do
-                expect(last_transaction).to have_action("TestClass#perform")
-              end
-            end
-
-            context "with class method name as job" do
-              let(:payload_object) { { :appsignal_name => "CustomClassMethod.perform" } }
-
-              it "wraps it in a transaction using the custom name" do
-                perform
-                expect(last_transaction).to have_action("CustomClassMethod.perform")
-              end
-            end
-          end
-
-          context "with payload_object acting like a Hash and returning a non-String value" do
-            class ClassActingAsHash
-              def self.[](_key)
-                Object.new
-              end
-
-              def self.appsignal_name
-                "ClassActingAsHash#perform"
-              end
-            end
-            let(:payload_object) { ClassActingAsHash }
-
-            # We check for hash values before object values
-            # this means ClassActingAsHash returns `Object.new` instead
-            # of `self.appsignal_name`. Since this isn't a valid `String`
-            # we return the default job name as action name.
-            it "wraps it in a transaction using the original job name" do
-              expect(last_transaction).to have_action("TestClass#perform")
-            end
+            event_names = transaction.to_h["events"].map { |e| e["name"] }
+            expect(event_names).to include("enqueue.active_job")
+            expect(event_names).to_not include("enqueue.delayed_job")
           end
         end
       end
+    end
 
-      context "with only job class name" do
-        let(:job_data) do
-          { :name => "Banana", :payload_object => payload_object }
-        end
+    describe "performing a job" do
+      context "with a normal job" do
+        it "wraps it in a background_job transaction" do
+          start_agent
+          job = Delayed::Job.enqueue(DelayedTestJob.new)
 
-        it "appends #perform to the class name" do
-          perform
-          expect(last_transaction).to have_action("Banana#perform")
+          keep_transactions { perform_job(job) }
+
+          transaction = last_transaction
+          expect(transaction).to have_namespace("background_job")
+          expect(transaction).to have_action("DelayedTestJob#perform")
+          expect(transaction).to_not have_error
+          expect(transaction).to include_event(:name => "perform_job.delayed_job")
+          expect(transaction).to include_tags("attempts" => 0, "priority" => 0)
         end
       end
 
-      if active_job_present?
-        require "active_job"
+      context "with a job that raises" do
+        before do
+          stub_const("DelayedErrorJob", Class.new do
+            def perform
+              raise ExampleException, "uh oh"
+            end
+          end)
+        end
 
-        context "when wrapped by ActiveJob" do
-          let(:payload_object) do
-            ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper.new(
-              "arguments"  => args,
-              "job_class"  => "TestClass",
-              "job_id"     => 123,
-              "locale"     => :en,
-              "queue_name" => "default"
-            )
-          end
-          let(:job) do
-            double(
-              :id             => 123,
-              :name           => "ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper",
-              :priority       => 1,
-              :attempts       => 1,
-              :queue          => "default",
-              :created_at     => created_at,
-              :run_at         => run_at,
-              :payload_object => payload_object
-            )
-          end
-          let(:args) { ["activejob_argument"] }
+        it "records the error on the transaction" do
+          start_agent
+          job = Delayed::Job.enqueue(DelayedErrorJob.new)
 
-          it "wraps it in a transaction with the correct params" do
-            perform
+          keep_transactions do
+            expect { perform_job(job) }.to raise_error(ExampleException, "uh oh")
+          end
+
+          transaction = last_transaction
+          expect(transaction).to have_namespace("background_job")
+          expect(transaction).to have_action("DelayedErrorJob#perform")
+          expect(transaction).to have_error("ExampleException", "uh oh")
+        end
+      end
+
+      context "with a custom appsignal_name" do
+        before do
+          stub_const("DelayedNamedJob", Class.new do
+            def perform
+            end
+
+            def appsignal_name
+              "CustomName#perform"
+            end
+          end)
+        end
+
+        it "uses the custom name as the action" do
+          start_agent
+          job = Delayed::Job.enqueue(DelayedNamedJob.new)
+
+          keep_transactions { perform_job(job) }
+
+          expect(last_transaction).to have_action("CustomName#perform")
+        end
+      end
+
+      if DependencyHelper.active_job_present?
+        context "when wrapped by Active Job" do
+          before do
+            require "active_job"
+            ActiveJob::Base.queue_adapter = :delayed_job
+            ActiveJob::Base.logger = nil
+
+            stub_const("DelayedActiveJob", Class.new(ActiveJob::Base) do
+              def perform(*)
+              end
+            end)
+          end
+
+          it "uses the Active Job class as the action" do
+            start_agent
+
+            keep_transactions do
+              DelayedActiveJob.perform_later("arg")
+              perform_job(Delayed::Backend::Test::Job.all.last)
+            end
 
             transaction = last_transaction
             expect(transaction).to have_namespace("background_job")
-            expect(transaction).to have_action("TestClass#perform")
-            expect(transaction).to_not have_error
-            expect(transaction).to include_event("name" => "perform_job.delayed_job")
-            expect(transaction).to include_tags(
-              "priority" => 1,
-              "attempts" => 1,
-              "queue" => "default",
-              "id" => "123"
-            )
-            expect(transaction).to include_params(["activejob_argument"])
-          end
-
-          context "with more complex params" do
-            let(:args) do
-              {
-                :foo => "Foo",
-                :bar => "Bar"
-              }
-            end
-
-            it "adds the more complex arguments" do
-              perform
-              transaction = last_transaction
-              expect(transaction).to have_action("TestClass#perform")
-              expect(transaction).to include_params(
-                "foo" => "Foo",
-                "bar" => "Bar"
-              )
-            end
-
-            context "with parameter filtering" do
-              let(:options) { { :filter_parameters => ["foo"] } }
-
-              it "filters selected arguments" do
-                perform
-                transaction = last_transaction
-                expect(transaction).to have_action("TestClass#perform")
-                expect(transaction).to include_params(
-                  "foo" => "[FILTERED]",
-                  "bar" => "Bar"
-                )
-              end
-            end
-          end
-
-          context "with run_at in the future" do
-            let(:run_at) { Time.parse("2017-01-01 10:01:00UTC") }
-
-            it "reports queue_start with run_at time" do
-              perform
-
-              expect(last_transaction).to have_queue_start(run_at.to_i * 1000)
-            end
+            expect(transaction).to have_action("DelayedActiveJob#perform")
+            expect(transaction).to include_params(["arg"])
           end
         end
       end
     end
 
-    context "with an erroring call" do
-      let(:error) { ExampleException.new("uh oh") }
-      before do
-        expect(invoked_block).to receive(:call).and_raise(error)
-      end
+    describe ".extract_value" do
+      let(:plugin) { Appsignal::Integrations::DelayedJobPlugin }
 
-      it "adds the error to the transaction" do
-        expect do
-          perform
-        end.to raise_error(error)
+      before { start_agent }
 
-        transaction = last_transaction
-        expect(transaction).to have_namespace("background_job")
-        expect(transaction).to have_action("TestClass#perform")
-        expect(transaction).to have_error("ExampleException", "uh oh")
-      end
-    end
-  end
+      context "for a hash" do
+        let(:hash) { { :key => "value", :bool_false => false } }
 
-  describe ".extract_value" do
-    let(:plugin) { Appsignal::Integrations::DelayedJobPlugin }
+        it "reads an existing key" do
+          expect(plugin.extract_value(hash, :key)).to eq("value")
+        end
 
-    context "for a hash" do
-      let(:hash) { { :key => "value", :bool_false => false } }
+        it "reads a false value" do
+          expect(plugin.extract_value(hash, :bool_false)).to be(false)
+        end
 
-      context "when the key exists" do
-        subject { plugin.extract_value(hash, :key) }
-
-        it { is_expected.to eq "value" }
-
-        context "when the value is false" do
-          subject { plugin.extract_value(hash, :bool_false) }
-
-          it { is_expected.to be false }
+        it "returns the default for a missing key" do
+          expect(plugin.extract_value(hash, :nope, 1)).to eq(1)
         end
       end
 
-      context "when the key does not exist" do
-        subject { plugin.extract_value(hash, :nonexistent_key) }
+      context "for an object" do
+        let(:object) { double(:existing_method => "value") }
 
-        it { is_expected.to be_nil }
-
-        context "with a default value" do
-          subject { plugin.extract_value(hash, :nonexistent_key, 1) }
-
-          it { is_expected.to eq 1 }
-        end
-      end
-    end
-
-    context "for a struct" do
-      let(:struct_class) { Struct.new(:key) }
-      let(:struct) { struct_class.new("value") }
-
-      context "when the key exists" do
-        subject { plugin.extract_value(struct, :key) }
-
-        it { is_expected.to eq "value" }
-      end
-
-      context "when the key does not exist" do
-        subject { plugin.extract_value(struct, :nonexistent_key) }
-
-        it { is_expected.to be_nil }
-
-        context "with a default value" do
-          subject { plugin.extract_value(struct, :nonexistent_key, 1) }
-
-          it { is_expected.to eq 1 }
-        end
-      end
-    end
-
-    context "for a struct with a method" do
-      before do
-        stub_const("TestStructClass", Class.new(Struct.new(:id)) do
-          def appsignal_name
-            "TestStruct#perform"
-          end
-
-          def bool_false
-            false
-          end
-        end)
-      end
-      let(:struct) { TestStructClass.new("id") }
-
-      context "when the Struct responds to a method" do
-        subject { plugin.extract_value(struct, :appsignal_name) }
-
-        it "returns the method value" do
-          is_expected.to eq "TestStruct#perform"
+        it "reads an existing method" do
+          expect(plugin.extract_value(object, :existing_method)).to eq("value")
         end
 
-        context "when the value is false" do
-          subject { plugin.extract_value(struct, :bool_false) }
-
-          it "returns the method value" do
-            is_expected.to be false
-          end
+        it "returns the default for a missing method" do
+          expect(plugin.extract_value(object, :nope, 1)).to eq(1)
         end
       end
 
-      context "when the key does not exist" do
-        subject { plugin.extract_value(struct, :nonexistent_key) }
-
-        context "without a method with the same name" do
-          it "returns nil" do
-            is_expected.to be_nil
-          end
-        end
-
-        context "with a default value" do
-          let(:default_value) { :my_default_value }
-          subject { plugin.extract_value(struct, :nonexistent_key, default_value) }
-
-          it "returns the default value" do
-            is_expected.to eq default_value
-          end
-        end
+      it "converts the value to a string when asked" do
+        object = double(:existing_method => 1)
+        expect(plugin.extract_value(object, :existing_method, nil, true)).to eq("1")
       end
-    end
-
-    context "for an object" do
-      let(:object) { double(:existing_method => "value") }
-
-      context "when the method exists" do
-        subject { plugin.extract_value(object, :existing_method) }
-
-        it { is_expected.to eq "value" }
-      end
-
-      context "when the method does not exist" do
-        subject { plugin.extract_value(object, :nonexistent_method) }
-
-        it { is_expected.to be_nil }
-
-        context "and there is a default value" do
-          subject { plugin.extract_value(object, :nonexistent_method, 1) }
-
-          it { is_expected.to eq 1 }
-        end
-      end
-    end
-
-    context "when we need to call to_s on the value" do
-      let(:object) { double(:existing_method => 1) }
-
-      subject { plugin.extract_value(object, :existing_method, nil, true) }
-
-      it { is_expected.to eq "1" }
     end
   end
 end

--- a/spec/lib/appsignal/integrations/delayed_job_plugin_spec.rb
+++ b/spec/lib/appsignal/integrations/delayed_job_plugin_spec.rb
@@ -48,6 +48,30 @@ if DependencyHelper.delayed_job_present?
         end
       end
 
+      context "with a custom appsignal_name" do
+        before do
+          stub_const("DelayedNamedJob", Class.new do
+            def perform
+            end
+
+            def appsignal_name
+              "CustomName#perform"
+            end
+          end)
+        end
+
+        it "titles the enqueue event with the custom name" do
+          start_agent
+          transaction = http_request_transaction
+          set_current_transaction(transaction)
+
+          Delayed::Job.enqueue(DelayedNamedJob.new)
+
+          event = transaction.to_h["events"].find { |e| e["name"] == "enqueue.delayed_job" }
+          expect(event["title"]).to eq("enqueue CustomName#perform job")
+        end
+      end
+
       context "without an active transaction" do
         it "is a transparent pass-through" do
           start_agent

--- a/spec/support/helpers/dependency_helper.rb
+++ b/spec/support/helpers/dependency_helper.rb
@@ -73,6 +73,10 @@ module DependencyHelper
     dependency_present? "resque"
   end
 
+  def delayed_job_present?
+    dependency_present? "delayed_job"
+  end
+
   def redis_client_present?
     dependency_present? "redis-client"
   end


### PR DESCRIPTION
This was neglected during the previous wave of enqueue PRs (for reference: [Active Job](https://github.com/appsignal/appsignal-ruby/pull/1527), [Resque](https://github.com/appsignal/appsignal-ruby/pull/1525), [Sidekiq](https://github.com/appsignal/appsignal-ruby/pull/1524), [Que](https://github.com/appsignal/appsignal-ruby/pull/1522), [Shoryuken](https://github.com/appsignal/appsignal-ruby/pull/1521)) as the purpose of them was to eventually implement trace context propagation, which cannot be implemented directly on the Delayed Job message object, as it does not offer a job envelope on which to attach trace propagation metadata.

Note that, when using Delayed Job via Active Job, it does support trace context propagation, as Active Job inserts its own envelope object (and its own enqueue event) that we can attach metadata to. This is already implemented in #1535.

---

Add an `around(:enqueue)` lifecycle callback that records an `enqueue.delayed_job` event on the active transaction, so enqueues made from within a web request or another job show up in the event timeline. Delayed Job was the only background job backend still missing this; it mirrors the Sidekiq, Resque, Que and Shoryuken enqueue instrumentation.

Like any AppSignal event, it only records when a transaction is active; an enqueue with no transaction is a transparent pass-through.

The integration is tested against Delayed Job's own in-memory test backend (under a new `delayed_job` gemfile), exercising the real enqueue and perform lifecycle instead of a stubbed `Delayed`.
