### PR TITLE
Fix Delayed Job hook spec order dependency

### DIFF
--- a/spec/lib/appsignal/hooks/delayed_job_spec.rb
+++ b/spec/lib/appsignal/hooks/delayed_job_spec.rb
@@ -10,7 +10,13 @@ describe Appsignal::Hooks::DelayedJobHook do
           @plugins ||= []
         end
       end)
-      start_agent
+      # Install the hook directly rather than through `start_agent`. Hooks
+      # install once per process and are never reset, so relying on
+      # `start_agent` made "adds the plugin" pass only when this spec was the
+      # first to install the Delayed Job hook -- it saw an empty stubbed worker
+      # (and failed) once any other spec had installed it first. Mirrors the
+      # Shoryuken hook spec.
+      described_class.new.install
     end
 
     describe "#dependencies_present?" do


### PR DESCRIPTION
The "adds the plugin" example relied on `start_agent` installing the process-global Delayed Job hook, which installs once and is never reset. Once any other spec installed it first (e.g. the integration spec under a different run order), the example saw an empty stubbed worker and failed. It only passed because `hooks/` sorts before `integrations/`.

Install the hook directly in the example, like the Shoryuken hook spec, so it no longer depends on global state or run order.

[skip changeset]
