### PR TITLE
Drop actionless transactions in collector mode

### DIFF
--- a/.changesets/drop-actionless-collector-transactions.md
+++ b/.changesets/drop-actionless-collector-transactions.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+In collector mode, drop a transaction that never set an action name instead of reporting it under the placeholder `appsignal.transaction <namespace>` action. A request that is not routed to an action -- for example a static asset served without a controller -- has no action to group by. Agent mode does not report such a transaction, but collector mode was surfacing every one of them under a single shared placeholder action. The transaction's root span is now flagged with `appsignal.ignore_subtrace` on completion, so the AppSignal Collector (0.10.0 and newer) drops it, matching agent mode.

--- a/lib/appsignal/transaction/opentelemetry_backend.rb
+++ b/lib/appsignal/transaction/opentelemetry_backend.rb
@@ -63,6 +63,7 @@ module Appsignal
         @breadcrumb_count = 0
         @queue_start = nil
         @start_time = Time.now
+        @action_set = false
 
         kind = SPAN_KIND_BY_NAMESPACE.fetch(namespace, DEFAULT_SPAN_KIND)
         @span = start_transaction_span(namespace, kind, opentelemetry_context)
@@ -116,6 +117,7 @@ module Appsignal
         # the collector treats the span name as authoritative for display.
         @span.name = action
         @span.set_attribute("appsignal.action_name", action)
+        @action_set = true
       end
 
       def set_namespace(namespace)
@@ -246,9 +248,12 @@ module Appsignal
       end
 
       def complete
-        # `teardown` sets `@completed`, so this guard also makes the metric
+        # `teardown` sets `@completed`, so this guard also makes the body
         # idempotent across a double `complete`, and skips it on `discard`.
-        emit_queue_duration_metric unless @completed
+        unless @completed
+          emit_queue_duration_metric
+          ignore_subtrace_without_action
+        end
         teardown
       end
 
@@ -299,6 +304,23 @@ module Appsignal
         end
         ::OpenTelemetry::Context.detach(@context_token) if @context_token
         @span&.finish
+      end
+
+      # An action name is required for performance monitoring, and a transaction
+      # that never set one has nothing to group by. Agent mode simply does not
+      # report such a transaction (e.g. a static-asset or otherwise unrouted
+      # request). Collector mode can't represent "no name": the root span keeps
+      # the placeholder name it was created with (`appsignal.transaction
+      # <namespace>`), so without this every actionless request would surface
+      # under that shared placeholder action. Mirror agent mode by flagging the
+      # subtrace so the collector drops it, exactly as `discard` does. The flag
+      # must be set before `teardown` finishes the span, since attributes set on
+      # an ended span are dropped. This is orthogonal to the queue-duration
+      # metric above, which is a namespace-level signal on its own stream.
+      def ignore_subtrace_without_action
+        return if @action_set
+
+        @span&.set_attribute("appsignal.ignore_subtrace", true)
       end
 
       # Emits the queue duration as a distribution metric in both the

--- a/spec/lib/appsignal/rack/abstract_middleware_spec.rb
+++ b/spec/lib/appsignal/rack/abstract_middleware_spec.rb
@@ -387,6 +387,11 @@ describe Appsignal::Rack::AbstractMiddleware do
             perform
 
             expect(root_span.attributes).to_not have_key("appsignal.action_name")
+            # With no action to group by, mirror agent mode (which does not
+            # report an actionless transaction) by flagging the subtrace so the
+            # collector drops it, instead of surfacing it under the placeholder
+            # span name.
+            expect(root_span.attributes["appsignal.ignore_subtrace"]).to be(true)
           end
         end
       end

--- a/spec/lib/appsignal/transaction/opentelemetry_backend_spec.rb
+++ b/spec/lib/appsignal/transaction/opentelemetry_backend_spec.rb
@@ -515,6 +515,31 @@ describe Appsignal::Transaction::OpenTelemetryBackend,
 
       expect(backend._completed?).to eq(true)
     end
+
+    context "when no action was set" do
+      it "flags the subtrace as ignored so the collector drops the placeholder-named root" do
+        backend = create_backend
+        span = backend.instance_variable_get(:@span)
+        backend.complete
+
+        finished = finished_span(span)
+        expect(finished.name).to eq("appsignal.transaction http_request")
+        expect(finished.attributes["appsignal.ignore_subtrace"]).to be(true)
+      end
+    end
+
+    context "when an action was set" do
+      it "does not flag the subtrace as ignored" do
+        backend = create_backend
+        backend.set_action("PagesController#show")
+        span = backend.instance_variable_get(:@span)
+        backend.complete
+
+        finished = finished_span(span)
+        expect(finished.attributes["appsignal.action_name"]).to eq("PagesController#show")
+        expect(finished.attributes).to_not have_key("appsignal.ignore_subtrace")
+      end
+    end
   end
 
   describe "#discard" do

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -392,7 +392,12 @@ describe Appsignal::Transaction do
         end
 
         describe "completing a restored transaction" do
+          # Set an action so this isolates the restore/discard behaviour: an
+          # actionless transaction would be flagged `ignore_subtrace` on its own
+          # (see "#complete" / actionless handling), which is unrelated to
+          # whether it was restored.
           def perform
+            transaction.set_action("SomeController#action")
             transaction.discard!
             transaction.restore!
             transaction.complete


### PR DESCRIPTION
Found while testing the collector-mode Ruby integration across the test-setups apps: in collector mode a request that is never routed to an action (for example a static asset served without a controller) surfaced as a shared `appsignal.transaction http_request` action, which agent mode never reports.

Verified end-to-end against the `rails7-postgres` collector setup. With this change the asset requests no longer appear as an action — the Collector logs `Not flushing trace with appsignal.ignore_subtrace = true` and drops them — while normal actioned requests are unaffected. This relies on the Collector honouring `appsignal.ignore_subtrace`, which landed in AppSignal Collector 0.10.0. It is the same attribute the `discard` path already uses.

---

A web request that never sets an action name (for example a static asset served without a controller) has no action to group by. Agent mode does not report such a transaction. In collector mode the root span is created with a placeholder name, `appsignal.transaction <namespace>`, so every actionless request was surfacing under that one shared placeholder action.

Track whether an action was set and, when it was not, flag the root span with `appsignal.ignore_subtrace` on completion, exactly as `discard` does. The AppSignal Collector (0.10.0 and newer) then drops the subtrace, so these requests no longer appear, matching agent mode.
