### PR TITLE
Mark Sequel query spans as CLIENT kind in collector mode

### DIFF
--- a/.changesets/sequel-query-spans-client-kind.md
+++ b/.changesets/sequel-query-spans-client-kind.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+type: fix
+---
+
+Mark Sequel query spans as CLIENT kind in collector mode. The sequel-rails gem
+emits its queries as `sql.sequel` ActiveSupport::Notifications events, which are
+recorded through the generic notifications integration rather than the dedicated
+Sequel hook. That path only tagged `sql.active_record` as an outgoing datastore
+call, so Sequel queries were exported with the default span kind. They now carry
+CLIENT kind, matching ActiveRecord and the dedicated Sequel hook.

--- a/lib/appsignal/integrations/active_support_notifications.rb
+++ b/lib/appsignal/integrations/active_support_notifications.rb
@@ -13,7 +13,13 @@ module Appsignal
         # `start_event` runs for every instrumented Rails event and span kind is
         # immutable, so only genuine client calls belong here. Object
         # instantiation (`instantiation.active_record`) is not a client call.
-        CLIENT_EVENT_NAMES = ["sql.active_record"].freeze
+        #
+        # `sql.sequel` is emitted by the sequel-rails gem through
+        # ActiveSupport::Notifications, so it reaches us here rather than through
+        # the dedicated Sequel hook (which already tags its own query events as
+        # CLIENT). Including it keeps a Sequel query CLIENT regardless of which
+        # path records it.
+        CLIENT_EVENT_NAMES = ["sql.active_record", "sql.sequel"].freeze
 
         # Events a dedicated AppSignal integration already records with richer
         # semantics, so the generic notifications path must not record them a

--- a/spec/lib/appsignal/hooks/active_support_notifications/instrument_shared_examples.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications/instrument_shared_examples.rb
@@ -42,6 +42,53 @@ shared_examples "activesupport instrument override" do
     end
   end
 
+  describe "a Sequel query event (emitted by sequel-rails)" do
+    def perform
+      as.instrument(
+        "sql.sequel",
+        :name => "Sequel::Postgres::Database",
+        :sql => "SQL"
+      ) { "value" }
+    end
+
+    it "in agent mode", :agent_mode do
+      start_agent
+      transaction = http_request_transaction
+      set_current_transaction(transaction)
+      as.notifier = notifier
+
+      expect(perform).to eq "value"
+      expect(transaction).to include_event(
+        "body" => "SQL",
+        "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
+        "count" => 1,
+        "name" => "sql.sequel",
+        "title" => "Sequel::Postgres::Database"
+      )
+    end
+
+    it "in collector mode", :collector_mode do
+      start_collector_agent
+      transaction = http_request_transaction
+      set_current_transaction(transaction)
+      as.notifier = notifier
+
+      expect(perform).to eq "value"
+      Appsignal::Transaction.complete_current!
+
+      expect(event_spans.size).to eq(1)
+      span = event_spans.find { |s| s.name == "Sequel::Postgres::Database" }
+      expect(span).not_to be_nil
+      expect(span.parent_span_id).to eq(root_span.span_id)
+      # A database query is an outgoing call, so it carries CLIENT kind.
+      expect(span.kind).to eq(:client)
+      expect(span.attributes["db.query.text"]).to eq("SQL")
+      expect(span.attributes["db.system.name"]).to eq("other_sql")
+      expect(span.attributes["appsignal.category"]).to eq("sql.sequel")
+      expect(span.attributes).not_to have_key("appsignal.body")
+    end
+  end
+
   describe "an event with no registered formatter" do
     def perform
       as.instrument("no-registered.formatter", :key => "something") { "value" }


### PR DESCRIPTION
The sequel-rails gem emits its queries as `sql.sequel`
ActiveSupport::Notifications events. Those are recorded through the
generic notifications integration, not the dedicated Sequel hook, so the
hook's CLIENT-kind tagging never applied to them.

The notifications integration only listed `sql.active_record` as an
outgoing datastore call, so Sequel queries were exported with the default
(INTERNAL) span kind in collector mode. Add `sql.sequel` to that list so a
Sequel query is CLIENT regardless of which path records it, matching
ActiveRecord and the dedicated Sequel hook.

Found while testing the Ruby collector-mode test setups: in
`ruby/rails7-sequel` (which uses sequel-rails with `instrument_sequel =
false`), the `sql.sequel` spans came through as INTERNAL while
`sql.active_record` spans elsewhere were CLIENT.