### PR TITLE
Fix extra job_options argument on Que 0.x

### DIFF
--- a/.changesets/fix-que-0-x-enqueue-arguments.md
+++ b/.changesets/fix-que-0-x-enqueue-arguments.md
@@ -1,0 +1,18 @@
+---
+bump: patch
+type: fix
+---
+
+Fix Que jobs on Que 0.x being enqueued with an extra `job_options` argument. The
+enqueue instrumentation added in version 4.9.0 always passed a `job_options`
+keyword argument on to Que, even when the caller had not passed one itself. Que
+0.x reads its scheduling options from a trailing hash instead of a `job_options`
+keyword argument, so it did not recognise that keyword and stored it as an extra
+job argument. The job then failed when it ran, because it was given one argument
+more than it expected.
+
+Que 1 and Que 2 were not affected, because both accept a `job_options` keyword
+argument and neither turns it into a job argument.
+
+The plugin now forwards the enqueue call to Que exactly as it was made. Que 0.x
+is also part of the test matrix from now on, so this is covered by tests.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 # This is a generated file by the `rake build_matrix:github:generate` task.
 # See `build_matrix.yml` for the build matrix.
 # Generate this file with `rake build_matrix:github:generate`.
-# Generated job count: 241
+# Generated job count: 248
 ---
 name: Ruby gem CI
 'on':
@@ -510,6 +510,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/psych-4.gemfile
+  ruby_4-0-0__que-0-14_ubuntu-latest:
+    name: Ruby 4.0.0 - que-0.14
+    needs: ruby_4-0-0_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 4.0.0
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/que-0.14.gemfile
   ruby_4-0-0__que-1_ubuntu-latest:
     name: Ruby 4.0.0 - que-1
     needs: ruby_4-0-0_ubuntu-latest
@@ -1486,6 +1513,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/psych-4.gemfile
+  ruby_3-4-1__que-0-14_ubuntu-latest:
+    name: Ruby 3.4.1 - que-0.14
+    needs: ruby_3-4-1_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.1
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/que-0.14.gemfile
   ruby_3-4-1__que-1_ubuntu-latest:
     name: Ruby 3.4.1 - que-1
     needs: ruby_3-4-1_ubuntu-latest
@@ -2489,6 +2543,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/psych-4.gemfile
+  ruby_3-3-4__que-0-14_ubuntu-latest:
+    name: Ruby 3.3.4 - que-0.14
+    needs: ruby_3-3-4_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.3.4
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/que-0.14.gemfile
   ruby_3-3-4__que-1_ubuntu-latest:
     name: Ruby 3.3.4 - que-1
     needs: ruby_3-3-4_ubuntu-latest
@@ -3438,6 +3519,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/psych-4.gemfile
+  ruby_3-2-5__que-0-14_ubuntu-latest:
+    name: Ruby 3.2.5 - que-0.14
+    needs: ruby_3-2-5_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.2.5
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/que-0.14.gemfile
   ruby_3-2-5__que-1_ubuntu-latest:
     name: Ruby 3.2.5 - que-1
     needs: ruby_3-2-5_ubuntu-latest
@@ -4360,6 +4468,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/psych-4.gemfile
+  ruby_3-1-6__que-0-14_ubuntu-latest:
+    name: Ruby 3.1.6 - que-0.14
+    needs: ruby_3-1-6_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.1.6
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/que-0.14.gemfile
   ruby_3-1-6__que-1_ubuntu-latest:
     name: Ruby 3.1.6 - que-1
     needs: ruby_3-1-6_ubuntu-latest
@@ -5201,6 +5336,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/psych-4.gemfile
+  ruby_3-0-7__que-0-14_ubuntu-latest:
+    name: Ruby 3.0.7 - que-0.14
+    needs: ruby_3-0-7_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.0.7
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/que-0.14.gemfile
   ruby_3-0-7__que-1_ubuntu-latest:
     name: Ruby 3.0.7 - que-1
     needs: ruby_3-0-7_ubuntu-latest
@@ -5934,6 +6096,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/psych-4.gemfile
+  ruby_2-7-8__que-0-14_ubuntu-latest:
+    name: Ruby 2.7.8 - que-0.14
+    needs: ruby_2-7-8_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7.8
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/que-0.14.gemfile
   ruby_2-7-8__que-1_ubuntu-latest:
     name: Ruby 2.7.8 - que-1
     needs: ruby_2-7-8_ubuntu-latest

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -219,6 +219,7 @@ matrix:
           - "3.1.6"
           - "3.0.7"
           - "2.7.8"
+    - gem: "que-0.14"
     - gem: "que-1"
     - gem: "que-2"
     - gem: "rails-6.0"

--- a/gemfiles/que-0.14.gemfile
+++ b/gemfiles/que-0.14.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "ostruct"
+gem "que", "~> 0.14"
+
+gemspec :path => "../"

--- a/lib/appsignal/integrations/que.rb
+++ b/lib/appsignal/integrations/que.rb
@@ -43,7 +43,16 @@ module Appsignal
     # from within a web request or another job); otherwise it's a transparent
     # pass-through.
     module QueClientPlugin
-      def enqueue(*_args, job_options: {}, **_rest)
+      # The keyword arguments are captured into a single `**kwargs` hash, rather
+      # than declaring a `job_options:` keyword with a default, so that an
+      # implicit `super` forwards the original call unchanged. Declaring
+      # `job_options: {}` would bind that default even when the caller did not
+      # pass it, and `super` would then forward it to Que. On Que 0.14, whose
+      # `enqueue` takes only positional arguments, that extra keyword ends up
+      # persisted as an additional job argument.
+      def enqueue(*_args, **kwargs)
+        job_options = kwargs[:job_options] || {}
+
         # Inside a `bulk_enqueue` block the batch is recorded once by the
         # `bulk_enqueue` wrapper, so each inner enqueue is a pass-through to
         # avoid recording an event per job.

--- a/spec/lib/appsignal/integrations/que_spec.rb
+++ b/spec/lib/appsignal/integrations/que_spec.rb
@@ -217,6 +217,14 @@ if DependencyHelper.que_present?
     end
     around { |example| keep_transactions { example.run } }
 
+    # The arguments are the fifth value Que passes to its `:insert_job` query on
+    # every version. Que 1 and up serialise them to JSON first; Que 0.x hands
+    # over the array itself.
+    def enqueued_args
+      args = captured[:values] && captured[:values][4]
+      args.is_a?(String) ? JSON.parse(args) : args
+    end
+
     # `data` is the last value Que passes to its `:insert_job` query on both Que
     # 1 and Que 2 (Que 2 inserts `kwargs` before it, shifting its index); the
     # tags live under it as a JSON string.
@@ -236,8 +244,18 @@ if DependencyHelper.que_present?
       end
     end
 
+    # Whatever the plugin does, it must forward the enqueue call to Que
+    # unchanged. This matters most on Que 0.x, which turns any keyword argument
+    # it does not recognise into an extra job argument. That means a keyword the
+    # plugin adds to the call itself, such as an empty `job_options` default,
+    # would be persisted as a job argument and break the job when it runs.
+    def expect_job_to_be_enqueued_unchanged
+      expect(enqueued_args).to eq(["post_id_123"])
+      expect(enqueued_tags).to eq(["user:42"]) if DependencyHelper.que1_present?
+    end
+
     context "with an active transaction" do
-      it "records an enqueue event and leaves the job's tags untouched" do
+      it "records an enqueue event and leaves the job's arguments untouched" do
         transaction = http_request_transaction
         set_current_transaction(transaction)
 
@@ -247,7 +265,7 @@ if DependencyHelper.que_present?
         event = transaction.to_h["events"].find { |e| e["name"] == "enqueue.que" }
         expect(event).to_not be_nil
         expect(event["title"]).to eq("enqueue MyQueJob job")
-        expect(enqueued_tags).to eq(["user:42"]) if DependencyHelper.que1_present?
+        expect_job_to_be_enqueued_unchanged
       end
     end
 
@@ -255,7 +273,7 @@ if DependencyHelper.que_present?
       it "is a transparent pass-through" do
         expect { enqueue }.to_not raise_error
 
-        expect(enqueued_tags).to eq(["user:42"]) if DependencyHelper.que1_present?
+        expect_job_to_be_enqueued_unchanged
       end
     end
 
@@ -270,6 +288,7 @@ if DependencyHelper.que_present?
         # The outer integration records the enqueue, so this one doesn't.
         event_names = transaction.to_h["events"].map { |event| event["name"] }
         expect(event_names).to_not include("enqueue.que")
+        expect_job_to_be_enqueued_unchanged
       end
     end
 

--- a/spec/lib/appsignal/integrations/que_spec.rb
+++ b/spec/lib/appsignal/integrations/que_spec.rb
@@ -123,7 +123,11 @@ if DependencyHelper.que_present?
             "arguments" => %w[post_id_123 user_id_123]
           )
           expect(transaction).to include_tags(
-            "attempts" => 0,
+            # Que 0.x handles the error inside its own `_run` and counts the
+            # failed attempt there. That happens before the plugin reads the job
+            # attributes, so it reports one attempt. Que 1 and up leave the
+            # count to the worker, so they still report none here.
+            "attempts" => DependencyHelper.que1_present? ? 0 : 1,
             "id" => 123,
             "priority" => 100,
             "queue" => "dfl",
@@ -202,6 +206,13 @@ if DependencyHelper.que_present?
         [{}]
       end
 
+      # After enqueueing, Que 0.x wakes a worker through its adapter, which
+      # needs a database connection.
+      unless DependencyHelper.que1_present?
+        allow(Que).to receive(:adapter)
+          .and_return(double(:wake_worker_after_commit => nil))
+      end
+
       start_agent
     end
     around { |example| keep_transactions { example.run } }
@@ -214,8 +225,15 @@ if DependencyHelper.que_present?
       data ? JSON.parse(data)["tags"] : nil
     end
 
-    def enqueue(tags: ["user:42"])
-      job.enqueue("post_id_123", :job_options => { :tags => tags })
+    # Que 0.x has no `job_options` keyword and no tags at all. It reads its
+    # scheduling options from top-level keys in a trailing hash instead. So the
+    # tags are only passed, and only asserted, on Que 1 and up.
+    def enqueue
+      if DependencyHelper.que1_present?
+        job.enqueue("post_id_123", :job_options => { :tags => ["user:42"] })
+      else
+        job.enqueue("post_id_123")
+      end
     end
 
     context "with an active transaction" do
@@ -229,7 +247,7 @@ if DependencyHelper.que_present?
         event = transaction.to_h["events"].find { |e| e["name"] == "enqueue.que" }
         expect(event).to_not be_nil
         expect(event["title"]).to eq("enqueue MyQueJob job")
-        expect(enqueued_tags).to eq(["user:42"])
+        expect(enqueued_tags).to eq(["user:42"]) if DependencyHelper.que1_present?
       end
     end
 
@@ -237,7 +255,7 @@ if DependencyHelper.que_present?
       it "is a transparent pass-through" do
         expect { enqueue }.to_not raise_error
 
-        expect(enqueued_tags).to eq(["user:42"])
+        expect(enqueued_tags).to eq(["user:42"]) if DependencyHelper.que1_present?
       end
     end
 

--- a/spec/support/helpers/dependency_helper.rb
+++ b/spec/support/helpers/dependency_helper.rb
@@ -164,6 +164,11 @@ module DependencyHelper
     dependency_present? "code_ownership"
   end
 
+  def que1_present?
+    que_present? &&
+      Gem.loaded_specs["que"].version >= Gem::Version.new("1.0.0")
+  end
+
   def que2_present?
     que_present? &&
       Gem.loaded_specs["que"].version >= Gem::Version.new("2.0.0")


### PR DESCRIPTION
Fixes https://github.com/appsignal/appsignal-ruby/issues/1556.

### [Test the last Que 0.x version in CI](https://github.com/appsignal/appsignal-ruby/commit/b8682306)

The Que integration supports Que 0.x, but the test matrix only covered
Que 1 and Que 2. That let a bug ship that only shows up on Que 0.x,
because its `enqueue` reads its scheduling options from a trailing hash
instead of a `job_options` keyword argument.

Add a gemfile for Que 0.14, which is the last of the 0.x releases. Every
0.x version that has an `enqueue` method declares it the same way, as
`enqueue(*args)` with a trailing options hash, so testing the last one
covers the whole 0.x line.

Three things in the Que specs needed to be made version aware to run
against Que 0.x. It wakes a worker through its adapter after enqueueing,
which needs a database connection, so the adapter is stubbed. It has no
tags, so the tags are only passed and asserted on Que 1 and up. It
counts a failed attempt inside its own `_run`, before the plugin reads
the job attributes, so it reports one attempt where Que 1 and up report
none.

### [Fix extra job_options argument on Que 0.x](https://github.com/appsignal/appsignal-ruby/commit/3f0b11d4)

The enqueue instrumentation declared `job_options` as a keyword argument
with an empty default. Ruby binds that default even when the caller did
not pass the keyword, and the implicit `super` then forwarded it on to
Que.

Que 1 and Que 2 both accept a `job_options` keyword argument, so neither
turned it into a job argument. Que 0.x reads its scheduling options from
a trailing hash instead, and it puts back anything it does not recognise
as a job argument. So a job enqueued with one argument was persisted
with two, and it failed when it ran because it was given one argument
too many.

Capture the keyword arguments into a single `kwargs` hash and read
`job_options` from that, so the implicit `super` forwards the call
exactly as it was made.
