### PR TITLE
Trim shared frames from error cause backtraces

### DIFF
--- a/lib/appsignal/transaction/opentelemetry_backend.rb
+++ b/lib/appsignal/transaction/opentelemetry_backend.rb
@@ -283,7 +283,7 @@ module Appsignal
       # (keys match the processor's `ErrorSubCause`); separate cause events would
       # each become their own incident. Each cause only carries the part of its
       # backtrace that the reported error's backtrace does not already end with
-      # (see `lines_without_shared_tail`).
+      # (see `trim_shared_tail`).
       def set_error(class_name, message, backtrace, causes, _root_cause_missing)
         span = current_span
         error_lines = Array(backtrace)
@@ -298,11 +298,15 @@ module Appsignal
         unless causes.empty?
           attributes["appsignal.error_causes"] = JSON.generate(
             causes.map do |cause|
-              {
+              lines, lines_omitted = trim_shared_tail(Array(cause[:backtrace]), error_lines)
+
+              cause_attributes = {
                 "name" => cause[:name],
                 "message" => cause[:message],
-                "lines" => lines_without_shared_tail(Array(cause[:backtrace]), error_lines)
+                "lines" => lines
               }
+              cause_attributes["lines_omitted"] = lines_omitted if lines_omitted.positive?
+              cause_attributes
             end
           )
         end
@@ -708,8 +712,9 @@ module Appsignal
         end
       end
 
-      # Returns the leading lines of a cause's backtrace that the reported
-      # error's own backtrace does not already end with.
+      # Returns two values: the leading lines of a cause's backtrace that the
+      # reported error's own backtrace does not already end with, and how many
+      # trailing lines were dropped to get there.
       #
       # A cause is raised somewhere inside the frames that led to the reported
       # error, so both backtraces share the same trailing frames -- everything
@@ -724,16 +729,22 @@ module Appsignal
       # backtrace unique to the cause: where it was raised. Lines are compared
       # from the end as plain strings. If every line is shared, keep the first
       # one, because a cause with no lines leaves the UI nothing to show.
-      def lines_without_shared_tail(cause_lines, error_lines)
+      #
+      # The dropped count is returned so that the cause can report it, which
+      # lets the UI say how much of the backtrace is not being shown. It counts
+      # the lines actually removed, so when a shared line is kept it is not
+      # counted as dropped.
+      def trim_shared_tail(cause_lines, error_lines)
         shared = 0
         while shared < cause_lines.length && shared < error_lines.length &&
             cause_lines[-1 - shared] == error_lines[-1 - shared]
           shared += 1
         end
 
-        return cause_lines if shared.zero?
+        return [cause_lines, 0] if shared.zero?
 
-        cause_lines.first([cause_lines.length - shared, 1].max)
+        kept = [cause_lines.length - shared, 1].max
+        [cause_lines.first(kept), cause_lines.length - kept]
       end
 
       # The OTel span name is what the collector surfaces as the event's

--- a/lib/appsignal/transaction/opentelemetry_backend.rb
+++ b/lib/appsignal/transaction/opentelemetry_backend.rb
@@ -281,14 +281,17 @@ module Appsignal
       # the collector to report it even on a child span; the collector computes
       # the digest. Causes ride on one `appsignal.error_causes` JSON attribute
       # (keys match the processor's `ErrorSubCause`); separate cause events would
-      # each become their own incident.
+      # each become their own incident. Each cause only carries the part of its
+      # backtrace that the reported error's backtrace does not already end with
+      # (see `lines_without_shared_tail`).
       def set_error(class_name, message, backtrace, causes, _root_cause_missing)
         span = current_span
+        error_lines = Array(backtrace)
 
         attributes = {
           "exception.type" => class_name,
           "exception.message" => message.to_s,
-          "exception.stacktrace" => Array(backtrace).join("\n"),
+          "exception.stacktrace" => error_lines.join("\n"),
           "appsignal.alert_this_error" => true
         }
 
@@ -298,7 +301,7 @@ module Appsignal
               {
                 "name" => cause[:name],
                 "message" => cause[:message],
-                "lines" => cause[:backtrace] || []
+                "lines" => lines_without_shared_tail(Array(cause[:backtrace]), error_lines)
               }
             end
           )
@@ -703,6 +706,34 @@ module Appsignal
           value = value.to_s if value.is_a?(Symbol)
           @span.set_attribute("appsignal.tag.#{key}", value)
         end
+      end
+
+      # Returns the leading lines of a cause's backtrace that the reported
+      # error's own backtrace does not already end with.
+      #
+      # A cause is raised somewhere inside the frames that led to the reported
+      # error, so both backtraces share the same trailing frames -- everything
+      # from the raise point outwards, which for a web request is the whole
+      # framework and web server stack. Those lines are already sent once, in
+      # `exception.stacktrace`. Repeating them for every cause pushed the
+      # `appsignal.error_causes` attribute past the length the collector
+      # accepts, and the collector truncates an over-long attribute into
+      # invalid JSON, so it could not read the causes at all and dropped them.
+      #
+      # Only the trailing lines are dropped, so what is left is the part of the
+      # backtrace unique to the cause: where it was raised. Lines are compared
+      # from the end as plain strings. If every line is shared, keep the first
+      # one, because a cause with no lines leaves the UI nothing to show.
+      def lines_without_shared_tail(cause_lines, error_lines)
+        shared = 0
+        while shared < cause_lines.length && shared < error_lines.length &&
+            cause_lines[-1 - shared] == error_lines[-1 - shared]
+          shared += 1
+        end
+
+        return cause_lines if shared.zero?
+
+        cause_lines.first([cause_lines.length - shared, 1].max)
       end
 
       # The OTel span name is what the collector surfaces as the event's

--- a/spec/lib/appsignal/transaction/opentelemetry_backend_spec.rb
+++ b/spec/lib/appsignal/transaction/opentelemetry_backend_spec.rb
@@ -880,6 +880,94 @@ describe Appsignal::Transaction::OpenTelemetryBackend,
       expect(parsed).to eq([{ "name" => "ArgumentError", "message" => "bad arg", "lines" => [] }])
     end
 
+    describe "a cause backtrace that shares its last lines with the error's" do
+      def cause_lines(backend)
+        JSON.parse(exception_event(backend).attributes["appsignal.error_causes"])
+          .map { |cause| cause["lines"] }
+      end
+
+      it "drops the trailing lines the cause shares with the error" do
+        backend = create_backend
+        causes = [
+          {
+            :name => "ArgumentError", :message => "bad arg",
+            :backtrace => ["cause 1", "cause 2", "shared 1", "shared 2"]
+          },
+          {
+            :name => "KeyError", :message => "missing",
+            :backtrace => ["cause 3", "shared 1", "shared 2"]
+          }
+        ]
+        backend.set_error(
+          "RuntimeError", "boom", ["line 1", "shared 1", "shared 2"], causes, false
+        )
+
+        expect(cause_lines(backend)).to eq([["cause 1", "cause 2"], ["cause 3"]])
+      end
+
+      it "keeps every line when the last lines differ" do
+        backend = create_backend
+        causes = [
+          {
+            :name => "ArgumentError", :message => "bad arg",
+            :backtrace => ["shared 1", "shared 2", "cause 1"]
+          }
+        ]
+        backend.set_error(
+          "RuntimeError", "boom", ["shared 1", "shared 2", "line 1"], causes, false
+        )
+
+        expect(cause_lines(backend)).to eq([["shared 1", "shared 2", "cause 1"]])
+      end
+
+      it "keeps the first line when every line is shared" do
+        backend = create_backend
+        causes = [
+          {
+            :name => "ArgumentError", :message => "bad arg",
+            :backtrace => ["shared 1", "shared 2"]
+          }
+        ]
+        backend.set_error(
+          "RuntimeError", "boom", ["line 1", "shared 1", "shared 2"], causes, false
+        )
+
+        expect(cause_lines(backend)).to eq([["shared 1"]])
+      end
+
+      it "keeps the first line when the cause's backtrace is the error's backtrace" do
+        backend = create_backend
+        lines = ["shared 1", "shared 2"]
+        causes = [{ :name => "ArgumentError", :message => "bad arg", :backtrace => lines }]
+        backend.set_error("RuntimeError", "boom", lines, causes, false)
+
+        expect(cause_lines(backend)).to eq([["shared 1"]])
+      end
+
+      it "keeps every line when the error has no backtrace" do
+        causes = [{ :name => "ArgumentError", :message => "bad arg", :backtrace => ["cause 1"] }]
+
+        nil_backtrace = create_backend
+        nil_backtrace.set_error("RuntimeError", "boom", nil, causes, false)
+        expect(cause_lines(nil_backtrace)).to eq([["cause 1"]])
+
+        empty_backtrace = create_backend
+        empty_backtrace.set_error("RuntimeError", "boom", [], causes, false)
+        expect(cause_lines(empty_backtrace)).to eq([["cause 1"]])
+      end
+
+      it "sends no lines for a cause without a backtrace" do
+        backend = create_backend
+        causes = [
+          { :name => "ArgumentError", :message => "bad arg", :backtrace => nil },
+          { :name => "KeyError", :message => "missing", :backtrace => [] }
+        ]
+        backend.set_error("RuntimeError", "boom", ["shared 1"], causes, false)
+
+        expect(cause_lines(backend)).to eq([[], []])
+      end
+    end
+
     it "does not set appsignal.error_causes when there are no causes" do
       backend = create_backend
       backend.set_error("RuntimeError", "boom", ["line 1"], [], false)

--- a/spec/lib/appsignal/transaction/opentelemetry_backend_spec.rb
+++ b/spec/lib/appsignal/transaction/opentelemetry_backend_spec.rb
@@ -881,9 +881,12 @@ describe Appsignal::Transaction::OpenTelemetryBackend,
     end
 
     describe "a cause backtrace that shares its last lines with the error's" do
-      def cause_lines(backend)
+      def parsed_causes(backend)
         JSON.parse(exception_event(backend).attributes["appsignal.error_causes"])
-          .map { |cause| cause["lines"] }
+      end
+
+      def cause_lines(backend)
+        parsed_causes(backend).map { |cause| cause["lines"] }
       end
 
       it "drops the trailing lines the cause shares with the error" do
@@ -965,6 +968,80 @@ describe Appsignal::Transaction::OpenTelemetryBackend,
         backend.set_error("RuntimeError", "boom", ["shared 1"], causes, false)
 
         expect(cause_lines(backend)).to eq([[], []])
+      end
+
+      it "reports how many lines were dropped from each cause" do
+        backend = create_backend
+        causes = [
+          {
+            :name => "ArgumentError", :message => "bad arg",
+            :backtrace => ["cause 1", "cause 2", "shared 1", "shared 2"]
+          },
+          {
+            :name => "KeyError", :message => "missing",
+            :backtrace => ["cause 3", "shared 2"]
+          }
+        ]
+        backend.set_error(
+          "RuntimeError", "boom", ["line 1", "shared 1", "shared 2"], causes, false
+        )
+
+        expect(parsed_causes(backend)).to eq(
+          [
+            {
+              "name" => "ArgumentError", "message" => "bad arg",
+              "lines" => ["cause 1", "cause 2"], "lines_omitted" => 2
+            },
+            {
+              "name" => "KeyError", "message" => "missing",
+              "lines" => ["cause 3"], "lines_omitted" => 1
+            }
+          ]
+        )
+      end
+
+      it "reports no dropped lines for a cause that shares no lines" do
+        backend = create_backend
+        causes = [
+          {
+            :name => "ArgumentError", :message => "bad arg",
+            :backtrace => ["shared 1", "shared 2", "cause 1"]
+          }
+        ]
+        backend.set_error(
+          "RuntimeError", "boom", ["shared 1", "shared 2", "line 1"], causes, false
+        )
+
+        expect(parsed_causes(backend).first).not_to have_key("lines_omitted")
+      end
+
+      # Every line is shared, but the first one is kept, so it was not dropped
+      # and is not counted.
+      it "does not count the shared line it keeps when every line is shared" do
+        backend = create_backend
+        causes = [
+          {
+            :name => "ArgumentError", :message => "bad arg",
+            :backtrace => ["shared 1", "shared 2", "shared 3"]
+          }
+        ]
+        backend.set_error(
+          "RuntimeError", "boom", ["line 1", "shared 1", "shared 2", "shared 3"], causes, false
+        )
+
+        cause = parsed_causes(backend).first
+        expect(cause["lines"]).to eq(["shared 1"])
+        expect(cause["lines_omitted"]).to eq(2)
+      end
+
+      it "reports no dropped lines when the only line a cause has is shared" do
+        backend = create_backend
+        causes = [{ :name => "ArgumentError", :message => "bad arg", :backtrace => ["shared 1"] }]
+        backend.set_error("RuntimeError", "boom", ["line 1", "shared 1"], causes, false)
+
+        cause = parsed_causes(backend).first
+        expect(cause["lines"]).to eq(["shared 1"])
+        expect(cause).not_to have_key("lines_omitted")
       end
     end
 


### PR DESCRIPTION
See also https://github.com/appsignal/appsignal-processor-rs/pull/2236 for the change to the processor that does _something_ with the omitted lines attribute.

### [Trim shared frames from error cause backtraces](https://github.com/appsignal/appsignal-ruby/commit/6019d2a3f15fead941c84e8c780f8d9e5b2baaa4)

In collector mode, an error's causes are sent as one JSON span-event
attribute, `appsignal.error_causes`, and each cause carried its full
backtrace.

A cause is raised inside the frames that led to the reported error, so
its backtrace ends with the same lines as the reported error's own
backtrace. For a web request that shared tail is the whole framework
and web server stack, and it was repeated for every cause. In a
measured three-deep cause chain from a Rails controller action, 88 of
each cause's 92 lines were a verbatim repeat, and the attribute came
to 21,080 characters.

The AppSignal Collector caps a span-event attribute value at 20,000
characters. When it truncates, the JSON is no longer valid, so the
collector could not read the causes and dropped the whole chain.
Nothing was shown under the error's causes in the trace.

Drop from each cause's backtrace the trailing lines it shares with the
reported error's backtrace. Those lines are already sent once, in
`exception.stacktrace`. What is left is where the cause was raised,
which is the part worth showing. On the measured payload this brings
the attribute down to about 904 characters. If a cause shares every
line, its first line is kept, because a cause with no lines leaves
nothing to show.

### [Report how many cause lines were omitted](https://github.com/appsignal/appsignal-ruby/commit/2fac3f6f6160bad46ad308d29116a1d5917e2496)

Each error cause in `appsignal.error_causes` no longer carries the
trailing backtrace lines it shares with the reported error's own
backtrace. A consumer of the attribute could not tell that lines were
left out, or how many of them there were.

Add a `lines_omitted` key to each cause, holding the number of trailing
lines that were dropped for that cause. The AppSignal Processor uses
the count to add a line reading "[88 repeated lines omitted]" to the
end of the cause's backtrace, so the trace shows how much is missing.

The count is the number of lines actually removed. When a cause shares
every line with the reported error, its first line is kept, so that
kept line does not count as removed. The key is left out entirely when
nothing was dropped, because a consumer reads a missing key as zero.
