### PR TITLE
Fix hang when stopping the check-in scheduler

### DIFF
--- a/.changesets/fix-check-in-scheduler-stop-hang.md
+++ b/.changesets/fix-check-in-scheduler-stop-hang.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+type: fix
+---
+
+Fix a rare hang when stopping AppSignal in an application that sends check-ins.
+Stopping AppSignal waits for any check-in events that have not been transmitted
+yet, and it could wait forever instead of finishing.

--- a/lib/appsignal/check_in/scheduler.rb
+++ b/lib/appsignal/check_in/scheduler.rb
@@ -60,21 +60,35 @@ module Appsignal
       end
 
       def stop
-        @mutex.synchronize do
-          # Flush all events before closing the queue.
-          push_events
-        rescue ClosedQueueError
-          # The queue is already closed (by a previous call to `#stop`)
-          # so it is not possible to push events to it anymore.
-        ensure
-          # Ensure calling `#stop` closes the queue and kills
-          # the waker thread, disallowing any further events from being
-          # scheduled with `#schedule`.
-          stop_waker
-          @queue.close
+        waker = nil
+        thread = nil
 
-          # Block until the thread has finished.
-          @thread&.join
+        begin
+          @mutex.synchronize do
+            # Flush all events before closing the queue. Do not schedule another
+            # debounce, since no more events will be transmitted after this one.
+            push_events(:reschedule => false)
+          rescue ClosedQueueError
+            # The queue is already closed (by a previous call to `#stop`)
+            # so it is not possible to push events to it anymore.
+          ensure
+            # Ensure calling `#stop` closes the queue and kills
+            # the waker thread, disallowing any further events from being
+            # scheduled with `#schedule`.
+            waker = kill_waker
+            @queue.close
+            thread = @thread
+          end
+        ensure
+          # Block until both threads have finished, even when stopping raised,
+          # so that events that were already pushed are still transmitted.
+          #
+          # Wait for them after the mutex has been released, because the waker
+          # thread must acquire the mutex in order to finish. Waiting for it
+          # while holding the mutex would deadlock if killing it did not take
+          # effect before it awoke from its debounce.
+          waker&.join
+          thread&.join
         end
       end
 
@@ -135,12 +149,16 @@ module Appsignal
 
       # Must be called from within a `@mutex.synchronize` block.
       def start_waker(debounce)
-        stop_waker
+        kill_waker
 
         @waker = Thread.new do
           sleep(debounce)
 
           @mutex.synchronize do
+            # Do nothing if this waker was replaced while it slept, which can
+            # happen when killing it did not take effect.
+            next unless @waker == Thread.current
+
             # Make sure this waker doesn't get killed, so it can push
             # events and schedule a new waker.
             @waker = nil
@@ -150,14 +168,22 @@ module Appsignal
       end
 
       # Must be called from within a `@mutex.synchronize` block.
-      def stop_waker
-        @waker&.kill
-        @waker&.join
+      #
+      # Returns the waker thread that was killed, if there was one, so that the
+      # caller can wait for it to finish after releasing the mutex.
+      def kill_waker
+        waker = @waker
         @waker = nil
+        waker&.kill
+        waker
       end
 
       # Must be called from within a `@mutex.synchronize` block.
-      def push_events
+      def push_events(reschedule: true)
+        # Do nothing when the queue is closed. This can happen when killing a
+        # waker thread did not take effect, and it awoke after the scheduler
+        # had been stopped.
+        return if @queue.closed?
         return if @events.empty?
 
         # Push a copy of the events to the queue, and clear the events array.
@@ -168,7 +194,7 @@ module Appsignal
         @queue.push(events)
         @events.clear
 
-        start_waker(BETWEEN_TRANSMISSIONS_DEBOUNCE_SECONDS)
+        start_waker(BETWEEN_TRANSMISSIONS_DEBOUNCE_SECONDS) if reschedule
       end
     end
   end

--- a/spec/lib/appsignal/check_in/scheduler_spec.rb
+++ b/spec/lib/appsignal/check_in/scheduler_spec.rb
@@ -236,6 +236,50 @@ describe Appsignal::CheckIn::Scheduler do
       expect(waker.alive?).to be(false)
       expect(scheduler.waker).to be_nil
     end
+
+    it "can be stopped when killing the debounce does not take effect" do
+      # Use a longer debounce interval than the other examples, so that the
+      # debounce thread is certain to still be sleeping when its kill is stubbed
+      # and when the scheduler is stopped. Stopping waits out the rest of the
+      # interval, so it has to stay below the timeout used below.
+      stub_const("Appsignal::CheckIn::Scheduler::INITIAL_DEBOUNCE_SECONDS", 1)
+
+      stubs << stub_cron_check_in_request(
+        :events => [
+          {
+            "identifier" => "test",
+            "kind" => "finish",
+            "check_in_type" => "cron"
+          }
+        ]
+      )
+
+      Appsignal::CheckIn.cron("test")
+
+      # Killing a thread is not guaranteed to take effect before it runs again.
+      # Simulate the debounce thread surviving the first time it is killed, so
+      # that it awakes and waits for the scheduler's mutex. Later kills are
+      # performed, so that the scheduler can be stopped in the `after` hook.
+      waker = scheduler.waker
+      first_kill = true
+      allow(waker).to receive(:kill).and_wrap_original do |original|
+        if first_kill
+          first_kill = false
+          waker
+        else
+          original.call
+        end
+      end
+
+      # Use a timeout, so that a scheduler that waits for the debounce thread
+      # while holding the mutex that it needs fails this test instead of
+      # hanging.
+      Timeout.timeout(5) do
+        expect { scheduler.stop }.not_to raise_error
+      end
+
+      expect(scheduler.transmitted).to eq(1)
+    end
   end
 
   describe "when many events are sent" do


### PR DESCRIPTION
Stopping the check-in scheduler killed the thread that waits out the
debounce interval, and then waited for that thread to finish. It did
both of those while holding the scheduler's mutex, which is a mutex
that the debounce thread must acquire before it can finish.

Killing a thread is not immediate. It only takes effect once the thread
runs again. If the kill did not take effect before the debounce thread
awoke and started waiting for the mutex, then the two threads waited
for each other, and neither could continue. Stopping the scheduler
never returned.

Wait for the debounce thread after the mutex has been released, so
that it can always run to completion. Nothing is killed and waited for
under the mutex anymore, so a debounce thread that outlives being
killed has to be harmless. It is: it does nothing when it awakes if it
has been replaced, and pushing events does nothing once the queue is
closed. Stopping the scheduler also no longer schedules a new debounce
interval that it then has to kill.

A test that stops the scheduler hung for five minutes in CI because of
this.

