### PR TITLE
Skip trace context when enqueue events are off

### DIFF
--- a/lib/appsignal/hooks/active_job.rb
+++ b/lib/appsignal/hooks/active_job.rb
@@ -159,10 +159,15 @@ module Appsignal
         # transparent pass-through when there's no active transaction, and
         # `inject_context` no-ops outside collector mode.
         def enqueue(*, **)
-          # Skip recording the event when enqueue events are suppressed. That is
-          # the case when enqueue instrumentation is disabled, and it keeps this
-          # integration consistent with the standalone adapters (Sidekiq, ...),
-          # which already gate their own enqueue event on this check.
+          # When enqueue instrumentation is disabled, drop the trace context
+          # along with the event. Without an enqueue event there is no producer
+          # span, so the context we would write is that of whatever span is
+          # current, such as the surrounding web request. The job that performs
+          # later would then link back to a span that is not a producer.
+          return super if Appsignal.config && !Appsignal.config[:enable_job_enqueue_instrumentation]
+
+          # Another enqueue integration is already recording this enqueue, so
+          # don't record it a second time.
           if Appsignal::Transaction.current? &&
               Appsignal::Transaction.current.job_enqueue_events_suppressed?
             return super

--- a/lib/appsignal/integrations/delayed_job_plugin.rb
+++ b/lib/appsignal/integrations/delayed_job_plugin.rb
@@ -25,6 +25,11 @@ module Appsignal
       # another job). An enqueue with no active transaction is a transparent
       # pass-through.
       def self.enqueue_with_instrumentation(job, block)
+        # Skip the enqueue event when enqueue instrumentation is disabled.
+        if Appsignal.config && !Appsignal.config[:enable_job_enqueue_instrumentation]
+          return block.call(job)
+        end
+
         # Under Active Job the enqueue is already recorded as an
         # `enqueue.active_job` event, so skip recording it again here.
         if Appsignal::Transaction.current? &&

--- a/lib/appsignal/integrations/que.rb
+++ b/lib/appsignal/integrations/que.rb
@@ -206,6 +206,16 @@ module Appsignal
       # performs links back. Yields the (possibly tag-augmented) `job_options` to
       # do the actual enqueue.
       def record_enqueue(job_options, event_name, title, bulk: false)
+        # When enqueue instrumentation is disabled, drop the trace context along
+        # with the event, so yield the job options untouched. Without an enqueue
+        # event there is no producer span, so the context we would write is that
+        # of whatever span is current, such as the surrounding web request. The
+        # job that performs later would then link back to a span that is not a
+        # producer.
+        if Appsignal.config && !Appsignal.config[:enable_job_enqueue_instrumentation]
+          return yield job_options
+        end
+
         # Under Active Job the enqueue is already recorded as an
         # `enqueue.active_job` event, so skip recording it again here. The trace
         # context is still injected so the performed job links back.

--- a/lib/appsignal/integrations/resque.rb
+++ b/lib/appsignal/integrations/resque.rb
@@ -48,6 +48,13 @@ module Appsignal
     # @!visibility private
     module ResquePushIntegration
       def push(queue, item)
+        # When enqueue instrumentation is disabled, drop the trace context along
+        # with the event. Without an enqueue event there is no producer span, so
+        # the context we would write is that of whatever span is current, such as
+        # the surrounding web request. The job that performs later would then
+        # link back to a span that is not a producer.
+        return super if Appsignal.config && !Appsignal.config[:enable_job_enqueue_instrumentation]
+
         # Under Active Job the enqueue is already recorded as an
         # `enqueue.active_job` event, so skip recording it again here. The trace
         # context is still injected so the performed job links back.

--- a/lib/appsignal/integrations/shoryuken.rb
+++ b/lib/appsignal/integrations/shoryuken.rb
@@ -165,6 +165,13 @@ module Appsignal
     # @!visibility private
     class ShoryukenClientMiddleware
       def call(options)
+        # When enqueue instrumentation is disabled, drop the trace context along
+        # with the event. Without an enqueue event there is no producer span, so
+        # the context we would write is that of whatever span is current, such as
+        # the surrounding web request. The job that performs later would then
+        # link back to a span that is not a producer.
+        return yield if Appsignal.config && !Appsignal.config[:enable_job_enqueue_instrumentation]
+
         # Under Active Job the enqueue is already recorded as an
         # `enqueue.active_job` event, so skip recording it again here. The trace
         # context is still injected so the performed job links back.

--- a/lib/appsignal/integrations/sidekiq.rb
+++ b/lib/appsignal/integrations/sidekiq.rb
@@ -115,6 +115,13 @@ module Appsignal
     # @!visibility private
     class SidekiqClientMiddleware
       def call(_worker_class, job, _queue, _redis_pool)
+        # When enqueue instrumentation is disabled, drop the trace context along
+        # with the event. Without an enqueue event there is no producer span, so
+        # the context we would write is that of whatever span is current, such as
+        # the surrounding web request. The job that performs later would then
+        # link back to a span that is not a producer.
+        return yield if Appsignal.config && !Appsignal.config[:enable_job_enqueue_instrumentation]
+
         # Under Active Job the enqueue is already recorded as an
         # `enqueue.active_job` event, so skip recording it again here. The trace
         # context is still injected so the performed job links back.

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -406,12 +406,13 @@ module Appsignal
     end
 
     # @!visibility private
+    #
+    # True when an outer integration (Active Job) is already recording this
+    # enqueue. Nested integrations use it to skip their own enqueue event, but
+    # they must still propagate trace context: the outer integration's producer
+    # span is what the performing job links back to, and only the nested
+    # integration owns the carrier that job travels on.
     def job_enqueue_events_suppressed?
-      # When enqueue instrumentation is disabled, every enqueue integration
-      # treats its event as suppressed. That is how the config option turns the
-      # enqueue events off across all integrations at once.
-      return true if Appsignal.config && !Appsignal.config[:enable_job_enqueue_instrumentation]
-
       store("job_enqueue")[:suppressed] == true
     end
 

--- a/spec/lib/appsignal/hooks/activejob_spec.rb
+++ b/spec/lib/appsignal/hooks/activejob_spec.rb
@@ -699,7 +699,23 @@ if DependencyHelper.active_job_present?
         let(:options) { { :enable_job_enqueue_instrumentation => false } }
         before { ActiveJob::Base.queue_adapter = :test }
 
-        it "does not record an enqueue event but still enqueues the job" do
+        # Captures the job as the adapter receives it, so the test can check what
+        # trace context the enqueue wrote onto it.
+        def enqueue_and_capture_job
+          captured = nil
+          adapter = ActiveJob::Base.queue_adapter
+          allow(adapter).to receive(:enqueue).and_wrap_original do |method, job|
+            captured = job
+            method.call(job)
+          end
+
+          set_current_transaction(http_request_transaction)
+          ActiveJobTestJob.perform_later
+
+          captured
+        end
+
+        it "does not record an enqueue event but still enqueues the job", :agent_mode do
           start_agent(**start_agent_args)
           transaction = http_request_transaction
           set_current_transaction(transaction)
@@ -709,6 +725,20 @@ if DependencyHelper.active_job_present?
           enqueue_events =
             transaction.to_h["events"].select { |event| event["name"] == "enqueue.active_job" }
           expect(enqueue_events).to be_empty
+          expect(ActiveJob::Base.queue_adapter.enqueued_jobs.count).to eq(1)
+        end
+
+        it "emits no enqueue span and writes no trace context", :collector_mode do
+          start_collector_agent
+
+          job = enqueue_and_capture_job
+          Appsignal::Transaction.complete_current!
+
+          # No enqueue event means no producer span, so there is nothing for the
+          # performing job to link back to and no trace context is written. The
+          # job starts its own trace instead of linking to the web request.
+          expect(event_spans_for("enqueue.active_job")).to be_empty
+          expect(job.serialize).to_not have_key("__otel_headers")
           expect(ActiveJob::Base.queue_adapter.enqueued_jobs.count).to eq(1)
         end
       end

--- a/spec/lib/appsignal/integrations/delayed_job_plugin_spec.rb
+++ b/spec/lib/appsignal/integrations/delayed_job_plugin_spec.rb
@@ -66,6 +66,36 @@ if DependencyHelper.delayed_job_present?
         end
       end
 
+      context "when enqueue instrumentation is disabled" do
+        let(:start_agent_args) do
+          { :options => { :enable_job_enqueue_instrumentation => false } }
+        end
+
+        it "records no enqueue event but still enqueues the job", :agent_mode do
+          start_agent(**start_agent_args)
+          transaction = http_request_transaction
+          set_current_transaction(transaction)
+
+          expect { Delayed::Job.enqueue(DelayedTestJob.new) }
+            .to change { Delayed::Backend::Test::Job.count }.by(1)
+
+          event_names = transaction.to_h["events"].map { |event| event["name"] }
+          expect(event_names).to_not include("enqueue.delayed_job")
+        end
+
+        it "emits no enqueue span but still enqueues the job", :collector_mode do
+          start_collector_agent
+          transaction = http_request_transaction
+          set_current_transaction(transaction)
+
+          expect { Delayed::Job.enqueue(DelayedTestJob.new) }
+            .to change { Delayed::Backend::Test::Job.count }.by(1)
+          Appsignal::Transaction.complete_current!
+
+          expect(event_spans_for("enqueue.delayed_job")).to be_empty
+        end
+      end
+
       context "without an active transaction" do
         it "is a transparent pass-through", :agent_mode do
           start_agent

--- a/spec/lib/appsignal/integrations/que_spec.rb
+++ b/spec/lib/appsignal/integrations/que_spec.rb
@@ -601,6 +601,40 @@ if DependencyHelper.que_present?
       end
     end
 
+    context "when enqueue instrumentation is disabled" do
+      let(:start_agent_args) do
+        { :options => { :enable_job_enqueue_instrumentation => false } }
+      end
+
+      it "in agent mode", :agent_mode do
+        start_agent(**start_agent_args)
+        transaction = http_request_transaction
+        set_current_transaction(transaction)
+
+        enqueue
+
+        event_names = transaction.to_h["events"].map { |event| event["name"] }
+        expect(event_names).to_not include("enqueue.que")
+        expect_job_arguments_untouched
+      end
+
+      it "in collector mode", :collector_mode do
+        start_collector_agent
+        transaction = http_request_transaction
+        set_current_transaction(transaction)
+
+        enqueue
+        Appsignal::Transaction.complete_current!
+
+        # No enqueue event means no producer span, so there is nothing for the
+        # performing job to link back to and no trace context is written. The
+        # job starts its own trace instead of linking to the web request.
+        expect(event_spans_for("enqueue.que")).to be_empty
+        expect(enqueued_tags).to eq(["user:42"]) if DependencyHelper.que1_present?
+        expect_job_arguments_untouched
+      end
+    end
+
     # `bulk_enqueue` is Que 2 only. The whole batch shares one `job_options`, so
     # it records a single producer event and the inner enqueues are pass-throughs.
     describe "#bulk_enqueue", :if => DependencyHelper.que2_present? do

--- a/spec/lib/appsignal/integrations/resque_spec.rb
+++ b/spec/lib/appsignal/integrations/resque_spec.rb
@@ -332,6 +332,38 @@ if DependencyHelper.resque_present?
           expect(item).to have_key("traceparent")
         end
       end
+
+      context "when enqueue instrumentation is disabled" do
+        let(:start_agent_args) do
+          { :options => { :enable_job_enqueue_instrumentation => false } }
+        end
+
+        it "in agent mode", :agent_mode do
+          start_agent(**start_agent_args)
+          transaction = http_request_transaction
+          set_current_transaction(transaction)
+
+          expect(enqueue).to eq(:pushed)
+
+          event_names = transaction.to_h["events"].map { |event| event["name"] }
+          expect(event_names).to_not include("enqueue.resque")
+        end
+
+        it "in collector mode", :collector_mode do
+          start_collector_agent
+          transaction = http_request_transaction
+          set_current_transaction(transaction)
+
+          expect(enqueue).to eq(:pushed)
+          Appsignal::Transaction.complete_current!
+
+          # No enqueue event means no producer span, so there is nothing for the
+          # performing job to link back to and no trace context is written. The
+          # job starts its own trace instead of linking to the web request.
+          expect(event_spans_for("enqueue.resque")).to be_empty
+          expect(item).to_not have_key("traceparent")
+        end
+      end
     end
 
     describe "does not set arguments for ActiveJob" do

--- a/spec/lib/appsignal/integrations/shoryuken_spec.rb
+++ b/spec/lib/appsignal/integrations/shoryuken_spec.rb
@@ -506,4 +506,36 @@ describe Appsignal::Integrations::ShoryukenClientMiddleware do
       expect(options[:message_attributes]).to have_key("traceparent")
     end
   end
+
+  context "when enqueue instrumentation is disabled" do
+    let(:start_agent_args) do
+      { :options => { :enable_job_enqueue_instrumentation => false } }
+    end
+
+    it "in agent mode", :agent_mode do
+      start_agent(**start_agent_args)
+      transaction = http_request_transaction
+      set_current_transaction(transaction)
+
+      enqueue
+
+      event_names = transaction.to_h["events"].map { |event| event["name"] }
+      expect(event_names).to_not include("enqueue.shoryuken")
+    end
+
+    it "in collector mode", :collector_mode do
+      start_collector_agent
+      transaction = http_request_transaction
+      set_current_transaction(transaction)
+
+      enqueue
+      Appsignal::Transaction.complete_current!
+
+      # No enqueue event means no producer span, so there is nothing for the
+      # performing job to link back to and no trace context is written. The job
+      # starts its own trace instead of linking to the web request.
+      expect(event_spans_for("enqueue.shoryuken")).to be_empty
+      expect(options).to_not have_key(:message_attributes)
+    end
+  end
 end

--- a/spec/lib/appsignal/integrations/sidekiq_spec.rb
+++ b/spec/lib/appsignal/integrations/sidekiq_spec.rb
@@ -486,6 +486,38 @@ if DependencyHelper.sidekiq_present?
         expect(job).to have_key("traceparent")
       end
     end
+
+    context "when enqueue instrumentation is disabled" do
+      let(:start_agent_args) do
+        { :options => { :enable_job_enqueue_instrumentation => false } }
+      end
+
+      it "in agent mode", :agent_mode do
+        start_agent(**start_agent_args)
+        transaction = http_request_transaction
+        set_current_transaction(transaction)
+
+        expect(enqueue).to eq(:enqueued)
+
+        event_names = transaction.to_h["events"].map { |event| event["name"] }
+        expect(event_names).to_not include("enqueue.sidekiq")
+      end
+
+      it "in collector mode", :collector_mode do
+        start_collector_agent
+        transaction = http_request_transaction
+        set_current_transaction(transaction)
+
+        expect(enqueue).to eq(:enqueued)
+        Appsignal::Transaction.complete_current!
+
+        # No enqueue event means no producer span, so there is nothing for the
+        # performing job to link back to and no trace context is written. The
+        # job starts its own trace instead of linking to the web request.
+        expect(event_spans_for("enqueue.sidekiq")).to be_empty
+        expect(job).to_not have_key("traceparent")
+      end
+    end
   end
 
   describe Appsignal::Integrations::SidekiqMiddleware do

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -1082,8 +1082,12 @@ describe Appsignal::Transaction do
     context "when enqueue instrumentation is disabled" do
       let(:options) { { :enable_job_enqueue_instrumentation => false } }
 
-      it "reports enqueue events as suppressed" do
-        expect(transaction.job_enqueue_events_suppressed?).to be(true)
+      # The config option is not part of this question. Each enqueue
+      # integration checks it separately, because disabling enqueue
+      # instrumentation also disables trace context propagation, while
+      # suppression by an outer integration keeps it.
+      it "does not report enqueue events as suppressed" do
+        expect(transaction.job_enqueue_events_suppressed?).to be(false)
       end
     end
   end


### PR DESCRIPTION
This fixes behaviour that didn't match the OpenTelemetry Semantic Conventions for Messaging Spans (it would link due to messaging spans, but link to the current OpenTelemetry context at enqueue time, not to the producer span, due to the creation of the producer span/event having been disabled by a config option) which should also make it have more coherent behaviour in relation to the changes in https://github.com/appsignal/appsignal-collector/pull/418 as currently implemented (to put it in the collector PR's terms: if a trace should be kept around until it `has_links`, then it also `has_messaging`; if it doesn't `has_messaging` because of the config option that disables that, then it also won't `has_links` later on)

---

When the `enable_job_enqueue_instrumentation` option is off, the job
enqueue integrations recorded no enqueue event but still wrote trace
context onto the outgoing job. There was no producer span to point at,
so what they wrote was the context of whatever span happened to be
current, such as the surrounding web request. The job that performed
later would then link back to a span that is not a producer, which the
OpenTelemetry messaging conventions do not allow.

Each enqueue integration now checks the option itself and skips the
enqueue entirely, so it writes no trace context either. Jobs enqueued
while the option is off start their own trace.

`Transaction#job_enqueue_events_suppressed?` no longer folds the option
in, so it answers only whether an outer integration such as Active Job
is already recording this enqueue. Those nested integrations must keep
propagating trace context. The outer integration's producer span is what
the performing job links back to, and only the nested integration owns
the carrier that the job travels on.

[skip changeset]