### PR TITLE
Emit OpenTelemetry attributes for integrations

### DIFF
--- a/.changesets/add-opentelemetry-attributes-helper.md
+++ b/.changesets/add-opentelemetry-attributes-helper.md
@@ -1,0 +1,21 @@
+---
+bump: minor
+type: add
+---
+
+Add an `Appsignal::Transaction#add_opentelemetry_attributes` method. In collector mode, AppSignal records each transaction as an OpenTelemetry span and each instrumented event as a child span. This method adds attributes to whichever of those spans is open when you call it: the innermost event started by `Appsignal.instrument`, or the transaction's own span when no event is open.
+
+Use it to describe what you are instrumenting in OpenTelemetry's own terms, following the OpenTelemetry semantic conventions where they apply:
+
+```ruby
+Appsignal.instrument("query.my_database") do
+  Appsignal::Transaction.current.add_opentelemetry_attributes(
+    "db.system.name" => "mysql"
+  )
+  run_the_query
+end
+```
+
+Attribute values must be a String, Integer, Float or boolean. Other values are converted to a String.
+
+Attributes have no equivalent outside collector mode, so this does nothing when collector mode is not active.

--- a/lib/appsignal/hooks/active_job.rb
+++ b/lib/appsignal/hooks/active_job.rb
@@ -84,6 +84,21 @@ module Appsignal
               )
             end
 
+          unless has_wrapper_transaction
+            # Describes this span as a job being performed. The messaging
+            # system is what the trace timeline reads to recognize background
+            # job work, and `active_job` is the value OpenTelemetry's own Active
+            # Job instrumentation uses.
+            #
+            # Only set when this hook created the transaction. When an adapter
+            # integration created it, that adapter already named itself, and its
+            # answer is the more specific one.
+            transaction.add_opentelemetry_attributes(
+              Appsignal::OpenTelemetry::Messaging
+                .perform_attributes("active_job", :destination => job["queue_name"])
+            )
+          end
+
           begin
             transaction.add_function_parameters_if_nil(job["arguments"])
 
@@ -174,6 +189,10 @@ module Appsignal
             :opentelemetry_kind => :producer,
             :opentelemetry_scope => ["appsignal-ruby/active_job", Appsignal::VERSION]
           ) do
+            Appsignal::Transaction.current.add_opentelemetry_attributes(
+              Appsignal::OpenTelemetry::Messaging
+                .enqueue_attributes("active_job", :destination => queue_name)
+            )
             Appsignal::OpenTelemetry.inject_context(__otel_headers)
             # Active Job enqueues through an adapter (Sidekiq, Resque, ...) that
             # has its own enqueue instrumentation. Suppress it so the enqueue is

--- a/lib/appsignal/integrations/active_support_notifications.rb
+++ b/lib/appsignal/integrations/active_support_notifications.rb
@@ -103,6 +103,7 @@ module Appsignal
           attributes = EVENT_ATTRIBUTES[name.to_s]
           transaction.add_opentelemetry_attributes(attributes) if attributes
           transaction.add_opentelemetry_attributes(payload_attributes(name, payload))
+          record_error_type(transaction, payload)
           transaction.finish_event(
             name.to_s,
             title,
@@ -142,6 +143,23 @@ module Appsignal
         def job_queue_name(payload)
           job = payload[:job]
           job.queue_name if job.respond_to?(:queue_name)
+        end
+
+        # Says what kind of failure ended the event, which the OpenTelemetry
+        # semantic conventions ask for on a span whose operation failed.
+        #
+        # ActiveSupport puts the exception in the payload when the instrumented
+        # block raised, and it does so before it hands control to any of the
+        # paths this integration hooks into. So the failure is readable here and
+        # there is nothing to rescue, whether the event was reported through a
+        # block or through a `start` and `finish` pair.
+        def record_error_type(transaction, payload)
+          error = payload[:exception_object]
+          return unless error
+
+          transaction.add_opentelemetry_attributes(
+            Appsignal::OpenTelemetry::ErrorType.attributes_for(error.class.name)
+          )
         end
 
         # Events starting with a bang are internal to Rails; suppressed events

--- a/lib/appsignal/integrations/active_support_notifications.rb
+++ b/lib/appsignal/integrations/active_support_notifications.rb
@@ -41,7 +41,9 @@ module Appsignal
             # This notification is only emitted for a search, so that is the
             # operation every one of these spans describes.
             "db.operation.name" => "search"
-          }.freeze
+          }.freeze,
+          "perform.active_job" =>
+            Appsignal::OpenTelemetry::Messaging.perform_attributes("active_job").freeze
         }.freeze
 
         # Events a dedicated AppSignal integration already records with richer
@@ -105,6 +107,8 @@ module Appsignal
           case name.to_s
           when "search.elasticsearch"
             { "db.collection.name" => search_index(payload) }.compact
+          when "perform.active_job"
+            { "messaging.destination.name" => job_queue_name(payload) }.compact
           else
             {}
           end
@@ -120,6 +124,13 @@ module Appsignal
 
           index = search[:index]
           index if index.is_a?(String)
+        end
+
+        # The queue the job being performed is on, which the notification carries
+        # as the job itself.
+        def job_queue_name(payload)
+          job = payload[:job]
+          job.queue_name if job.respond_to?(:queue_name)
         end
 
         # Events starting with a bang are internal to Rails; suppressed events

--- a/lib/appsignal/integrations/active_support_notifications.rb
+++ b/lib/appsignal/integrations/active_support_notifications.rb
@@ -19,7 +19,30 @@ module Appsignal
         # the dedicated Sequel hook (which already tags its own query events as
         # CLIENT). Including it keeps a Sequel query CLIENT regardless of which
         # path records it.
-        CLIENT_EVENT_NAMES = ["sql.active_record", "sql.sequel"].freeze
+        #
+        # `search.elasticsearch` is a query sent to an Elasticsearch cluster, so
+        # it is a client call for the same reason a SQL query is.
+        CLIENT_EVENT_NAMES = [
+          "sql.active_record",
+          "sql.sequel",
+          "search.elasticsearch"
+        ].freeze
+
+        # OpenTelemetry attributes to add to an event's span, by event name.
+        # These name the kind of work an event represents, which is what the
+        # trace timeline reads to tell one kind of span from another.
+        #
+        # SQL events are not listed here: their span already gets
+        # `db.system.name` from the SQL body format, which also tells the
+        # collector to sanitize the query.
+        EVENT_ATTRIBUTES = {
+          "search.elasticsearch" => {
+            "db.system.name" => "elasticsearch",
+            # This notification is only emitted for a search, so that is the
+            # operation every one of these spans describes.
+            "db.operation.name" => "search"
+          }.freeze
+        }.freeze
 
         # Events a dedicated AppSignal integration already records with richer
         # semantics, so the generic notifications path must not record them a
@@ -61,12 +84,42 @@ module Appsignal
           return unless record_event?(name)
 
           title, body, body_format = Appsignal::EventFormatter.format(name, payload)
-          Appsignal::Transaction.current.finish_event(
+          transaction = Appsignal::Transaction.current
+          # Set while the event's span is still open, so the attributes land on
+          # the event rather than on the transaction.
+          attributes = EVENT_ATTRIBUTES[name.to_s]
+          transaction.add_opentelemetry_attributes(attributes) if attributes
+          transaction.add_opentelemetry_attributes(payload_attributes(name, payload))
+          transaction.finish_event(
             name.to_s,
             title,
             body,
             body_format
           )
+        end
+
+        # Attributes whose value has to be read from the event's payload, so they
+        # cannot live in the static map above. An event with nothing to read gets
+        # no attributes.
+        def payload_attributes(name, payload)
+          case name.to_s
+          when "search.elasticsearch"
+            { "db.collection.name" => search_index(payload) }.compact
+          else
+            {}
+          end
+        end
+
+        # The index a search ran against, which the notification carries in the
+        # search it describes. A search that names more than one index, or none
+        # at all, is left without this attribute rather than described with a
+        # value that is not an index name.
+        def search_index(payload)
+          search = payload[:search]
+          return unless search.respond_to?(:[])
+
+          index = search[:index]
+          index if index.is_a?(String)
         end
 
         # Events starting with a bang are internal to Rails; suppressed events

--- a/lib/appsignal/integrations/active_support_notifications.rb
+++ b/lib/appsignal/integrations/active_support_notifications.rb
@@ -28,6 +28,12 @@ module Appsignal
           "search.elasticsearch"
         ].freeze
 
+        # Template rendering has no semantic convention to describe it, so
+        # these events say which group they belong to directly. The trace
+        # timeline reads `appsignal.group` before it looks at any convention
+        # attribute, and "render" is the group it shows as "Templating".
+        RENDER_ATTRIBUTES = { "appsignal.group" => "render" }.freeze
+
         # OpenTelemetry attributes to add to an event's span, by event name.
         # These name the kind of work an event represents, which is what the
         # trace timeline reads to tell one kind of span from another.
@@ -43,7 +49,12 @@ module Appsignal
             "db.operation.name" => "search"
           }.freeze,
           "perform.active_job" =>
-            Appsignal::OpenTelemetry::Messaging.perform_attributes("active_job").freeze
+            Appsignal::OpenTelemetry::Messaging.perform_attributes("active_job").freeze,
+          "render_template.action_view" => RENDER_ATTRIBUTES,
+          "render_partial.action_view" => RENDER_ATTRIBUTES,
+          "render_collection.action_view" => RENDER_ATTRIBUTES,
+          "render_layout.action_view" => RENDER_ATTRIBUTES,
+          "render.view_component" => RENDER_ATTRIBUTES
         }.freeze
 
         # Events a dedicated AppSignal integration already records with richer

--- a/lib/appsignal/integrations/delayed_job_plugin.rb
+++ b/lib/appsignal/integrations/delayed_job_plugin.rb
@@ -38,6 +38,14 @@ module Appsignal
           :opentelemetry_kind => :producer,
           :opentelemetry_scope => ["appsignal-ruby/delayed_job", Appsignal::VERSION]
         ) do
+          # Describes this span as a job being enqueued. The messaging system
+          # is what the trace timeline reads to recognize background job work,
+          # and `delayed_job` is the value OpenTelemetry's own Delayed Job
+          # instrumentation uses.
+          Appsignal::Transaction.current.add_opentelemetry_attributes(
+            Appsignal::OpenTelemetry::Messaging
+              .enqueue_attributes("delayed_job", :destination => queue_name(job))
+          )
           block.call(job)
         end
       end
@@ -48,6 +56,12 @@ module Appsignal
       # `enqueue Class#method job` rather than the bare `enqueue Class job`. We
       # accept that inconsistency so the enqueue and perform events stay tied to
       # the same name for the rare job that sets it.
+      # The queue a job is on. Not every Delayed Job backend has queues, so a
+      # job that does not know its queue is described without one.
+      def self.queue_name(job)
+        job.queue if job.respond_to?(:queue)
+      end
+
       def self.enqueue_name(job)
         payload = job.payload_object
         appsignal_name = extract_value(payload, :appsignal_name, nil)
@@ -64,12 +78,20 @@ module Appsignal
             :opentelemetry_kind => :consumer,
             :opentelemetry_relationship => :both
           )
+        transaction.add_opentelemetry_attributes(
+          Appsignal::OpenTelemetry::Messaging
+            .perform_attributes("delayed_job", :destination => queue_name(job))
+        )
 
         begin
           Appsignal.instrument(
             "perform_job.delayed_job",
             :opentelemetry_scope => ["appsignal-ruby/delayed_job", Appsignal::VERSION]
           ) do
+            Appsignal::Transaction.current.add_opentelemetry_attributes(
+              Appsignal::OpenTelemetry::Messaging
+                .perform_attributes("delayed_job", :destination => queue_name(job))
+            )
             block.call(job)
           end
         rescue Exception => error

--- a/lib/appsignal/integrations/excon.rb
+++ b/lib/appsignal/integrations/excon.rb
@@ -26,9 +26,31 @@ module Appsignal
           rails_name,
           title,
           :opentelemetry_kind => :client,
-          :opentelemetry_scope => ["appsignal-ruby/excon", Appsignal::VERSION],
-          &block
-        )
+          :opentelemetry_scope => ["appsignal-ruby/excon", Appsignal::VERSION]
+        ) do
+          # Describes the span as an outgoing HTTP request. Together with the
+          # CLIENT kind, this is what the trace timeline reads to recognize it
+          # as one. Excon reports the request and the response as two separate
+          # notifications, and only the request one says where the request went,
+          # so nothing is set for the response one.
+          Appsignal::Transaction.current.add_opentelemetry_attributes(
+            Appsignal::OpenTelemetry::HttpClientRequest.attributes_for(
+              :method => data[:method],
+              :scheme => data[:scheme],
+              :host => data[:host],
+              :port => data[:port],
+              :path => data[:path]
+            )
+          )
+          # Describes the response, which the semantic conventions ask for
+          # whenever one was received. Only the response notification carries the
+          # status, so this is the span it lands on, which is not the same span
+          # the rest of the request's attributes are on.
+          Appsignal::Transaction.current.add_opentelemetry_attributes(
+            Appsignal::OpenTelemetry::HttpResponse.attributes_for(data[:status])
+          )
+          block&.call
+        end
       end
     end
   end

--- a/lib/appsignal/integrations/faraday.rb
+++ b/lib/appsignal/integrations/faraday.rb
@@ -21,6 +21,18 @@ module Appsignal
           :opentelemetry_kind => :client,
           :opentelemetry_scope => ["appsignal-ruby/faraday", Appsignal::VERSION]
         ) do
+          # Describes the span as an outgoing HTTP request. Together with the
+          # CLIENT kind, this is what the trace timeline reads to recognize it
+          # as one.
+          Appsignal::Transaction.current.add_opentelemetry_attributes(
+            Appsignal::OpenTelemetry::HttpClientRequest.attributes_for(
+              :method => env[:method],
+              :scheme => uri.scheme,
+              :host => uri.host,
+              :port => uri.port,
+              :path => uri.path
+            )
+          )
           # Write trace context onto the outgoing request so the called service
           # joins this trace. Injected inside the instrument block, so the written
           # `traceparent` reflects the Faraday client event's span. No-op outside
@@ -32,11 +44,23 @@ module Appsignal
           # instruments. Suppress the adapter's own instrumentation so the
           # request appears once (as the Faraday event) rather than as nested
           # Faraday + Net::HTTP client events.
-          if Appsignal::Transaction.current?
-            Appsignal::Transaction.current.suppress_http_client_events { @app.call(env) }
-          else
-            @app.call(env)
-          end
+          response =
+            if Appsignal::Transaction.current?
+              Appsignal::Transaction.current.suppress_http_client_events { @app.call(env) }
+            else
+              @app.call(env)
+            end
+
+          # Describes the response on the same span, which the semantic
+          # conventions ask for whenever one was received. The event is still
+          # open here, so it lands on the request's own span. The status is read
+          # off the environment rather than the returned response, because an
+          # adapter fills the response in later than it fills in the environment.
+          Appsignal::Transaction.current.add_opentelemetry_attributes(
+            Appsignal::OpenTelemetry::HttpResponse.attributes_for(env[:status])
+          )
+
+          response
         end
       end
     end

--- a/lib/appsignal/integrations/http.rb
+++ b/lib/appsignal/integrations/http.rb
@@ -13,9 +13,30 @@ module Appsignal
           "request.http_rb",
           "#{verb.to_s.upcase} #{request_uri}",
           :opentelemetry_kind => :client,
-          :opentelemetry_scope => ["appsignal-ruby/http_rb", Appsignal::VERSION],
-          &block
-        )
+          :opentelemetry_scope => ["appsignal-ruby/http_rb", Appsignal::VERSION]
+        ) do
+          # Describes the span as an outgoing HTTP request. Together with the
+          # CLIENT kind, this is what the trace timeline reads to recognize it
+          # as one.
+          Appsignal::Transaction.current.add_opentelemetry_attributes(
+            Appsignal::OpenTelemetry::HttpClientRequest.attributes_for(
+              :method => verb,
+              :scheme => parsed_request_uri.scheme,
+              :host => parsed_request_uri.host,
+              :port => parsed_request_uri.port,
+              :path => parsed_request_uri.path
+            )
+          )
+          # Describes the response on the same span, which the semantic
+          # conventions ask for whenever one was received. The event is still
+          # open here, so it lands on the request's own span. A request that
+          # followed redirects reports the status of the response it ended on.
+          block.call.tap do |response|
+            Appsignal::Transaction.current.add_opentelemetry_attributes(
+              Appsignal::OpenTelemetry::HttpResponse.attributes_for(response&.code)
+            )
+          end
+        end
       end
 
       # The event is recorded at the request boundary, so a redirected request

--- a/lib/appsignal/integrations/mongo_ruby_driver.rb
+++ b/lib/appsignal/integrations/mongo_ruby_driver.rb
@@ -26,6 +26,20 @@ module Appsignal
           :opentelemetry_kind => :client,
           :opentelemetry_scope => ["appsignal-ruby/mongo", Appsignal::VERSION]
         )
+        # Names the datastore this span talks to, which is what the trace
+        # timeline reads to recognize a database call, along with the command
+        # that ran, what it ran against, and the server it went to. Set here,
+        # where the event span it describes is the open one.
+        transaction.add_opentelemetry_attributes(
+          {
+            "db.system.name" => "mongodb",
+            "db.operation.name" => event.command_name,
+            "db.collection.name" => collection_name(event),
+            "db.namespace" => event.database_name,
+            "server.address" => event.address&.host,
+            "server.port" => event.address&.port
+          }.compact
+        )
       end
 
       # Called by Mongo::Monitor when query succeeds
@@ -51,6 +65,20 @@ module Appsignal
         store   = transaction.store("mongo_driver")
         command = store.delete(event.request_id) || {}
 
+        # MongoDB's own code for the error, which the conventions ask for
+        # whenever the database reported one. The driver reports a failure by
+        # calling us rather than by raising, so this is the only place it can be
+        # read. Set before the event is finished, so it lands on the query's own
+        # span.
+        #
+        # Only a failure event carries a failure, which is what tells the two
+        # apart here.
+        if event.respond_to?(:failure)
+          transaction.add_opentelemetry_attributes(
+            { "db.response.status_code" => error_code(event.failure) }.compact
+          )
+        end
+
         # Finish the event. The sanitized command is a (nested) Hash; emit it
         # as a JSON string so it works with both transaction backends. The
         # agent serializes structured bodies to JSON anyway, so this is
@@ -68,6 +96,29 @@ module Appsignal
           event.duration,
           :database => event.database_name
         )
+      end
+
+      private
+
+      # The collection a command worked on. MongoDB puts it in the field named
+      # after the command itself, as in `{ "find" => "users" }`. A command that
+      # works on the database as a whole rather than on one collection has
+      # something else in that field, such as the number 1, so only a String
+      # counts as a collection name.
+      def collection_name(event)
+        return unless event.command.respond_to?(:[])
+
+        collection = event.command[event.command_name]
+        collection if collection.is_a?(String)
+      end
+
+      # MongoDB's own code for an error, which it puts in the `code` field of the
+      # error document it replies with. Reported as a String, which is what the
+      # conventions ask for.
+      def error_code(failure)
+        return unless failure.respond_to?(:[])
+
+        failure["code"]&.to_s
       end
     end
   end

--- a/lib/appsignal/integrations/mongo_ruby_driver.rb
+++ b/lib/appsignal/integrations/mongo_ruby_driver.rb
@@ -65,15 +65,20 @@ module Appsignal
         store   = transaction.store("mongo_driver")
         command = store.delete(event.request_id) || {}
 
-        # MongoDB's own code for the error, which the conventions ask for
-        # whenever the database reported one. The driver reports a failure by
-        # calling us rather than by raising, so this is the only place it can be
-        # read. Set before the event is finished, so it lands on the query's own
-        # span.
+        # Say what kind of failure ended the query, which the OpenTelemetry
+        # semantic conventions ask for on a span whose operation failed. The
+        # driver reports a failure by calling us rather than by raising, so this
+        # is the only place it can be read. Set before the event is finished, so
+        # it lands on the query's own span.
         #
         # Only a failure event carries a failure, which is what tells the two
         # apart here.
         if event.respond_to?(:failure)
+          transaction.add_opentelemetry_attributes(
+            Appsignal::OpenTelemetry::ErrorType.attributes_for(error_name(event.failure))
+          )
+          # MongoDB's own code for the error, which the conventions ask for
+          # whenever the database reported one.
           transaction.add_opentelemetry_attributes(
             { "db.response.status_code" => error_code(event.failure) }.compact
           )
@@ -119,6 +124,13 @@ module Appsignal
         return unless failure.respond_to?(:[])
 
         failure["code"]&.to_s
+      end
+
+      # MongoDB names an error in the `codeName` field of the error document it
+      # replies with. A failure the driver never got a document for, such as a
+      # connection that dropped, has no name.
+      def error_name(failure)
+        failure["codeName"] if failure.respond_to?(:[])
       end
     end
   end

--- a/lib/appsignal/integrations/net_http.rb
+++ b/lib/appsignal/integrations/net_http.rb
@@ -18,11 +18,34 @@ module Appsignal
           :opentelemetry_kind => :client,
           :opentelemetry_scope => ["appsignal-ruby/net_http", Appsignal::VERSION]
         ) do
+          # Describes the span as an outgoing HTTP request. Together with the
+          # CLIENT kind, this is what the trace timeline reads to recognize it
+          # as one.
+          #
+          # The client's own `address` and `port` name the host being called.
+          # The request's `path` is a request target, so it can carry a query
+          # string, which the attribute builder cuts off.
+          Appsignal::Transaction.current.add_opentelemetry_attributes(
+            Appsignal::OpenTelemetry::HttpClientRequest.attributes_for(
+              :method => request.method,
+              :scheme => use_ssl? ? "https" : "http",
+              :host => address,
+              :port => port,
+              :path => request.path
+            )
+          )
           # Write trace context onto the outgoing request so the called service
           # joins this trace. No-op outside collector mode. The request object
           # is a valid carrier (it responds to `[]=`).
           Appsignal::OpenTelemetry.inject_context(request)
-          super
+          # Describes the response on the same span, which the semantic
+          # conventions ask for whenever one was received. The event is still
+          # open here, so it lands on the request's own span.
+          super.tap do |response|
+            Appsignal::Transaction.current.add_opentelemetry_attributes(
+              Appsignal::OpenTelemetry::HttpResponse.attributes_for(response&.code)
+            )
+          end
         end
       end
     end

--- a/lib/appsignal/integrations/que.rb
+++ b/lib/appsignal/integrations/que.rb
@@ -127,12 +127,25 @@ module Appsignal
             :opentelemetry_kind => :consumer,
             :opentelemetry_relationship => relationship
           )
+        # Describes this span as a job being performed. The messaging system is
+        # what the trace timeline reads to recognize background job work, and
+        # `que` is the value OpenTelemetry's own Que instrumentation uses.
+        transaction.add_opentelemetry_attributes(
+          Appsignal::OpenTelemetry::Messaging
+            .perform_attributes("que", :destination => local_attrs[:queue])
+        )
 
         begin
           Appsignal.instrument(
             "perform_job.que",
             :opentelemetry_scope => ["appsignal-ruby/que", Appsignal::VERSION]
-          ) { super }
+          ) do
+            Appsignal::Transaction.current.add_opentelemetry_attributes(
+              Appsignal::OpenTelemetry::Messaging
+                .perform_attributes("que", :destination => local_attrs[:queue])
+            )
+            super
+          end
         rescue Exception => error
           transaction.set_error(error)
           raise error
@@ -220,6 +233,10 @@ module Appsignal
           :opentelemetry_kind => :producer,
           :opentelemetry_scope => ["appsignal-ruby/que", Appsignal::VERSION]
         ) do
+          Appsignal::Transaction.current.add_opentelemetry_attributes(
+            Appsignal::OpenTelemetry::Messaging
+              .enqueue_attributes("que", :destination => job_options[:queue])
+          )
           yield job_options_with_context(job_options, :bulk => bulk)
         end
       end

--- a/lib/appsignal/integrations/redis.rb
+++ b/lib/appsignal/integrations/redis.rb
@@ -11,6 +11,7 @@ module Appsignal
           else
             "#{command[0]}#{" ?" * (command.size - 1)}"
           end
+        operation_name = command[0].to_s
 
         Appsignal.instrument(
           "query.redis",
@@ -19,6 +20,23 @@ module Appsignal
           :opentelemetry_kind => :client,
           :opentelemetry_scope => ["appsignal-ruby/redis", Appsignal::VERSION]
         ) do
+          # Names the datastore this span talks to, which is what the trace
+          # timeline reads to recognize a cache call, along with the command that
+          # was run and the database it ran against. The command stays in the
+          # event body rather than moving to `db.query.text`: it is already
+          # sanitized here, and the collector sanitizes `db.query.text` again
+          # for Redis, which would mangle what we send.
+          #
+          # The command name is reported in the case the application wrote it,
+          # which is what the semantic conventions ask for. The database is
+          # reported as the index the connection is on, as a String.
+          Appsignal::Transaction.current.add_opentelemetry_attributes(
+            {
+              "db.system.name" => "redis",
+              "db.operation.name" => (operation_name unless operation_name.empty?),
+              "db.namespace" => (db.to_s if respond_to?(:db) && db)
+            }.compact
+          )
           super
         end
       end

--- a/lib/appsignal/integrations/redis_client.rb
+++ b/lib/appsignal/integrations/redis_client.rb
@@ -11,6 +11,7 @@ module Appsignal
           else
             "#{command[0]}#{" ?" * (command.size - 1)}"
           end
+        operation_name = command[0].to_s
 
         Appsignal.instrument(
           "query.redis",
@@ -19,6 +20,23 @@ module Appsignal
           :opentelemetry_kind => :client,
           :opentelemetry_scope => ["appsignal-ruby/redis_client", Appsignal::VERSION]
         ) do
+          # Names the datastore this span talks to, which is what the trace
+          # timeline reads to recognize a cache call, along with the command that
+          # was run and the database it ran against. The command stays in the
+          # event body rather than moving to `db.query.text`: it is already
+          # sanitized here, and the collector sanitizes `db.query.text` again
+          # for Redis, which would mangle what we send.
+          #
+          # The command name is reported in the case the application wrote it,
+          # which is what the semantic conventions ask for. The database is
+          # reported as the index the connection is on, as a String.
+          Appsignal::Transaction.current.add_opentelemetry_attributes(
+            {
+              "db.system.name" => "redis",
+              "db.operation.name" => (operation_name unless operation_name.empty?),
+              "db.namespace" => (@config.db.to_s if @config.respond_to?(:db) && @config.db)
+            }.compact
+          )
           super
         end
       end

--- a/lib/appsignal/integrations/resque.rb
+++ b/lib/appsignal/integrations/resque.rb
@@ -14,11 +14,22 @@ module Appsignal
           :opentelemetry_kind => :consumer,
           :opentelemetry_relationship => :both
         )
+        # Describes this span as a job being performed. The messaging system is
+        # what the trace timeline reads to recognize background job work, and
+        # `resque` is the value OpenTelemetry's own Resque instrumentation uses.
+        transaction.add_opentelemetry_attributes(
+          Appsignal::OpenTelemetry::Messaging
+            .perform_attributes("resque", :destination => queue)
+        )
 
         Appsignal.instrument(
           "perform.resque",
           :opentelemetry_scope => ["appsignal-ruby/resque", Appsignal::VERSION]
         ) do
+          Appsignal::Transaction.current.add_opentelemetry_attributes(
+            Appsignal::OpenTelemetry::Messaging
+              .perform_attributes("resque", :destination => queue)
+          )
           super
         end
       rescue Exception => exception
@@ -63,6 +74,10 @@ module Appsignal
           :opentelemetry_kind => :producer,
           :opentelemetry_scope => ["appsignal-ruby/resque", Appsignal::VERSION]
         ) do
+          Appsignal::Transaction.current.add_opentelemetry_attributes(
+            Appsignal::OpenTelemetry::Messaging
+              .enqueue_attributes("resque", :destination => queue)
+          )
           Appsignal::OpenTelemetry.inject_context(item)
           super
         end

--- a/lib/appsignal/integrations/shoryuken.rb
+++ b/lib/appsignal/integrations/shoryuken.rb
@@ -70,6 +70,8 @@ module Appsignal
     class ShoryukenMiddleware
       def call(worker_instance, queue, sqs_msg, body, &block)
         batch = sqs_msg.is_a?(Array)
+        # How many messages this call covers, which is only reported for a batch.
+        batch_size = sqs_msg.size if batch
 
         # Read the incoming trace context off the message so the transaction
         # links back to the enqueuer. A batch carries messages from multiple
@@ -84,12 +86,27 @@ module Appsignal
           :opentelemetry_kind => :consumer,
           :opentelemetry_relationship => :both
         )
+        # Describes this span as a job being performed. The messaging system is
+        # what the trace timeline reads to recognize background job work.
+        # Shoryuken runs on Amazon SQS, so it takes the `aws_sqs` value the
+        # OpenTelemetry semantic conventions define for it.
+        transaction.add_opentelemetry_attributes(
+          Appsignal::OpenTelemetry::Messaging.perform_attributes(
+            "aws_sqs", :destination => queue, :batch_size => batch_size
+          )
+        )
 
         Appsignal.instrument(
           "perform_job.shoryuken",
-          :opentelemetry_scope => ["appsignal-ruby/shoryuken", Appsignal::VERSION],
-          &block
-        )
+          :opentelemetry_scope => ["appsignal-ruby/shoryuken", Appsignal::VERSION]
+        ) do
+          Appsignal::Transaction.current.add_opentelemetry_attributes(
+            Appsignal::OpenTelemetry::Messaging.perform_attributes(
+              "aws_sqs", :destination => queue, :batch_size => batch_size
+            )
+          )
+          block.call
+        end
       rescue Exception => error
         transaction.set_error(error)
         raise
@@ -180,6 +197,10 @@ module Appsignal
           :opentelemetry_kind => :producer,
           :opentelemetry_scope => ["appsignal-ruby/shoryuken", Appsignal::VERSION]
         ) do
+          Appsignal::Transaction.current.add_opentelemetry_attributes(
+            Appsignal::OpenTelemetry::Messaging
+              .enqueue_attributes("aws_sqs", :destination => queue_name(options))
+          )
           ShoryukenTraceContext.inject(options)
           yield
         end
@@ -194,8 +215,13 @@ module Appsignal
         worker_class = options.dig(:message_attributes, "shoryuken_class", :string_value)
         return "enqueue #{worker_class} job" if worker_class
 
-        queue = options[:queue_url].to_s.split("/").last
-        "enqueue on #{queue}"
+        "enqueue on #{queue_name(options)}"
+      end
+
+      # The queue a message is being sent to, which SQS identifies by a URL whose
+      # last segment is the queue's name.
+      def queue_name(options)
+        options[:queue_url].to_s.split("/").last
       end
     end
   end

--- a/lib/appsignal/integrations/sidekiq.rb
+++ b/lib/appsignal/integrations/sidekiq.rb
@@ -44,6 +44,9 @@ module Appsignal
             :opentelemetry_kind => :consumer,
             :opentelemetry_relationship => :both
           )
+          transaction.add_opentelemetry_attributes(
+            Appsignal::OpenTelemetry::Messaging.perform_attributes("sidekiq")
+          )
           transaction.set_action_if_nil("SidekiqInternal")
           transaction.set_metadata("sidekiq_error", sidekiq_context[:context])
           transaction.add_function_parameters_if_nil(:jobstr => sidekiq_context[:jobstr])
@@ -131,6 +134,14 @@ module Appsignal
           :opentelemetry_kind => :producer,
           :opentelemetry_scope => ["appsignal-ruby/sidekiq", Appsignal::VERSION]
         ) do
+          # Describes this span as a job being enqueued. The messaging system
+          # is what the trace timeline reads to recognize background job work,
+          # and `sidekiq` is the value OpenTelemetry's own Sidekiq
+          # instrumentation uses.
+          Appsignal::Transaction.current.add_opentelemetry_attributes(
+            Appsignal::OpenTelemetry::Messaging
+              .enqueue_attributes("sidekiq", :destination => job["queue"])
+          )
           Appsignal::OpenTelemetry.inject_context(job)
           yield
         end
@@ -165,6 +176,10 @@ module Appsignal
           :opentelemetry_kind => :consumer,
           :opentelemetry_relationship => :both
         )
+        transaction.add_opentelemetry_attributes(
+          Appsignal::OpenTelemetry::Messaging
+            .perform_attributes("sidekiq", :destination => item["queue"])
+        )
         transaction.set_action_if_nil(action_name)
 
         formatted_metadata(item).each do |key, value|
@@ -174,9 +189,14 @@ module Appsignal
         begin
           Appsignal.instrument(
             "perform_job.sidekiq",
-            :opentelemetry_scope => ["appsignal-ruby/sidekiq", Appsignal::VERSION],
-            &block
-          )
+            :opentelemetry_scope => ["appsignal-ruby/sidekiq", Appsignal::VERSION]
+          ) do
+            Appsignal::Transaction.current.add_opentelemetry_attributes(
+              Appsignal::OpenTelemetry::Messaging
+                .perform_attributes("sidekiq", :destination => item["queue"])
+            )
+            block.call
+          end
         rescue Exception => exception
           job_status = :failed
           raise exception

--- a/lib/appsignal/integrations/webmachine.rb
+++ b/lib/appsignal/integrations/webmachine.rb
@@ -23,6 +23,26 @@ module Appsignal
             )
           end
 
+        unless has_parent_transaction
+          # Describes the transaction's span as an incoming HTTP request.
+          # Together with the SERVER span kind the transaction already carries,
+          # this is what the trace timeline reads to recognize a web request.
+          # Set here, where the transaction is created, so they land on the
+          # transaction's own span rather than on the event started below.
+          #
+          # Webmachine isn't Rack: the path, scheme and query string come off the
+          # request's `URI` rather than from Rack's readers. The request's own
+          # `query` is the parsed form, so the URI is where the string itself is.
+          transaction.add_opentelemetry_attributes(
+            Appsignal::OpenTelemetry::HttpServerRequest.attributes_for(
+              :method => request.method,
+              :path => request.uri&.path,
+              :scheme => request.uri&.scheme,
+              :query => request.uri&.query
+            )
+          )
+        end
+
         begin
           transaction.add_query_parameters_if_nil { request.query }
           transaction.add_headers_if_nil { request.headers if request.respond_to?(:headers) }
@@ -36,7 +56,17 @@ module Appsignal
         ensure
           transaction.set_action_if_nil("#{resource.class.name}##{request.method}")
 
-          Appsignal::Transaction.complete_current! unless has_parent_transaction
+          unless has_parent_transaction
+            # Describes the response on the transaction's span, which the
+            # semantic conventions ask for whenever a response was sent. The
+            # event above has closed by now, so this lands on the transaction's
+            # own span.
+            transaction.add_opentelemetry_attributes(
+              Appsignal::OpenTelemetry::HttpResponse.attributes_for(response.code)
+            )
+
+            Appsignal::Transaction.complete_current!
+          end
         end
       end
 

--- a/lib/appsignal/opentelemetry.rb
+++ b/lib/appsignal/opentelemetry.rb
@@ -2,6 +2,9 @@
 
 require "appsignal/opentelemetry/attributes"
 require "appsignal/opentelemetry/dependencies"
+require "appsignal/opentelemetry/http_client_request"
+require "appsignal/opentelemetry/http_method"
+require "appsignal/opentelemetry/http_response"
 
 module Appsignal
   # @!visibility private

--- a/lib/appsignal/opentelemetry.rb
+++ b/lib/appsignal/opentelemetry.rb
@@ -2,6 +2,7 @@
 
 require "appsignal/opentelemetry/attributes"
 require "appsignal/opentelemetry/dependencies"
+require "appsignal/opentelemetry/error_type"
 require "appsignal/opentelemetry/http_client_request"
 require "appsignal/opentelemetry/http_method"
 require "appsignal/opentelemetry/http_response"

--- a/lib/appsignal/opentelemetry.rb
+++ b/lib/appsignal/opentelemetry.rb
@@ -5,6 +5,7 @@ require "appsignal/opentelemetry/dependencies"
 require "appsignal/opentelemetry/http_client_request"
 require "appsignal/opentelemetry/http_method"
 require "appsignal/opentelemetry/http_response"
+require "appsignal/opentelemetry/http_server_request"
 
 module Appsignal
   # @!visibility private

--- a/lib/appsignal/opentelemetry.rb
+++ b/lib/appsignal/opentelemetry.rb
@@ -6,6 +6,7 @@ require "appsignal/opentelemetry/http_client_request"
 require "appsignal/opentelemetry/http_method"
 require "appsignal/opentelemetry/http_response"
 require "appsignal/opentelemetry/http_server_request"
+require "appsignal/opentelemetry/messaging"
 
 module Appsignal
   # @!visibility private

--- a/lib/appsignal/opentelemetry/error_type.rb
+++ b/lib/appsignal/opentelemetry/error_type.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Appsignal
+  module OpenTelemetry
+    # @!visibility private
+    #
+    # Builds the OpenTelemetry attribute that describes what kind of failure
+    # ended an operation.
+    #
+    # The semantic conventions ask for `error.type` on a span whose operation
+    # failed, and for it to be left unset on one that succeeded. The value has to
+    # have low cardinality, which for an exception means its class name rather
+    # than its message. A failure we have no name for becomes `_OTHER`, which is
+    # the fallback the conventions define.
+    module ErrorType
+      ATTRIBUTE = "error.type"
+
+      # The value the semantic conventions use for a failure the
+      # instrumentation has no name for.
+      OTHER = "_OTHER"
+
+      class << self
+        # The attributes describing the given failure, as a Hash to pass to
+        # `add_opentelemetry_attributes`. Takes the name of the failure: an
+        # exception's class name, or the error code a datastore reported.
+        #
+        # An anonymous exception class has no name, and a datastore does not
+        # always report a code, so a missing name falls back to `_OTHER` rather
+        # than leaving the span with no `error.type` at all.
+        def attributes_for(name)
+          value = name.to_s
+          { ATTRIBUTE => value.empty? ? OTHER : value }
+        end
+      end
+    end
+  end
+end

--- a/lib/appsignal/opentelemetry/http_client_request.rb
+++ b/lib/appsignal/opentelemetry/http_client_request.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Appsignal
+  module OpenTelemetry
+    # @!visibility private
+    #
+    # Builds the OpenTelemetry attributes that describe an outgoing HTTP request.
+    #
+    # The semantic conventions ask for the request method, the host and port
+    # being called, and the full URL. Those together are also what the trace
+    # timeline reads to recognize an outgoing request.
+    #
+    # The URL is built from the parts rather than taken whole, which has two
+    # consequences worth knowing about.
+    #
+    # It never contains credentials. A URL can carry a username and password,
+    # which the conventions say must not be sent. Building the URL from the
+    # scheme, host, port and path means there is nowhere for them to come from.
+    #
+    # It never contains the query string either. The conventions do ask for it,
+    # but the query string of a call to somebody else's API is the part most
+    # likely to carry a key or a token, and unlike an incoming request it is not
+    # something the application chose the shape of. Anything a caller passes as a
+    # path is cut at the first question mark for the same reason, because some
+    # clients hand us a request target rather than a path.
+    module HttpClientRequest
+      ADDRESS_ATTRIBUTE = "server.address"
+      PORT_ATTRIBUTE = "server.port"
+      URL_ATTRIBUTE = "url.full"
+
+      # The port each scheme uses when a URL does not name one. Left out of the
+      # URL, which is how a URL is normally written, but still reported as the
+      # port, which the conventions ask for either way.
+      DEFAULT_PORTS = {
+        "http" => 80,
+        "https" => 443
+      }.freeze
+
+      class << self
+        # The attributes describing the given request, as a Hash to pass to
+        # `add_opentelemetry_attributes`. Takes the request's parts, because
+        # some clients hand us a URI and others only the parts.
+        def attributes_for(method:, scheme: nil, host: nil, port: nil, path: nil)
+          attributes = HttpMethod.attributes_for(method)
+          attributes[ADDRESS_ATTRIBUTE] = host.to_s unless host.to_s.empty?
+
+          port = port_for(scheme, port)
+          attributes[PORT_ATTRIBUTE] = port if port
+
+          url = url_for(scheme, host, port, path)
+          attributes[URL_ATTRIBUTE] = url if url
+
+          attributes
+        end
+
+        private
+
+        # A client that was not given a port uses the one its scheme implies, so
+        # report that rather than nothing.
+        def port_for(scheme, port)
+          Integer(port, :exception => false) || DEFAULT_PORTS[scheme.to_s]
+        end
+
+        def url_for(scheme, host, port, path)
+          return if scheme.to_s.empty? || host.to_s.empty?
+
+          url = +"#{scheme}://#{host}"
+          url << ":#{port}" if port && port != DEFAULT_PORTS[scheme.to_s]
+          url << path_without_query(path)
+          url
+        end
+
+        # Some clients report the path of a request to the root of a host as
+        # empty, and others as "/". The request goes to "/" either way, so say so
+        # rather than let the URL differ by which client made the request.
+        def path_without_query(path)
+          without_query = path.to_s.split("?", 2).first.to_s
+          without_query.empty? ? "/" : without_query
+        end
+      end
+    end
+  end
+end

--- a/lib/appsignal/opentelemetry/http_method.rb
+++ b/lib/appsignal/opentelemetry/http_method.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Appsignal
+  module OpenTelemetry
+    # @!visibility private
+    #
+    # Builds the OpenTelemetry attributes that describe an HTTP request method.
+    #
+    # The semantic conventions treat `http.request.method` as a closed set of
+    # known method names, so an arbitrary value cannot be passed through. A
+    # method outside the set becomes `_OTHER`, and a method that only matches
+    # after upcasing is replaced by its canonical form. Both of those cases keep
+    # the value we were given in `http.request.method_original`, so the original
+    # is never lost.
+    module HttpMethod
+      # The methods the semantic conventions know about: those defined in
+      # RFC 9110, plus PATCH from RFC 5789.
+      KNOWN_METHODS = [
+        "CONNECT",
+        "DELETE",
+        "GET",
+        "HEAD",
+        "OPTIONS",
+        "PATCH",
+        "POST",
+        "PUT",
+        "TRACE"
+      ].freeze
+
+      # The value the semantic conventions use for a method they do not know.
+      OTHER = "_OTHER"
+
+      METHOD_ATTRIBUTE = "http.request.method"
+      ORIGINAL_ATTRIBUTE = "http.request.method_original"
+
+      class << self
+        # The attributes describing the given request method, as a Hash to pass
+        # to `add_opentelemetry_attributes`. Returns an empty Hash when there is
+        # no method to describe, so a caller that could not read one can pass
+        # the result on without checking.
+        def attributes_for(method)
+          original = method.to_s
+          return {} if original.empty?
+
+          # Method names are case sensitive, so a value that already matches a
+          # known method is used as it is, with nothing to preserve.
+          return { METHOD_ATTRIBUTE => original } if KNOWN_METHODS.include?(original)
+
+          canonical = original.upcase
+          if KNOWN_METHODS.include?(canonical)
+            { METHOD_ATTRIBUTE => canonical, ORIGINAL_ATTRIBUTE => original }
+          else
+            { METHOD_ATTRIBUTE => OTHER, ORIGINAL_ATTRIBUTE => original }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/appsignal/opentelemetry/http_response.rb
+++ b/lib/appsignal/opentelemetry/http_response.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Appsignal
+  module OpenTelemetry
+    # @!visibility private
+    #
+    # Builds the OpenTelemetry attributes that describe an HTTP response.
+    #
+    # The semantic conventions ask for the response status code on the span of an
+    # HTTP request, whether that is a request this application handled or one it
+    # made. They ask for it only when a response was actually received or sent,
+    # so a request that never got one is described without it.
+    module HttpResponse
+      STATUS_CODE_ATTRIBUTE = "http.response.status_code"
+
+      class << self
+        # The attributes describing the given response status, as a Hash to pass
+        # to `add_opentelemetry_attributes`. Returns an empty Hash when there is
+        # no status to describe, so a caller whose request produced no response
+        # can pass the result on without checking.
+        def attributes_for(status)
+          code = Integer(status, :exception => false)
+          return {} unless code
+
+          { STATUS_CODE_ATTRIBUTE => code }
+        end
+      end
+    end
+  end
+end

--- a/lib/appsignal/opentelemetry/http_server_request.rb
+++ b/lib/appsignal/opentelemetry/http_server_request.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Appsignal
+  module OpenTelemetry
+    # @!visibility private
+    #
+    # Builds the OpenTelemetry attributes that describe an incoming HTTP
+    # request.
+    #
+    # The semantic conventions ask for the request method, the path and the
+    # scheme on the span of a request a server handled. Those three together are
+    # also what the trace timeline reads to recognize a web request.
+    #
+    # The path is the concrete path the request was made to, such as `/users/1`.
+    # It is not the route template the application matched it against, which the
+    # conventions call `http.route` and which a Rack application does not
+    # necessarily have.
+    #
+    # The query string is asked for whenever the request had one. It is sent
+    # whole, without the leading question mark, and it is not filtered here. The
+    # collector filters it with the `filter_request_query_parameters` option, and
+    # builds the request's query parameters out of it.
+    #
+    # Every value is optional, because reading any of them from the request can
+    # fail. An attribute we have no value for is left out rather than sent
+    # empty.
+    module HttpServerRequest
+      PATH_ATTRIBUTE = "url.path"
+      SCHEME_ATTRIBUTE = "url.scheme"
+      QUERY_ATTRIBUTE = "url.query"
+
+      class << self
+        # The attributes describing the given request, as a Hash to pass to
+        # `add_opentelemetry_attributes`.
+        def attributes_for(method:, path: nil, scheme: nil, query: nil)
+          attributes = HttpMethod.attributes_for(method)
+          attributes[PATH_ATTRIBUTE] = path.to_s unless path.to_s.empty?
+          attributes[SCHEME_ATTRIBUTE] = scheme.to_s unless scheme.to_s.empty?
+          attributes[QUERY_ATTRIBUTE] = query.to_s unless query.to_s.empty?
+          attributes
+        end
+      end
+    end
+  end
+end

--- a/lib/appsignal/opentelemetry/messaging.rb
+++ b/lib/appsignal/opentelemetry/messaging.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Appsignal
+  module OpenTelemetry
+    # @!visibility private
+    #
+    # Builds the OpenTelemetry attributes that describe a messaging operation,
+    # which for AppSignal means a background job being enqueued or performed.
+    #
+    # The semantic conventions ask for the messaging system, the name of the
+    # operation, and the kind of operation it was. The name is the job library's
+    # own word for what happened. The kind is one of the five values the
+    # conventions define, and AppSignal only ever produces two of them:
+    # enqueuing a job sends a message, and performing one processes it.
+    #
+    # They also ask for the destination of the message, which for a job library
+    # is the queue it is on, and for how many messages a span covers when it
+    # covers a batch of them.
+    #
+    # The system is the only part that differs per job library, so each
+    # integration passes its own.
+    module Messaging
+      SYSTEM_ATTRIBUTE = "messaging.system"
+      OPERATION_NAME_ATTRIBUTE = "messaging.operation.name"
+      OPERATION_TYPE_ATTRIBUTE = "messaging.operation.type"
+      DESTINATION_ATTRIBUTE = "messaging.destination.name"
+      BATCH_COUNT_ATTRIBUTE = "messaging.batch.message_count"
+
+      # The operations AppSignal records, and the kind of operation the
+      # conventions class each of them as.
+      ENQUEUE = "enqueue"
+      PERFORM = "perform"
+      OPERATION_TYPES = {
+        ENQUEUE => "send",
+        PERFORM => "process"
+      }.freeze
+
+      class << self
+        # The attributes describing a job being enqueued, as a Hash to pass to
+        # `add_opentelemetry_attributes`.
+        def enqueue_attributes(system, destination: nil, batch_size: nil)
+          attributes_for(system, ENQUEUE, destination, batch_size)
+        end
+
+        # The attributes describing a job being performed, as a Hash to pass to
+        # `add_opentelemetry_attributes`.
+        def perform_attributes(system, destination: nil, batch_size: nil)
+          attributes_for(system, PERFORM, destination, batch_size)
+        end
+
+        private
+
+        def attributes_for(system, operation, destination, batch_size)
+          {
+            SYSTEM_ATTRIBUTE => system,
+            OPERATION_NAME_ATTRIBUTE => operation,
+            OPERATION_TYPE_ATTRIBUTE => OPERATION_TYPES.fetch(operation),
+            DESTINATION_ATTRIBUTE => destination_name(destination),
+            BATCH_COUNT_ATTRIBUTE => batch_count(batch_size)
+          }.compact
+        end
+
+        # The queue the job is on, which the conventions call the destination of
+        # the message. A job whose queue we cannot name is described without it.
+        def destination_name(destination)
+          name = destination.to_s
+          name unless name.empty?
+        end
+
+        # How many messages the span covers. The conventions ask for this only
+        # when a span describes a batch, and say it must not be set on a span
+        # that describes a single message.
+        def batch_count(batch_size)
+          return unless batch_size
+
+          count = batch_size.to_i
+          count if count.positive?
+        end
+      end
+    end
+  end
+end

--- a/lib/appsignal/rack.rb
+++ b/lib/appsignal/rack.rb
@@ -7,9 +7,46 @@ module Appsignal
     APPSIGNAL_EVENT_HANDLER_ID = "appsignal.event_handler_id"
     APPSIGNAL_EVENT_HANDLER_HAS_ERROR = "appsignal.event_handler.error"
     APPSIGNAL_RESPONSE_INSTRUMENTED = "appsignal.response_instrumentation_active"
+    APPSIGNAL_RESPONSE_STATUS = "appsignal.response_status"
     RACK_AFTER_REPLY = "rack.after_reply"
 
     class Utils
+      # Fetch the HTTP request method from the request.
+      #
+      # The request class is configurable, so reading the method can raise.
+      # Log and return nil in that case, leaving it to the caller to skip
+      # whatever it needed the method for.
+      #
+      # @param request [Rack::Request] Request object.
+      # @return [String, NilClass]
+      def self.request_method_from(request)
+        request.request_method
+      rescue => error
+        Appsignal.internal_logger.error(
+          "Exception while fetching the HTTP request method: #{error.class}: #{error}"
+        )
+        nil
+      end
+
+      # Fetch a value that describes the request, named after the method that
+      # reads it.
+      #
+      # The request class is configurable, so reading from the request can
+      # raise. Log and return nil in that case, leaving it to the caller to skip
+      # whatever it needed the value for.
+      #
+      # @param request [Rack::Request] Request object.
+      # @param name [Symbol] Name of the method that reads the value.
+      # @return [Object, NilClass]
+      def self.request_value_from(request, name)
+        request.public_send(name)
+      rescue => error
+        Appsignal.internal_logger.error(
+          "Exception while fetching the HTTP request #{name}: #{error.class}: #{error}"
+        )
+        nil
+      end
+
       # Fetch the queue start time from the request environment.
       #
       # @since 3.11.0
@@ -53,7 +90,7 @@ module Appsignal
         # TODO: Remove in next major/minor version
         transaction.set_metadata("path", request_path)
 
-        request_method = request_method_for(request)
+        request_method = Appsignal::Rack::Utils.request_method_from(request)
         if request_method
           transaction.set_metadata("request_method", request_method)
           # TODO: Remove in next major/minor version
@@ -80,15 +117,6 @@ module Appsignal
         Appsignal.internal_logger.error(
           "Exception while fetching params from '#{request.class}##{@params_method}': " \
             "#{error.class} #{error}"
-        )
-        nil
-      end
-
-      def request_method_for(request)
-        request.request_method
-      rescue => error
-        Appsignal.internal_logger.error(
-          "Exception while fetching the HTTP request method: #{error.class}: #{error}"
         )
         nil
       end

--- a/lib/appsignal/rack/abstract_middleware.rb
+++ b/lib/appsignal/rack/abstract_middleware.rb
@@ -49,6 +49,7 @@ module Appsignal
             # middleware can detect if there is parent instrumentation
             # middleware active.
             env[Appsignal::Rack::APPSIGNAL_TRANSACTION] = transaction
+            add_opentelemetry_request_attributes(transaction, request)
           end
 
           begin
@@ -67,8 +68,13 @@ module Appsignal
           ensure
             add_transaction_metadata_after(transaction, request)
 
-            # Complete transaction because this is the top instrumentation middleware.
-            Appsignal::Transaction.complete_current! unless wrapped_instrumentation
+            unless wrapped_instrumentation
+              add_opentelemetry_response_attributes(transaction, request)
+
+              # Complete transaction because this is the top instrumentation
+              # middleware.
+              Appsignal::Transaction.complete_current!
+            end
           end
         else
           @app.call(env)
@@ -76,6 +82,47 @@ module Appsignal
       end
 
       private
+
+      # Describes the transaction's span as an incoming HTTP request. Together
+      # with the SERVER span kind the transaction already carries, this is what
+      # the trace timeline reads to recognize a web request.
+      #
+      # Set here, where the transaction is created, and not alongside the rest
+      # of the request metadata in {ApplyRackRequest}. That runs after the app
+      # has been called, when an event span may be open, and the attributes
+      # would land on that event instead of on the transaction's own span.
+      # Only the middleware that created the transaction sets them, so nested
+      # middleware doesn't write them a second time onto whatever span is open
+      # by then.
+      def add_opentelemetry_request_attributes(transaction, request)
+        transaction.add_opentelemetry_attributes(
+          Appsignal::OpenTelemetry::HttpServerRequest.attributes_for(
+            :method => Appsignal::Rack::Utils.request_method_from(request),
+            :path => Appsignal::Rack::Utils.request_value_from(request, :path),
+            :scheme => Appsignal::Rack::Utils.request_value_from(request, :scheme),
+            :query => Appsignal::Rack::Utils.request_value_from(request, :query_string)
+          )
+        )
+      end
+
+      # Describes the response the app produced on the transaction's span, which
+      # the semantic conventions ask for whenever a response was sent.
+      #
+      # Set from the `ensure` in {#call} rather than from {#call_app}, where the
+      # status is first known. That runs inside the instrumented event, so the
+      # attribute would land on the event span instead of on the transaction's
+      # own span. The status travels between the two in the request environment
+      # for that reason.
+      #
+      # A request whose app raised never produced a status, and is described
+      # without one.
+      def add_opentelemetry_response_attributes(transaction, request)
+        transaction.add_opentelemetry_attributes(
+          Appsignal::OpenTelemetry::HttpResponse.attributes_for(
+            request.env[Appsignal::Rack::APPSIGNAL_RESPONSE_STATUS]
+          )
+        )
+      end
 
       # Another instrumentation middleware is active earlier in the stack, so
       # don't report any exceptions here, the top instrumentation middleware
@@ -100,6 +147,9 @@ module Appsignal
 
       def call_app(env, transaction)
         status, headers, obody = @app.call(env)
+        # Remember the status for {#add_opentelemetry_response_attributes}, which
+        # runs once this event has closed.
+        env[Appsignal::Rack::APPSIGNAL_RESPONSE_STATUS] = status
         body =
           if env[Appsignal::Rack::APPSIGNAL_RESPONSE_INSTRUMENTED]
             obody

--- a/lib/appsignal/rack/event_handler.rb
+++ b/lib/appsignal/rack/event_handler.rb
@@ -68,6 +68,22 @@ module Appsignal
             :opentelemetry_context => Appsignal::OpenTelemetry.extract_rack_context(request.env),
             :opentelemetry_scope => ["appsignal-ruby/rack", Appsignal::VERSION]
           )
+          # Describes the transaction's span as an incoming HTTP request.
+          # Together with the SERVER span kind the transaction already carries,
+          # this is what the trace timeline reads to recognize a web request.
+          #
+          # Set before the event below starts, because attributes go on
+          # whichever span is open and these belong on the transaction's own
+          # span. That event stays open until the response finishes, so there is
+          # no later point in the request at which these could be set.
+          transaction.add_opentelemetry_attributes(
+            Appsignal::OpenTelemetry::HttpServerRequest.attributes_for(
+              :method => Appsignal::Rack::Utils.request_method_from(request),
+              :path => Appsignal::Rack::Utils.request_value_from(request, :path),
+              :scheme => Appsignal::Rack::Utils.request_value_from(request, :scheme),
+              :query => Appsignal::Rack::Utils.request_value_from(request, :query_string)
+            )
+          )
           transaction.start_event(
             :opentelemetry_scope => ["appsignal-ruby/rack", Appsignal::VERSION]
           )
@@ -131,6 +147,17 @@ module Appsignal
           end
           queue_start = Appsignal::Rack::Utils.queue_start_from(request.env)
           transaction.set_queue_start(queue_start) if queue_start
+          # Describes the response on the transaction's span, which the semantic
+          # conventions ask for whenever a response was sent. It can be set here
+          # because the `process_request.rack` event was finished above, which
+          # leaves the transaction's own span as the one attributes go on.
+          #
+          # Only a response the app actually produced counts. The 500 below
+          # stands in for a status that was never sent, so it is reported as a
+          # tag and a metric but not as this attribute.
+          transaction.add_opentelemetry_attributes(
+            Appsignal::OpenTelemetry::HttpResponse.attributes_for(response&.status)
+          )
           response_status =
             if response
               response.status

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -823,6 +823,41 @@ module Appsignal
       @backend.set_metadata(key, value)
     end
 
+    # Add OpenTelemetry attributes to the span AppSignal is currently
+    # recording.
+    #
+    # In collector mode, AppSignal records a transaction as an OpenTelemetry
+    # span, and every instrumented event as a child span. This adds attributes
+    # to whichever of those spans is open right now: the innermost event
+    # started by {Appsignal::Helpers::Instrumentation#instrument}, or the
+    # transaction's own span when no event is open.
+    #
+    # Use this to describe what is being instrumented in OpenTelemetry's own
+    # terms, following the OpenTelemetry semantic conventions where they apply.
+    # Attributes have no equivalent outside collector mode, so this does
+    # nothing when collector mode is not active.
+    #
+    # @example Describing a database query
+    #   Appsignal.instrument("query.my_database") do
+    #     Appsignal::Transaction.current.add_opentelemetry_attributes(
+    #       "db.system.name" => "mysql"
+    #     )
+    #     run_the_query
+    #   end
+    #
+    # @param attributes [Hash<String, Object>, nil] Attributes to add to the
+    #   current span. Values that are not a String, Integer, Float or boolean
+    #   are converted to a String. Nothing is added when this is nil or empty.
+    # @return [void]
+    #
+    # @see https://opentelemetry.io/docs/specs/semconv/
+    #   OpenTelemetry semantic conventions
+    def add_opentelemetry_attributes(attributes = {})
+      return if attributes.nil? || attributes.empty?
+
+      @backend.set_attributes(attributes)
+    end
+
     # @!visibility private
     # @see Appsignal::Helpers::Instrumentation#report_error
     def add_error(error, source: nil, &block)

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -954,6 +954,26 @@ module Appsignal
         :opentelemetry_scope => opentelemetry_scope
       )
       yield if block_given?
+    rescue Exception => error
+      # The block raised, so the operation this event describes failed. Say what
+      # kind of failure it was, which is what the OpenTelemetry semantic
+      # conventions ask for. This runs before the `ensure` below finishes the
+      # event, so the attribute lands on the event's own span.
+      #
+      # An error that reaches this point is not reported here. Whatever catches
+      # it decides that, and if it ends up on the transaction the error type is
+      # recorded there as well.
+      #
+      # A paused transaction never started an event span, so there is no span of
+      # this event's to describe and the attribute would land on an unrelated
+      # one.
+      unless paused?
+        add_opentelemetry_attributes(
+          Appsignal::OpenTelemetry::ErrorType.attributes_for(error.class.name)
+        )
+      end
+
+      raise
     ensure
       finish_event(name, title, body, body_format)
     end

--- a/lib/appsignal/transaction/base_backend.rb
+++ b/lib/appsignal/transaction/base_backend.rb
@@ -42,6 +42,13 @@ module Appsignal
         raise NotImplementedError
       end
 
+      # OpenTelemetry span attributes, set on whichever span the backend is
+      # currently recording. Only meaningful in collector mode; agent mode has
+      # no span to hang them on.
+      def set_attributes(_attributes)
+        raise NotImplementedError
+      end
+
       # Maps each logical params channel (`:params`, `:request_payload`,
       # `:function_parameters`) to the storage bucket it lands in. Channels that
       # share a bucket merge into one `SampleData` object on the transaction;

--- a/lib/appsignal/transaction/extension_backend.rb
+++ b/lib/appsignal/transaction/extension_backend.rb
@@ -75,6 +75,13 @@ module Appsignal
         @handle.set_metadata(key, value)
       end
 
+      # Agent mode has no OpenTelemetry spans, so there is nothing to set the
+      # attributes on. A transaction event has no attribute equivalent in the
+      # agent protocol either, so they are dropped rather than stored somewhere
+      # else.
+      def set_attributes(_attributes)
+      end
+
       # The agent has a single params slot, so every params channel maps to one
       # `:params` bucket. The transaction merges the channels into it, and only
       # the `:params` key ever reaches `set_sample_data`.

--- a/lib/appsignal/transaction/opentelemetry_backend.rb
+++ b/lib/appsignal/transaction/opentelemetry_backend.rb
@@ -228,6 +228,23 @@ module Appsignal
         @span.set_attribute("appsignal.tag.#{key}", value)
       end
 
+      # Sets OpenTelemetry attributes on AppSignal's current span -- the open
+      # event span, or the root span when no event is open. This is how an
+      # integration describes what it instrumented in OpenTelemetry's own terms,
+      # such as `db.system.name` on a database query.
+      #
+      # The target is AppSignal's own span, not the OTel current span, which may
+      # belong to another instrumentation. We never write attributes onto a span
+      # we did not create.
+      #
+      # Values are coerced to the primitives OTLP accepts, the same way the
+      # metric and log backends coerce theirs.
+      def set_attributes(attributes)
+        current_span.add_attributes(
+          Appsignal::OpenTelemetry::Attributes.format(attributes)
+        )
+      end
+
       # The collector keeps the request payload, the function parameters and the
       # query parameters as separate attributes, so each gets its own bucket.
       # Legacy `params` has no channel of its own, so it maps to the request

--- a/lib/appsignal/transaction/opentelemetry_backend.rb
+++ b/lib/appsignal/transaction/opentelemetry_backend.rb
@@ -322,6 +322,12 @@ module Appsignal
         end
 
         span.add_event("exception", :attributes => attributes)
+        # `error.type` is what the semantic conventions read to tell what kind of
+        # failure ended the operation. It is an attribute of the span, unlike the
+        # `exception.type` above, which is an attribute of the exception event.
+        # When a span collects more than one error the last one wins, because a
+        # span can only say one thing here.
+        span.add_attributes(Appsignal::OpenTelemetry::ErrorType.attributes_for(class_name))
         span.status = ::OpenTelemetry::Trace::Status.error
       end
 

--- a/lib/appsignal/transaction/opentelemetry_backend.rb
+++ b/lib/appsignal/transaction/opentelemetry_backend.rb
@@ -735,12 +735,15 @@ module Appsignal
       end
 
       def write_event_body_attributes(span, body, body_format)
-        return if body.nil? || body.empty?
+        has_body = !body.to_s.empty?
 
         if body_format == Appsignal::EventFormatter::SQL_BODY_FORMAT
-          span.set_attribute("db.query.text", body)
+          # Name the datastore whether or not there is a query to record with it.
+          # The semantic conventions require the attribute on every database
+          # span, and a SQL event with nothing in its body is still a SQL event.
           span.set_attribute("db.system.name", SQL_DB_SYSTEM)
-        else
+          span.set_attribute("db.query.text", body) if has_body
+        elsif has_body
           span.set_attribute("appsignal.body", body)
         end
       end

--- a/sig/appsignal.rbi
+++ b/sig/appsignal.rbi
@@ -2022,6 +2022,36 @@ module Appsignal
     # _@param_ `start` — Queue start time in milliseconds.
     sig { params(start: Integer).void }
     def set_queue_start(start); end
+
+    # Add OpenTelemetry attributes to the span AppSignal is currently
+    # recording.
+    # 
+    # In collector mode, AppSignal records a transaction as an OpenTelemetry
+    # span, and every instrumented event as a child span. This adds attributes
+    # to whichever of those spans is open right now: the innermost event
+    # started by {Appsignal::Helpers::Instrumentation#instrument}, or the
+    # transaction's own span when no event is open.
+    # 
+    # Use this to describe what is being instrumented in OpenTelemetry's own
+    # terms, following the OpenTelemetry semantic conventions where they apply.
+    # Attributes have no equivalent outside collector mode, so this does
+    # nothing when collector mode is not active.
+    # 
+    # _@param_ `attributes` — Attributes to add to the current span. Values that are not a String, Integer, Float or boolean are converted to a String. Nothing is added when this is nil or empty.
+    # 
+    # Describing a database query
+    # ```ruby
+    # Appsignal.instrument("query.my_database") do
+    #   Appsignal::Transaction.current.add_opentelemetry_attributes(
+    #     "db.system.name" => "mysql"
+    #   )
+    #   run_the_query
+    # end
+    # ```
+    # 
+    # _@see_ `https://opentelemetry.io/docs/specs/semconv/` — OpenTelemetry semantic conventions
+    sig { params(attributes: T.nilable(T::Hash[String, Object])).void }
+    def add_opentelemetry_attributes(attributes = {}); end
   end
 
   # Custom markers are used on AppSignal.com to indicate events in an

--- a/sig/appsignal.rbs
+++ b/sig/appsignal.rbs
@@ -1849,6 +1849,35 @@ module Appsignal
     # 
     # _@param_ `start` — Queue start time in milliseconds.
     def set_queue_start: (Integer start) -> void
+
+    # Add OpenTelemetry attributes to the span AppSignal is currently
+    # recording.
+    # 
+    # In collector mode, AppSignal records a transaction as an OpenTelemetry
+    # span, and every instrumented event as a child span. This adds attributes
+    # to whichever of those spans is open right now: the innermost event
+    # started by {Appsignal::Helpers::Instrumentation#instrument}, or the
+    # transaction's own span when no event is open.
+    # 
+    # Use this to describe what is being instrumented in OpenTelemetry's own
+    # terms, following the OpenTelemetry semantic conventions where they apply.
+    # Attributes have no equivalent outside collector mode, so this does
+    # nothing when collector mode is not active.
+    # 
+    # _@param_ `attributes` — Attributes to add to the current span. Values that are not a String, Integer, Float or boolean are converted to a String. Nothing is added when this is nil or empty.
+    # 
+    # Describing a database query
+    # ```ruby
+    # Appsignal.instrument("query.my_database") do
+    #   Appsignal::Transaction.current.add_opentelemetry_attributes(
+    #     "db.system.name" => "mysql"
+    #   )
+    #   run_the_query
+    # end
+    # ```
+    # 
+    # _@see_ `https://opentelemetry.io/docs/specs/semconv/` — OpenTelemetry semantic conventions
+    def add_opentelemetry_attributes: (?::Hash[String, Object]? attributes) -> void
   end
 
   # Custom markers are used on AppSignal.com to indicate events in an

--- a/spec/lib/appsignal/hooks/active_support_notifications/instrument_shared_examples.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications/instrument_shared_examples.rb
@@ -41,6 +41,7 @@ shared_examples "activesupport instrument override" do
       # The scope is derived from the event group (the part after the last dot).
       expect(scope_of(span)).to eq(["appsignal-ruby/active_record", Appsignal::VERSION])
       expect(span.attributes).not_to have_key("appsignal.body")
+      expect(span.attributes).not_to have_key("error.type")
     end
   end
 
@@ -414,6 +415,8 @@ shared_examples "activesupport instrument override" do
       expect(span.kind).to eq(:client)
       expect(span.attributes["db.query.text"]).to eq("SQL")
       expect(span.attributes["db.system.name"]).to eq("other_sql")
+      # The block raised, so the operation the span describes failed.
+      expect(span.attributes["error.type"]).to eq("ExampleException")
     end
   end
 

--- a/spec/lib/appsignal/hooks/active_support_notifications/instrument_shared_examples.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications/instrument_shared_examples.rb
@@ -187,6 +187,50 @@ shared_examples "activesupport instrument override" do
     end
   end
 
+  describe "a template render event" do
+    def perform
+      as.instrument("render_template.action_view", :identifier => "/app/views/a.erb") { "value" }
+    end
+
+    it "in agent mode", :agent_mode do
+      start_agent
+      transaction = http_request_transaction
+      set_current_transaction(transaction)
+      as.notifier = notifier
+
+      expect(perform).to eq "value"
+      # The title comes from the Action View formatter, which only registers
+      # when Rails is loaded. These shared examples also run under gemfiles
+      # that have ActiveSupport without Rails, where the event has no title,
+      # so match any String rather than one particular value.
+      expect(transaction).to include_event(
+        "name" => "render_template.action_view",
+        "title" => kind_of(String)
+      )
+      # The render group only means something to the trace timeline, so
+      # nothing is recorded for it here.
+      expect(transaction).to_not include_tags("appsignal.group" => "render")
+    end
+
+    it "in collector mode", :collector_mode do
+      start_collector_agent
+      transaction = http_request_transaction
+      set_current_transaction(transaction)
+      as.notifier = notifier
+
+      expect(perform).to eq "value"
+      Appsignal::Transaction.complete_current!
+
+      span = event_span_for("render_template.action_view")
+      expect(span).not_to be_nil
+      expect(span.parent_span_id).to eq(root_span.span_id)
+      # There is no OpenTelemetry convention for template rendering, so the
+      # span says which group it belongs to directly.
+      expect(span.attributes["appsignal.group"]).to eq("render")
+      expect(scope_of(span)).to eq(["appsignal-ruby/action_view", Appsignal::VERSION])
+    end
+  end
+
   describe "an event with no registered formatter" do
     def perform
       as.instrument("no-registered.formatter", :key => "something") { "value" }

--- a/spec/lib/appsignal/hooks/active_support_notifications/instrument_shared_examples.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications/instrument_shared_examples.rb
@@ -92,6 +92,101 @@ shared_examples "activesupport instrument override" do
     end
   end
 
+  describe "an Elasticsearch search event" do
+    def perform
+      as.instrument(
+        "search.elasticsearch",
+        :name => "Search",
+        :klass => "User",
+        :search => { :index => "users" }
+      ) { "value" }
+    end
+
+    it "in agent mode", :agent_mode do
+      start_agent
+      transaction = http_request_transaction
+      set_current_transaction(transaction)
+      as.notifier = notifier
+
+      expect(perform).to eq "value"
+      expect(transaction).to include_event(
+        "name" => "search.elasticsearch",
+        "title" => "Search: User",
+        # The formatter inspects the sanitized search, and Hash#inspect changed
+        # format in Ruby 3.4, so match on the content rather than the layout.
+        "body" => a_string_including("users")
+      )
+    end
+
+    it "in collector mode", :collector_mode do
+      start_collector_agent
+      transaction = http_request_transaction
+      set_current_transaction(transaction)
+      as.notifier = notifier
+
+      expect(perform).to eq "value"
+      Appsignal::Transaction.complete_current!
+
+      span = event_span_for("search.elasticsearch")
+      expect(span).not_to be_nil
+      expect(span.parent_span_id).to eq(root_span.span_id)
+      # A search is an outgoing call to the cluster, so it carries CLIENT kind.
+      expect(span.kind).to eq(:client)
+      # There is no SQL body to infer the datastore from, so it is named
+      # explicitly. Without it the trace timeline cannot tell this span apart
+      # from any other kind of work.
+      expect(span.attributes["db.system.name"]).to eq("elasticsearch")
+      # This notification is only emitted for a search, so that is the
+      # operation. The index comes off the search itself.
+      expect(span.attributes["db.operation.name"]).to eq("search")
+      expect(span.attributes["db.collection.name"]).to eq("users")
+      expect(event_category(span)).to eq("search.elasticsearch")
+      expect(scope_of(span)).to eq(["appsignal-ruby/elasticsearch", Appsignal::VERSION])
+    end
+  end
+
+  describe "an Elasticsearch search event across more than one index" do
+    def perform
+      as.instrument(
+        "search.elasticsearch",
+        :name => "Search",
+        :klass => "User",
+        :search => { :index => ["users", "admins"] }
+      ) { "value" }
+    end
+
+    it "in agent mode", :agent_mode do
+      start_agent
+      transaction = http_request_transaction
+      set_current_transaction(transaction)
+      as.notifier = notifier
+
+      expect(perform).to eq "value"
+      expect(transaction).to include_event(
+        "name" => "search.elasticsearch",
+        "title" => "Search: User",
+        "body" => a_string_including("users")
+      )
+    end
+
+    it "in collector mode", :collector_mode do
+      start_collector_agent
+      transaction = http_request_transaction
+      set_current_transaction(transaction)
+      as.notifier = notifier
+
+      expect(perform).to eq "value"
+      Appsignal::Transaction.complete_current!
+
+      span = event_span_for("search.elasticsearch")
+      expect(span).not_to be_nil
+      expect(span.attributes["db.operation.name"]).to eq("search")
+      # The attribute names one index, so a search across several is left
+      # without it rather than described with a value that is not an index name.
+      expect(span.attributes).to_not have_key("db.collection.name")
+    end
+  end
+
   describe "an event with no registered formatter" do
     def perform
       as.instrument("no-registered.formatter", :key => "something") { "value" }

--- a/spec/lib/appsignal/hooks/active_support_notifications/start_finish_shared_examples.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications/start_finish_shared_examples.rb
@@ -39,10 +39,11 @@ shared_examples "activesupport start finish override" do
       expect(span.parent_span_id).to eq(root_span.span_id)
       # A database query is an outgoing call, so it carries CLIENT kind.
       expect(span.kind).to eq(:client)
-      # The formatter received an empty finish payload, so body is empty —
-      # the OTel backend skips writing db.query.text / db.system.name.
+      # The formatter received an empty finish payload, so there is no query to
+      # record. The datastore is named anyway, because this is a database query
+      # either way.
       expect(span.attributes).not_to have_key("db.query.text")
-      expect(span.attributes).not_to have_key("db.system.name")
+      expect(span.attributes["db.system.name"]).to eq("other_sql")
     end
   end
 

--- a/spec/lib/appsignal/hooks/activejob_spec.rb
+++ b/spec/lib/appsignal/hooks/activejob_spec.rb
@@ -154,6 +154,10 @@ if DependencyHelper.active_job_present?
         last_transaction.complete
 
         expect(root_span.kind).to eq(:consumer)
+        expect(root_span.attributes["messaging.system"]).to eq("active_job")
+        expect(root_span.attributes["messaging.operation.name"]).to eq("perform")
+        expect(root_span.attributes["messaging.operation.type"]).to eq("process")
+        expect(root_span.attributes["messaging.destination.name"]).to eq("default")
         expect(scope_of(root_span)).to eq(["appsignal-ruby/active_job", Appsignal::VERSION])
         expect(root_span.attributes["appsignal.namespace"]).to eq("background")
         expect(root_span.attributes["appsignal.action_name"]).to eq("ActiveJobTestJob#perform")
@@ -603,6 +607,10 @@ if DependencyHelper.active_job_present?
           expect(producer.name).to eq("enqueue.active_job (enqueue ActiveJobTestJob job)")
           expect(scope_of(producer)).to eq(["appsignal-ruby/active_job", Appsignal::VERSION])
           expect(producer.kind).to eq(:producer)
+          expect(producer.attributes["messaging.system"]).to eq("active_job")
+          expect(producer.attributes["messaging.operation.name"]).to eq("enqueue")
+          expect(producer.attributes["messaging.operation.type"]).to eq("send")
+          expect(producer.attributes["messaging.destination.name"]).to eq("default")
           expect(producer.parent_span_id).to eq(root_span.span_id)
 
           # The serialized job carries that span's context, so the performed job

--- a/spec/lib/appsignal/hooks/excon_spec.rb
+++ b/spec/lib/appsignal/hooks/excon_spec.rb
@@ -114,6 +114,10 @@ describe Appsignal::Hooks::ExconHook do
           span = event_spans.first
           expect(span.name).to eq("request.excon (GET http://www.google.com)")
           expect(span.kind).to eq(:client)
+          expect(span.attributes["http.request.method"]).to eq("GET")
+          # The client hands us the method as a lowercase Symbol, so the
+          # canonical form is recorded and the original kept alongside it.
+          expect(span.attributes["http.request.method_original"]).to eq("get")
           expect(span.parent_span_id).to eq(root_span.span_id)
           expect(event_category(span)).to eq("request.excon")
           expect(span.attributes).not_to have_key("appsignal.body")
@@ -156,6 +160,9 @@ describe Appsignal::Hooks::ExconHook do
           expect(span.parent_span_id).to eq(root_span.span_id)
           expect(event_category(span)).to eq("response.excon")
           expect(span.attributes).not_to have_key("appsignal.body")
+          # This notification carries no request method, so none is set rather
+          # than an empty one.
+          expect(span.attributes).not_to have_key("http.request.method")
         end
       end
     end

--- a/spec/lib/appsignal/hooks/redis_client_spec.rb
+++ b/spec/lib/appsignal/hooks/redis_client_spec.rb
@@ -112,6 +112,11 @@ describe Appsignal::Hooks::RedisClientHook do
                   expect(span.attributes["appsignal.body"]).to eq("get ?")
                   expect(event_category(span)).to eq("query.redis")
                   expect(scope_of(span)).to eq(["appsignal-ruby/redis_client", Appsignal::VERSION])
+                  expect(span.attributes["db.system.name"]).to eq("redis")
+                  # The command name, in the case the application wrote it.
+                  expect(span.attributes["db.operation.name"]).to eq("get")
+                  # The index of the database the connection is on, as a String.
+                  expect(span.attributes["db.namespace"]).to eq("0")
                   expect(span.attributes).not_to have_key("db.query.text")
                 end
               end
@@ -153,6 +158,11 @@ describe Appsignal::Hooks::RedisClientHook do
                   expect(span.parent_span_id).to eq(root_span.span_id)
                   expect(span.attributes["appsignal.body"]).to eq("#{script} ? ?")
                   expect(event_category(span)).to eq("query.redis")
+                  expect(span.attributes["db.system.name"]).to eq("redis")
+                  # A script is run with the EVAL command, so that is the operation.
+                  # The script itself stays in the event body.
+                  expect(span.attributes["db.operation.name"]).to eq("eval")
+                  expect(span.attributes["db.namespace"]).to eq("0")
                   expect(span.attributes).not_to have_key("db.query.text")
                 end
               end
@@ -244,6 +254,11 @@ describe Appsignal::Hooks::RedisClientHook do
                     expect(span.parent_span_id).to eq(root_span.span_id)
                     expect(span.attributes["appsignal.body"]).to eq("get ?")
                     expect(event_category(span)).to eq("query.redis")
+                    expect(span.attributes["db.system.name"]).to eq("redis")
+                    # The command name, in the case the application wrote it.
+                    expect(span.attributes["db.operation.name"]).to eq("get")
+                    # The index of the database the connection is on, as a String.
+                    expect(span.attributes["db.namespace"]).to eq("0")
                     expect(span.attributes).not_to have_key("db.query.text")
                   end
                 end
@@ -284,6 +299,11 @@ describe Appsignal::Hooks::RedisClientHook do
                     expect(span.parent_span_id).to eq(root_span.span_id)
                     expect(span.attributes["appsignal.body"]).to eq("#{script} ? ?")
                     expect(event_category(span)).to eq("query.redis")
+                    expect(span.attributes["db.system.name"]).to eq("redis")
+                    # A script is run with the EVAL command, so that is the operation.
+                    # The script itself stays in the event body.
+                    expect(span.attributes["db.operation.name"]).to eq("eval")
+                    expect(span.attributes["db.namespace"]).to eq("0")
                     expect(span.attributes).not_to have_key("db.query.text")
                   end
                 end

--- a/spec/lib/appsignal/hooks/redis_spec.rb
+++ b/spec/lib/appsignal/hooks/redis_spec.rb
@@ -63,6 +63,12 @@ describe Appsignal::Hooks::RedisHook do
                     "stub_id"
                   end
 
+                  # The index of the database the connection is on, which the
+                  # real client exposes the same way.
+                  def db
+                    3
+                  end
+
                   def write(_commands)
                     "stub_write"
                   end
@@ -106,6 +112,11 @@ describe Appsignal::Hooks::RedisHook do
                   expect(span.attributes["appsignal.body"]).to eq("get ?")
                   expect(event_category(span)).to eq("query.redis")
                   expect(scope_of(span)).to eq(["appsignal-ruby/redis", Appsignal::VERSION])
+                  expect(span.attributes["db.system.name"]).to eq("redis")
+                  # The command name, in the case the application wrote it.
+                  expect(span.attributes["db.operation.name"]).to eq("get")
+                  # The index of the database the connection is on, as a String.
+                  expect(span.attributes["db.namespace"]).to eq("3")
                   expect(span.attributes).not_to have_key("db.query.text")
                 end
               end
@@ -146,6 +157,11 @@ describe Appsignal::Hooks::RedisHook do
                   expect(span.parent_span_id).to eq(root_span.span_id)
                   expect(span.attributes["appsignal.body"]).to eq("#{script} ? ?")
                   expect(event_category(span)).to eq("query.redis")
+                  expect(span.attributes["db.system.name"]).to eq("redis")
+                  # A script is run with the EVAL command, so that is the
+                  # operation. The script itself stays in the event body.
+                  expect(span.attributes["db.operation.name"]).to eq("eval")
+                  expect(span.attributes["db.namespace"]).to eq("3")
                   expect(span.attributes).not_to have_key("db.query.text")
                 end
               end

--- a/spec/lib/appsignal/integrations/delayed_job_plugin_spec.rb
+++ b/spec/lib/appsignal/integrations/delayed_job_plugin_spec.rb
@@ -40,7 +40,7 @@ if DependencyHelper.delayed_job_present?
           transaction = http_request_transaction
           set_current_transaction(transaction)
 
-          Delayed::Job.enqueue(DelayedTestJob.new)
+          Delayed::Job.enqueue(DelayedTestJob.new, :queue => "dj-queue")
 
           event = transaction.to_h["events"].find { |e| e["name"] == "enqueue.delayed_job" }
           expect(event).to_not be_nil
@@ -52,7 +52,7 @@ if DependencyHelper.delayed_job_present?
           transaction = http_request_transaction
           set_current_transaction(transaction)
 
-          Delayed::Job.enqueue(DelayedTestJob.new)
+          Delayed::Job.enqueue(DelayedTestJob.new, :queue => "dj-queue")
           Appsignal::Transaction.complete_current!
 
           # Delayed Job has no envelope to carry trace context, so -- like
@@ -62,6 +62,10 @@ if DependencyHelper.delayed_job_present?
           expect(producer.name).to eq("enqueue.delayed_job (enqueue DelayedTestJob job)")
           expect(scope_of(producer)).to eq(["appsignal-ruby/delayed_job", Appsignal::VERSION])
           expect(producer.kind).to eq(:producer)
+          expect(producer.attributes["messaging.system"]).to eq("delayed_job")
+          expect(producer.attributes["messaging.operation.name"]).to eq("enqueue")
+          expect(producer.attributes["messaging.operation.type"]).to eq("send")
+          expect(producer.attributes["messaging.destination.name"]).to eq("dj-queue")
           expect(producer.parent_span_id).to eq(root_span.span_id)
         end
       end
@@ -144,7 +148,7 @@ if DependencyHelper.delayed_job_present?
       context "with a normal job" do
         it "wraps it in a background_job transaction", :agent_mode do
           start_agent
-          job = Delayed::Job.enqueue(DelayedTestJob.new)
+          job = Delayed::Job.enqueue(DelayedTestJob.new, :queue => "dj-queue")
 
           keep_transactions { perform_job(job) }
 
@@ -158,16 +162,24 @@ if DependencyHelper.delayed_job_present?
 
         it "wraps it in a consumer span", :collector_mode do
           start_collector_agent
-          job = Delayed::Job.enqueue(DelayedTestJob.new)
+          job = Delayed::Job.enqueue(DelayedTestJob.new, :queue => "dj-queue")
 
           perform_job(job)
           Appsignal::Transaction.complete_current!
 
           expect(root_span.kind).to eq(:consumer)
+          expect(root_span.attributes["messaging.system"]).to eq("delayed_job")
+          expect(root_span.attributes["messaging.operation.name"]).to eq("perform")
+          expect(root_span.attributes["messaging.operation.type"]).to eq("process")
+          expect(root_span.attributes["messaging.destination.name"]).to eq("dj-queue")
           expect(root_span.attributes["appsignal.action_name"]).to eq("DelayedTestJob#perform")
           expect(root_span.attributes["appsignal.namespace"]).to eq("background")
           expect(event_spans.map(&:name)).to include("perform_job.delayed_job")
           perform_span = event_spans.find { |s| s.name == "perform_job.delayed_job" }
+          expect(perform_span.attributes["messaging.system"]).to eq("delayed_job")
+          expect(perform_span.attributes["messaging.operation.name"]).to eq("perform")
+          expect(perform_span.attributes["messaging.operation.type"]).to eq("process")
+          expect(perform_span.attributes["messaging.destination.name"]).to eq("dj-queue")
           expect(scope_of(root_span)).to eq(["appsignal-ruby/delayed_job", Appsignal::VERSION])
           expect(scope_of(perform_span)).to eq(["appsignal-ruby/delayed_job", Appsignal::VERSION])
         end

--- a/spec/lib/appsignal/integrations/excon_spec.rb
+++ b/spec/lib/appsignal/integrations/excon_spec.rb
@@ -38,6 +38,19 @@ if DependencyHelper.excon_present?
         span = event_span_for("request.excon")
         expect(span).not_to be_nil
         expect(span.kind).to eq(:client)
+        expect(span.attributes["http.request.method"]).to eq("GET")
+        # The client hands us the method as a lowercase Symbol, so the
+        # canonical form is recorded and the original kept alongside it.
+        expect(span.attributes["http.request.method_original"]).to eq("get")
+        expect(span.attributes["server.address"]).to eq("www.example.com")
+        expect(span.attributes["server.port"]).to eq(80)
+        expect(span.attributes["url.full"]).to eq("http://www.example.com/")
+        # Excon reports the request and the response as two separate
+        # notifications, so the status lands on the response's own span rather
+        # than on this one.
+        expect(span.attributes).to_not have_key("http.response.status_code")
+        expect(event_span_for("response.excon").attributes["http.response.status_code"])
+          .to eq(200)
         expect(span.parent_span_id).to eq(root_span.span_id)
         expect(scope_of(span)).to eq(["appsignal-ruby/excon", Appsignal::VERSION])
 

--- a/spec/lib/appsignal/integrations/faraday_spec.rb
+++ b/spec/lib/appsignal/integrations/faraday_spec.rb
@@ -45,6 +45,14 @@ if DependencyHelper.faraday_present?
         faraday_span = event_span("request.faraday")
         expect(faraday_span).not_to be_nil
         expect(faraday_span.kind).to eq(:client)
+        expect(faraday_span.attributes["http.request.method"]).to eq("GET")
+        # The client hands us the method as a lowercase Symbol, so the
+        # canonical form is recorded and the original kept alongside it.
+        expect(faraday_span.attributes["http.request.method_original"]).to eq("get")
+        expect(faraday_span.attributes["server.address"]).to eq("www.example.com")
+        expect(faraday_span.attributes["server.port"]).to eq(80)
+        expect(faraday_span.attributes["url.full"]).to eq("http://www.example.com/")
+        expect(faraday_span.attributes["http.response.status_code"]).to eq(200)
         expect(faraday_span.parent_span_id).to eq(root_span.span_id)
         expect(scope_of(faraday_span)).to eq(["appsignal-ruby/faraday", Appsignal::VERSION])
 

--- a/spec/lib/appsignal/integrations/http_spec.rb
+++ b/spec/lib/appsignal/integrations/http_spec.rb
@@ -39,6 +39,14 @@ if DependencyHelper.http_present?
         span = event_spans.first
         expect(span.name).to eq("request.http_rb (GET http://www.google.com)")
         expect(span.kind).to eq(:client)
+        expect(span.attributes["http.request.method"]).to eq("GET")
+        # The client hands us the method as a lowercase Symbol, so the
+        # canonical form is recorded and the original kept alongside it.
+        expect(span.attributes["http.request.method_original"]).to eq("get")
+        expect(span.attributes["server.address"]).to eq("www.google.com")
+        expect(span.attributes["server.port"]).to eq(80)
+        expect(span.attributes["url.full"]).to eq("http://www.google.com/")
+        expect(span.attributes["http.response.status_code"]).to eq(200)
         expect(span.parent_span_id).to eq(root_span.span_id)
         expect(event_category(span)).to eq("request.http_rb")
         expect(scope_of(span)).to eq(["appsignal-ruby/http_rb", Appsignal::VERSION])
@@ -84,6 +92,14 @@ if DependencyHelper.http_present?
         span = event_spans.first
         expect(span.name).to eq("request.http_rb (GET https://www.google.com)")
         expect(span.kind).to eq(:client)
+        expect(span.attributes["http.request.method"]).to eq("GET")
+        # The client hands us the method as a lowercase Symbol, so the
+        # canonical form is recorded and the original kept alongside it.
+        expect(span.attributes["http.request.method_original"]).to eq("get")
+        expect(span.attributes["server.address"]).to eq("www.google.com")
+        expect(span.attributes["server.port"]).to eq(443)
+        expect(span.attributes["url.full"]).to eq("https://www.google.com/")
+        expect(span.attributes["http.response.status_code"]).to eq(200)
         expect(span.parent_span_id).to eq(root_span.span_id)
         expect(event_category(span)).to eq("request.http_rb")
         expect(scope_of(span)).to eq(["appsignal-ruby/http_rb", Appsignal::VERSION])
@@ -125,6 +141,10 @@ if DependencyHelper.http_present?
           expect(event_category(span)).to eq("request.http_rb")
           expect(scope_of(span)).to eq(["appsignal-ruby/http_rb", Appsignal::VERSION])
           expect(span.attributes).not_to have_key("appsignal.body")
+          # The query parameters are the client's to add, and they stay out of
+          # the URL too.
+          expect(span.attributes["url.full"]).to eq("https://www.google.com/")
+          expect(span.attributes["http.response.status_code"]).to eq(200)
         end
       end
 
@@ -199,6 +219,10 @@ if DependencyHelper.http_present?
         span = event_spans.first
         expect(span.name).to eq("request.http_rb (GET http://www.google.com)")
         expect(span.kind).to eq(:client)
+        expect(span.attributes["http.request.method"]).to eq("GET")
+        # The client hands us the method as a lowercase Symbol, so the
+        # canonical form is recorded and the original kept alongside it.
+        expect(span.attributes["http.request.method_original"]).to eq("get")
         expect(event_category(span)).to eq("request.http_rb")
         expect(scope_of(span)).to eq(["appsignal-ruby/http_rb", Appsignal::VERSION])
       end

--- a/spec/lib/appsignal/integrations/mongo_ruby_driver_spec.rb
+++ b/spec/lib/appsignal/integrations/mongo_ruby_driver_spec.rb
@@ -26,8 +26,8 @@ describe Appsignal::Hooks::MongoMonitorSubscriber do
       )
     end
 
-    # `failure` is the error document MongoDB replied with, which carries its
-    # own code for the error in the `code` field.
+    # `failure` is the error document MongoDB replied with, which names the error
+    # in its `codeName` field.
     def command_failed_event( # rubocop:disable Metrics/ParameterLists
       started_event, request_id: 1, command_name: "find",
       database_name: "test", duration: 0.9919,
@@ -103,7 +103,7 @@ describe Appsignal::Hooks::MongoMonitorSubscriber do
         # This command names no collection, so none is reported.
         expect(span.attributes).not_to have_key("db.collection.name")
         expect(span.attributes["appsignal.body"]).to eq("{\"foo\":\"?\"}")
-        expect(span.attributes).not_to have_key("db.response.status_code")
+        expect(span.attributes).not_to have_key("error.type")
 
         snapshot = metric_snapshot("mongodb_query_duration")
         expect(snapshot).not_to be_nil
@@ -194,13 +194,14 @@ describe Appsignal::Hooks::MongoMonitorSubscriber do
         expect(scope_of(span)).to eq(["appsignal-ruby/mongo", Appsignal::VERSION])
         expect(span.attributes["db.system.name"]).to eq("mongodb")
         expect(span.attributes["appsignal.body"]).to eq("{\"foo\":\"?\"}")
-        # The query failed, and MongoDB reported its own code for the error in
-        # the document it replied with.
+        # The query failed, and MongoDB named the error in the document it
+        # replied with, along with its own code for it.
+        expect(span.attributes["error.type"]).to eq("NamespaceNotFound")
         expect(span.attributes["db.response.status_code"]).to eq("26")
       end
     end
 
-    describe "instrumenting a query that failed without an error code" do
+    describe "instrumenting a query that failed without a named error" do
       let(:started_event) { command_started_event(:request_id => 2) }
       let(:failed_event) do
         command_failed_event(started_event, :request_id => 2, :failure => {})
@@ -235,7 +236,9 @@ describe Appsignal::Hooks::MongoMonitorSubscriber do
         span = event_span_for("query.mongodb")
         expect(span).not_to be_nil
         # A dropped connection is a failure MongoDB never replied to, so there
-        # is no code to report.
+        # is no error name or code to report. The span says what it can with
+        # the fallback the semantic conventions define.
+        expect(span.attributes["error.type"]).to eq("_OTHER")
         expect(span.attributes).to_not have_key("db.response.status_code")
       end
     end

--- a/spec/lib/appsignal/integrations/mongo_ruby_driver_spec.rb
+++ b/spec/lib/appsignal/integrations/mongo_ruby_driver_spec.rb
@@ -26,12 +26,15 @@ describe Appsignal::Hooks::MongoMonitorSubscriber do
       )
     end
 
-    def command_failed_event(
+    # `failure` is the error document MongoDB replied with, which carries its
+    # own code for the error in the `code` field.
+    def command_failed_event( # rubocop:disable Metrics/ParameterLists
       started_event, request_id: 1, command_name: "find",
-      database_name: "test", duration: 0.9919
+      database_name: "test", duration: 0.9919,
+      failure: { "code" => 26, "codeName" => "NamespaceNotFound" }
     )
       Mongo::Monitoring::Event::CommandFailed.new(
-        command_name, database_name, address, request_id, 1, "message", {}, duration,
+        command_name, database_name, address, request_id, 1, "message", failure, duration,
         :started_event => started_event
       )
     end
@@ -92,12 +95,64 @@ describe Appsignal::Hooks::MongoMonitorSubscriber do
         expect(span.parent_span_id).to eq(root_span.span_id)
         expect(event_category(span)).to eq("query.mongodb")
         expect(scope_of(span)).to eq(["appsignal-ruby/mongo", Appsignal::VERSION])
+        expect(span.attributes["db.system.name"]).to eq("mongodb")
+        expect(span.attributes["db.operation.name"]).to eq("find")
+        expect(span.attributes["db.namespace"]).to eq("test")
+        expect(span.attributes["server.address"]).to eq("127.0.0.1")
+        expect(span.attributes["server.port"]).to eq(27_017)
+        # This command names no collection, so none is reported.
+        expect(span.attributes).not_to have_key("db.collection.name")
         expect(span.attributes["appsignal.body"]).to eq("{\"foo\":\"?\"}")
+        expect(span.attributes).not_to have_key("db.response.status_code")
 
         snapshot = metric_snapshot("mongodb_query_duration")
         expect(snapshot).not_to be_nil
         expect(snapshot.data_points.first.sum).to be_within(0.0001).of(0.9919)
         expect(snapshot.data_points.first.attributes).to eq("database" => "test")
+      end
+    end
+
+    describe "instrumenting a query on a collection" do
+      let(:started_event) do
+        command_started_event(
+          :request_id => 2,
+          :command => { "find" => "users", "filter" => { "foo" => "bar" } }
+        )
+      end
+      let(:succeeded_event) { command_succeeded_event(started_event, :request_id => 2) }
+
+      def perform
+        subscriber.started(started_event)
+        subscriber.succeeded(succeeded_event)
+      end
+
+      it "in agent mode", :agent_mode do
+        start_agent
+        transaction = http_request_transaction
+        set_current_transaction(transaction)
+
+        perform
+
+        expect(transaction).to include_event(
+          "name" => "query.mongodb",
+          "title" => "find | test | SUCCEEDED",
+          "body" => "{\"find\":\"users\",\"filter\":{\"foo\":\"?\"}}"
+        )
+      end
+
+      it "in collector mode", :collector_mode do
+        start_collector_agent
+        transaction = http_request_transaction
+        set_current_transaction(transaction)
+        perform
+        Appsignal::Transaction.complete_current!
+
+        span = event_span_for("query.mongodb")
+        expect(span).not_to be_nil
+        # MongoDB names the collection in the field named after the command, so
+        # a query on one reports it.
+        expect(span.attributes["db.collection.name"]).to eq("users")
+        expect(span.attributes["db.operation.name"]).to eq("find")
       end
     end
 
@@ -137,7 +192,51 @@ describe Appsignal::Hooks::MongoMonitorSubscriber do
         expect(span.kind).to eq(:client)
         expect(event_category(span)).to eq("query.mongodb")
         expect(scope_of(span)).to eq(["appsignal-ruby/mongo", Appsignal::VERSION])
+        expect(span.attributes["db.system.name"]).to eq("mongodb")
         expect(span.attributes["appsignal.body"]).to eq("{\"foo\":\"?\"}")
+        # The query failed, and MongoDB reported its own code for the error in
+        # the document it replied with.
+        expect(span.attributes["db.response.status_code"]).to eq("26")
+      end
+    end
+
+    describe "instrumenting a query that failed without an error code" do
+      let(:started_event) { command_started_event(:request_id => 2) }
+      let(:failed_event) do
+        command_failed_event(started_event, :request_id => 2, :failure => {})
+      end
+
+      def perform
+        subscriber.started(started_event)
+        subscriber.failed(failed_event)
+      end
+
+      it "in agent mode", :agent_mode do
+        start_agent
+        transaction = http_request_transaction
+        set_current_transaction(transaction)
+
+        perform
+
+        expect(transaction).to include_event(
+          "name" => "query.mongodb",
+          "title" => "find | test | FAILED",
+          "body" => "{\"foo\":\"?\"}"
+        )
+      end
+
+      it "in collector mode", :collector_mode do
+        start_collector_agent
+        transaction = http_request_transaction
+        set_current_transaction(transaction)
+        perform
+        Appsignal::Transaction.complete_current!
+
+        span = event_span_for("query.mongodb")
+        expect(span).not_to be_nil
+        # A dropped connection is a failure MongoDB never replied to, so there
+        # is no code to report.
+        expect(span.attributes).to_not have_key("db.response.status_code")
       end
     end
 

--- a/spec/lib/appsignal/integrations/net_http_spec.rb
+++ b/spec/lib/appsignal/integrations/net_http_spec.rb
@@ -32,6 +32,11 @@ describe Appsignal::Integrations::NetHttpIntegration do
       span = event_spans.first
       expect(span.name).to eq("request.net_http (GET http://www.google.com)")
       expect(span.kind).to eq(:client)
+      expect(span.attributes["http.request.method"]).to eq("GET")
+      expect(span.attributes["server.address"]).to eq("www.google.com")
+      expect(span.attributes["server.port"]).to eq(80)
+      expect(span.attributes["url.full"]).to eq("http://www.google.com/")
+      expect(span.attributes["http.response.status_code"]).to eq(200)
       expect(span.parent_span_id).to eq(root_span.span_id)
       expect(event_category(span)).to eq("request.net_http")
       expect(scope_of(span)).to eq(["appsignal-ruby/net_http", Appsignal::VERSION])
@@ -78,6 +83,11 @@ describe Appsignal::Integrations::NetHttpIntegration do
       span = event_spans.first
       expect(span.name).to eq("request.net_http (GET https://www.google.com)")
       expect(span.kind).to eq(:client)
+      expect(span.attributes["http.request.method"]).to eq("GET")
+      expect(span.attributes["server.address"]).to eq("www.google.com")
+      expect(span.attributes["server.port"]).to eq(443)
+      expect(span.attributes["url.full"]).to eq("https://www.google.com/")
+      expect(span.attributes["http.response.status_code"]).to eq(200)
       expect(span.parent_span_id).to eq(root_span.span_id)
       expect(event_category(span)).to eq("request.net_http")
       expect(scope_of(span)).to eq(["appsignal-ruby/net_http", Appsignal::VERSION])
@@ -85,6 +95,72 @@ describe Appsignal::Integrations::NetHttpIntegration do
 
       expect(injected_traceparent("https://www.google.com/"))
         .to eq("00-#{span.hex_trace_id}-#{span.hex_span_id}-01")
+    end
+  end
+
+  describe "a request with a path and a query string" do
+    def perform
+      stub_request(:any, "http://www.google.com/search?q=secret")
+
+      Net::HTTP.get_response(URI.parse("http://www.google.com/search?q=secret"))
+    end
+
+    it "in agent mode", :agent_mode do
+      start_agent
+      transaction = http_request_transaction
+      set_current_transaction(transaction)
+      perform
+
+      expect(transaction).to include_event(
+        "name" => "request.net_http",
+        "title" => "GET http://www.google.com",
+        "body" => ""
+      )
+    end
+
+    it "in collector mode", :collector_mode do
+      start_collector_agent
+      transaction = http_request_transaction
+      set_current_transaction(transaction)
+      perform
+      Appsignal::Transaction.complete_current!
+
+      span = event_spans.first
+      # The client gives us a request target, which carries the query string.
+      # The URL keeps the path and drops the query string.
+      expect(span.attributes["url.full"]).to eq("http://www.google.com/search")
+    end
+  end
+
+  describe "a request the server answered with an error" do
+    def perform
+      stub_request(:any, "http://www.google.com/").to_return(:status => 503)
+
+      Net::HTTP.get_response(URI.parse("http://www.google.com"))
+    end
+
+    it "in agent mode", :agent_mode do
+      start_agent
+      transaction = http_request_transaction
+      set_current_transaction(transaction)
+      perform
+
+      expect(transaction).to include_event(
+        "name" => "request.net_http",
+        "title" => "GET http://www.google.com"
+      )
+    end
+
+    it "in collector mode", :collector_mode do
+      start_collector_agent
+      transaction = http_request_transaction
+      set_current_transaction(transaction)
+      perform
+      Appsignal::Transaction.complete_current!
+
+      # A response the server answered with an error is still a response, so it
+      # is reported the same way a successful one is.
+      expect(event_spans.first.attributes["http.response.status_code"]).to eq(503)
     end
   end
 

--- a/spec/lib/appsignal/integrations/que_spec.rb
+++ b/spec/lib/appsignal/integrations/que_spec.rb
@@ -80,11 +80,19 @@ if DependencyHelper.que_present?
             expect { perform }.to change { created_transactions.length }.by(1)
 
             expect(root_span.kind).to eq(:consumer)
+            expect(root_span.attributes["messaging.system"]).to eq("que")
+            expect(root_span.attributes["messaging.operation.name"]).to eq("perform")
+            expect(root_span.attributes["messaging.operation.type"]).to eq("process")
+            expect(root_span.attributes["messaging.destination.name"]).to eq("dfl")
             expect(root_span.attributes["appsignal.namespace"])
               .to eq("background")
             expect(root_span.attributes["appsignal.action_name"]).to eq("MyQueJob#run")
             expect(exception_events).to be_empty
             span = event_spans.find { |s| s.name == "perform_job.que" }
+            expect(span.attributes["messaging.system"]).to eq("que")
+            expect(span.attributes["messaging.operation.name"]).to eq("perform")
+            expect(span.attributes["messaging.operation.type"]).to eq("process")
+            expect(span.attributes["messaging.destination.name"]).to eq("dfl")
             expect(span).not_to be_nil
             expect(span.parent_span_id).to eq(root_span.span_id)
             expect(span.attributes).not_to have_key("appsignal.body")
@@ -500,6 +508,13 @@ if DependencyHelper.que_present?
         expect(producer.name).to eq("enqueue.que (enqueue MyQueJob job)")
         expect(scope_of(producer)).to eq(["appsignal-ruby/que", Appsignal::VERSION])
         expect(producer.kind).to eq(:producer)
+        expect(producer.attributes["messaging.system"]).to eq("que")
+        expect(producer.attributes["messaging.operation.name"]).to eq("enqueue")
+        expect(producer.attributes["messaging.operation.type"]).to eq("send")
+        # Que only records the queue on the job itself. An enqueue that does not
+        # name one gets Que's default, which this integration cannot see, so no
+        # queue is reported.
+        expect(producer.attributes).to_not have_key("messaging.destination.name")
         expect(producer.parent_span_id).to eq(root_span.span_id)
 
         if DependencyHelper.que1_present?
@@ -654,6 +669,12 @@ if DependencyHelper.que_present?
           producer = producers.first
           expect(producer.name).to eq("bulk_enqueue.que (bulk enqueue MyQueJob jobs)")
           expect(producer.kind).to eq(:producer)
+          expect(producer.attributes["messaging.system"]).to eq("que")
+          expect(producer.attributes["messaging.operation.name"]).to eq("enqueue")
+          expect(producer.attributes["messaging.operation.type"]).to eq("send")
+          # As with a single enqueue, a batch that does not name a queue gets
+          # Que's default, which this integration cannot see.
+          expect(producer.attributes).to_not have_key("messaging.destination.name")
           expect(producer.parent_span_id).to eq(root_span.span_id)
 
           # Every job in the batch carries the one producer span's context, plus

--- a/spec/lib/appsignal/integrations/resque_spec.rb
+++ b/spec/lib/appsignal/integrations/resque_spec.rb
@@ -53,12 +53,20 @@ if DependencyHelper.resque_present?
         perform
 
         expect(root_span.kind).to eq(:consumer)
+        expect(root_span.attributes["messaging.system"]).to eq("resque")
+        expect(root_span.attributes["messaging.operation.name"]).to eq("perform")
+        expect(root_span.attributes["messaging.operation.type"]).to eq("process")
+        expect(root_span.attributes["messaging.destination.name"]).to eq("default")
         expect(root_span.attributes["appsignal.namespace"]).to eq("background")
         expect(root_span.attributes["appsignal.action_name"]).to eq("ResqueTestJob#perform")
         expect(exception_events).to be_empty
         expect(root_span.attributes).to_not have_key("appsignal.tag.metadata_key")
         expect(root_span.attributes["appsignal.tag.queue"]).to eq(queue)
         span = event_spans.find { |s| s.name == "perform.resque" }
+        expect(span.attributes["messaging.system"]).to eq("resque")
+        expect(span.attributes["messaging.operation.name"]).to eq("perform")
+        expect(span.attributes["messaging.operation.type"]).to eq("process")
+        expect(span.attributes["messaging.destination.name"]).to eq("default")
         expect(span).not_to be_nil
         expect(span.parent_span_id).to eq(root_span.span_id)
         expect(scope_of(root_span)).to eq(["appsignal-ruby/resque", Appsignal::VERSION])
@@ -271,6 +279,10 @@ if DependencyHelper.resque_present?
           expect(producer.name).to eq("enqueue.resque (enqueue ResqueTestJob job)")
           expect(scope_of(producer)).to eq(["appsignal-ruby/resque", Appsignal::VERSION])
           expect(producer.kind).to eq(:producer)
+          expect(producer.attributes["messaging.system"]).to eq("resque")
+          expect(producer.attributes["messaging.operation.name"]).to eq("enqueue")
+          expect(producer.attributes["messaging.operation.type"]).to eq("send")
+          expect(producer.attributes["messaging.destination.name"]).to eq("default")
           expect(producer.parent_span_id).to eq(root_span.span_id)
 
           # The job carries the producer span's trace context, so the job that

--- a/spec/lib/appsignal/integrations/shoryuken_client_spec.rb
+++ b/spec/lib/appsignal/integrations/shoryuken_client_spec.rb
@@ -61,6 +61,10 @@ if DependencyHelper.shoryuken_present?
       producer = event_span_for("enqueue.shoryuken")
       expect(producer.name).to eq("enqueue.shoryuken (enqueue on test-queue)")
       expect(producer.kind).to eq(:producer)
+      expect(producer.attributes["messaging.system"]).to eq("aws_sqs")
+      expect(producer.attributes["messaging.operation.name"]).to eq("enqueue")
+      expect(producer.attributes["messaging.operation.type"]).to eq("send")
+      expect(producer.attributes["messaging.destination.name"]).to eq("test-queue")
 
       # The middleware the hook registered injected the producer span's trace
       # context onto the real outgoing message, wire-equivalent to OpenTelemetry's

--- a/spec/lib/appsignal/integrations/shoryuken_spec.rb
+++ b/spec/lib/appsignal/integrations/shoryuken_spec.rb
@@ -79,6 +79,10 @@ describe Appsignal::Integrations::ShoryukenMiddleware do
           expect { perform }.to change { created_transactions.length }.by(1)
 
           expect(root_span.kind).to eq(:consumer)
+          expect(root_span.attributes["messaging.system"]).to eq("aws_sqs")
+          expect(root_span.attributes["messaging.operation.name"]).to eq("perform")
+          expect(root_span.attributes["messaging.operation.type"]).to eq("process")
+          expect(root_span.attributes["messaging.destination.name"]).to eq("some-funky-queue-name")
           expect(root_span.attributes["appsignal.namespace"])
             .to eq("background")
           expect(root_span.name).to eq("DemoShoryukenWorker#perform")
@@ -86,6 +90,14 @@ describe Appsignal::Integrations::ShoryukenMiddleware do
             .to eq("DemoShoryukenWorker#perform")
           expect(exception_events).to be_empty
           span = event_spans.find { |s| s.name == "perform_job.shoryuken" }
+          expect(span.attributes["messaging.system"]).to eq("aws_sqs")
+          expect(span.attributes["messaging.operation.name"]).to eq("perform")
+          expect(span.attributes["messaging.operation.type"]).to eq("process")
+          expect(span.attributes["messaging.destination.name"]).to eq("some-funky-queue-name")
+          # A single message is not a batch, so the conventions say a span for
+          # one must not carry a message count.
+          expect(root_span.attributes).to_not have_key("messaging.batch.message_count")
+          expect(span.attributes).to_not have_key("messaging.batch.message_count")
           expect(span).not_to be_nil
           expect(span.parent_span_id).to eq(root_span.span_id)
           expect(span.attributes).not_to have_key("appsignal.body")
@@ -349,6 +361,9 @@ describe Appsignal::Integrations::ShoryukenMiddleware do
           )
         expect(root_span.attributes["appsignal.tag.batch"]).to eq(true)
         expect(root_span.attributes["appsignal.tag.queue"]).to eq("some-funky-queue-name")
+        # This call covers a batch, so it says how many messages are in it.
+        expect(root_span.attributes["messaging.batch.message_count"]).to eq(2)
+        expect(span.attributes["messaging.batch.message_count"]).to eq(2)
         # Earliest/oldest timestamp from messages
         expect(root_span.attributes["appsignal.tag.SentTimestamp"])
           .to eq(sent_timestamp.to_s)
@@ -414,6 +429,10 @@ describe Appsignal::Integrations::ShoryukenClientMiddleware do
         expect(producer.name).to eq("enqueue.shoryuken (enqueue MyShoryukenWorker job)")
         expect(scope_of(producer)).to eq(["appsignal-ruby/shoryuken", Appsignal::VERSION])
         expect(producer.kind).to eq(:producer)
+        expect(producer.attributes["messaging.system"]).to eq("aws_sqs")
+        expect(producer.attributes["messaging.operation.name"]).to eq("enqueue")
+        expect(producer.attributes["messaging.operation.type"]).to eq("send")
+        expect(producer.attributes["messaging.destination.name"]).to eq("my-queue")
         expect(producer.parent_span_id).to eq(root_span.span_id)
 
         # The message carries the producer span's trace context as an SQS message

--- a/spec/lib/appsignal/integrations/sidekiq_spec.rb
+++ b/spec/lib/appsignal/integrations/sidekiq_spec.rb
@@ -140,6 +140,12 @@ if DependencyHelper.sidekiq_present?
             perform
 
             expect(root_span.kind).to eq(:consumer)
+            expect(root_span.attributes["messaging.system"]).to eq("sidekiq")
+            expect(root_span.attributes["messaging.operation.name"]).to eq("perform")
+            expect(root_span.attributes["messaging.operation.type"]).to eq("process")
+            # This transaction stands in for a job that could not be processed,
+            # so there is no job and no queue to name.
+            expect(root_span.attributes).to_not have_key("messaging.destination.name")
             expect(scope_of(root_span)).to eq(["appsignal-ruby/sidekiq", Appsignal::VERSION])
             expect(root_span.attributes["appsignal.action_name"])
               .to eq("SidekiqInternal")
@@ -327,7 +333,9 @@ if DependencyHelper.sidekiq_present?
 
   describe Appsignal::Integrations::SidekiqClientMiddleware do
     let(:plugin) { described_class.new }
-    let(:job) { { "class" => "TestClass", "args" => [] } }
+    # Sidekiq fills the queue in before it calls the client middleware, so the
+    # job hash the middleware is given always names one.
+    let(:job) { { "class" => "TestClass", "args" => [], "queue" => "default" } }
 
     def enqueue
       plugin.call("TestClass", job, "default", nil) { :enqueued }
@@ -362,6 +370,10 @@ if DependencyHelper.sidekiq_present?
         producer = event_span_for("enqueue.sidekiq")
         expect(producer.name).to eq("enqueue.sidekiq (enqueue TestClass job)")
         expect(producer.kind).to eq(:producer)
+        expect(producer.attributes["messaging.system"]).to eq("sidekiq")
+        expect(producer.attributes["messaging.operation.name"]).to eq("enqueue")
+        expect(producer.attributes["messaging.operation.type"]).to eq("send")
+        expect(producer.attributes["messaging.destination.name"]).to eq("default")
         expect(producer.parent_span_id).to eq(root_span.span_id)
         expect(scope_of(producer)).to eq(["appsignal-ruby/sidekiq", Appsignal::VERSION])
 
@@ -901,6 +913,10 @@ if DependencyHelper.sidekiq_present?
           expect(root_span.attributes["appsignal.tag.request_id"]).to eq(jid)
           expect(event_spans.size).to eq(1)
           span = event_spans.find { |s| s.name == "perform_job.sidekiq" }
+          expect(span.attributes["messaging.system"]).to eq("sidekiq")
+          expect(span.attributes["messaging.operation.name"]).to eq("perform")
+          expect(span.attributes["messaging.operation.type"]).to eq("process")
+          expect(span.attributes["messaging.destination.name"]).to eq("default")
           expect(span).not_to be_nil
           expect(span.parent_span_id).to eq(root_span.span_id)
           expect(span.attributes).not_to have_key("appsignal.body")

--- a/spec/lib/appsignal/integrations/webmachine_spec.rb
+++ b/spec/lib/appsignal/integrations/webmachine_spec.rb
@@ -74,6 +74,46 @@ if DependencyHelper.webmachine_present?
         end
       end
 
+      describe "marking the transaction as an incoming HTTP request" do
+        # These describe the request as a whole, so they belong on the
+        # transaction's span and on none of the events recorded within it.
+        it "sets the request attributes on the transaction span only", :collector_mode do
+          start_collector_agent
+          perform
+
+          expect(root_span.attributes["http.request.method"]).to eq("GET")
+          # The path and scheme come off the request's URI, which Webmachine
+          # builds from the full request URL. The query string is a separate
+          # attribute, so it must not end up in the path.
+          expect(root_span.attributes["url.path"]).to eq("/foo")
+          expect(root_span.attributes["url.scheme"]).to eq("http")
+          expect(root_span.attributes["url.query"])
+            .to eq("param1=value1&param2=value2")
+          expect(event_spans).to_not be_empty
+          event_spans.each do |span|
+            expect(span.attributes).to_not have_key("http.request.method")
+            expect(span.attributes).to_not have_key("url.path")
+            expect(span.attributes).to_not have_key("url.scheme")
+            expect(span.attributes).to_not have_key("url.query")
+          end
+        end
+      end
+
+      describe "describing the response" do
+        # The event has closed by the time the response code is known, which is
+        # what makes the transaction's own span the one this lands on.
+        it "sets the response status on the transaction span only", :collector_mode do
+          start_collector_agent
+          perform
+
+          expect(root_span.attributes["http.response.status_code"]).to eq(200)
+          expect(event_spans).to_not be_empty
+          event_spans.each do |span|
+            expect(span.attributes).to_not have_key("http.response.status_code")
+          end
+        end
+      end
+
       context "with action already set" do
         let(:app) do
           proc do

--- a/spec/lib/appsignal/opentelemetry/error_type_spec.rb
+++ b/spec/lib/appsignal/opentelemetry/error_type_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+describe Appsignal::OpenTelemetry::ErrorType do
+  describe ".attributes_for" do
+    it "uses an exception class name as it is" do
+      expect(described_class.attributes_for("RuntimeError")).to eq(
+        "error.type" => "RuntimeError"
+      )
+    end
+
+    it "uses a datastore's error code as it is" do
+      expect(described_class.attributes_for("NamespaceNotFound")).to eq(
+        "error.type" => "NamespaceNotFound"
+      )
+    end
+
+    # An anonymous exception class has no name, and a datastore does not always
+    # report a code, so there has to be something to fall back to.
+    it "reports a failure without a name as _OTHER" do
+      expect(described_class.attributes_for(nil)).to eq("error.type" => "_OTHER")
+      expect(described_class.attributes_for("")).to eq("error.type" => "_OTHER")
+    end
+
+    it "reports an anonymous exception class as _OTHER" do
+      error_class = Class.new(StandardError)
+
+      expect(described_class.attributes_for(error_class.name)).to eq(
+        "error.type" => "_OTHER"
+      )
+    end
+  end
+end

--- a/spec/lib/appsignal/opentelemetry/http_client_request_spec.rb
+++ b/spec/lib/appsignal/opentelemetry/http_client_request_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+describe Appsignal::OpenTelemetry::HttpClientRequest do
+  describe ".attributes_for" do
+    def attributes_for(**args)
+      described_class.attributes_for(**args)
+    end
+
+    it "describes the method, the host and port, and the URL" do
+      expect(
+        attributes_for(
+          :method => "GET",
+          :scheme => "https",
+          :host => "example.com",
+          :port => 443,
+          :path => "/users/1"
+        )
+      ).to eq(
+        "http.request.method" => "GET",
+        "server.address" => "example.com",
+        "server.port" => 443,
+        "url.full" => "https://example.com/users/1"
+      )
+    end
+
+    # A URL is normally written without the port its scheme implies, but the
+    # conventions ask for the port either way.
+    it "leaves a scheme's own port out of the URL" do
+      expect(
+        attributes_for(:method => "GET", :scheme => "http", :host => "example.com", :port => 80)
+      ).to include(
+        "server.port" => 80,
+        "url.full" => "http://example.com/"
+      )
+    end
+
+    it "keeps a port the scheme does not imply in the URL" do
+      expect(
+        attributes_for(
+          :method => "GET", :scheme => "http", :host => "example.com", :port => 8080,
+          :path => "/path"
+        )
+      ).to include(
+        "server.port" => 8080,
+        "url.full" => "http://example.com:8080/path"
+      )
+    end
+
+    # Some clients only name a port when the URL did, so the scheme's own port
+    # has to stand in. The conventions ask for the port on every client span.
+    it "falls back to the scheme's own port" do
+      expect(
+        attributes_for(:method => "GET", :scheme => "https", :host => "example.com")
+      ).to include(
+        "server.port" => 443,
+        "url.full" => "https://example.com/"
+      )
+    end
+
+    it "accepts a port given as a String" do
+      expect(
+        attributes_for(:method => "GET", :scheme => "http", :host => "example.com", :port => "8080")
+      ).to include("server.port" => 8080)
+    end
+
+    # Some clients hand us a request target rather than a path, which can carry
+    # the query string along with it.
+    it "cuts the query string off the path" do
+      expect(
+        attributes_for(
+          :method => "GET", :scheme => "https", :host => "example.com",
+          :path => "/search?q=secret"
+        )
+      ).to include("url.full" => "https://example.com/search")
+    end
+
+    # A URL can carry a username and password, which must not be sent. Building
+    # the URL from the parts means there is nowhere for them to come from.
+    it "cannot include credentials" do
+      expect(
+        attributes_for(
+          :method => "GET", :scheme => "https", :host => "example.com", :path => "/path"
+        )["url.full"]
+      ).to eq("https://example.com/path")
+    end
+
+    it "leaves out the URL when there is no host to build it from" do
+      attributes = attributes_for(:method => "GET", :scheme => "https")
+
+      expect(attributes).to_not have_key("url.full")
+      expect(attributes).to_not have_key("server.address")
+      expect(attributes["http.request.method"]).to eq("GET")
+    end
+
+    it "leaves out the URL when there is no scheme to build it from" do
+      attributes = attributes_for(:method => "GET", :host => "example.com")
+
+      expect(attributes).to_not have_key("url.full")
+      expect(attributes).to_not have_key("server.port")
+      expect(attributes["server.address"]).to eq("example.com")
+    end
+
+    it "normalizes the request method" do
+      expect(
+        attributes_for(:method => :get, :scheme => "https", :host => "example.com")
+      ).to include(
+        "http.request.method" => "GET",
+        "http.request.method_original" => "get"
+      )
+    end
+
+    # Some clients report the path of a request to the root of a host as empty,
+    # and others as "/". The request goes to "/" either way.
+    it "describes a request without a path as one to the root" do
+      expect(
+        attributes_for(:method => "GET", :scheme => "https", :host => "example.com", :path => "")
+      ).to include("url.full" => "https://example.com/")
+    end
+
+    it "returns no attributes when there is nothing to describe" do
+      expect(attributes_for(:method => nil)).to eq({})
+    end
+  end
+end

--- a/spec/lib/appsignal/opentelemetry/http_method_spec.rb
+++ b/spec/lib/appsignal/opentelemetry/http_method_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+describe Appsignal::OpenTelemetry::HttpMethod do
+  describe ".attributes_for" do
+    it "passes a known method through, with nothing to preserve" do
+      expect(described_class.attributes_for("GET")).to eq(
+        "http.request.method" => "GET"
+      )
+    end
+
+    it "recognizes every method the semantic conventions define" do
+      %w[CONNECT DELETE GET HEAD OPTIONS PATCH POST PUT TRACE].each do |method|
+        expect(described_class.attributes_for(method)).to eq(
+          "http.request.method" => method
+        )
+      end
+    end
+
+    # Method names are case sensitive, so a lowercase method is not the known
+    # method. It is replaced by the canonical form, keeping what we were given.
+    it "upcases a known method given in another case, keeping the original" do
+      expect(described_class.attributes_for("get")).to eq(
+        "http.request.method" => "GET",
+        "http.request.method_original" => "get"
+      )
+    end
+
+    it "accepts a Symbol, as the HTTP client integrations pass" do
+      expect(described_class.attributes_for(:post)).to eq(
+        "http.request.method" => "POST",
+        "http.request.method_original" => "post"
+      )
+    end
+
+    # The conventions treat the method as a closed set, so anything outside it
+    # has to be reported as `_OTHER` rather than passed through.
+    it "reports an unknown method as _OTHER, keeping the original" do
+      expect(described_class.attributes_for("PROPFIND")).to eq(
+        "http.request.method" => "_OTHER",
+        "http.request.method_original" => "PROPFIND"
+      )
+    end
+
+    it "keeps the original of an unknown method exactly as given" do
+      expect(described_class.attributes_for("PropFind")).to eq(
+        "http.request.method" => "_OTHER",
+        "http.request.method_original" => "PropFind"
+      )
+    end
+
+    # Callers that could not read a method pass the result on without checking,
+    # and an empty Hash adds no attributes.
+    it "returns no attributes when there is no method" do
+      expect(described_class.attributes_for(nil)).to eq({})
+      expect(described_class.attributes_for("")).to eq({})
+    end
+  end
+end

--- a/spec/lib/appsignal/opentelemetry/http_response_spec.rb
+++ b/spec/lib/appsignal/opentelemetry/http_response_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+describe Appsignal::OpenTelemetry::HttpResponse do
+  describe ".attributes_for" do
+    it "describes the status code" do
+      expect(described_class.attributes_for(200)).to eq(
+        "http.response.status_code" => 200
+      )
+    end
+
+    it "describes a status code given as a String" do
+      expect(described_class.attributes_for("404")).to eq(
+        "http.response.status_code" => 404
+      )
+    end
+
+    # Callers whose request never produced a response pass the result on without
+    # checking.
+    it "returns no attributes when there is no status" do
+      expect(described_class.attributes_for(nil)).to eq({})
+    end
+
+    it "returns no attributes for a status that is not a number" do
+      expect(described_class.attributes_for("nonsense")).to eq({})
+      expect(described_class.attributes_for("")).to eq({})
+    end
+  end
+end

--- a/spec/lib/appsignal/opentelemetry/http_server_request_spec.rb
+++ b/spec/lib/appsignal/opentelemetry/http_server_request_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+describe Appsignal::OpenTelemetry::HttpServerRequest do
+  describe ".attributes_for" do
+    it "describes the method, path, scheme and query string" do
+      expect(
+        described_class.attributes_for(
+          :method => "GET",
+          :path => "/users/1",
+          :scheme => "https",
+          :query => "page=2&query=lorem"
+        )
+      ).to eq(
+        "http.request.method" => "GET",
+        "url.path" => "/users/1",
+        "url.scheme" => "https",
+        "url.query" => "page=2&query=lorem"
+      )
+    end
+
+    # A request without a query string gets no query attribute, rather than an
+    # empty one. Rack reports a missing query string as an empty String.
+    it "leaves out an empty query string" do
+      expect(
+        described_class.attributes_for(:method => "GET", :path => "/", :query => "")
+      ).to eq(
+        "http.request.method" => "GET",
+        "url.path" => "/"
+      )
+    end
+
+    # The method goes through the same normalization as anywhere else, so an
+    # unknown method is reported as `_OTHER` with the original kept.
+    it "normalizes the request method" do
+      expect(
+        described_class.attributes_for(:method => "get", :path => "/", :scheme => "http")
+      ).to eq(
+        "http.request.method" => "GET",
+        "http.request.method_original" => "get",
+        "url.path" => "/",
+        "url.scheme" => "http"
+      )
+    end
+
+    # Reading any of these from the request can fail, and the callers pass on
+    # whatever they got without checking.
+    it "leaves out a value it was not given" do
+      expect(described_class.attributes_for(:method => "GET")).to eq(
+        "http.request.method" => "GET"
+      )
+    end
+
+    it "leaves out an empty value" do
+      expect(
+        described_class.attributes_for(
+          :method => "GET", :path => "", :scheme => "", :query => ""
+        )
+      ).to eq("http.request.method" => "GET")
+    end
+
+    it "returns no attributes when there is nothing to describe" do
+      expect(described_class.attributes_for(:method => nil)).to eq({})
+    end
+  end
+end

--- a/spec/lib/appsignal/opentelemetry/messaging_spec.rb
+++ b/spec/lib/appsignal/opentelemetry/messaging_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+describe Appsignal::OpenTelemetry::Messaging do
+  describe ".enqueue_attributes" do
+    # Enqueuing a job is one of the five kinds of operation the conventions
+    # define: it sends a message.
+    it "describes a job being enqueued" do
+      expect(described_class.enqueue_attributes("sidekiq")).to eq(
+        "messaging.system" => "sidekiq",
+        "messaging.operation.name" => "enqueue",
+        "messaging.operation.type" => "send"
+      )
+    end
+
+    it "names the queue the job is being put on" do
+      expect(
+        described_class.enqueue_attributes("sidekiq", :destination => "mailers")
+      ).to include("messaging.destination.name" => "mailers")
+    end
+  end
+
+  describe ".perform_attributes" do
+    # Performing a job processes a message, which is another of the five.
+    it "describes a job being performed" do
+      expect(described_class.perform_attributes("resque")).to eq(
+        "messaging.system" => "resque",
+        "messaging.operation.name" => "perform",
+        "messaging.operation.type" => "process"
+      )
+    end
+
+    it "names the queue the job came off" do
+      expect(
+        described_class.perform_attributes("resque", :destination => "mailers")
+      ).to include("messaging.destination.name" => "mailers")
+    end
+  end
+
+  describe "a span that covers a batch" do
+    it "says how many messages the batch holds" do
+      expect(
+        described_class.perform_attributes("aws_sqs", :batch_size => 3)
+      ).to include("messaging.batch.message_count" => 3)
+    end
+
+    # The conventions say a span describing a single message must not carry a
+    # count, so only a batch gets one.
+    it "leaves out the count when the span is not a batch" do
+      expect(described_class.perform_attributes("aws_sqs")).to_not have_key(
+        "messaging.batch.message_count"
+      )
+    end
+
+    it "leaves out a count of nothing" do
+      expect(
+        described_class.perform_attributes("aws_sqs", :batch_size => 0)
+      ).to_not have_key("messaging.batch.message_count")
+    end
+  end
+
+  # Not every job library records a queue, and not every job is on one, so the
+  # attribute is left out rather than sent empty.
+  it "leaves out a queue it was not given" do
+    expect(described_class.perform_attributes("resque")).to_not have_key(
+      "messaging.destination.name"
+    )
+    expect(
+      described_class.perform_attributes("resque", :destination => "")
+    ).to_not have_key("messaging.destination.name")
+  end
+end

--- a/spec/lib/appsignal/rack/abstract_middleware_spec.rb
+++ b/spec/lib/appsignal/rack/abstract_middleware_spec.rb
@@ -113,6 +113,32 @@ describe Appsignal::Rack::AbstractMiddleware do
           end
         end
 
+        context "with a nested instrumentation middleware" do
+          let(:options) { { :instrument_event_name => "outer_event.category" } }
+          let(:app) do
+            described_class.new(
+              DummyApp.new,
+              :instrument_event_name => "inner_event.category"
+            )
+          end
+
+          # Only the middleware that created the transaction describes the
+          # response. The nested one finishes while the outer one's event is
+          # still open, so it would describe that event rather than the
+          # transaction.
+          it "describes the response on the transaction span only", :collector_mode do
+            start_collector_agent
+            make_request
+
+            expect(root_span.attributes["http.response.status_code"]).to eq(200)
+            expect(event_spans.map(&:name))
+              .to include("outer_event.category", "inner_event.category")
+            event_spans.each do |span|
+              expect(span.attributes).to_not have_key("http.response.status_code")
+            end
+          end
+        end
+
         context "without :instrument_event_name option set" do
           let(:options) { {} }
 

--- a/spec/lib/appsignal/rack/event_handler_spec.rb
+++ b/spec/lib/appsignal/rack/event_handler_spec.rb
@@ -132,6 +132,44 @@ describe Appsignal::Rack::EventHandler do
       end
     end
 
+    describe "marking the transaction as an incoming HTTP request" do
+      # The `process_request.rack` event opens together with the transaction and
+      # stays open until the response finishes. An attribute set anywhere later
+      # in the request would land on that event span instead of the transaction
+      # span, which is why these are set before the event starts.
+      it "sets the request attributes on the transaction span only", :collector_mode do
+        start_collector_agent
+        on_start
+        Appsignal::Transaction.complete_current!
+
+        expect(root_span.attributes["http.request.method"]).to eq("POST")
+        expect(root_span.attributes["url.path"]).to eq("/path")
+        # Sent whole and unfiltered. The collector filters it with the
+        # `filter_request_query_parameters` option.
+        expect(root_span.attributes["url.query"])
+          .to eq("query_param1=value1&query_param2=value2")
+        # This environment carries no scheme, so there is nothing to report and
+        # the attribute is left out rather than sent empty.
+        expect(root_span.attributes).to_not have_key("url.scheme")
+        expect(event_spans).to_not be_empty
+        event_spans.each do |span|
+          expect(span.attributes).to_not have_key("http.request.method")
+          expect(span.attributes).to_not have_key("url.path")
+          expect(span.attributes).to_not have_key("url.scheme")
+          expect(span.attributes).to_not have_key("url.query")
+        end
+      end
+
+      it "reads the scheme off the request", :collector_mode do
+        env["rack.url_scheme"] = "https"
+        start_collector_agent
+        on_start
+        Appsignal::Transaction.complete_current!
+
+        expect(root_span.attributes["url.scheme"]).to eq("https")
+      end
+    end
+
     context "when not active" do
       let(:appsignal_env) { :inactive_env }
 
@@ -790,6 +828,19 @@ describe Appsignal::Rack::EventHandler do
           end
         end
 
+        it "does not describe a response that was never sent", :collector_mode do
+          start_collector_agent
+          use_test_logger
+          on_start
+          on_error(ExampleStandardError.new("the error"))
+          on_finish(request, nil)
+
+          # The 500 stands in for a status the app never sent, so it is reported
+          # as a tag but not as the attribute the conventions define.
+          expect(root_span.attributes["appsignal.tag.response_status"]).to eq(500)
+          expect(root_span.attributes).to_not have_key("http.response.status_code")
+        end
+
         describe "increments the response status counter for response status 500" do
           def perform
             on_start
@@ -935,6 +986,33 @@ describe Appsignal::Rack::EventHandler do
     end
 
     context "with response" do
+      describe "describing the response" do
+        # The `process_request.rack` event is finished at the start of
+        # `on_finish`, which leaves the transaction's own span as the one
+        # attributes go on.
+        it "sets the response status on the transaction span only", :collector_mode do
+          start_collector_agent
+          use_test_logger
+          on_start
+          on_finish
+
+          expect(root_span.attributes["http.response.status_code"]).to eq(200)
+          expect(event_spans).to_not be_empty
+          event_spans.each do |span|
+            expect(span.attributes).to_not have_key("http.response.status_code")
+          end
+        end
+
+        it "reads the status off the response", :collector_mode do
+          start_collector_agent
+          use_test_logger
+          on_start
+          on_finish(request, Rack::Events::BufferedResponse.new(404, {}, ["body"]))
+
+          expect(root_span.attributes["http.response.status_code"]).to eq(404)
+        end
+      end
+
       describe "sets the response status as a tag" do
         def perform
           on_start

--- a/spec/lib/appsignal/rack/instrumentation_middleware_spec.rb
+++ b/spec/lib/appsignal/rack/instrumentation_middleware_spec.rb
@@ -33,6 +33,89 @@ describe Appsignal::Rack::InstrumentationMiddleware do
         expect(scope_of(span)).to eq(["appsignal-ruby/rack", Appsignal::VERSION])
       end
     end
+
+    describe "marking the transaction as an incoming HTTP request" do
+      # These describe the request as a whole, so they belong on the
+      # transaction's span and on none of the events recorded within it.
+      it "sets the request attributes on the transaction span only", :collector_mode do
+        start_collector_agent
+        make_request(env)
+
+        expect(root_span.attributes["http.request.method"]).to eq("GET")
+        expect(root_span.attributes["url.path"]).to eq("/some/path")
+        expect(root_span.attributes["url.scheme"]).to eq("http")
+        # This request has no query string, so there is nothing to report and
+        # the attribute is left out rather than sent empty.
+        expect(root_span.attributes).to_not have_key("url.query")
+        expect(event_spans).to_not be_empty
+        event_spans.each do |span|
+          expect(span.attributes).to_not have_key("http.request.method")
+          expect(span.attributes).to_not have_key("url.path")
+          expect(span.attributes).to_not have_key("url.scheme")
+          expect(span.attributes).to_not have_key("url.query")
+        end
+      end
+
+      it "reads the method off the request", :collector_mode do
+        start_collector_agent
+        make_request(Rack::MockRequest.env_for("/some/path", :method => "POST"))
+
+        expect(root_span.attributes["http.request.method"]).to eq("POST")
+      end
+
+      it "reads the path, scheme and query string off the request", :collector_mode do
+        start_collector_agent
+        make_request(Rack::MockRequest.env_for("https://example.com/other/path?query=value"))
+
+        # The path is the path on its own. The query string is a separate
+        # attribute, so it must not end up in the path.
+        expect(root_span.attributes["url.path"]).to eq("/other/path")
+        expect(root_span.attributes["url.scheme"]).to eq("https")
+        # Sent whole and unfiltered. The collector filters it with the
+        # `filter_request_query_parameters` option.
+        expect(root_span.attributes["url.query"]).to eq("query=value")
+      end
+    end
+
+    describe "describing the response" do
+      # The status is only known after the app has been called, by which time the
+      # instrumented event has closed. That is what makes the transaction's own
+      # span the one this lands on.
+      it "sets the response status on the transaction span only", :collector_mode do
+        start_collector_agent
+        make_request(env)
+
+        expect(root_span.attributes["http.response.status_code"]).to eq(200)
+        expect(event_spans).to_not be_empty
+        event_spans.each do |span|
+          expect(span.attributes).to_not have_key("http.response.status_code")
+        end
+      end
+
+      context "when the app responds with an error status" do
+        let(:app) { DummyApp.new { |_env| [404, {}, ["Not found"]] } }
+
+        it "reads the status off the response", :collector_mode do
+          start_collector_agent
+          make_request(env)
+
+          expect(root_span.attributes["http.response.status_code"]).to eq(404)
+        end
+      end
+
+      context "when the app raises" do
+        let(:app) { DummyApp.new { |_env| raise ExampleException, "error" } }
+
+        # The conventions ask for the status only when a response was sent, and
+        # a request that raised never sent one.
+        it "sets no response status", :collector_mode do
+          start_collector_agent
+          expect { make_request(env) }.to raise_error(ExampleException)
+
+          expect(root_span.attributes).to_not have_key("http.response.status_code")
+        end
+      end
+    end
   end
 
   context "with custom action name" do

--- a/spec/lib/appsignal/transaction/extension_backend_spec.rb
+++ b/spec/lib/appsignal/transaction/extension_backend_spec.rb
@@ -96,6 +96,15 @@ describe Appsignal::Transaction::ExtensionBackend do
       backend.set_metadata("key", "value")
     end
 
+    # OpenTelemetry attributes have nowhere to go in the agent protocol, so the
+    # backend drops them rather than storing them somewhere else.
+    it "drops #set_attributes without touching the handle" do
+      expect(handle).to_not receive(:set_metadata)
+      expect(handle).to_not receive(:set_sample_data)
+
+      expect { backend.set_attributes("db.system.name" => "redis") }.to_not raise_error
+    end
+
     it "serializes the sample data to Data and forwards #set_sample_data to the handle" do
       raw = { "a" => 1 }
       data = Appsignal::Utils::Data.generate(raw)

--- a/spec/lib/appsignal/transaction/opentelemetry_backend_spec.rb
+++ b/spec/lib/appsignal/transaction/opentelemetry_backend_spec.rb
@@ -1348,6 +1348,22 @@ describe Appsignal::Transaction::OpenTelemetryBackend,
         expect(empty_body.attributes).not_to have_key("db.query.text")
       end
 
+      # The semantic conventions require the datastore on every database span,
+      # and an event with a SQL body format is a database span whether or not
+      # there is a query to record with it.
+      it "names the datastore for a SQL body format without a query" do
+        backend = create_backend
+        backend.start_event
+        backend.finish_event("sql.no_query", "T", nil,
+          Appsignal::EventFormatter::SQL_BODY_FORMAT)
+
+        attrs = span_exporter.finished_spans
+          .find { |s| s.name == "sql.no_query (T)" }.attributes
+        expect(attrs["db.system.name"]).to eq("other_sql")
+        expect(attrs).not_to have_key("db.query.text")
+        expect(attrs).not_to have_key("appsignal.body")
+      end
+
       it "falls back to the event name as the span name when title is empty or nil" do
         backend = create_backend
         backend.start_event

--- a/spec/lib/appsignal/transaction/opentelemetry_backend_spec.rb
+++ b/spec/lib/appsignal/transaction/opentelemetry_backend_spec.rb
@@ -769,6 +769,91 @@ describe Appsignal::Transaction::OpenTelemetryBackend,
     end
   end
 
+  describe "#set_attributes" do
+    def root_span_of(backend)
+      finished_span(backend.instance_variable_get(:@span))
+    end
+
+    it "sets the attributes on the root span when no event is open" do
+      backend = create_backend
+      backend.set_attributes("http.request.method" => "GET")
+      backend.complete
+
+      expect(root_span_of(backend).attributes["http.request.method"]).to eq("GET")
+    end
+
+    it "sets the attributes on the open event span" do
+      backend = create_backend
+      backend.start_event
+      event_span = backend.instance_variable_get(:@event_stack).last.first
+      backend.set_attributes("db.system.name" => "redis")
+      backend.finish_event("query.redis", "GET foo", nil, Appsignal::EventFormatter::DEFAULT)
+      backend.complete
+
+      expect(finished_span(event_span).attributes["db.system.name"]).to eq("redis")
+    end
+
+    # The span an attribute lands on decides how the trace timeline reads it, so
+    # an attribute meant for the transaction must not leak onto an event.
+    it "leaves the root span untouched when an event is open" do
+      backend = create_backend
+      backend.start_event
+      backend.set_attributes("db.system.name" => "redis")
+      backend.finish_event("query.redis", "GET foo", nil, Appsignal::EventFormatter::DEFAULT)
+      backend.complete
+
+      expect(root_span_of(backend).attributes).to_not have_key("db.system.name")
+    end
+
+    it "sets the attributes on the innermost open event span" do
+      backend = create_backend
+      backend.start_event
+      outer_span = backend.instance_variable_get(:@event_stack).last.first
+      backend.start_event
+      inner_span = backend.instance_variable_get(:@event_stack).last.first
+      backend.set_attributes("db.system.name" => "redis")
+      backend.finish_event("query.redis", "GET foo", nil, Appsignal::EventFormatter::DEFAULT)
+      backend.finish_event("perform.job", "MyJob", nil, Appsignal::EventFormatter::DEFAULT)
+      backend.complete
+
+      expect(finished_span(inner_span).attributes["db.system.name"]).to eq("redis")
+      expect(finished_span(outer_span).attributes).to_not have_key("db.system.name")
+    end
+
+    it "converts values OTLP does not accept to strings" do
+      backend = create_backend
+      backend.set_attributes("appsignal.group" => :render)
+      backend.complete
+
+      expect(root_span_of(backend).attributes["appsignal.group"]).to eq("render")
+    end
+
+    it "keeps the values OTLP accepts as they are" do
+      backend = create_backend
+      backend.set_attributes(
+        "string" => "value",
+        "integer" => 1,
+        "float" => 1.5,
+        "boolean" => true
+      )
+      backend.complete
+
+      attributes = root_span_of(backend).attributes
+      expect(attributes["string"]).to eq("value")
+      expect(attributes["integer"]).to eq(1)
+      expect(attributes["float"]).to eq(1.5)
+      expect(attributes["boolean"]).to be(true)
+    end
+
+    it "converts symbol keys to strings" do
+      backend = create_backend
+      backend.set_attributes(:"db.system.name" => "redis")
+      backend.complete
+
+      expect(root_span_of(backend).attributes["db.system.name"]).to eq("redis")
+    end
+  end
+
   describe "appsignal.namespace attribute" do
     # The backend converts the internal namespaces to the values the collector
     # expects; everything else passes through.
@@ -1401,6 +1486,36 @@ describe Appsignal::Transaction::OpenTelemetryBackend,
         expect(event_names(finished_span(foreign))).not_to include("exception")
         expect(event_names(finished_span(backend.instance_variable_get(:@span))))
           .not_to include("exception")
+      end
+
+      it "sets attributes on the root span, not a foreign current span" do
+        backend = create_backend
+        foreign = nil
+        with_foreign_current_span do |f|
+          foreign = f
+          backend.set_attributes("http.request.method" => "GET")
+        end
+        backend.complete
+
+        expect(finished_span(backend.instance_variable_get(:@span))
+          .attributes["http.request.method"]).to eq("GET")
+        expect(finished_span(foreign).attributes).to_not have_key("http.request.method")
+      end
+
+      it "sets attributes on the open event span, not a foreign current span" do
+        backend = create_backend
+        backend.start_event
+        event_span = backend.instance_variable_get(:@event_stack).last.first
+        foreign = nil
+        with_foreign_current_span do |f|
+          foreign = f
+          backend.set_attributes("db.system.name" => "redis")
+        end
+        backend.finish_event("query.redis", "GET foo", nil, Appsignal::EventFormatter::DEFAULT)
+        backend.complete
+
+        expect(finished_span(event_span).attributes["db.system.name"]).to eq("redis")
+        expect(finished_span(foreign).attributes).to_not have_key("db.system.name")
       end
 
       it "records a breadcrumb on the root span, not a foreign current span" do

--- a/spec/lib/appsignal/transaction/opentelemetry_backend_spec.rb
+++ b/spec/lib/appsignal/transaction/opentelemetry_backend_spec.rb
@@ -903,9 +903,12 @@ describe Appsignal::Transaction::OpenTelemetryBackend,
   describe "#set_error" do
     def exception_event(backend)
       backend.complete
+      root_span_of(backend).events.find { |e| e.name == "exception" }
+    end
+
+    def root_span_of(backend)
       backend_span_id = backend.instance_variable_get(:@span).context.span_id
-      root = span_exporter.finished_spans.find { |s| s.span_id == backend_span_id }
-      root.events.find { |e| e.name == "exception" }
+      span_exporter.finished_spans.find { |s| s.span_id == backend_span_id }
     end
 
     it "records an exception span-event on the root span" do
@@ -927,6 +930,43 @@ describe Appsignal::Transaction::OpenTelemetryBackend,
       backend_span_id = backend.instance_variable_get(:@span).context.span_id
       root = span_exporter.finished_spans.find { |s| s.span_id == backend_span_id }
       expect(root.status.code).to eq(::OpenTelemetry::Trace::Status::ERROR)
+    end
+
+    it "sets error.type on the span to the exception class" do
+      backend = create_backend
+      backend.set_error("RuntimeError", "boom", ["line 1"], [], false)
+      backend.complete
+
+      expect(root_span_of(backend).attributes["error.type"]).to eq("RuntimeError")
+    end
+
+    it "keeps the last error.type when a span collects more than one error" do
+      backend = create_backend
+      backend.set_error("RuntimeError", "first", ["line 1"], [], false)
+      backend.set_error("ArgumentError", "second", ["line 2"], [], false)
+      backend.complete
+
+      expect(root_span_of(backend).attributes["error.type"]).to eq("ArgumentError")
+    end
+
+    it "sets error.type on the span that is current when called" do
+      backend = create_backend
+      backend.start_event
+      backend.set_error("RuntimeError", "boom", ["line 1"], [], false)
+      backend.finish_event("sql.query", "title", "body", Appsignal::EventFormatter::DEFAULT)
+      backend.complete
+
+      event_span = span_exporter.finished_spans.find { |s| s.name == "sql.query (title)" }
+
+      expect(event_span.attributes["error.type"]).to eq("RuntimeError")
+      expect(root_span_of(backend).attributes).not_to have_key("error.type")
+    end
+
+    it "does not set error.type when no error is set" do
+      backend = create_backend
+      backend.complete
+
+      expect(root_span_of(backend).attributes).not_to have_key("error.type")
     end
 
     it "omits exception.stacktrace content when there is no backtrace" do

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -1692,6 +1692,97 @@ describe Appsignal::Transaction do
     end
   end
 
+  describe "#add_opentelemetry_attributes" do
+    let(:transaction) { new_transaction }
+
+    describe "adding attributes when no event is open" do
+      def perform
+        transaction.add_opentelemetry_attributes("http.request.method" => "GET")
+      end
+
+      # Attributes describe an OpenTelemetry span, and agent mode has none, so
+      # they are dropped rather than stored as some other kind of data.
+      it "in agent mode", :agent_mode do
+        start_agent(**start_agent_args)
+        perform
+        transaction._sample
+
+        expect(transaction).to_not include_tags("http.request.method" => "GET")
+        expect(transaction).to_not include_metadata("http.request.method" => "GET")
+      end
+
+      it "in collector mode", :collector_mode do
+        start_collector_agent
+        perform
+        transaction.complete
+
+        expect(root_span.attributes["http.request.method"]).to eq("GET")
+      end
+    end
+
+    describe "adding attributes while an event is open" do
+      def perform
+        set_current_transaction(transaction)
+        Appsignal.instrument("query.redis") do
+          transaction.add_opentelemetry_attributes("db.system.name" => "redis")
+        end
+      end
+
+      it "in agent mode", :agent_mode do
+        start_agent(**start_agent_args)
+        perform
+        transaction._sample
+
+        expect(transaction).to_not include_tags("db.system.name" => "redis")
+        expect(transaction).to_not include_metadata("db.system.name" => "redis")
+      end
+
+      # Which span an attribute lands on decides how the trace timeline reads
+      # it, so an event's attributes must not spill onto the transaction.
+      it "in collector mode", :collector_mode do
+        start_collector_agent
+        perform
+        transaction.complete
+
+        expect(event_span_for("query.redis").attributes["db.system.name"]).to eq("redis")
+        expect(root_span.attributes).to_not have_key("db.system.name")
+      end
+    end
+
+    describe "adding attributes after an event has finished" do
+      def perform
+        set_current_transaction(transaction)
+        Appsignal.instrument("query.redis") { nil }
+        transaction.add_opentelemetry_attributes("http.request.method" => "GET")
+      end
+
+      it "in agent mode", :agent_mode do
+        start_agent(**start_agent_args)
+        perform
+        transaction._sample
+
+        expect(transaction).to_not include_tags("http.request.method" => "GET")
+      end
+
+      it "in collector mode", :collector_mode do
+        start_collector_agent
+        perform
+        transaction.complete
+
+        expect(root_span.attributes["http.request.method"]).to eq("GET")
+        expect(event_span_for("query.redis").attributes)
+          .to_not have_key("http.request.method")
+      end
+    end
+
+    describe "when no attributes are given" do
+      it_in_both_modes "does nothing" do
+        expect { transaction.add_opentelemetry_attributes }.to_not raise_error
+        expect { transaction.add_opentelemetry_attributes(nil) }.to_not raise_error
+      end
+    end
+  end
+
   describe "#add_params deprecation" do
     let(:transaction) { new_transaction }
 

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -3265,6 +3265,7 @@ describe Appsignal do
         expect(span.attributes["appsignal.body"]).to eq("body")
         expect(span.attributes).not_to have_key("db.query.text")
         expect(span.attributes).not_to have_key("db.system.name")
+        expect(span.attributes).not_to have_key("error.type")
       end
     end
 
@@ -3295,6 +3296,39 @@ describe Appsignal do
         expect(span.name).to eq("name (title)")
         expect(span.attributes).not_to have_key("appsignal.category")
         expect(span.attributes["appsignal.body"]).to eq("body")
+        # The block raised, so the operation the span describes failed.
+        expect(span.attributes["error.type"]).to eq("ExampleException")
+      end
+    end
+
+    describe "when an error is raised in the block of an ignored event" do
+      def perform
+        expect do
+          Appsignal.ignore_instrumentation_events do
+            Appsignal.instrument("name", "title", "body") { raise ExampleException, "foo" }
+          end
+        end.to raise_error(ExampleException, "foo")
+      end
+
+      it "in agent mode", :agent_mode do
+        start_agent
+        set_current_transaction(transaction)
+        perform
+
+        expect(transaction).to_not include_event("name" => "name")
+      end
+
+      it "in collector mode", :collector_mode do
+        start_collector_agent
+        set_current_transaction(transaction)
+        perform
+        Appsignal::Transaction.complete_current!
+
+        # No event span was started, so there is no span of this event's to
+        # describe. The failure must not end up on the transaction's own span
+        # instead.
+        expect(event_spans).to be_empty
+        expect(root_span.attributes).not_to have_key("error.type")
       end
     end
 
@@ -3325,6 +3359,9 @@ describe Appsignal do
         expect(span.name).to eq("name (title)")
         expect(span.attributes).not_to have_key("appsignal.category")
         expect(span.attributes["appsignal.body"]).to eq("body")
+        # Throwing a symbol is control flow rather than a failure, so there is
+        # no kind of failure to report.
+        expect(span.attributes).not_to have_key("error.type")
       end
     end
   end


### PR DESCRIPTION
Stacked on `wip-otel-rework`, so review after #1535.

In collector mode, AppSignal records a transaction as an OpenTelemetry span and each instrumented event as a child span. Those spans were nearly bare. They carried a name, a body and AppSignal's own attributes, and almost nothing that says what kind of work they represent in OpenTelemetry's own terms.

Two things follow from that. The trace timeline in the UI decides what kind of work a span represents by reading its attributes, so with none of them nearly everything was shown in one colour, under "Other". And anything else reading the trace learned nothing about what our spans were doing.

This adds a way to put attributes on the span AppSignal is currently recording, then goes through the spans we produce one category at a time: outgoing HTTP requests, incoming HTTP requests, database queries, background jobs, template renders, and finally the error type that applies to a span in any of those categories. Each category is described in full in one commit, following the OpenTelemetry semantic conventions for its area and setting whatever the trace timeline needs along the way.

A few attributes the conventions ask for are still missing on purpose, each for a reason given in the commit that would have set it. Those are `http.route`, the HTTP method and URL on an Elasticsearch span, the query string inside `url.full` on an outgoing request, and a batch count on Que's bulk enqueue. Span names are left alone too: the format the conventions mandate conflicts with the one the collector reads to work out an event's category.

Everything here is collector mode only. The attributes go through a method that does nothing in agent mode, so none of it can change what agent mode reports.

### [Add an OpenTelemetry span attributes method](https://github.com/appsignal/appsignal-ruby/commit/70f68973)

Integrations need to describe what they instrument in OpenTelemetry's
own terms. A database query span should carry `db.system.name`, an
outgoing request span should carry `http.request.method`, and so on.
Transaction events have nowhere to put that: they have a name, a title
and a body, and nothing else.

Add `Appsignal::Transaction#add_opentelemetry_attributes`, which sets
attributes on the span AppSignal is currently recording. That is the
innermost open event span, or the transaction's own span when no event
is open. Agent mode has no spans, so the extension backend drops the
attributes rather than storing them as some other kind of data.

The attributes go on AppSignal's own span rather than on OpenTelemetry's
current span. The current span may belong to another instrumentation,
and we never write attributes onto a span we did not create. Reading it
from AppSignal's own event stack makes that hold by construction, so no
caller has to remember it.

Attributes are set on a span that already exists, unlike the span kind
and the instrumentation scope, which cannot change after the span is
created. That is why this is a method rather than another
`opentelemetry_` keyword argument on every method that starts a span.

Which span an attribute lands on decides how the trace timeline reads
it, so the specs check placement directly. An attribute added inside an
event must not appear on the transaction span, and one added outside an
event must not appear on any event span.

### [Describe outgoing HTTP requests](https://github.com/appsignal/appsignal-ruby/commit/2a8764a3)

The trace timeline decides what kind of work a span represents by
looking at its OpenTelemetry attributes. A span with none of them is
shown under "Other", in the same colour as everything else it cannot
place. Our HTTP client spans had none, so an outgoing request looked no
different from an uninstrumented block of code.

Describe them the way the semantic conventions ask. That means the
request method, the host and port being called, the full URL, and the
response status code when a response came back. The method, together
with the CLIENT span kind these spans already carry, is also what the
timeline reads to recognise an outgoing HTTP call.

The conventions treat the method as a closed set of names rather than
free text. A method outside the set is reported as `_OTHER`, and one
that only matches after upcasing is replaced by its canonical form. Both
keep the value we were given alongside, so nothing is lost. Faraday,
Excon and HTTP.rb hand us a lowercase Symbol, so their spans carry the
canonical form with the original next to it.

The URL is built from the parts rather than taken whole, which has two
consequences worth knowing about.

It can never contain credentials. A URL can carry a username and a
password, which the conventions say must not be sent, and building the
URL from the scheme, host, port and path leaves nowhere for them to come
from.

It does not contain the query string either. The conventions do ask for
it, but the query string of a call to somebody else's API is the part
most likely to carry a key or a token, and unlike an incoming request it
is not something the application chose the shape of. A path a client
hands us is cut at the first question mark for the same reason, because
some clients report a request target rather than a path.

Every client reports the port, either directly or through the port its
scheme implies. A URL leaves out the port its scheme implies, which is
how a URL is normally written, but the port attribute reports it either
way.

Each client hands the response over differently, so each integration
reads the status from where that client puts it. Faraday's status is
read off the request environment rather than the response object,
because an adapter fills the environment in first. Excon is the
exception: it reports the request and the response as two separate
notifications, so AppSignal records them as two events, and only the
response one carries the status. That span is therefore the only one
that can describe the response.

A status the server answered with an error is still a status, and is
reported the same way a successful one is. A request that never got a
response has no status to report.

### [Describe incoming HTTP requests](https://github.com/appsignal/appsignal-ruby/commit/7eabb0cc)

A web transaction's span already carried the SERVER span kind, but the
trace timeline needs an HTTP attribute alongside it before it will read
the span as a web request. Without one the request was shown under
"Other", the same as work the timeline cannot place.

Describe it the way the semantic conventions ask. That means the request
method, the path, the scheme, the query string when the request had one,
and the response status code when a response was sent. The method goes
through the same normalization as an outgoing request, so it is one of
the names the conventions define rather than free text.

The path is the concrete path the request was made to, without the query
string. It is not the route template the application matched the request
against, which the conventions call `http.route` and which a Rack
application does not necessarily have.

The query string is sent whole, without the leading question mark, and
it is not filtered here. The collector already filters this attribute
with the `filter_request_query_parameters` option, and builds the
request's query parameters out of it when the integration did not send
them itself.

The request's own attributes are set where the transaction is created,
in the Rack middleware, the Rack event handler and the Webmachine
integration, rather than alongside the rest of the request metadata in
`ApplyRackRequest`. Attributes land on whichever span is open, and these
belong on the transaction's own span. `ApplyRackRequest` runs after the
app has been called, and under the Rack event handler an event span is
open for the whole request, so setting them there would put them on that
event instead. The specs check this directly: they assert the attributes
are on the transaction span and on none of its event spans.

The status is only known once the app has responded, which is later than
the rest. It has to be set at a point where the transaction's own span
is the one attributes go on, and not an event span that is still open.
In the event handler that point is right after the request event is
finished. In the middleware it is the `ensure` that completes the
transaction, so the status travels there from the app call in the
request environment.

A request that raised never sent a response, so it gets no status. The
event handler already reports 500 as a tag and a metric in that case,
which stands in for a status the app never produced. That stand-in does
not belong in an attribute the conventions define.

Only the middleware that created the transaction describes the response.
A nested middleware finishes while the outer one's event is still open,
so it would describe that event rather than the transaction.

Reading anything off the request can raise, because the request class is
configurable. That was already handled for the request method inside
`ApplyRackRequest`, so the rescue moves to `Appsignal::Rack::Utils`
where every caller can share it.

### [Describe database queries](https://github.com/appsignal/appsignal-ruby/commit/9baa5479)

The trace timeline recognises a datastore call by its `db.system.name`
attribute, and splits caches out from databases by the value. SQL query
spans already got it from the SQL body format, which is also what tells
the collector to sanitize the query. Every other datastore span had
nothing, so a Redis, MongoDB or Elasticsearch query was shown under
"Other".

Describe them the way the semantic conventions ask. The datastore name
comes first, because without it the timeline cannot tell these spans
apart from any other kind of work. Redis and redis-client queries are
`redis`, MongoDB queries are `mongodb`, and Elasticsearch searches are
`elasticsearch`. Those are the values the conventions define, and the
same ones OpenTelemetry's own instrumentation for these libraries uses.

Each datastore's own page then raises some of the rest to a requirement.

Redis requires the command name, and asks for the database when it can
be captured reliably. The command name is reported in the case the
application wrote it, which is what the conventions ask for. A script is
run with the EVAL command, so that is the command name reported for one,
and the script itself stays in the event body. The database is the index
the connection is on, reported as a String, and a client that does not
tell us gets none reported.

MongoDB requires the command that ran and the collection it worked on,
and asks for the database, the server and the database's own code for an
error. All of it is in the events the driver hands us. MongoDB names the
collection in the field named after the command itself, as in `{ "find"
=> "users" }`. A command that works on the database as a whole rather
than on one collection has something else in that field, so only a name
that is really a name is reported.

Elasticsearch requires the operation, and asks for the index. This
notification is only emitted for a search, so the operation is the same
for every one of these spans. The index has to be read out of the search
the notification describes, which the static map of attributes per event
cannot do, so payload-derived attributes have a path of their own. The
attribute names one index, so a search across several is left without it
rather than described with a value that is not an index name.

A search is also an outgoing call to a cluster, exactly as a SQL query
is, so it now carries CLIENT kind. It was recorded with the default
INTERNAL kind because the generic notifications path only knew about the
two SQL events.

Two attributes the conventions require on an Elasticsearch span stay
missing: the HTTP method and the URL of the request to the cluster. This
notification comes from the model layer and carries neither. Setting
them would mean instrumenting the transport layer instead, which is what
OpenTelemetry's own Elasticsearch instrumentation does.

The Redis command stays in the event body rather than moving to
`db.query.text`. It is already sanitized when we record it, and the
collector sanitizes `db.query.text` again for Redis, which would mangle
what we send.

Finally, a SQL event's span was named as a database span only when the
event had a query to record. An event with an empty body got neither the
query nor the name of the datastore, which the conventions require on
every database span. Name it either way. A real case for this is an
ActiveSupport notification that reports the query at `start` but is
finished with an empty payload.

### [Describe background job spans](https://github.com/appsignal/appsignal-ruby/commit/a7f7eb52)

The trace timeline recognises background job work by the
`messaging.system` attribute, and uses the span kind to tell an enqueue
apart from the job it enqueued. Our job spans carried the kind but not
the attribute, so both were shown under "Other".

Describe them the way the semantic conventions ask. The messaging system
comes first, because without it the timeline cannot place these spans.
Sidekiq, Resque, Que, Delayed Job and Active Job take their own name,
which is what OpenTelemetry's instrumentation for each of them uses.
Shoryuken runs on Amazon SQS, so it takes the `aws_sqs` value the
conventions define.

The conventions also require the name of the operation the span
describes. The name is the job library's own word for what happened, so
a job being put on a queue is an `enqueue` and a job being run is a
`perform`. And they ask for the kind of operation it was, as one of five
values they define. AppSignal only ever produces two of them: enqueuing
a job sends a message, and performing one processes it. The three
attributes always travel together, so one place builds them and every
integration passes its own messaging system.

They ask for the destination of the message, which for a job library is
the queue the job is on. Every integration knows it, on both the enqueue
and the perform side. Not every job has one, though. Que only records
the queue on the job itself, so an enqueue that does not name one gets
Que's default, which the integration cannot see. Delayed Job has
backends without queues. A span with no queue to name is described
without one rather than with an empty name.

They ask for the number of messages a span covers when it covers a batch
of them, and say a span that describes a single message must not carry
the count. Shoryuken is the one integration that can answer this: its
server middleware is handed an array of messages when it is running a
batch. Que's bulk enqueue also produces a batch, but it does not know
how many jobs the batch holds, because the jobs are enqueued by the
block it wraps.

All of this goes on the job's own span, on the event recorded while the
job runs, and on the enqueue event.

Active Job only describes itself when it created the transaction. When
an adapter integration created it, that adapter has already described
itself, and its answer is the more specific one.

Active Job's own perform event arrives through the generic notifications
path rather than a dedicated integration, so its attributes come from
the tables there.

The transaction Sidekiq's error handler creates for an error outside a
job is described as a perform with no queue. It stands in for a job that
could not be processed, and there is no job behind it to name a queue
from.

### [Mark render events as templating work](https://github.com/appsignal/appsignal-ruby/commit/0fcac817)

Template rendering was the last kind of work the trace timeline could
not place, so an Action View or ViewComponent render was shown under
"Other".

OpenTelemetry has no semantic convention for template rendering, and its
own Action View instrumentation sets no convention attribute either, so
there is nothing to follow here. The timeline does read an
`appsignal.group` attribute before it looks at any convention, so these
spans say which group they belong to directly.

This covers the four Action View render events and ViewComponent's
render event. All of them arrive through ActiveSupport::Notifications,
so they are named in the lookup table there.

### [Record the error type on spans that failed](https://github.com/appsignal/appsignal-ruby/commit/6f022514)

The OpenTelemetry semantic conventions ask for an `error.type` attribute
on a span whose operation ended with an error, and for it to be left
unset on a span whose operation succeeded. The value has to have low
cardinality, so for an exception it is the class name rather than the
message. Note that this is an attribute of the span. The
`exception.type` we already set is an attribute of the exception event,
which is a different thing.

Set it wherever an error is set on a transaction. That is the span the
error is already recorded on, so it is also the span whose operation
failed. When a span collects more than one error the last one wins,
because a span can only say one thing here.

An error that only passes through an instrumented event is never set on
the transaction, so that does not describe it. By the time the
transaction records it, if it ever does, the event's span has already
closed. Catch it where the event is recorded instead. That is one place
for every event recorded through `Appsignal.instrument`, which covers
the outgoing HTTP requests, the Redis commands, and the job enqueue and
perform events.

Two integrations report a failure without raising, so they read it from
what they were given. ActiveSupport puts the exception in the event's
payload. The MongoDB driver reports a failed query by calling us with
the error document it replied with, which names the error in its
`codeName` field.
