### PR TITLE
Rebuild the Excon integration

### DIFF
--- a/.changesets/record-an-excon-request-as-one-event.md
+++ b/.changesets/record-an-excon-request-as-one-event.md
@@ -1,0 +1,22 @@
+---
+bump: minor
+type: change
+---
+
+Fix Excon requests being reported as taking almost no time. An Excon request was
+recorded as two events, one for sending the request and one for reading the
+response, and neither of them covered the wait for the remote service. So a slow
+Excon request looked fast in the event timeline, however long it really took.
+
+An Excon request is now recorded as a single `request.excon` event covering the
+whole request, so the event lasts as long as the request did. A request that
+Excon retried, or that was redirected, is also one event, covering every attempt
+or every hop.
+
+The `response.excon`, `retry.excon` and `error.excon` events no longer exist.
+Excon does not tell an instrumentor which request those events belonged to, so
+`response.excon` never had a title and `error.excon` was always titled `" ://"`.
+
+AppSignal also no longer registers itself as Excon's instrumentor. Excon allows
+only one instrumentor, so an application that set up its own was having it
+replaced. Your own instrumentor now keeps working.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 # This is a generated file by the `rake build_matrix:github:generate` task.
 # See `build_matrix.yml` for the build matrix.
 # Generate this file with `rake build_matrix:github:generate`.
-# Generated job count: 248
+# Generated job count: 255
 ---
 name: Ruby gem CI
 'on':
@@ -267,6 +267,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/dry-monitor.gemfile
+  ruby_4-0-0__excon_ubuntu-latest:
+    name: Ruby 4.0.0 - excon
+    needs: ruby_4-0-0_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 4.0.0
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/excon.gemfile
   ruby_4-0-0__faraday-1_ubuntu-latest:
     name: Ruby 4.0.0 - faraday-1
     needs: ruby_4-0-0_ubuntu-latest
@@ -1162,6 +1189,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/dry-monitor.gemfile
+  ruby_3-4-1__excon_ubuntu-latest:
+    name: Ruby 3.4.1 - excon
+    needs: ruby_3-4-1_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.1
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/excon.gemfile
   ruby_3-4-1__faraday-1_ubuntu-latest:
     name: Ruby 3.4.1 - faraday-1
     needs: ruby_3-4-1_ubuntu-latest
@@ -2192,6 +2246,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/dry-monitor.gemfile
+  ruby_3-3-4__excon_ubuntu-latest:
+    name: Ruby 3.3.4 - excon
+    needs: ruby_3-3-4_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.3.4
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/excon.gemfile
   ruby_3-3-4__faraday-1_ubuntu-latest:
     name: Ruby 3.3.4 - faraday-1
     needs: ruby_3-3-4_ubuntu-latest
@@ -3168,6 +3249,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/dry-monitor.gemfile
+  ruby_3-2-5__excon_ubuntu-latest:
+    name: Ruby 3.2.5 - excon
+    needs: ruby_3-2-5_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.2.5
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/excon.gemfile
   ruby_3-2-5__faraday-1_ubuntu-latest:
     name: Ruby 3.2.5 - faraday-1
     needs: ruby_3-2-5_ubuntu-latest
@@ -4144,6 +4252,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/dry-monitor.gemfile
+  ruby_3-1-6__excon_ubuntu-latest:
+    name: Ruby 3.1.6 - excon
+    needs: ruby_3-1-6_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.1.6
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/excon.gemfile
   ruby_3-1-6__faraday-1_ubuntu-latest:
     name: Ruby 3.1.6 - faraday-1
     needs: ruby_3-1-6_ubuntu-latest
@@ -5039,6 +5174,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/dry-monitor.gemfile
+  ruby_3-0-7__excon_ubuntu-latest:
+    name: Ruby 3.0.7 - excon
+    needs: ruby_3-0-7_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.0.7
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/excon.gemfile
   ruby_3-0-7__faraday-1_ubuntu-latest:
     name: Ruby 3.0.7 - faraday-1
     needs: ruby_3-0-7_ubuntu-latest
@@ -5880,6 +6042,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/delayed_job.gemfile
+  ruby_2-7-8__excon_ubuntu-latest:
+    name: Ruby 2.7.8 - excon
+    needs: ruby_2-7-8_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7.8
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/excon.gemfile
   ruby_2-7-8__faraday-1_ubuntu-latest:
     name: Ruby 2.7.8 - faraday-1
     needs: ruby_2-7-8_ubuntu-latest

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -151,6 +151,7 @@ matrix:
           - "3.2.5"
           - "3.1.6"
           - "3.0.7"
+    - gem: "excon"
     - gem: "faraday-1"
     - gem: "faraday-2"
       only:

--- a/gemfiles/excon.gemfile
+++ b/gemfiles/excon.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "excon"
+
+gemspec :path => "../"

--- a/lib/appsignal/hooks/excon.rb
+++ b/lib/appsignal/hooks/excon.rb
@@ -18,6 +18,8 @@ module Appsignal
         # there is only room for one of them, so registering ours would replace
         # any the application set up itself.
         ::Excon::Connection.prepend Appsignal::Integrations::ExconIntegration
+
+        Appsignal::Environment.report_enabled("excon")
       end
     end
   end

--- a/lib/appsignal/hooks/excon.rb
+++ b/lib/appsignal/hooks/excon.rb
@@ -12,7 +12,12 @@ module Appsignal
 
       def install
         require "appsignal/integrations/excon"
-        ::Excon.defaults[:instrumentor] = Appsignal::Integrations::ExconIntegration
+        # Instrument the request at the connection, rather than by registering
+        # AppSignal as Excon's instrumentor. An instrumentor is told about a
+        # request in pieces, none of which covers the wait for the response, and
+        # there is only room for one of them, so registering ours would replace
+        # any the application set up itself.
+        ::Excon::Connection.prepend Appsignal::Integrations::ExconIntegration
       end
     end
   end

--- a/lib/appsignal/integrations/excon.rb
+++ b/lib/appsignal/integrations/excon.rb
@@ -4,25 +4,53 @@ module Appsignal
   module Integrations
     # @!visibility private
     module ExconIntegration
-      def self.instrument(name, data, &block)
+      # The title of the event, built the way the Net::HTTP integration builds
+      # its own: the request method and where the request went, without the
+      # path, so paths stay out of event titles.
+      #
+      # Excon splits a request's data between the connection it is made on and
+      # the call that makes it, so both are read to build this. Excon defaults
+      # the method to GET itself, so the same default is applied here.
+      def self.title_for(datum)
+        method = (datum[:method] || :get).to_s.upcase
+        "#{method} #{datum[:scheme]}://#{datum[:host]}"
+      end
+
+      def request(params = {})
         # Skip when an outer HTTP client integration (Faraday) already records
-        # this request, so it isn't instrumented twice. Excon calls the
-        # instrumentor for block-less notifications too, hence the `block_given?`.
+        # this request, so it isn't instrumented twice.
         if Appsignal::Transaction.current? &&
             Appsignal::Transaction.current.http_client_events_suppressed?
-          return block_given? ? yield : nil
+          return super
         end
 
-        namespace, *event = name.split(".")
-        rails_name = [event, namespace].flatten.join(".")
+        # This method is the whole of a request. Excon sends the request here,
+        # waits for the response, reads it, and only then returns.
+        #
+        # Excon can also report a request through an instrumentor, but an
+        # instrumentor cannot measure a request. Excon runs its middleware once
+        # to send the request and again to read the response, and the reading
+        # happens in a middleware that sits outside the one that calls the
+        # instrumentor. So the wait for the remote service, which is the part of
+        # a request worth measuring, falls outside everything an instrumentor is
+        # told about.
+        #
+        # A pipelined request is the exception to this method being the whole of
+        # a request. It returns before the response is read, so its event covers
+        # only the sending.
+        title = ExconIntegration.title_for(data.merge(params))
 
-        title =
-          if rails_name == "response.excon"
-            data[:host]
+        Appsignal.instrument("request.excon", title) do
+          if Appsignal::Transaction.current?
+            # Excon retries a request, and follows a redirect, by calling this
+            # method again from inside the request it is retrying or following.
+            # Suppressing those means they count towards this event rather than
+            # becoming events of their own, so one request stays one event.
+            Appsignal::Transaction.current.suppress_http_client_events { super }
           else
-            "#{data[:method].to_s.upcase} #{data[:scheme]}://#{data[:host]}"
+            super
           end
-        Appsignal.instrument(rails_name, title, &block)
+        end
       end
     end
   end

--- a/spec/lib/appsignal/hooks/excon_spec.rb
+++ b/spec/lib/appsignal/hooks/excon_spec.rb
@@ -29,38 +29,6 @@ describe Appsignal::Hooks::ExconHook do
         expect(Excon.defaults[:instrumentor]).to eql(Appsignal::Integrations::ExconIntegration)
       end
     end
-
-    describe "instrumentation" do
-      let(:transaction) { http_request_transaction }
-      before { set_current_transaction(transaction) }
-      around { |example| keep_transactions { example.run } }
-
-      it "instruments a http request" do
-        data = {
-          :host => "www.google.com",
-          :method => :get,
-          :scheme => "http"
-        }
-        Excon.defaults[:instrumentor].instrument("excon.request", data) {} # rubocop:disable Lint/EmptyBlock
-
-        expect(transaction).to include_event(
-          "name" => "request.excon",
-          "title" => "GET http://www.google.com",
-          "body" => ""
-        )
-      end
-
-      it "instruments a http response" do
-        data = { :host => "www.google.com" }
-        Excon.defaults[:instrumentor].instrument("excon.response", data) {} # rubocop:disable Lint/EmptyBlock
-
-        expect(transaction).to include_event(
-          "name" => "response.excon",
-          "title" => "www.google.com",
-          "body" => ""
-        )
-      end
-    end
   end
 
   context "without Excon" do

--- a/spec/lib/appsignal/hooks/excon_spec.rb
+++ b/spec/lib/appsignal/hooks/excon_spec.rb
@@ -4,11 +4,8 @@ describe Appsignal::Hooks::ExconHook do
 
   context "with Excon" do
     before do
-      stub_const("Excon", Class.new do
-        def self.defaults
-          @defaults ||= {}
-        end
-      end)
+      stub_const("Excon", Module.new)
+      stub_const("Excon::Connection", Class.new)
       Appsignal::Hooks::ExconHook.new.install
     end
 
@@ -25,8 +22,9 @@ describe Appsignal::Hooks::ExconHook do
     end
 
     describe "#install" do
-      it "adds the AppSignal instrumentor to Excon" do
-        expect(Excon.defaults[:instrumentor]).to eql(Appsignal::Integrations::ExconIntegration)
+      it "adds the AppSignal integration to Excon connections" do
+        expect(Excon::Connection.ancestors)
+          .to include(Appsignal::Integrations::ExconIntegration)
       end
     end
   end

--- a/spec/lib/appsignal/integrations/excon_spec.rb
+++ b/spec/lib/appsignal/integrations/excon_spec.rb
@@ -1,0 +1,196 @@
+if DependencyHelper.excon_present?
+  require "excon"
+  require "appsignal/integrations/excon"
+
+  # Integration test against the real Excon gem. The hook registers AppSignal as
+  # Excon's instrumentor, and Excon calls an instrumentor three times per
+  # request: once when it sends the request, once when it reads the response, and
+  # once when the request fails. AppSignal turns each of those calls into its own
+  # event.
+  #
+  # These examples record what that produces today, including the parts of it
+  # that are wrong.
+  describe "Excon integration" do
+    before { Appsignal::Hooks::ExconHook.new.install }
+
+    let(:transaction) { http_request_transaction }
+    before do
+      start_agent
+      set_current_transaction(transaction)
+    end
+
+    def event_names
+      transaction.to_h["events"].map { |event| event["name"] }
+    end
+
+    def event_duration(name)
+      transaction.to_h["events"].find { |event| event["name"] == name }["duration"]
+    end
+
+    describe "a request that succeeds" do
+      def perform
+        stub_request(:get, "http://www.example.com/")
+        Excon.get("http://www.example.com/")
+      end
+
+      it "records the request and the response as two separate events" do
+        perform
+
+        expect(event_names).to eq(["request.excon", "response.excon"])
+      end
+
+      it "titles the request event after the request" do
+        perform
+
+        expect(transaction).to include_event(
+          "name" => "request.excon",
+          "title" => "GET http://www.example.com",
+          "body" => ""
+        )
+      end
+
+      # Excon gives an instrumentor only the response when it reads one, and the
+      # response holds no host, so the title this event is built from is never
+      # there. It has been titleless since the integration was written.
+      it "leaves the response event without a title" do
+        perform
+
+        expect(transaction).to include_event(
+          "name" => "response.excon",
+          "title" => "",
+          "body" => ""
+        )
+      end
+    end
+
+    # Excon runs its middleware stack twice for a request: once on the way out to
+    # send it, and again on the way back to read the response. Those are two
+    # separate passes, and the middleware that reads the response off the socket
+    # runs outside the one that calls the instrumentor.
+    #
+    # So the time spent waiting for the remote service lands on neither event. An
+    # Excon request is reported as taking almost no time, however slow it was.
+    describe "the time spent reading the response" do
+      # Stands in for Excon's own ResponseParser middleware. It spends time in
+      # the response pass, in the same place Excon really blocks.
+      let(:slow_response_middleware) do
+        Class.new(Excon::Middleware::Base) do
+          def response_call(datum)
+            sleep 0.1
+            @stack.response_call(datum)
+          end
+        end
+      end
+
+      def perform
+        stub_request(:get, "http://www.example.com/")
+        Excon.get(
+          "http://www.example.com/",
+          :middlewares => [slow_response_middleware] + Excon.defaults[:middlewares]
+        )
+      end
+
+      it "is recorded on neither event" do
+        perform
+
+        expect(event_duration("request.excon")).to be < 50
+        expect(event_duration("response.excon")).to be < 50
+      end
+    end
+
+    describe "a request that fails" do
+      def perform
+        stub_request(:get, "http://www.example.com/").to_timeout
+        expect { Excon.get("http://www.example.com/") }
+          .to raise_error(Excon::Error::Timeout)
+      end
+
+      it "records the request and the failure as two separate events" do
+        perform
+
+        expect(event_names).to eq(["request.excon", "error.excon"])
+      end
+
+      # Excon gives an instrumentor only the error when a request fails. The
+      # title is built from a request that is not there, so every failed request
+      # is titled with the leftover punctuation of that format.
+      it "titles the failure event with an empty request" do
+        perform
+
+        expect(transaction).to include_event(
+          "name" => "error.excon",
+          "title" => " ://",
+          "body" => ""
+        )
+      end
+    end
+
+    # An outer HTTP client integration, such as Faraday, records a request
+    # itself and asks the client it runs on not to record it again.
+    describe "a request made while HTTP client events are suppressed" do
+      def perform
+        stub_request(:get, "http://www.example.com/")
+        Appsignal::Transaction.current.suppress_http_client_events do
+          Excon.get("http://www.example.com/")
+        end
+      end
+
+      it "records no event, and still returns the response" do
+        expect(perform.status).to eq(200)
+
+        expect(event_names).to be_empty
+      end
+    end
+
+    # Excon retries a request when it is marked idempotent and fails with a
+    # socket error. It retries by asking the connection to make the request
+    # again, so each attempt is instrumented on its own.
+    describe "a request that is retried" do
+      def perform
+        stub_request(:get, "http://www.example.com/").to_timeout
+        expect do
+          Excon.get(
+            "http://www.example.com/",
+            :idempotent => true,
+            :retry_limit => 3
+          )
+        end.to raise_error(Excon::Error::Timeout)
+      end
+
+      it "records an event per attempt, and one for the failure" do
+        perform
+
+        expect(event_names).to eq(
+          ["request.excon", "retry.excon", "retry.excon", "error.excon"]
+        )
+      end
+    end
+
+    # Excon follows a redirect by making the request again against the new
+    # location, so each hop is instrumented on its own. The hop that redirects
+    # never reaches the instrumentor with its response, because the middleware
+    # that follows the redirect replaces it, so only the last hop records one.
+    describe "a request that is redirected" do
+      def perform
+        stub_request(:get, "http://www.example.com/").to_return(
+          :status => 302,
+          :headers => { "Location" => "http://www.example.com/next" }
+        )
+        stub_request(:get, "http://www.example.com/next")
+        Excon.get(
+          "http://www.example.com/",
+          :middlewares =>
+            [Excon::Middleware::RedirectFollower] + Excon.defaults[:middlewares]
+        )
+      end
+
+      it "records an event per hop, and one response for the last hop" do
+        perform
+
+        expect(event_names).to eq(
+          ["request.excon", "request.excon", "response.excon"]
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/appsignal/integrations/excon_spec.rb
+++ b/spec/lib/appsignal/integrations/excon_spec.rb
@@ -2,14 +2,9 @@ if DependencyHelper.excon_present?
   require "excon"
   require "appsignal/integrations/excon"
 
-  # Integration test against the real Excon gem. The hook registers AppSignal as
-  # Excon's instrumentor, and Excon calls an instrumentor three times per
-  # request: once when it sends the request, once when it reads the response, and
-  # once when the request fails. AppSignal turns each of those calls into its own
-  # event.
-  #
-  # These examples record what that produces today, including the parts of it
-  # that are wrong.
+  # Integration test against the real Excon gem. The hook instruments the
+  # connection, so a request is one event that covers the whole of it: sending
+  # the request, waiting for the remote service, and reading the response.
   describe "Excon integration" do
     before { Appsignal::Hooks::ExconHook.new.install }
 
@@ -33,15 +28,10 @@ if DependencyHelper.excon_present?
         Excon.get("http://www.example.com/")
       end
 
-      it "records the request and the response as two separate events" do
+      it "records the request as one event" do
         perform
 
-        expect(event_names).to eq(["request.excon", "response.excon"])
-      end
-
-      it "titles the request event after the request" do
-        perform
-
+        expect(event_names).to eq(["request.excon"])
         expect(transaction).to include_event(
           "name" => "request.excon",
           "title" => "GET http://www.example.com",
@@ -49,27 +39,15 @@ if DependencyHelper.excon_present?
         )
       end
 
-      # Excon gives an instrumentor only the response when it reads one, and the
-      # response holds no host, so the title this event is built from is never
-      # there. It has been titleless since the integration was written.
-      it "leaves the response event without a title" do
-        perform
-
-        expect(transaction).to include_event(
-          "name" => "response.excon",
-          "title" => "",
-          "body" => ""
-        )
+      it "returns the response to the caller" do
+        expect(perform.status).to eq(200)
       end
     end
 
     # Excon runs its middleware stack twice for a request: once on the way out to
-    # send it, and again on the way back to read the response. Those are two
-    # separate passes, and the middleware that reads the response off the socket
-    # runs outside the one that calls the instrumentor.
-    #
-    # So the time spent waiting for the remote service lands on neither event. An
-    # Excon request is reported as taking almost no time, however slow it was.
+    # send it, and again on the way back to read the response. Instrumenting the
+    # connection puts both passes inside the event, so the wait for the remote
+    # service is measured.
     describe "the time spent reading the response" do
       # Stands in for Excon's own ResponseParser middleware. It spends time in
       # the response pass, in the same place Excon really blocks.
@@ -90,11 +68,10 @@ if DependencyHelper.excon_present?
         )
       end
 
-      it "is recorded on neither event" do
+      it "is recorded on the event" do
         perform
 
-        expect(event_duration("request.excon")).to be < 50
-        expect(event_duration("response.excon")).to be < 50
+        expect(event_duration("request.excon")).to be >= 100
       end
     end
 
@@ -105,23 +82,10 @@ if DependencyHelper.excon_present?
           .to raise_error(Excon::Error::Timeout)
       end
 
-      it "records the request and the failure as two separate events" do
+      it "records the request as one event, and lets the error through" do
         perform
 
-        expect(event_names).to eq(["request.excon", "error.excon"])
-      end
-
-      # Excon gives an instrumentor only the error when a request fails. The
-      # title is built from a request that is not there, so every failed request
-      # is titled with the leftover punctuation of that format.
-      it "titles the failure event with an empty request" do
-        perform
-
-        expect(transaction).to include_event(
-          "name" => "error.excon",
-          "title" => " ://",
-          "body" => ""
-        )
+        expect(event_names).to eq(["request.excon"])
       end
     end
 
@@ -144,7 +108,8 @@ if DependencyHelper.excon_present?
 
     # Excon retries a request when it is marked idempotent and fails with a
     # socket error. It retries by asking the connection to make the request
-    # again, so each attempt is instrumented on its own.
+    # again, from inside the request it is retrying, so the retries are part of
+    # the same event.
     describe "a request that is retried" do
       def perform
         stub_request(:get, "http://www.example.com/").to_timeout
@@ -157,19 +122,16 @@ if DependencyHelper.excon_present?
         end.to raise_error(Excon::Error::Timeout)
       end
 
-      it "records an event per attempt, and one for the failure" do
+      it "records every attempt as one event" do
         perform
 
-        expect(event_names).to eq(
-          ["request.excon", "retry.excon", "retry.excon", "error.excon"]
-        )
+        expect(event_names).to eq(["request.excon"])
       end
     end
 
-    # Excon follows a redirect by making the request again against the new
-    # location, so each hop is instrumented on its own. The hop that redirects
-    # never reaches the instrumentor with its response, because the middleware
-    # that follows the redirect replaces it, so only the last hop records one.
+    # Excon follows a redirect the same way, by making the request again from
+    # inside the request being redirected, so every hop is part of the same
+    # event.
     describe "a request that is redirected" do
       def perform
         stub_request(:get, "http://www.example.com/").to_return(
@@ -184,11 +146,15 @@ if DependencyHelper.excon_present?
         )
       end
 
-      it "records an event per hop, and one response for the last hop" do
+      it "records every hop as one event" do
         perform
 
-        expect(event_names).to eq(
-          ["request.excon", "request.excon", "response.excon"]
+        expect(event_names).to eq(["request.excon"])
+        # The event is titled after the request that was made, not the location
+        # it ended up at.
+        expect(transaction).to include_event(
+          "name" => "request.excon",
+          "title" => "GET http://www.example.com"
         )
       end
     end

--- a/spec/lib/appsignal/integrations/faraday_spec.rb
+++ b/spec/lib/appsignal/integrations/faraday_spec.rb
@@ -62,7 +62,10 @@ if DependencyHelper.faraday_present?
           "body" => ""
         )
         # Excon is suppressed under Faraday, so it isn't recorded again.
-        expect(transaction).to_not include_event("name" => "request.excon")
+        # Asserted on the whole list of event names, so that an Excon event with
+        # any title at all fails this.
+        expect(transaction.to_h["events"].map { |event| event["name"] })
+          .to eq(["request.faraday"])
       end
     end
   end


### PR DESCRIPTION
This does for Excon what #1523 did for Faraday: it turns the integration into
something the OpenTelemetry work can build on. The OpenTelemetry side, meaning
the client span kind, the trace context propagation and the span attributes,
follows separately on #1566.

The reason it needs rebuilding is that Excon's own instrumentor cannot measure a
request. A slow Excon request has been reported as taking almost no time.

### [Add an Excon gemfile to the test matrix](https://github.com/appsignal/appsignal-ruby/commit/298da4e93f8612ee40cf424464916102f1cf275c)

The Excon integration has never been tested against the real Excon gem.
Its spec replaces Excon with a stub class and calls the instrumentor by
hand, so nothing checks that Excon calls us the way the integration
expects. The only place the real gem is installed today is the faraday-2
gemfile, which needs it for Faraday's Excon adapter.

Add a gemfile for it and run it in CI. The gem is not pinned to a
version. Excon 1.6 needs Ruby 3.1 and Excon 1.0 needs Ruby 2.7, so the
Ruby versions already in the matrix resolve a spread of Excon versions
between them.

### [Test the Excon integration against the real gem](https://github.com/appsignal/appsignal-ruby/commit/7b149141d91850eebe6698e9038902e433ebec32)

Excon calls an instrumentor three times per request, and AppSignal
records each call as its own event. Nothing tested that against Excon
itself. The hook spec stubbed Excon out and called the instrumentor by
hand, feeding it data of its own making, so it could not tell whether
Excon calls us the way the integration expects.

Add an integration spec that drives real Excon requests, and record what
the integration produces today. Three things it produces are wrong.

The response event has no title. Excon gives an instrumentor only the
response when it reads one, and a response holds no host, so the title
the integration builds from the host has never been there. The old hook
spec passed a host in itself, which is why it never noticed.

The failure event is titled " ://". Excon gives an instrumentor only the
error when a request fails, and the integration builds a title out of a
request that is not there.

The time spent waiting for the remote service is recorded on neither
event. Excon runs its middleware stack twice, once to send the request
and again to read the response, and the middleware that reads the
response off the socket sits outside the one that calls the
instrumentor. So an Excon request is reported as taking almost no time,
however slow it really was.

A retried request records an event per attempt and one for the failure,
and a redirected request records an event per hop, so one request can
become four or more unrelated events.

Move the instrumentation tests out of the hook spec, which now covers
what the other hook specs cover: whether the dependency is there, and
whether installing works.

The Faraday spec's claim that Excon is not recorded a second time under
Faraday was passing whatever happened. The matcher it used fills in an
empty title for the keys it is not given, and a real Excon event has a
title, so the claim ruled out nothing. It now asserts on the whole list
of event names.

### [Record an Excon request as one event](https://github.com/appsignal/appsignal-ruby/commit/0a0f098527fa435a4830394fcec4364bbbf2596c)

Excon reports a request to an instrumentor in pieces: one when it sends
the request, one when it reads the response, and one when the request
fails. AppSignal recorded each piece as its own event, so one request
became two or more events, and none of them measured the request.

None of them could. Excon runs its middleware stack twice, once to send
the request and again to read the response, and the middleware that
reads the response off the socket sits outside the one that calls the
instrumentor. So the wait for the remote service falls outside every
piece an instrumentor is told about.

Instrument the connection instead. Excon::Connection#request sends the
request, waits for the response, reads it and only then returns, so one
event around that method covers the whole request and lasts as long as
the request did.

Excon retries a request, and follows a redirect, by calling that same
method again from inside the request it is retrying or following. Those
calls are suppressed with the flag the Faraday integration already
uses, so they count towards the event of the request that started them
rather than becoming events of their own.

AppSignal also no longer registers itself as Excon's instrumentor. Excon
allows only one, so an application that set up its own was having it
replaced.

### [Report the Excon integration as enabled](https://github.com/appsignal/appsignal-ruby/commit/1c65693af7e3c0a7fd098225f80ac43c35520842)

Every other HTTP client hook reports itself once it has installed, so
AppSignal knows the integration is active and not merely that the gem is
there. The Excon hook never did, so an application using Excon looked
like one that happened to have Excon installed.
