### PR TITLE
Fix the negated include_event matcher

### DIFF
--- a/spec/lib/appsignal/rack/body_wrapper_spec.rb
+++ b/spec/lib/appsignal/rack/body_wrapper_spec.rb
@@ -120,30 +120,28 @@ describe Appsignal::Rack::BodyWrapper do
         expect { |b| enum.each(&b) }.to yield_successive_args("a", "b", "c")
       end
 
+      # Iterating the returned Enumerator reads the body through the same
+      # instrumented `each`, so it is recorded exactly as passing a block is.
       it "in agent mode", :agent_mode do
         start_agent
 
         perform
 
-        expect(transaction).to_not include_event("name" => "process_response_body.rack")
+        expect(transaction).to include_event(
+          "name" => "process_response_body.rack",
+          "title" => "Process Rack response body (#each)"
+        )
       end
 
       it "in collector mode", :collector_mode do
         start_collector_agent
 
         perform
-        transaction.complete
 
-        # Mirrors the agent `to_not include_event` here: that matcher only
-        # excludes a *default-shaped* event (empty title). Iterating the
-        # returned Enumerator still instruments `each`, so the recorded event
-        # carries the "#each" title -- there is just never a title-less one.
-        # A title-less event names the span after its category alone, without
-        # a parenthesized title; the "#each" one never does.
-        titleless_event = event_spans_for("process_response_body.rack").find do |span|
-          span.name == "process_response_body.rack"
-        end
-        expect(titleless_event).to be_nil
+        expect_collector_event(
+          "process_response_body.rack",
+          "Process Rack response body (#each)"
+        )
       end
     end
 

--- a/spec/support/matchers/transaction.rb
+++ b/spec/support/matchers/transaction.rb
@@ -108,7 +108,13 @@ RSpec::Matchers.define :include_event do |event|
   match_when_negated(:notify_expectation_failures => true) do |transaction|
     events = transaction.to_h["events"]
     if event
-      expect(events).to_not include(format_event(event))
+      # Match on the given keys alone, rather than through `format_event`. Every
+      # key the caller leaves out is given a default there, and an event that
+      # differs from that default in any of them does not match. So an event
+      # ruled out by name alone still matched nothing as soon as it had a title,
+      # which nearly every event has, and the expectation passed while the event
+      # it ruled out was there all along.
+      expect(events).to_not include(hash_including(event.transform_keys(&:to_s)))
     else
       expect(events).to be_empty
     end


### PR DESCRIPTION
Fix the negated include_event matcher

The include_event matcher fills in a default for every key the caller
leaves out. In the negated form that made the expectation pass almost
regardless: an event ruled out by name alone was only matched if its
title was empty too, and nearly every event has a title. So a spec
saying an event was not recorded was saying nothing, and would have gone
on passing if that event appeared.

Match on the given keys alone when the matcher is negated. The Faraday
spec is the one that was leaning on this. Its claim that Net::HTTP is
not recorded a second time under Faraday now fails if the suppression is
taken away, where before it passed either way.

Iterating a Rack response body's Enumerator turns out to record an event
that a spec said it did not. It reads the body through the same
instrumented each, so it is recorded exactly as passing a block is, and
that spec now says so. Its collector mode counterpart was written around
the old matcher's behaviour, so it says the same thing now as well.

[skip changeset]

