### PR TITLE
Fix the event formatter registry

### DIFF
--- a/.changesets/fix-event-formatter-self-registration.md
+++ b/.changesets/fix-event-formatter-self-registration.md
@@ -1,0 +1,14 @@
+---
+bump: patch
+type: fix
+---
+
+Fix event formatters that register or unregister themselves. Calling
+`unregister` on the formatter itself, as in `MyFormatter.unregister("my.event")`,
+did nothing at all. The formatter stayed registered, and no error was raised and
+nothing was logged to say so. Calling `register` on the formatter itself stored
+it where AppSignal never looked for it, so it was never used to format an event.
+
+Registering and unregistering through `Appsignal::EventFormatter` itself, as in
+`Appsignal::EventFormatter.unregister("my.event", MyFormatter)`, was not
+affected and keeps working the same way.

--- a/lib/appsignal/event_formatter.rb
+++ b/lib/appsignal/event_formatter.rb
@@ -11,15 +11,26 @@ module Appsignal
   # So only keep global configuration as state and pass the payload around as an
   # argument if you need to use helper methods.
   class EventFormatter
+    # There is one registry of event formatters, shared by this class and by
+    # every formatter that inherits from it. It is kept in a constant because a
+    # class instance variable is not shared with subclasses. Without this, a
+    # formatter that registers or unregisters itself would read and write a
+    # registry of its own that nothing else looks at.
+    REGISTRY = {
+      :formatters => {},
+      :formatter_classes => {}
+    }.freeze
+    private_constant :REGISTRY
+
     class << self
       # @!visibility private
       def formatters
-        @formatters ||= {}
+        REGISTRY[:formatters]
       end
 
       # @!visibility private
       def formatter_classes
-        @formatter_classes ||= {}
+        REGISTRY[:formatter_classes]
       end
 
       # Registers an event formatter for a specific event name.

--- a/lib/appsignal/event_formatter/action_view/render_formatter.rb
+++ b/lib/appsignal/event_formatter/action_view/render_formatter.rb
@@ -4,7 +4,7 @@ module Appsignal
   class EventFormatter
     # @!visibility private
     module ActionView
-      class RenderFormatter
+      class RenderFormatter < Appsignal::EventFormatter
         BLANK = ""
 
         def format(payload)

--- a/lib/appsignal/event_formatter/active_record/instantiation_formatter.rb
+++ b/lib/appsignal/event_formatter/active_record/instantiation_formatter.rb
@@ -4,7 +4,7 @@ module Appsignal
   class EventFormatter
     # @!visibility private
     module ActiveRecord
-      class InstantiationFormatter
+      class InstantiationFormatter < Appsignal::EventFormatter
         def format(payload)
           [payload[:class_name], nil]
         end

--- a/lib/appsignal/event_formatter/active_record/sql_formatter.rb
+++ b/lib/appsignal/event_formatter/active_record/sql_formatter.rb
@@ -4,7 +4,7 @@ module Appsignal
   class EventFormatter
     # @!visibility private
     module ActiveRecord
-      class SqlFormatter
+      class SqlFormatter < Appsignal::EventFormatter
         def format(payload)
           [payload[:name], payload[:sql], SQL_BODY_FORMAT]
         end

--- a/lib/appsignal/event_formatter/elastic_search/search_formatter.rb
+++ b/lib/appsignal/event_formatter/elastic_search/search_formatter.rb
@@ -4,7 +4,7 @@ module Appsignal
   class EventFormatter
     # @!visibility private
     module ElasticSearch
-      class SearchFormatter
+      class SearchFormatter < Appsignal::EventFormatter
         def format(payload)
           [
             "#{payload[:name]}: #{payload[:klass]}",

--- a/lib/appsignal/event_formatter/rom/sql_formatter.rb
+++ b/lib/appsignal/event_formatter/rom/sql_formatter.rb
@@ -4,7 +4,7 @@ module Appsignal
   class EventFormatter
     # @!visibility private
     module Rom
-      class SqlFormatter
+      class SqlFormatter < Appsignal::EventFormatter
         def format(payload)
           ["query.#{payload[:name]}", payload[:query], SQL_BODY_FORMAT]
         end

--- a/lib/appsignal/event_formatter/sequel/sql_formatter.rb
+++ b/lib/appsignal/event_formatter/sequel/sql_formatter.rb
@@ -9,7 +9,7 @@ module Appsignal
       # that conflict with our own sequel instrumentor. Without this event
       # formatter the sequel-rails events are recorded without the SQL query
       # that's being executed.
-      class SqlFormatter
+      class SqlFormatter < Appsignal::EventFormatter
         def format(payload)
           [payload[:name].to_s, payload[:sql], SQL_BODY_FORMAT]
         end

--- a/lib/appsignal/event_formatter/view_component/render_formatter.rb
+++ b/lib/appsignal/event_formatter/view_component/render_formatter.rb
@@ -4,7 +4,7 @@ module Appsignal
   class EventFormatter
     # @!visibility private
     module ViewComponent
-      class RenderFormatter
+      class RenderFormatter < Appsignal::EventFormatter
         BLANK = ""
 
         def format(payload)

--- a/spec/lib/appsignal/event_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter_spec.rb
@@ -39,12 +39,26 @@ end
 
 describe Appsignal::EventFormatter do
   let(:klass) { described_class }
+
+  # Registering an event formatter writes to a registry that is shared by the
+  # whole test suite, so this file has to leave it as it found it.
+  before(:context) do
+    @formatters = Appsignal::EventFormatter.formatters.dup
+    @formatter_classes = Appsignal::EventFormatter.formatter_classes.dup
+  end
+
+  after(:context) do
+    expect(Appsignal::EventFormatter.formatters).to eq(@formatters)
+    expect(Appsignal::EventFormatter.formatter_classes).to eq(@formatter_classes)
+  end
+
   around do |example|
-    original_formatters = described_class.formatters
+    formatters = described_class.formatters.dup
+    formatter_classes = described_class.formatter_classes.dup
     example.run
-    # rubocop:disable Style/ClassVars
-    described_class.class_variable_set(:@@formatters, original_formatters)
-    # rubocop:enable Style/ClassVars
+  ensure
+    described_class.formatters.replace(formatters)
+    described_class.formatter_classes.replace(formatter_classes)
   end
 
   describe "the event formatters in this gem" do

--- a/spec/lib/appsignal/event_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter_spec.rb
@@ -69,6 +69,15 @@ describe Appsignal::EventFormatter do
       end
     end
 
+    context "when the formatter registers itself" do
+      it "registers it where the other formatters are registered" do
+        MockFormatter.register("mock.self_register", MockFormatter)
+
+        expect(klass.registered?("mock.self_register")).to be_truthy
+        expect(klass.format("mock.self_register", {})).to eq ["title", "some value"]
+      end
+    end
+
     context "when there is an error initializing the formatter" do
       it "does not register the formatter and logs an error" do
         logs = capture_logs do
@@ -164,6 +173,17 @@ describe Appsignal::EventFormatter do
 
         klass.unregister("mock.unregister", MockFormatter)
         expect(klass.registered?("mock.unregister")).to be_falsy
+      end
+    end
+
+    context "when the formatter unregisters itself" do
+      it "unregisters the formatter" do
+        klass.register("mock.self_unregister", MockFormatter)
+        expect(klass.registered?("mock.self_unregister")).to be_truthy
+
+        MockFormatter.unregister("mock.self_unregister")
+
+        expect(klass.registered?("mock.self_unregister")).to be_falsy
       end
     end
 

--- a/spec/lib/appsignal/event_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter_spec.rb
@@ -47,6 +47,12 @@ describe Appsignal::EventFormatter do
     # rubocop:enable Style/ClassVars
   end
 
+  describe "the event formatters in this gem" do
+    it "inherit from Appsignal::EventFormatter" do
+      expect(klass.formatter_classes.values.uniq).to all(be < described_class)
+    end
+  end
+
   describe ".register" do
     it "registers a formatter" do
       expect(klass.registered?("mock")).to be_falsy


### PR DESCRIPTION
### [Fix event formatters registering themselves](https://github.com/appsignal/appsignal-ruby/commit/049c5cf5)

The registry of event formatters was kept in class instance variables on
Appsignal::EventFormatter. A class instance variable is not shared with
subclasses, so a formatter that called `register` or `unregister` on
itself read and wrote a registry of its own that nothing else looks at.

Unregistering was the worse of the two. Its second argument defaults to
`self`, so that a formatter can unregister itself without repeating its
own name. That default was the one call shape that could not work, and
it failed silently: the method found nothing to unregister and returned
without raising an error or logging anything.

The registry now lives in a constant, which is found from anywhere in
the class hierarchy.

### [Inherit event formatters from the base class](https://github.com/appsignal/appsignal-ruby/commit/8d5700ef)

The documentation on Appsignal::EventFormatter tells anyone writing a
formatter to inherit from it, but none of the formatters in this gem
did. They were plain classes nested inside it for namespacing only.

They inherit now, so the gem follows the advice it gives. Nothing about
how they behave changes, because a formatter is looked up and called by
name rather than by type.

The Mongo query formatter is left out. It is not registered as an event
formatter, and the Mongo integration calls it directly instead of
looking it up by name. Its `format` is also a class method that takes
two arguments, so it would override the class method of the same name
that it would inherit.

### [Leave the event formatter registry as it was found](https://github.com/appsignal/appsignal-ruby/commit/f5ac6a46)

The event formatter spec registers formatters to test with, and it tried
to put the registry back as it found it after every example. That did
not work. It restored a class variable named `@@formatters`, which
nothing reads, rather than the registry itself. It also kept a reference
to the registry instead of a copy of it, so there was nothing left to
restore by the time it tried.

Every formatter that spec registered stayed registered for the rest of
the suite. Nothing failed over it, because the names it registers are
made up and no other spec looks them up.

Restore both halves of the registry by copying them and putting the
copies back, and check that the file leaves the registry as it found it.
