### PR TITLE
Name ROM query events after ROM

### DIFF
--- a/.changesets/name-rom-query-events-after-rom.md
+++ b/.changesets/name-rom-query-events-after-rom.md
@@ -1,0 +1,21 @@
+---
+bump: patch
+type: change
+---
+
+Name ROM query events after ROM, rather than after the database they ran
+against.
+
+A query made through ROM was reported as `query.postgres`, or `query.sqlite`,
+or whatever else the application's database was. The part after the dot is what
+AppSignal groups events by, so an application's queries were split into a group
+per database engine, and the same application reported one group in production
+and another one in its test suite. Those queries are now all reported as
+`query.rom`.
+
+Events that dry-monitor reports and AppSignal has no formatter for are now named
+after their event id followed by `.dry`, so an event reported as `foo` becomes
+`foo.dry`. They had no group at all before.
+
+If you have a dashboard, trigger or saved filter that names one of these events,
+point it at the new name.

--- a/lib/appsignal/event_formatter/rom/sql_formatter.rb
+++ b/lib/appsignal/event_formatter/rom/sql_formatter.rb
@@ -5,8 +5,17 @@ module Appsignal
     # @!visibility private
     module Rom
       class SqlFormatter < Appsignal::EventFormatter
+        # dry-monitor reports an event under an id rather than a name, so the
+        # first value here names the event. Naming it after ROM keeps every ROM
+        # query in one group.
+        #
+        # The payload also says which database ROM is talking to, as Sequel's
+        # database type. That is deliberately not part of the name. It would
+        # put an application's queries in a group per database engine, so the
+        # same application would report one group in production and another in
+        # its tests.
         def format(payload)
-          ["query.#{payload[:name]}", payload[:query], SQL_BODY_FORMAT]
+          ["query.rom", payload[:query], SQL_BODY_FORMAT]
         end
       end
     end

--- a/lib/appsignal/integrations/dry_monitor.rb
+++ b/lib/appsignal/integrations/dry_monitor.rb
@@ -9,11 +9,16 @@ module Appsignal
 
         super
       ensure
-        title, body, body_format = Appsignal::EventFormatter.format("#{event_id}.dry", payload)
+        name = "#{event_id}.dry"
+        event_name, body, body_format = Appsignal::EventFormatter.format(name, payload)
 
+        # dry-monitor reports an event under an id, such as `sql`, rather than
+        # a name. A formatter names the event it knows about, and an event
+        # without one is named after its id in the dry-monitor group. Either
+        # way the name has a group, which is what an event is listed under.
         Appsignal::Transaction.current.finish_event(
-          title || event_id.to_s,
-          title,
+          event_name || name,
+          nil,
           body,
           body_format
         )

--- a/spec/lib/appsignal/event_formatter/rom/sql_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/rom/sql_formatter_spec.rb
@@ -9,14 +9,21 @@ describe Appsignal::EventFormatter::Rom::SqlFormatter do
   end
 
   describe "#format" do
-    let(:payload) do
-      {
-        :name => "postgres",
-        :query => "SELECT * FROM users"
-      }
-    end
     subject { formatter.format(payload) }
 
-    it { is_expected.to eq ["query.postgres", "SELECT * FROM users", 1] }
+    # ROM reports the database it is talking to as the event's `name`, as
+    # Sequel's database type. Every ROM query is named after ROM whichever
+    # database that is, so that they are all in one group.
+    context "with a PostgreSQL database" do
+      let(:payload) { { :name => :postgres, :query => "SELECT * FROM users" } }
+
+      it { is_expected.to eq ["query.rom", "SELECT * FROM users", 1] }
+    end
+
+    context "with a SQLite database" do
+      let(:payload) { { :name => :sqlite, :query => "SELECT * FROM users" } }
+
+      it { is_expected.to eq ["query.rom", "SELECT * FROM users", 1] }
+    end
   end
 end

--- a/spec/lib/appsignal/hooks/dry_monitor_spec.rb
+++ b/spec/lib/appsignal/hooks/dry_monitor_spec.rb
@@ -43,19 +43,19 @@ if DependencyHelper.dry_monitor_present?
       let(:event_id) { :sql }
       let(:payload) do
         {
-          :name => "postgres",
+          :name => :postgres,
           :query => "SELECT * FROM users"
         }
       end
 
-      it "creates an sql event" do
+      it "creates an sql event named after ROM" do
         notifications.instrument(event_id, payload)
         expect(transaction).to include_event(
           "body" => "SELECT * FROM users",
           "body_format" => Appsignal::EventFormatter::SQL_BODY_FORMAT,
           "count" => 1,
-          "name" => "query.postgres",
-          "title" => "query.postgres"
+          "name" => "query.rom",
+          "title" => ""
         )
       end
     end
@@ -68,13 +68,13 @@ if DependencyHelper.dry_monitor_present?
         }
       end
 
-      it "creates a generic event" do
+      it "creates a generic event in the dry-monitor group" do
         notifications.instrument(event_id, payload)
         expect(transaction).to include_event(
           "body" => "",
           "body_format" => Appsignal::EventFormatter::DEFAULT,
           "count" => 1,
-          "name" => "foo",
+          "name" => "foo.dry",
           "title" => ""
         )
       end


### PR DESCRIPTION
A ROM query was reported as `query.postgres`, or `query.sqlite`, or
whatever else the application's database was. AppSignal groups events by
the part of the name after the dot, so this put an application's queries
in a group per database engine. The same application reported one group
in production and another in its test suite, and two applications
reaching the same database through ROM and through Sequel ended up in
unrelated groups.

The database is an attribute of the query, not its identity. ROM reports
it in the event's payload as Sequel's database type, and this used it as
the name. The name is now `query.rom` whichever database it was.

dry-monitor reports an event under an id, such as `sql`, rather than a
name. So the first value a formatter returns is what names the event
here, which is why this is the formatter's decision. An event with no
formatter was named after its id alone, which left it with no group at
all, and is now named after its id in the dry-monitor group.

The title was the event name repeated, so it is dropped. It showed the
same string twice.

