### PR TITLE
Title collection and layout render events

### DIFF
--- a/.changesets/title-collection-and-layout-renders.md
+++ b/.changesets/title-collection-and-layout-renders.md
@@ -1,0 +1,20 @@
+---
+bump: patch
+type: change
+---
+
+Report which template was rendered for collection and layout render events.
+
+Rendering a template or a partial is reported with the template's path, so you
+can tell one from another. Rendering a collection or a layout was reported
+without one. Every collection render in an application was recorded as the same
+event, however many different partials it rendered, and so was every layout
+render.
+
+They now carry the template's path as well. A collection render reports the
+partial it rendered for each item in the collection, and a layout render
+reports the layout.
+
+This means an application that renders several collections, or several layouts,
+now sees one event per template where it used to see one event in total. That
+is what makes it possible to tell which of them is the slow one.

--- a/lib/appsignal/event_formatter/action_view/render_formatter.rb
+++ b/lib/appsignal/event_formatter/action_view/render_formatter.rb
@@ -30,4 +30,15 @@ if defined?(Rails)
     "render_template.action_view",
     Appsignal::EventFormatter::ActionView::RenderFormatter
   )
+  # Action View reports the template's path for these two as well, so they are
+  # titled the same way. A collection reports the partial it rendered for each
+  # item, and a layout reports itself.
+  Appsignal::EventFormatter.register(
+    "render_collection.action_view",
+    Appsignal::EventFormatter::ActionView::RenderFormatter
+  )
+  Appsignal::EventFormatter.register(
+    "render_layout.action_view",
+    Appsignal::EventFormatter::ActionView::RenderFormatter
+  )
 end

--- a/spec/lib/appsignal/event_formatter/action_view/render_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/action_view/render_formatter_spec.rb
@@ -8,10 +8,14 @@ describe Appsignal::EventFormatter::ActionView::RenderFormatter do
       let(:formatter) { klass.new }
       before { allow(Rails.root).to receive(:to_s).and_return("/var/www/app/20130101") }
 
-      it "registers render_partial.action_view and render_template.action_view" do
+      it "registers every event that renders a template" do
         expect(Appsignal::EventFormatter.registered?("render_partial.action_view",
           klass)).to be_truthy
         expect(Appsignal::EventFormatter.registered?("render_template.action_view",
+          klass)).to be_truthy
+        expect(Appsignal::EventFormatter.registered?("render_collection.action_view",
+          klass)).to be_truthy
+        expect(Appsignal::EventFormatter.registered?("render_layout.action_view",
           klass)).to be_truthy
       end
 
@@ -53,6 +57,10 @@ describe Appsignal::EventFormatter::ActionView::RenderFormatter do
         expect(Appsignal::EventFormatter.registered?("render_partial.action_view",
           klass)).to be_falsy
         expect(Appsignal::EventFormatter.registered?("render_template.action_view",
+          klass)).to be_falsy
+        expect(Appsignal::EventFormatter.registered?("render_collection.action_view",
+          klass)).to be_falsy
+        expect(Appsignal::EventFormatter.registered?("render_layout.action_view",
           klass)).to be_falsy
       end
     end


### PR DESCRIPTION
Rendering a template or a partial is titled with the template's path,
made relative to the application's root. Rendering a collection or a
layout was not titled at all, so every collection render in an
application was recorded as one event however many different partials it
rendered, and so was every layout render.

Action View reports the template's path for all four of these events, so
there was nothing to work out. These two were simply never registered
with the formatter that reads it.

Registering them means an application sees one event per template where
it saw one event in total. That is the point: it is what makes it
possible to tell which collection is the slow one.

A collection rendered from a heterogeneous set has no single template to
name, and Action View reports no path for it. The formatter already
returns no title when there is no path, so those keep the title they
have now, which is none.

