### PR TITLE
Load the Rails app before running demo

### DIFF
--- a/.changesets/fix-demo-rails-app-loading.md
+++ b/.changesets/fix-demo-rails-app-loading.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+type: fix
+---
+
+Load the host Rails application before the `appsignal demo` command reads its
+configuration. This allows `config/appsignal.rb` to reference Rails application
+state, matching the behavior of `appsignal diagnose`.

--- a/lib/appsignal/cli/demo.rb
+++ b/lib/appsignal/cli/demo.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "appsignal/cli/helpers"
 require "appsignal/demo"
 
 module Appsignal
@@ -40,6 +41,8 @@ module Appsignal
     # @see https://docs.appsignal.com/support/debugging.html
     #   Debugging AppSignal guide
     class Demo
+      extend CLI::Helpers
+
       class << self
         # @param options [Hash]
         # @option options :environment [String] environment to load
@@ -47,6 +50,7 @@ module Appsignal
         # @return [void]
         def run(options = {})
           ENV["APPSIGNAL_APP_ENV"] = options[:environment] if options[:environment]
+          require_rails_app_if_present(options[:environment])
 
           puts "Sending demonstration sample data..."
           if Appsignal::Demo.transmit
@@ -63,6 +67,19 @@ module Appsignal
             puts
             exit 1
           end
+        end
+
+        private
+
+        def require_rails_app_if_present(environment)
+          return unless rails_present?
+
+          load_rails_app(environment)
+        rescue LoadError, StandardError => error
+          puts
+          puts "ERROR: Error encountered while loading the Rails app"
+          puts "#{error.class}: #{error.message}"
+          puts error.backtrace
         end
       end
     end

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -635,17 +635,9 @@ module Appsignal
         def require_rails_app_if_present(env_option)
           return unless rails_present?
 
-          # Set the environment given as an option to the diagnose CLI so the
-          # Rails app uses it when loaded.
-          ENV["_APPSIGNAL_CONFIG_FILE_ENV"] = env_option
           # Mark app as Rails app
           data[:app][:rails] = true
-          # Manually require the railtie, because it wasn't loaded when the CLI
-          # started and AppSignal loaded, because the `Rails` constant wasn't
-          # present.
-          require "appsignal/integrations/railtie"
-          # Start the Rails app, including railties and initializers.
-          require Appsignal::Utils::RailsHelper.environment_config_path
+          load_rails_app(env_option)
         rescue LoadError, StandardError => error
           print_empty_line
           puts "ERROR: Error encountered while loading the Rails app"
@@ -653,16 +645,6 @@ module Appsignal
           puts error.backtrace
           data[:app][:load_error] =
             "#{error.class}: #{error.message}\n#{error.backtrace.join("\n")}"
-        ensure
-          ENV.delete("_APPSIGNAL_CONFIG_FILE_ENV")
-        end
-
-        def rails_present?
-          # Try and load the Rails gem
-          require "rails"
-          true
-        rescue LoadError
-          false
         end
       end
     end

--- a/lib/appsignal/cli/helpers.rb
+++ b/lib/appsignal/cli/helpers.rb
@@ -36,6 +36,21 @@ module Appsignal
         "\e[#{color_code}m#{text}\e[#{reset_color_code}m"
       end
 
+      def load_rails_app(environment)
+        ENV["_APPSIGNAL_CONFIG_FILE_ENV"] = environment
+        require "appsignal/integrations/railtie"
+        require Appsignal::Utils::RailsHelper.environment_config_path
+      ensure
+        ENV.delete("_APPSIGNAL_CONFIG_FILE_ENV")
+      end
+
+      def rails_present?
+        require "rails"
+        true
+      rescue LoadError
+        false
+      end
+
       def periods
         3.times do
           print "."

--- a/spec/lib/appsignal/cli/demo_spec.rb
+++ b/spec/lib/appsignal/cli/demo_spec.rb
@@ -42,5 +42,19 @@ describe Appsignal::CLI::Demo do
       run
       expect(output).to include("Demonstration sample data sent!")
     end
+
+    context "when Rails is present" do
+      before do
+        allow(described_class).to receive(:rails_present?).and_return(true)
+      end
+
+      it "loads the Rails application before transmitting" do
+        expect(described_class).to receive(:load_rails_app)
+          .with("development").ordered
+        expect(Appsignal::Demo).to receive(:transmit).ordered.and_return(true)
+
+        run
+      end
+    end
   end
 end

--- a/spec/lib/appsignal/cli/helpers_spec.rb
+++ b/spec/lib/appsignal/cli/helpers_spec.rb
@@ -49,6 +49,48 @@ describe Appsignal::CLI::Helpers do
     end
   end
 
+  describe ".load_rails_app" do
+    let(:environment_path) { "/app/config/environment.rb" }
+
+    before do
+      allow(Appsignal::Utils::RailsHelper).to receive(:environment_config_path)
+        .and_return(environment_path)
+    end
+
+    it "loads the railtie and application with the selected environment" do
+      expect(cli).to receive(:require)
+        .with("appsignal/integrations/railtie").ordered
+      expect(cli).to receive(:require).with(environment_path).ordered do
+        expect(ENV.fetch("_APPSIGNAL_CONFIG_FILE_ENV", nil)).to eq("staging")
+      end
+
+      cli.send(:load_rails_app, "staging")
+
+      expect(ENV).not_to have_key("_APPSIGNAL_CONFIG_FILE_ENV")
+    end
+
+    it "clears the selected environment when loading fails" do
+      allow(cli).to receive(:require).and_raise(LoadError)
+
+      expect { cli.send(:load_rails_app, "staging") }.to raise_error(LoadError)
+      expect(ENV).not_to have_key("_APPSIGNAL_CONFIG_FILE_ENV")
+    end
+  end
+
+  describe ".rails_present?" do
+    it "returns true when Rails can be loaded" do
+      expect(cli).to receive(:require).with("rails")
+
+      expect(cli.send(:rails_present?)).to be(true)
+    end
+
+    it "returns false when Rails cannot be loaded" do
+      expect(cli).to receive(:require).with("rails").and_raise(LoadError)
+
+      expect(cli.send(:rails_present?)).to be(false)
+    end
+  end
+
   describe ".periods" do
     it "prints three periods" do
       capture_stdout(out_stream) { cli.send :periods }


### PR DESCRIPTION
`appsignal demo` now boots a Rails application before transmitting, matching `appsignal diagnose`. This lets `config/appsignal.rb` reference Rails state and passes the selected environment through while the app boots.

Both commands use the same loader, which also clears the temporary config environment if loading fails.

Fixes #1571