### PR TITLE
Match `monitor`'s arguments in `monitor_and_stop`

### DIFF
--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -193,6 +193,14 @@ module Appsignal
       #   within the block with {#set_action}.
       #   This will not update the active transaction's action if
       #   {.monitor} is called when another transaction is already active.
+      # @param opentelemetry_kind [Symbol] In collector mode, the OpenTelemetry
+      #   span kind: one of `:server`, `:consumer`, `:producer` or `:internal`.
+      #   Defaults to `:server`.
+      # @param opentelemetry_relationship [Symbol] In collector mode, how an
+      #   incoming `opentelemetry_context` relates to this transaction's span:
+      #   one of `:parent`, `:link`, `:both` or `:none`. Defaults to `:parent`.
+      # @param opentelemetry_context In collector mode, an incoming OpenTelemetry
+      #   trace context to relate this transaction's span to.
       # @param opentelemetry_scope [Array(String, String)] In collector mode, the
       #   OpenTelemetry instrumentation scope to record this transaction's spans
       #   under, given as a `[name, version]` pair. Defaults to the AppSignal
@@ -204,7 +212,15 @@ module Appsignal
       # @return [Object, nil] The value of the given block is returned.
       #
       # @see monitor
-      def monitor_and_stop(action:, namespace: nil, opentelemetry_scope: nil, &block)
+      def monitor_and_stop( # rubocop:disable Metrics/ParameterLists
+        action:,
+        namespace: nil,
+        opentelemetry_context: nil,
+        opentelemetry_scope: nil,
+        opentelemetry_kind: nil,
+        opentelemetry_relationship: nil,
+        &block
+      )
         Appsignal::Utils::StdoutAndLoggerMessage.warning \
           "The `Appsignal.monitor_and_stop` helper is deprecated. " \
             "Use the `Appsignal.monitor` along with our `enable_at_exit_hook` " \
@@ -213,7 +229,10 @@ module Appsignal
         monitor(
           :namespace => namespace,
           :action => action,
+          :opentelemetry_context => opentelemetry_context,
           :opentelemetry_scope => opentelemetry_scope,
+          :opentelemetry_kind => opentelemetry_kind,
+          :opentelemetry_relationship => opentelemetry_relationship,
           &block
         )
       ensure

--- a/sig/appsignal.rbi
+++ b/sig/appsignal.rbi
@@ -424,6 +424,12 @@ module Appsignal
   # 
   # _@param_ `action` — The action name for the transaction. The action name is required to be set for the transaction to be reported. The argument can be set to `nil` or `:set_later` if the action is set within the block with {#set_action}. This will not update the active transaction's action if {.monitor} is called when another transaction is already active.
   # 
+  # _@param_ `opentelemetry_kind` — In collector mode, the OpenTelemetry span kind: one of `:server`, `:consumer`, `:producer` or `:internal`. Defaults to `:server`.
+  # 
+  # _@param_ `opentelemetry_relationship` — In collector mode, how an incoming `opentelemetry_context` relates to this transaction's span: one of `:parent`, `:link`, `:both` or `:none`. Defaults to `:parent`.
+  # 
+  # _@param_ `opentelemetry_context` — In collector mode, an incoming OpenTelemetry trace context to relate this transaction's span to.
+  # 
   # _@param_ `opentelemetry_scope` — In collector mode, the OpenTelemetry instrumentation scope to record this transaction's spans under, given as a `[name, version]` pair. Defaults to the AppSignal scope.
   # 
   # _@return_ — The value of the given block is returned.
@@ -433,11 +439,14 @@ module Appsignal
     params(
       action: T.any(String, Symbol, NilClass),
       namespace: T.nilable(T.any(String, Symbol)),
+      opentelemetry_context: T.untyped,
       opentelemetry_scope: T.nilable([String, String]),
+      opentelemetry_kind: T.nilable(Symbol),
+      opentelemetry_relationship: T.nilable(Symbol),
       block: T.proc.returns(Object)
     ).returns(T.nilable(Object))
   end
-  def self.monitor_and_stop(action:, namespace: nil, opentelemetry_scope: nil, &block); end
+  def self.monitor_and_stop(action:, namespace: nil, opentelemetry_context: nil, opentelemetry_scope: nil, opentelemetry_kind: nil, opentelemetry_relationship: nil, &block); end
 
   # Send an error to AppSignal regardless of the context.
   # 
@@ -2323,6 +2332,12 @@ module Appsignal
       # 
       # _@param_ `action` — The action name for the transaction. The action name is required to be set for the transaction to be reported. The argument can be set to `nil` or `:set_later` if the action is set within the block with {#set_action}. This will not update the active transaction's action if {.monitor} is called when another transaction is already active.
       # 
+      # _@param_ `opentelemetry_kind` — In collector mode, the OpenTelemetry span kind: one of `:server`, `:consumer`, `:producer` or `:internal`. Defaults to `:server`.
+      # 
+      # _@param_ `opentelemetry_relationship` — In collector mode, how an incoming `opentelemetry_context` relates to this transaction's span: one of `:parent`, `:link`, `:both` or `:none`. Defaults to `:parent`.
+      # 
+      # _@param_ `opentelemetry_context` — In collector mode, an incoming OpenTelemetry trace context to relate this transaction's span to.
+      # 
       # _@param_ `opentelemetry_scope` — In collector mode, the OpenTelemetry instrumentation scope to record this transaction's spans under, given as a `[name, version]` pair. Defaults to the AppSignal scope.
       # 
       # _@return_ — The value of the given block is returned.
@@ -2332,11 +2347,14 @@ module Appsignal
         params(
           action: T.any(String, Symbol, NilClass),
           namespace: T.nilable(T.any(String, Symbol)),
+          opentelemetry_context: T.untyped,
           opentelemetry_scope: T.nilable([String, String]),
+          opentelemetry_kind: T.nilable(Symbol),
+          opentelemetry_relationship: T.nilable(Symbol),
           block: T.proc.returns(Object)
         ).returns(T.nilable(Object))
       end
-      def monitor_and_stop(action:, namespace: nil, opentelemetry_scope: nil, &block); end
+      def monitor_and_stop(action:, namespace: nil, opentelemetry_context: nil, opentelemetry_scope: nil, opentelemetry_kind: nil, opentelemetry_relationship: nil, &block); end
 
       # Send an error to AppSignal regardless of the context.
       # 

--- a/sig/appsignal.rbs
+++ b/sig/appsignal.rbs
@@ -378,12 +378,25 @@ module Appsignal
   # 
   # _@param_ `action` — The action name for the transaction. The action name is required to be set for the transaction to be reported. The argument can be set to `nil` or `:set_later` if the action is set within the block with {#set_action}. This will not update the active transaction's action if {.monitor} is called when another transaction is already active.
   # 
+  # _@param_ `opentelemetry_kind` — In collector mode, the OpenTelemetry span kind: one of `:server`, `:consumer`, `:producer` or `:internal`. Defaults to `:server`.
+  # 
+  # _@param_ `opentelemetry_relationship` — In collector mode, how an incoming `opentelemetry_context` relates to this transaction's span: one of `:parent`, `:link`, `:both` or `:none`. Defaults to `:parent`.
+  # 
+  # _@param_ `opentelemetry_context` — In collector mode, an incoming OpenTelemetry trace context to relate this transaction's span to.
+  # 
   # _@param_ `opentelemetry_scope` — In collector mode, the OpenTelemetry instrumentation scope to record this transaction's spans under, given as a `[name, version]` pair. Defaults to the AppSignal scope.
   # 
   # _@return_ — The value of the given block is returned.
   # 
   # _@see_ `monitor`
-  def self.monitor_and_stop: (action: (String | Symbol | NilClass), ?namespace: (String | Symbol)?, ?opentelemetry_scope: [String, String]?) ?{ () -> Object } -> Object?
+  def self.monitor_and_stop: (
+                               action: (String | Symbol | NilClass),
+                               ?namespace: (String | Symbol)?,
+                               ?opentelemetry_context: untyped,
+                               ?opentelemetry_scope: [String, String]?,
+                               ?opentelemetry_kind: Symbol?,
+                               ?opentelemetry_relationship: Symbol?
+                             ) ?{ () -> Object } -> Object?
 
   # Send an error to AppSignal regardless of the context.
   # 
@@ -2138,12 +2151,25 @@ module Appsignal
       # 
       # _@param_ `action` — The action name for the transaction. The action name is required to be set for the transaction to be reported. The argument can be set to `nil` or `:set_later` if the action is set within the block with {#set_action}. This will not update the active transaction's action if {.monitor} is called when another transaction is already active.
       # 
+      # _@param_ `opentelemetry_kind` — In collector mode, the OpenTelemetry span kind: one of `:server`, `:consumer`, `:producer` or `:internal`. Defaults to `:server`.
+      # 
+      # _@param_ `opentelemetry_relationship` — In collector mode, how an incoming `opentelemetry_context` relates to this transaction's span: one of `:parent`, `:link`, `:both` or `:none`. Defaults to `:parent`.
+      # 
+      # _@param_ `opentelemetry_context` — In collector mode, an incoming OpenTelemetry trace context to relate this transaction's span to.
+      # 
       # _@param_ `opentelemetry_scope` — In collector mode, the OpenTelemetry instrumentation scope to record this transaction's spans under, given as a `[name, version]` pair. Defaults to the AppSignal scope.
       # 
       # _@return_ — The value of the given block is returned.
       # 
       # _@see_ `monitor`
-      def monitor_and_stop: (action: (String | Symbol | NilClass), ?namespace: (String | Symbol)?, ?opentelemetry_scope: [String, String]?) ?{ () -> Object } -> Object?
+      def monitor_and_stop: (
+                              action: (String | Symbol | NilClass),
+                              ?namespace: (String | Symbol)?,
+                              ?opentelemetry_context: untyped,
+                              ?opentelemetry_scope: [String, String]?,
+                              ?opentelemetry_kind: Symbol?,
+                              ?opentelemetry_relationship: Symbol?
+                            ) ?{ () -> Object } -> Object?
 
       # Send an error to AppSignal regardless of the context.
       # 

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -1538,6 +1538,46 @@ describe Appsignal do
           end
         end.to yield_control
       end
+
+      describe "OpenTelemetry attributes" do
+        it "threads the OpenTelemetry attributes to the created transaction" do
+          allow(Appsignal).to receive(:stop)
+
+          otel_context = "some-otel-context"
+          expect(Appsignal::Transaction).to receive(:create).with(
+            Appsignal::Transaction::BACKGROUND_JOB,
+            :opentelemetry_context => otel_context,
+            :opentelemetry_scope => ["appsignal-ruby/custom", "1.2.3"],
+            :opentelemetry_kind => :consumer,
+            :opentelemetry_relationship => :both
+          ).and_call_original
+
+          silence do
+            Appsignal.monitor_and_stop(
+              :action => "MyAction",
+              :namespace => Appsignal::Transaction::BACKGROUND_JOB,
+              :opentelemetry_context => otel_context,
+              :opentelemetry_scope => ["appsignal-ruby/custom", "1.2.3"],
+              :opentelemetry_kind => :consumer,
+              :opentelemetry_relationship => :both
+            )
+          end
+        end
+
+        it "uses the given opentelemetry_kind for the span", :collector_mode do
+          start_collector_agent
+          allow(Appsignal).to receive(:stop)
+
+          silence do
+            Appsignal.monitor_and_stop(
+              :action => "MyAction",
+              :opentelemetry_kind => :consumer
+            )
+          end
+
+          expect(root_span.kind).to eq(:consumer)
+        end
+      end
     end
 
     describe ".tag_request" do


### PR DESCRIPTION
The `monitor_and_stop` helper accepted `opentelemetry_scope`, but not
`opentelemetry_context`, `opentelemetry_kind` or
`opentelemetry_relationship`. It creates its transaction by calling
`monitor`, which accepts all four, so those three were out of reach for
anyone using this helper.

The four arguments were added to the instrumentation helpers in two
separate changes. The first added `opentelemetry_scope` and included
`monitor_and_stop`. The second added the other three and did not
revisit this method. Being deprecated is no reason for the helper to
offer less than the method it delegates to, so it now accepts all four
and passes them on.

[skip changeset]
