### PR TITLE
Honor CA file environment variables during agent download

### DIFF
--- a/.changesets/honor-agent-download-ca-file-path.md
+++ b/.changesets/honor-agent-download-ca-file-path.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Honor `APPSIGNAL_CA_FILE_PATH` and `SSL_CERT_FILE` when downloading the agent during extension installation.

--- a/ext/base.rb
+++ b/ext/base.rb
@@ -22,6 +22,11 @@ def ext_path(path)
   File.join(EXT_PATH, path)
 end
 
+def ca_cert_path
+  ENV.values_at("APPSIGNAL_CA_FILE_PATH", "SSL_CERT_FILE")
+    .find { |path| path && !path.strip.empty? } || CA_CERT_PATH
+end
+
 def report
   @report ||=
     begin
@@ -132,7 +137,7 @@ def download_archive(type)
       proxy, _error = http_proxy
       args = [
         download_url,
-        { :ssl_ca_cert => CA_CERT_PATH,
+        { :ssl_ca_cert => ca_cert_path,
           :proxy => proxy }
       ]
       if URI.respond_to?(:open) # rubocop:disable Style/GuardClause

--- a/spec/ext/base_spec.rb
+++ b/spec/ext/base_spec.rb
@@ -1,0 +1,44 @@
+require File.expand_path("../../ext/base", __dir__)
+
+describe "extension installer CA certificate path" do
+  env_keys = %w[APPSIGNAL_CA_FILE_PATH SSL_CERT_FILE]
+
+  around do |example|
+    original_values = ENV.to_h.slice(*env_keys)
+    env_keys.each { |key| ENV.delete(key) }
+    example.run
+  ensure
+    env_keys.each { |key| ENV.delete(key) }
+    original_values.each { |key, value| ENV[key] = value }
+  end
+
+  it "uses the packaged CA certificate path by default" do
+    expect(ca_cert_path).to eq(CA_CERT_PATH)
+  end
+
+  it "uses APPSIGNAL_CA_FILE_PATH when configured" do
+    ENV["APPSIGNAL_CA_FILE_PATH"] = "/path/to/appsignal-ca.pem"
+
+    expect(ca_cert_path).to eq("/path/to/appsignal-ca.pem")
+  end
+
+  it "uses SSL_CERT_FILE when configured" do
+    ENV["SSL_CERT_FILE"] = "/path/to/system-ca.pem"
+
+    expect(ca_cert_path).to eq("/path/to/system-ca.pem")
+  end
+
+  it "prefers APPSIGNAL_CA_FILE_PATH over SSL_CERT_FILE" do
+    ENV["APPSIGNAL_CA_FILE_PATH"] = "/path/to/appsignal-ca.pem"
+    ENV["SSL_CERT_FILE"] = "/path/to/system-ca.pem"
+
+    expect(ca_cert_path).to eq("/path/to/appsignal-ca.pem")
+  end
+
+  it "ignores blank environment values" do
+    ENV["APPSIGNAL_CA_FILE_PATH"] = " "
+    ENV["SSL_CERT_FILE"] = ""
+
+    expect(ca_cert_path).to eq(CA_CERT_PATH)
+  end
+end


### PR DESCRIPTION
## Summary

Use configured CA certificate paths when downloading the AppSignal agent during extension installation.

The installer currently always uses the bundled `resources/cacert.pem`. This causes installation to fail behind TLS-intercepting proxies such as Zscaler, even when `APPSIGNAL_CA_FILE_PATH` points to the trusted system CA bundle.

The installer now selects the CA certificate path in this order:

1. `APPSIGNAL_CA_FILE_PATH`
2. `SSL_CERT_FILE`
3. The existing bundled `resources/cacert.pem`

The existing default behavior remains unchanged when neither environment variable is configured.

## Motivation

For the past years in our company we were able to disable Zscaler while installing gems or building containers and never bothered to touch the AppSignal gem.
With recent policy changes, Zscaler is now running non-stop and without the change we can't get AppSignal running.

## Testing

- Added specs covering the configured paths, precedence, blank values, and bundled fallback.
- RuboCop passes for the changed Ruby files.
- Verified `rake extension:install` successfully downloads and installs the agent behind Zscaler when `APPSIGNAL_CA_FILE_PATH` is configured.
- Verified installation from the fork in an affected Rails devcontainer.