### PR TITLE
Honor the CA file path when downloading the agent

### DIFF
--- a/.changesets/honor-ca-file-path-in-installer.md
+++ b/.changesets/honor-ca-file-path-in-installer.md
@@ -1,0 +1,19 @@
+---
+bump: patch
+type: fix
+---
+
+Use the CA certificate configured in `APPSIGNAL_CA_FILE_PATH` to download the
+AppSignal agent when installing this gem.
+
+The gem downloads the agent from our servers over HTTPS during installation. It
+always used the CA certificate bundled with the gem to verify that connection,
+whatever the value of the `ca_file_path` configuration option. This meant the
+installation failed behind a proxy that intercepts TLS connections, such as
+Zscaler, even when `APPSIGNAL_CA_FILE_PATH` pointed to a CA bundle that trusts
+the proxy.
+
+The bundled CA certificate is still used when `APPSIGNAL_CA_FILE_PATH` is not
+set.
+
+Thanks @Cosmo for your contribution!

--- a/ext/base.rb
+++ b/ext/base.rb
@@ -22,6 +22,13 @@ def ext_path(path)
   File.join(EXT_PATH, path)
 end
 
+def ca_file_path
+  configured_path = ENV.fetch("APPSIGNAL_CA_FILE_PATH", nil)
+  return configured_path if configured_path && !configured_path.strip.empty?
+
+  CA_CERT_PATH
+end
+
 def report
   @report ||=
     begin
@@ -132,7 +139,7 @@ def download_archive(type)
       proxy, _error = http_proxy
       args = [
         download_url,
-        { :ssl_ca_cert => CA_CERT_PATH,
+        { :ssl_ca_cert => ca_file_path,
           :proxy => proxy }
       ]
       if URI.respond_to?(:open) # rubocop:disable Style/GuardClause

--- a/spec/ext/base_spec.rb
+++ b/spec/ext/base_spec.rb
@@ -1,0 +1,21 @@
+require_relative "../../ext/base"
+
+describe "extension installer" do
+  describe "#ca_file_path" do
+    it "uses the CA certificate bundled with the gem" do
+      expect(ca_file_path).to eq(CA_CERT_PATH)
+    end
+
+    it "uses the CA certificate configured with APPSIGNAL_CA_FILE_PATH" do
+      ENV["APPSIGNAL_CA_FILE_PATH"] = "/path/to/ca.pem"
+
+      expect(ca_file_path).to eq("/path/to/ca.pem")
+    end
+
+    it "uses the bundled CA certificate when the configured path is blank" do
+      ENV["APPSIGNAL_CA_FILE_PATH"] = " "
+
+      expect(ca_file_path).to eq(CA_CERT_PATH)
+    end
+  end
+end


### PR DESCRIPTION
Replaces #1574 by @Cosmo. The one difference from that pull request is that this does not honor OpenSSL's `SSL_CERT_FILE`, because no other part of the gem honors it.

Installing this gem downloads the AppSignal agent over HTTPS, and that
download always verified the connection against the CA certificate
bundled with the gem. Behind a proxy that intercepts TLS connections,
such as Zscaler, the connection is signed by the proxy instead, so the
installation failed and configuring `ca_file_path` did not help.

The installer reads `APPSIGNAL_CA_FILE_PATH` from the environment, as it
already does for the proxy configuration. It cannot load
`Appsignal::Config`, because that loads the gem, and the gem needs the
extension that is being installed. A path set in `appsignal.yml` is
therefore still ignored here.
