### PR TITLE
Link the contributor mention in the changeset

### DIFF
--- a/.changesets/honor-ca-file-path-in-installer.md
+++ b/.changesets/honor-ca-file-path-in-installer.md
@@ -16,4 +16,4 @@ the proxy.
 The bundled CA certificate is still used when `APPSIGNAL_CA_FILE_PATH` is not
 set.
 
-Thanks @Cosmo for your contribution!
+Thanks [@Cosmo](https://github.com/Cosmo) for your contribution!


### PR DESCRIPTION
A changeset becomes an entry in the public changelog, which is rendered outside
GitHub. A bare `@` mention is not a link there, so the profile is linked
explicitly.

This touches the changeset added in #1575, which has not been released yet.

[skip changeset] [skip review]
