### PR TITLE
Default `instrument_sql` to a client span

### DIFF
--- a/lib/appsignal/helpers/instrumentation.rb
+++ b/lib/appsignal/helpers/instrumentation.rb
@@ -1027,6 +1027,10 @@ module Appsignal
       #   naming guide listed under "See also".
       # @param title [String, nil] Human readable name of the event.
       # @param body [String, nil] SQL query that's being executed.
+      # @param opentelemetry_kind [Symbol] In collector mode, the OpenTelemetry
+      #   span kind for the event's span. Defaults to `:client`, because a query
+      #   is an outgoing call to a datastore. Pass `:internal` for a query that
+      #   is not an outgoing call.
       # @param opentelemetry_scope [Array(String, String)] In collector mode, the
       #   OpenTelemetry instrumentation scope to record the event's span under,
       #   given as a `[name, version]` pair. Defaults to the AppSignal scope.
@@ -1039,12 +1043,20 @@ module Appsignal
       #   AppSignal custom instrumentation guide
       # @see https://docs.appsignal.com/api/event-names.html
       #   AppSignal event naming guide
-      def instrument_sql(name, title = nil, body = nil, opentelemetry_scope: nil, &block)
+      def instrument_sql(
+        name,
+        title = nil,
+        body = nil,
+        opentelemetry_kind: :client,
+        opentelemetry_scope: nil,
+        &block
+      )
         instrument(
           name,
           title,
           body,
           Appsignal::EventFormatter::SQL_BODY_FORMAT,
+          :opentelemetry_kind => opentelemetry_kind,
           :opentelemetry_scope => opentelemetry_scope,
           &block
         )

--- a/sig/appsignal.rbi
+++ b/sig/appsignal.rbi
@@ -1062,6 +1062,8 @@ module Appsignal
   # 
   # _@param_ `body` — SQL query that's being executed.
   # 
+  # _@param_ `opentelemetry_kind` — In collector mode, the OpenTelemetry span kind for the event's span. Defaults to `:client`, because a query is an outgoing call to a datastore. Pass `:internal` for a query that is not an outgoing call.
+  # 
   # _@param_ `opentelemetry_scope` — In collector mode, the OpenTelemetry instrumentation scope to record the event's span under, given as a `[name, version]` pair. Defaults to the AppSignal scope.
   # 
   # _@return_ — Returns the block's return value.
@@ -1092,11 +1094,12 @@ module Appsignal
       name: String,
       title: T.nilable(String),
       body: T.nilable(String),
+      opentelemetry_kind: Symbol,
       opentelemetry_scope: T.nilable([String, String]),
       block: T.untyped
     ).returns(Object)
   end
-  def self.instrument_sql(name, title = nil, body = nil, opentelemetry_scope: nil, &block); end
+  def self.instrument_sql(name, title = nil, body = nil, opentelemetry_kind: :client, opentelemetry_scope: nil, &block); end
 
   # Convenience method for ignoring instrumentation events in a block of
   # code.
@@ -2970,6 +2973,8 @@ module Appsignal
       # 
       # _@param_ `body` — SQL query that's being executed.
       # 
+      # _@param_ `opentelemetry_kind` — In collector mode, the OpenTelemetry span kind for the event's span. Defaults to `:client`, because a query is an outgoing call to a datastore. Pass `:internal` for a query that is not an outgoing call.
+      # 
       # _@param_ `opentelemetry_scope` — In collector mode, the OpenTelemetry instrumentation scope to record the event's span under, given as a `[name, version]` pair. Defaults to the AppSignal scope.
       # 
       # _@return_ — Returns the block's return value.
@@ -3000,11 +3005,12 @@ module Appsignal
           name: String,
           title: T.nilable(String),
           body: T.nilable(String),
+          opentelemetry_kind: Symbol,
           opentelemetry_scope: T.nilable([String, String]),
           block: T.untyped
         ).returns(Object)
       end
-      def instrument_sql(name, title = nil, body = nil, opentelemetry_scope: nil, &block); end
+      def instrument_sql(name, title = nil, body = nil, opentelemetry_kind: :client, opentelemetry_scope: nil, &block); end
 
       # Convenience method for ignoring instrumentation events in a block of
       # code.

--- a/sig/appsignal.rbs
+++ b/sig/appsignal.rbs
@@ -985,6 +985,8 @@ module Appsignal
   # 
   # _@param_ `body` — SQL query that's being executed.
   # 
+  # _@param_ `opentelemetry_kind` — In collector mode, the OpenTelemetry span kind for the event's span. Defaults to `:client`, because a query is an outgoing call to a datastore. Pass `:internal` for a query that is not an outgoing call.
+  # 
   # _@param_ `opentelemetry_scope` — In collector mode, the OpenTelemetry instrumentation scope to record the event's span under, given as a `[name, version]` pair. Defaults to the AppSignal scope.
   # 
   # _@return_ — Returns the block's return value.
@@ -1014,6 +1016,7 @@ module Appsignal
                              String name,
                              ?String? title,
                              ?String? body,
+                             ?opentelemetry_kind: Symbol,
                              ?opentelemetry_scope: [String, String]?
                            ) -> Object
 
@@ -2758,6 +2761,8 @@ module Appsignal
       # 
       # _@param_ `body` — SQL query that's being executed.
       # 
+      # _@param_ `opentelemetry_kind` — In collector mode, the OpenTelemetry span kind for the event's span. Defaults to `:client`, because a query is an outgoing call to a datastore. Pass `:internal` for a query that is not an outgoing call.
+      # 
       # _@param_ `opentelemetry_scope` — In collector mode, the OpenTelemetry instrumentation scope to record the event's span under, given as a `[name, version]` pair. Defaults to the AppSignal scope.
       # 
       # _@return_ — Returns the block's return value.
@@ -2787,6 +2792,7 @@ module Appsignal
                             String name,
                             ?String? title,
                             ?String? body,
+                            ?opentelemetry_kind: Symbol,
                             ?opentelemetry_scope: [String, String]?
                           ) -> Object
 

--- a/spec/integration/collector_mode_traces_spec.rb
+++ b/spec/integration/collector_mode_traces_spec.rb
@@ -45,6 +45,10 @@ if DependencyHelper.opentelemetry_present?
       expect(attribute_value(sql, "db.query.text")).to eq("SELECT * FROM users")
       expect(attribute_value(sql, "db.system.name")).to eq("other_sql")
 
+      # A query is an outgoing call to a datastore, so its span is a client
+      # span. The runner does not pass a span kind, so this is the default.
+      expect(sql.kind).to eq(:SPAN_KIND_CLIENT)
+
       # Allocation counts: the transaction total on the root span and a per-event
       # count on each event span. The values are real allocations, so assert the
       # wiring (present and non-negative) rather than exact counts. The monitored

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -3442,6 +3442,49 @@ describe Appsignal do
         expect(span.attributes).not_to have_key("appsignal.body")
       end
     end
+
+    describe "the OpenTelemetry span kind" do
+      it "is client when no kind is given", :collector_mode do
+        start_collector_agent
+        set_current_transaction(transaction)
+
+        Appsignal.instrument_sql("name", "title", "body") { :do_nothing }
+        Appsignal::Transaction.complete_current!
+
+        expect(event_spans.size).to eq(1)
+        expect(event_spans.first.kind).to eq(:client)
+      end
+
+      it "is the given kind when one is given", :collector_mode do
+        start_collector_agent
+        set_current_transaction(transaction)
+
+        Appsignal.instrument_sql(
+          "name", "title", "body",
+          :opentelemetry_kind => :internal
+        ) { :do_nothing }
+        Appsignal::Transaction.complete_current!
+
+        expect(event_spans.size).to eq(1)
+        expect(event_spans.first.kind).to eq(:internal)
+      end
+
+      it "is internal when the kind is explicitly nil", :collector_mode do
+        start_collector_agent
+        set_current_transaction(transaction)
+
+        Appsignal.instrument_sql(
+          "name", "title", "body",
+          :opentelemetry_kind => nil
+        ) { :do_nothing }
+        Appsignal::Transaction.complete_current!
+
+        # The default only applies when the argument is omitted. An explicit
+        # `nil` means "unspecified", which uses the OpenTelemetry default.
+        expect(event_spans.size).to eq(1)
+        expect(event_spans.first.kind).to eq(:internal)
+      end
+    end
   end
 
   describe ".ignore_instrumentation_events" do


### PR DESCRIPTION
`Appsignal.instrument_sql` accepted `opentelemetry_scope`, but not
`opentelemetry_kind`. It delegates to `Appsignal.instrument`, which
accepts both, so the span kind was out of reach for anyone using this
helper. Its spans got the OpenTelemetry default kind of `:internal`.

Every other path in the gem that records a SQL span already produces a
client span, because a query is an outgoing call to a datastore. The
Sequel hook, the Data Mapper integration and the ActiveRecord, ROM and
Sequel event formatters all do this. The public helper was the only SQL
path that did not, so it now accepts `opentelemetry_kind` and defaults
it to `:client`.

The default lives in the signature rather than being substituted when
the argument is forwarded. A Ruby keyword default applies only when the
argument is omitted, so passing an explicit `nil` still forwards `nil`
and lands on the OpenTelemetry default. That keeps `nil` meaning
"unspecified" here, which is what it means everywhere else in this
codebase.

[skip changeset]
