### PR TITLE
Suppress native events even when hooks are off

### DIFF
--- a/.changesets/report-notifications-for-disabled-integrations.md
+++ b/.changesets/report-notifications-for-disabled-integrations.md
@@ -1,6 +1,0 @@
----
-bump: patch
-type: change
----
-
-Report Active Job's and Faraday's own instrumentation events again when AppSignal's instrumentation for those libraries is turned off. Since version 4.9.0, an application that set `instrument_active_job` or `instrument_faraday` to `false` got no event for that work at all.

--- a/lib/appsignal/hooks/active_job.rb
+++ b/lib/appsignal/hooks/active_job.rb
@@ -6,6 +6,22 @@ module Appsignal
     class ActiveJobHook < Appsignal::Hooks::Hook
       register :active_job
 
+      # This integration records the enqueue itself, as a producer event that
+      # also injects trace context, and Active Job's own `enqueue.active_job`
+      # notification fires nested inside it. Claim the event so that the
+      # generic notification paths leave it alone.
+      #
+      # Claimed here, when this file is required, rather than in `install`.
+      # `install` only runs when Active Job instrumentation is turned on, but
+      # a customer who turns it off does not want to see the native
+      # notification reported instead. This call does not touch any
+      # `ActiveJob` constant, so it is safe to run even when the library is
+      # not present.
+      Appsignal::EventFormatter.register(
+        "enqueue.active_job",
+        Appsignal::EventFormatter::RecordedElsewhere
+      )
+
       def self.version_7_1_or_higher?
         @version_7_1_or_higher ||=
           if dependencies_present?
@@ -27,20 +43,6 @@ module Appsignal
       end
 
       def install
-        # This integration records the enqueue itself, as a producer event that
-        # also injects trace context, and Active Job's own
-        # `enqueue.active_job` notification fires nested inside it. Claim the
-        # event so that the generic notification paths leave it alone.
-        #
-        # Claimed on install, so that the event is only claimed while this
-        # integration is recording it. With Active Job instrumentation turned
-        # off there is nothing for the notification to duplicate, so it is left
-        # to be recorded like any other.
-        Appsignal::EventFormatter.register(
-          "enqueue.active_job",
-          Appsignal::EventFormatter::RecordedElsewhere
-        )
-
         ActiveSupport.on_load(:active_job) do
           ::ActiveJob::Base
             .extend ::Appsignal::Hooks::ActiveJobHook::ActiveJobClassInstrumentation

--- a/lib/appsignal/hooks/faraday.rb
+++ b/lib/appsignal/hooks/faraday.rb
@@ -6,6 +6,22 @@ module Appsignal
     class FaradayHook < Appsignal::Hooks::Hook
       register :faraday
 
+      # This integration records the request itself, so Faraday's own
+      # instrumentation middleware would report the same work again as a
+      # `request.faraday` notification. Claim it so the generic notification
+      # paths leave it alone.
+      #
+      # Claimed here, when this file is required, rather than in `install`.
+      # `install` only runs when Faraday instrumentation is turned on, but a
+      # customer who turns it off does not want to see the native
+      # notification reported instead. This call does not touch any
+      # `Faraday` constant, so it is safe to run even when the library is not
+      # present.
+      Appsignal::EventFormatter.register(
+        "request.faraday",
+        Appsignal::EventFormatter::RecordedElsewhere
+      )
+
       def dependencies_present?
         defined?(::Faraday) && Appsignal.config && Appsignal.config[:instrument_faraday]
       end
@@ -13,18 +29,6 @@ module Appsignal
       def install
         require "appsignal/integrations/faraday"
         ::Faraday::RackBuilder.prepend(Appsignal::Integrations::FaradayRackBuilderPatch)
-
-        # This integration records the request itself, so Faraday's own
-        # instrumentation middleware would report the same work again as a
-        # `request.faraday` notification. Claim it so the generic notification
-        # paths leave it alone.
-        #
-        # Claimed on install, so the claim lasts exactly as long as this
-        # integration is recording the work.
-        Appsignal::EventFormatter.register(
-          "request.faraday",
-          Appsignal::EventFormatter::RecordedElsewhere
-        )
 
         Appsignal::Environment.report_enabled("faraday")
       end

--- a/spec/lib/appsignal/hooks/activejob_spec.rb
+++ b/spec/lib/appsignal/hooks/activejob_spec.rb
@@ -36,39 +36,50 @@ if DependencyHelper.active_job_present?
         path, _line_number = ActiveJob::Base.method(:execute).source_location
         expect(path).to end_with("/lib/appsignal/hooks/active_job.rb")
       end
+    end
 
-      context "when claiming the enqueue.active_job event" do
-        # The event formatter registry is shared by the whole test suite, so
-        # put back whatever this example changes.
-        around do |example|
-          formatters = Appsignal::EventFormatter.formatters.dup
-          formatter_classes = Appsignal::EventFormatter.formatter_classes.dup
-          example.run
-        ensure
-          Appsignal::EventFormatter.formatters.replace(formatters)
-          Appsignal::EventFormatter.formatter_classes.replace(formatter_classes)
-        end
+    describe "claiming the enqueue.active_job event" do
+      # The event formatter registry is shared by the whole test suite, so
+      # put back whatever this example changes. Reloading the hook file
+      # below also re-registers it in the hooks registry, so put that back
+      # too.
+      around do |example|
+        formatters = Appsignal::EventFormatter.formatters.dup
+        formatter_classes = Appsignal::EventFormatter.formatter_classes.dup
+        hooks = Appsignal::Hooks.hooks.dup
+        example.run
+      ensure
+        Appsignal::EventFormatter.formatters.replace(formatters)
+        Appsignal::EventFormatter.formatter_classes.replace(formatter_classes)
+        Appsignal::Hooks.hooks.replace(hooks)
+      end
 
-        before do
-          Appsignal::EventFormatter.unregister(
-            "enqueue.active_job",
-            Appsignal::EventFormatter::RecordedElsewhere
-          )
-        end
+      # This integration records the enqueue itself, so the generic
+      # notification paths must not record it a second time. The hook file
+      # claims the event as soon as it is required, rather than when
+      # `install` runs, so the claim holds even when Active Job
+      # instrumentation ends up disabled and `install` never runs. A
+      # customer who turns the instrumentation off should not see the
+      # native notification reported instead.
+      #
+      # By this point in the suite, the hook file has already been
+      # required once, and `require` does not run a file's body again. Force
+      # the event back to unclaimed, then load the file with `load` instead
+      # of `require` so its body runs again. That proves the claim comes
+      # from loading the file, since `install` is never called here.
+      it "stays claimed when Active Job instrumentation is disabled" do
+        configure(:options => { :instrument_active_job => false })
+        expect(described_class.new.dependencies_present?).to be(false)
 
-        # This integration records the enqueue itself, so the generic
-        # notification paths must not record it a second time. Installing is
-        # what claims it, and this hook only installs when Active Job
-        # instrumentation is enabled, which the tests above cover. With it
-        # disabled nothing records the enqueue twice, so the notification is
-        # left to be recorded like any other.
-        it "claims the event" do
-          expect(Appsignal::EventFormatter.record?("enqueue.active_job")).to be(true)
+        Appsignal::EventFormatter.unregister(
+          "enqueue.active_job",
+          Appsignal::EventFormatter::RecordedElsewhere
+        )
+        expect(Appsignal::EventFormatter.record?("enqueue.active_job")).to be(true)
 
-          described_class.new.install
+        load "appsignal/hooks/active_job.rb"
 
-          expect(Appsignal::EventFormatter.record?("enqueue.active_job")).to be(false)
-        end
+        expect(Appsignal::EventFormatter.record?("enqueue.active_job")).to be(false)
       end
     end
   end

--- a/spec/lib/appsignal/integrations/faraday_spec.rb
+++ b/spec/lib/appsignal/integrations/faraday_spec.rb
@@ -12,29 +12,44 @@ if DependencyHelper.faraday_present?
 
     describe "claiming the request.faraday event" do
       # The event formatter registry is shared by the whole test suite, so put
-      # back whatever this example changes.
+      # back whatever this example changes. Reloading the hook file below also
+      # re-registers it in the hooks registry, so put that back too.
       around do |example|
         formatters = Appsignal::EventFormatter.formatters.dup
         formatter_classes = Appsignal::EventFormatter.formatter_classes.dup
+        hooks = Appsignal::Hooks.hooks.dup
         example.run
       ensure
         Appsignal::EventFormatter.formatters.replace(formatters)
         Appsignal::EventFormatter.formatter_classes.replace(formatter_classes)
+        Appsignal::Hooks.hooks.replace(hooks)
       end
 
       # This integration records the request itself, so Faraday's own
-      # notification must not record it a second time. Installing is what
-      # claims it, and this hook only installs when Faraday instrumentation is
-      # enabled. With it disabled nothing records the request twice, so the
-      # notification is left to be recorded like any other.
-      it "is claimed on install" do
+      # notification must not record it a second time. The hook file claims
+      # the event as soon as it is required, rather than when `install`
+      # runs, so the claim holds even when Faraday instrumentation ends up
+      # disabled and `install` never runs. A customer who turns the
+      # instrumentation off should not see the native notification reported
+      # instead.
+      #
+      # The outer `before` above already installed the hook once, and the
+      # hook file has already been required, so `require` will not run its
+      # body again. Force the event back to unclaimed, then load the file
+      # with `load` instead of `require` so its body runs again. That
+      # proves the claim comes from loading the file, not from `install`,
+      # which this example does not call again.
+      it "stays claimed when Faraday instrumentation is disabled" do
+        configure(:options => { :instrument_faraday => false })
+        expect(Appsignal::Hooks::FaradayHook.new.dependencies_present?).to be(false)
+
         Appsignal::EventFormatter.unregister(
           "request.faraday",
           Appsignal::EventFormatter::RecordedElsewhere
         )
         expect(Appsignal::EventFormatter.record?("request.faraday")).to be(true)
 
-        Appsignal::Hooks::FaradayHook.new.install
+        load "appsignal/hooks/faraday.rb"
 
         expect(Appsignal::EventFormatter.record?("request.faraday")).to be(false)
       end


### PR DESCRIPTION
Active Job and Faraday each record their own event for the enqueue
or the request. AppSignal also has its own instrumentation for that
same work, so it claims Active Job's `enqueue.active_job` event and
Faraday's `request.faraday` event, telling the generic notification
paths to leave them alone.

That claim used to happen inside each hook's `install` method, which
only runs when the matching config option (`instrument_active_job` or
`instrument_faraday`) is turned on. Turning the option off also
turned the claim off, so AppSignal's own instrumentation stopped
running but the native event started being reported instead. A
customer who disables one of these integrations does not expect to
see an event for that work at all, so seeing the library's own event
appear instead was surprising.

Both hook files are already required unconditionally, so move the
claim out of `install` and into the class body, where it runs as soon
as the file loads. This is safe without a `defined?` guard: claiming
an event only touches AppSignal's own formatter registry, never the
`ActiveJob` or `Faraday` constants, so it cannot fail when the
library is absent.

This also reverts the change from the changeset it removes. That
changeset described the previous behavior as intentional, but it
never shipped in a release, so there is nothing to tell a customer.

[skip changeset]