### PR TITLE
Name the real SQL engine in db.system.name

### DIFF
--- a/lib/appsignal/event_formatter/active_record/sql_formatter.rb
+++ b/lib/appsignal/event_formatter/active_record/sql_formatter.rb
@@ -10,6 +10,20 @@ module Appsignal
           :client
         end
 
+        # The payload carries the connection the query ran on (Rails 6.0+),
+        # whose `adapter_name` is each adapter's own name for itself, such as
+        # `"PostgreSQL"` or `"Mysql2"`. A name the mapping does not recognise
+        # is left to the SQL sentinel, same as an adapter this gem has never
+        # heard of.
+        def opentelemetry_attributes(payload)
+          name = Appsignal::OpenTelemetry::SqlDbSystem.name_for_active_record(
+            payload[:connection]&.adapter_name
+          )
+          return unless name
+
+          { "db.system.name" => name }
+        end
+
         def format(payload)
           [payload[:name], payload[:sql], SQL_BODY_FORMAT]
         end

--- a/lib/appsignal/event_formatter/rom/sql_formatter.rb
+++ b/lib/appsignal/event_formatter/rom/sql_formatter.rb
@@ -29,6 +29,18 @@ module Appsignal
         def format(payload)
           ["query.rom", payload[:query], SQL_BODY_FORMAT]
         end
+
+        # The payload's `name` is Sequel's `database_type` symbol for the
+        # database ROM is talking to, so this uses Sequel's own lookup
+        # rather than a coincidentally similar one. A symbol the mapping does
+        # not recognise is left to the SQL sentinel, same as an engine this
+        # gem has never heard of.
+        def opentelemetry_attributes(payload)
+          name = Appsignal::OpenTelemetry::SqlDbSystem.name_for_sequel(payload[:name])
+          return unless name
+
+          { "db.system.name" => name }
+        end
       end
     end
   end

--- a/lib/appsignal/hooks/sequel.rb
+++ b/lib/appsignal/hooks/sequel.rb
@@ -14,6 +14,9 @@ module Appsignal
           :opentelemetry_kind => :client,
           :opentelemetry_scope => ["appsignal-ruby/sequel", Appsignal::VERSION]
         ) do
+          Appsignal::Transaction.current.add_opentelemetry_attributes(
+            Appsignal::Hooks::SequelHook.sequel_db_attributes(self)
+          )
           super
         end
       end
@@ -31,6 +34,9 @@ module Appsignal
           :opentelemetry_kind => :client,
           :opentelemetry_scope => ["appsignal-ruby/sequel", Appsignal::VERSION]
         ) do
+          Appsignal::Transaction.current.add_opentelemetry_attributes(
+            Appsignal::Hooks::SequelHook.sequel_db_attributes(self)
+          )
           super
         end
       end
@@ -38,6 +44,26 @@ module Appsignal
 
     class SequelHook < Appsignal::Hooks::Hook
       register :sequel
+
+      # The query's `Sequel::Database` names both the engine it talks to and
+      # the database it is connected to, neither of which the sql.sequel
+      # formatter can see -- it only gets the query text. Shared by both
+      # extensions above, whichever one a given Sequel version registers.
+      #
+      # @!visibility private
+      def self.sequel_db_attributes(database)
+        attributes = {}
+
+        name = Appsignal::OpenTelemetry::SqlDbSystem.name_for_sequel(database.database_type)
+        attributes["db.system.name"] = name if name
+
+        # `opts[:database]` is Sequel's own option key for the database to
+        # connect to, so it doubles as the database's name.
+        namespace = database.opts[:database].to_s
+        attributes["db.namespace"] = namespace unless namespace.empty?
+
+        attributes
+      end
 
       def dependencies_present?
         defined?(::Sequel::Database) &&

--- a/lib/appsignal/integrations/data_mapper.rb
+++ b/lib/appsignal/integrations/data_mapper.rb
@@ -12,10 +12,18 @@ module Appsignal
       ].freeze
 
       def log(message)
+        attributes = {}
+
         # If scheme is SQL-like, try to sanitize it, otherwise clear the body
         if SQL_CLASSES.include?(self.class.to_s)
           body_content = message.query
           body_format = Appsignal::EventFormatter::SQL_BODY_FORMAT
+          # The connection class names the engine it talks to, one of the four
+          # SQL_CLASSES above; a class this map does not recognise leaves the
+          # SQL sentinel to apply, same as it would for a fifth SQL_CLASSES
+          # entry this map has not been taught about.
+          db_system = Appsignal::OpenTelemetry::SqlDbSystem.name_for_data_mapper(self.class.to_s)
+          attributes["db.system.name"] = db_system if db_system
         else
           body_content = ""
           body_format = Appsignal::EventFormatter::DEFAULT
@@ -30,7 +38,8 @@ module Appsignal
           message.duration,
           body_format,
           :opentelemetry_kind => :client,
-          :opentelemetry_scope => ["appsignal-ruby/data_mapper", Appsignal::VERSION]
+          :opentelemetry_scope => ["appsignal-ruby/data_mapper", Appsignal::VERSION],
+          :opentelemetry_attributes => attributes
         )
         super
       end

--- a/lib/appsignal/integrations/dry_monitor.rb
+++ b/lib/appsignal/integrations/dry_monitor.rb
@@ -29,6 +29,11 @@ module Appsignal
           super
         ensure
           event_name, body, body_format = Appsignal::EventFormatter.format(name, payload)
+          # Set while the event's span is still open, so the attributes land
+          # on the event rather than on the transaction.
+          Appsignal::Transaction.current.add_opentelemetry_attributes(
+            Appsignal::EventFormatter.opentelemetry_attributes(name, payload)
+          )
 
           # dry-monitor reports an event under an id, such as `sql`, rather than
           # a name. A formatter names the event it knows about, and an event

--- a/lib/appsignal/opentelemetry.rb
+++ b/lib/appsignal/opentelemetry.rb
@@ -9,6 +9,7 @@ require "appsignal/opentelemetry/http_response"
 require "appsignal/opentelemetry/http_server_request"
 require "appsignal/opentelemetry/messaging"
 require "appsignal/opentelemetry/rendering"
+require "appsignal/opentelemetry/sql_db_system"
 
 module Appsignal
   # @!visibility private

--- a/lib/appsignal/opentelemetry/sql_db_system.rb
+++ b/lib/appsignal/opentelemetry/sql_db_system.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Appsignal
+  module OpenTelemetry
+    # @!visibility private
+    #
+    # Maps a SQL library's own name for the engine it is talking to onto the
+    # `db.system.name` semantic conventions value for that engine.
+    #
+    # Each library names engines differently, and none of them matches the
+    # semantic conventions spelling, so every SQL integration needs a lookup.
+    # Kept as one map per library, each keyed on that library's own
+    # vocabulary, rather than one shared map: ActiveRecord's `ADAPTER_NAME`
+    # strings, Sequel's `database_type` symbols, and DataMapper's
+    # `DataObjects` connection class names do not collide today, but nothing
+    # about that is enforced by combining them. A wrong value passed into the
+    # wrong library's lookup would silently return another library's answer
+    # instead of nil, and a library's own gaps would be invisible next to two
+    # other libraries' complete entries. ROM is the exception: its payload
+    # already carries Sequel's own `database_type` symbol, so it is
+    # legitimate for it to share Sequel's map, not just convenient.
+    #
+    # A name none of these maps recognise returns `nil`, so the caller's own
+    # `other_sql` fallback applies -- exactly what already happens for a
+    # library this gem has no mapping for at all.
+    #
+    # This intentionally follows the older semantic conventions value set:
+    # SQL Server maps to `mssql`, not the current registry's
+    # `microsoft.sql_server`, and Oracle maps to `oracle`, not `oracle.db`.
+    # That is what the AppSignal collector's sanitizer recognizes today;
+    # emitting the newer values would silently turn sanitization off for
+    # those engines' queries.
+    module SqlDbSystem
+      # ActiveRecord's `ADAPTER_NAME`. Rails bundles the Postgres, Mysql2,
+      # SQLite and (7.1+) Trilogy adapters; SQL Server and Oracle come from
+      # the separate `activerecord-sqlserver-adapter` and
+      # `activerecord-oracle_enhanced-adapter` gems, which declare
+      # `ADAPTER_NAME` the same way.
+      ACTIVE_RECORD = {
+        "PostgreSQL" => "postgresql",
+        "Mysql2" => "mysql",
+        "Trilogy" => "mysql",
+        "SQLite" => "sqlite",
+        "SQLServer" => "mssql",
+        "OracleEnhanced" => "oracle"
+      }.freeze
+
+      # Sequel's `database_type`. ROM's dry-monitor payload reuses this
+      # symbol directly, so `name_for_sequel` is also ROM's lookup.
+      SEQUEL = {
+        :postgres => "postgresql",
+        :mysql => "mysql",
+        :sqlite => "sqlite",
+        :mssql => "mssql",
+        :oracle => "oracle"
+      }.freeze
+
+      # DataMapper's `DataObjects` connection classes.
+      DATA_MAPPER = {
+        "DataObjects::Postgres::Connection" => "postgresql",
+        "DataObjects::Mysql::Connection" => "mysql",
+        "DataObjects::Sqlite3::Connection" => "sqlite",
+        "DataObjects::SqlServer::Connection" => "mssql"
+      }.freeze
+
+      class << self
+        # The `db.system.name` value for an ActiveRecord connection's
+        # `adapter_name`, or `nil` when the adapter is not one this map
+        # recognises.
+        def name_for_active_record(adapter_name)
+          ACTIVE_RECORD[adapter_name]
+        end
+
+        # The `db.system.name` value for Sequel's `database_type`, or `nil`
+        # when it is not one this map recognises. Also the lookup ROM's
+        # formatter uses, since ROM reports this same symbol.
+        def name_for_sequel(database_type)
+          SEQUEL[database_type]
+        end
+
+        # The `db.system.name` value for DataMapper's connection class name,
+        # or `nil` when it is not one this map recognises.
+        def name_for_data_mapper(connection_class_name)
+          DATA_MAPPER[connection_class_name]
+        end
+      end
+    end
+  end
+end

--- a/lib/appsignal/transaction.rb
+++ b/lib/appsignal/transaction.rb
@@ -922,7 +922,8 @@ module Appsignal
       duration,
       body_format = Appsignal::EventFormatter::DEFAULT,
       opentelemetry_kind: nil,
-      opentelemetry_scope: nil
+      opentelemetry_scope: nil,
+      opentelemetry_attributes: nil
     )
       return if paused?
 
@@ -933,7 +934,8 @@ module Appsignal
         body_format || Appsignal::EventFormatter::DEFAULT,
         duration,
         :opentelemetry_kind => opentelemetry_kind,
-        :opentelemetry_scope => opentelemetry_scope
+        :opentelemetry_scope => opentelemetry_scope,
+        :opentelemetry_attributes => opentelemetry_attributes
       )
     end
 

--- a/lib/appsignal/transaction/extension_backend.rb
+++ b/lib/appsignal/transaction/extension_backend.rb
@@ -55,7 +55,7 @@ module Appsignal
 
       # Agent mode has no span kind or instrumentation scope;
       # `opentelemetry_kind` and `opentelemetry_scope` are ignored here.
-      def record_event(name, title, body, body_format, duration, opentelemetry_kind: nil, opentelemetry_scope: nil) # rubocop:disable Lint/UnusedMethodArgument, Metrics/ParameterLists, Layout/LineLength
+      def record_event(name, title, body, body_format, duration, opentelemetry_kind: nil, opentelemetry_scope: nil, opentelemetry_attributes: nil) # rubocop:disable Lint/UnusedMethodArgument, Metrics/ParameterLists, Layout/LineLength
         @handle.record_event(name, title, body, body_format, duration, 0)
       end
 

--- a/lib/appsignal/transaction/opentelemetry_backend.rb
+++ b/lib/appsignal/transaction/opentelemetry_backend.rb
@@ -172,7 +172,7 @@ module Appsignal
       # mirroring `start_event`. `nil` leaves the SDK default (INTERNAL).
       def record_event( # rubocop:disable Metrics/ParameterLists
         name, title, body, body_format, duration,
-        opentelemetry_kind: nil, opentelemetry_scope: nil
+        opentelemetry_kind: nil, opentelemetry_scope: nil, opentelemetry_attributes: nil
       )
         start_time = Time.now - (duration / 1_000_000_000.0)
         span = tracer_for(opentelemetry_scope).start_span(
@@ -181,10 +181,16 @@ module Appsignal
           :kind => opentelemetry_kind
         )
         write_event_span_name(span, name, title)
-        # A recorded event never opens an event frame, so there is nothing to
-        # track a mid-event `db.system.name` on; the sentinel is always the
-        # fallback here.
-        write_event_body_attributes(span, body, body_format, false)
+        # A recorded event has no window between start and finish, so this is
+        # its only chance to attach attributes -- there is no event frame for
+        # a later `set_attributes` call to note a `db.system.name` on.
+        formatted_attributes = Appsignal::OpenTelemetry::Attributes.format(
+          opentelemetry_attributes || {}
+        )
+        span.add_attributes(formatted_attributes) unless formatted_attributes.empty?
+        write_event_body_attributes(
+          span, body, body_format, named_db_system?(formatted_attributes)
+        )
         # A recorded event has no start hook, so we never measured its
         # allocations. We deliberately set no allocation attribute rather than a
         # misleading zero. Its allocations instead fall into the enclosing

--- a/lib/appsignal/transaction/opentelemetry_backend.rb
+++ b/lib/appsignal/transaction/opentelemetry_backend.rb
@@ -98,7 +98,13 @@ module Appsignal
       # (nil when allocation tracking is off), and `child_allocation_count`
       # accumulates the full allocation counts of the event's finished children,
       # so the event's own allocations are `full - child_allocation_count`.
-      EventFrame = Struct.new(:span, :token, :allocation_start, :child_allocation_count)
+      # `db_system_name_set` tracks whether the event itself already set
+      # `db.system.name` (through `set_attributes`) before it finishes, so the
+      # SQL sentinel written at finish only fills in a value that is missing.
+      EventFrame = Struct.new(
+        :span, :token, :allocation_start, :child_allocation_count,
+        :db_system_name_set
+      )
 
       def initialize( # rubocop:disable Metrics/ParameterLists
         transaction_id,
@@ -156,7 +162,7 @@ module Appsignal
 
         frame = @event_stack.pop
         write_event_span_name(frame.span, name, title)
-        write_event_body_attributes(frame.span, body, body_format)
+        write_event_body_attributes(frame.span, body, body_format, frame.db_system_name_set)
         write_event_allocation_count(frame)
         ::OpenTelemetry::Context.detach(frame.token)
         frame.span.finish
@@ -175,7 +181,10 @@ module Appsignal
           :kind => opentelemetry_kind
         )
         write_event_span_name(span, name, title)
-        write_event_body_attributes(span, body, body_format)
+        # A recorded event never opens an event frame, so there is nothing to
+        # track a mid-event `db.system.name` on; the sentinel is always the
+        # fallback here.
+        write_event_body_attributes(span, body, body_format, false)
         # A recorded event has no start hook, so we never measured its
         # allocations. We deliberately set no allocation attribute rather than a
         # misleading zero. Its allocations instead fall into the enclosing
@@ -235,9 +244,15 @@ module Appsignal
       # Never the OTel current span, which may belong to another
       # instrumentation. Values are coerced to the primitives OTLP accepts.
       def set_attributes(attributes)
-        current_span.add_attributes(
-          Appsignal::OpenTelemetry::Attributes.format(attributes)
-        )
+        formatted = Appsignal::OpenTelemetry::Attributes.format(attributes)
+        # Note on the open event frame, if there is one, that this event
+        # already named a real `db.system.name`, so `write_event_body_attributes`
+        # knows not to overwrite it with the SQL sentinel when the event
+        # finishes.
+        if named_db_system?(formatted) && (frame = @event_stack.last)
+          frame.db_system_name_set = true
+        end
+        current_span.add_attributes(formatted)
       end
 
       # The collector keeps the request payload, the function parameters and the
@@ -743,18 +758,32 @@ module Appsignal
         span.name = has_title ? "#{name} (#{title})" : name
       end
 
-      def write_event_body_attributes(span, body, body_format)
+      def write_event_body_attributes(span, body, body_format, db_system_name_set)
         has_body = !body.to_s.empty?
 
         if body_format == Appsignal::EventFormatter::SQL_BODY_FORMAT
           # Name the datastore whether or not there is a query to record with it.
           # The semantic conventions require the attribute on every database
           # span, and a SQL event with nothing in its body is still a SQL event.
-          span.set_attribute("db.system.name", SQL_DB_SYSTEM)
+          # Only fall back to the sentinel when nothing set a real engine name
+          # earlier in the event, so an integration's own `db.system.name`
+          # always wins over it.
+          span.set_attribute("db.system.name", SQL_DB_SYSTEM) unless db_system_name_set
           span.set_attribute("db.query.text", body) if has_body
         elsif has_body
           span.set_attribute("appsignal.body", body)
         end
+      end
+
+      # Whether a formatted attributes hash names a real `db.system.name`,
+      # as opposed to merely having the key. `Attributes.format` coerces an
+      # explicit `nil` (or any other non-primitive) to `""`, so the key can
+      # be present with a blank value. A blank value must not count as set:
+      # it would block the SQL sentinel the same way a real value should,
+      # but leave the span with nothing the collector's sanitizer
+      # recognizes, instead of the sentinel that keeps sanitization on.
+      def named_db_system?(formatted_attributes)
+        !formatted_attributes["db.system.name"].to_s.empty?
       end
     end
   end

--- a/spec/lib/appsignal/event_formatter/active_record/sql_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/active_record/sql_formatter_spec.rb
@@ -24,4 +24,48 @@ describe Appsignal::EventFormatter::ActiveRecord::SqlFormatter do
 
     it { is_expected.to eq ["User load", "SELECT * FROM users", 1] }
   end
+
+  describe "#opentelemetry_attributes" do
+    subject { formatter.opentelemetry_attributes(payload) }
+
+    context "with a connection whose adapter the mapping recognises" do
+      let(:payload) { { :connection => double(:adapter_name => "PostgreSQL") } }
+
+      it "names the engine" do
+        is_expected.to eq("db.system.name" => "postgresql")
+      end
+    end
+
+    context "with a connection whose adapter is activerecord-sqlserver-adapter's" do
+      let(:payload) { { :connection => double(:adapter_name => "SQLServer") } }
+
+      it "names the engine with the older semantic conventions value" do
+        is_expected.to eq("db.system.name" => "mssql")
+      end
+    end
+
+    context "with a connection whose adapter is activerecord-oracle_enhanced-adapter's" do
+      let(:payload) { { :connection => double(:adapter_name => "OracleEnhanced") } }
+
+      it "names the engine" do
+        is_expected.to eq("db.system.name" => "oracle")
+      end
+    end
+
+    context "with a connection whose adapter the mapping does not recognise" do
+      let(:payload) { { :connection => double(:adapter_name => "DB2") } }
+
+      it "names nothing, leaving the SQL sentinel to apply" do
+        is_expected.to be_nil
+      end
+    end
+
+    context "without a connection (Rails versions that do not report one)" do
+      let(:payload) { {} }
+
+      it "names nothing, leaving the SQL sentinel to apply" do
+        is_expected.to be_nil
+      end
+    end
+  end
 end

--- a/spec/lib/appsignal/event_formatter/rom/sql_formatter_spec.rb
+++ b/spec/lib/appsignal/event_formatter/rom/sql_formatter_spec.rb
@@ -40,4 +40,24 @@ describe Appsignal::EventFormatter::Rom::SqlFormatter do
       it { is_expected.to eq ["query.rom", "SELECT * FROM users", 1] }
     end
   end
+
+  describe "#opentelemetry_attributes" do
+    subject { formatter.opentelemetry_attributes(payload) }
+
+    context "with a database type the mapping recognises" do
+      let(:payload) { { :name => :postgres, :query => "SELECT * FROM users" } }
+
+      it "names the engine" do
+        is_expected.to eq("db.system.name" => "postgresql")
+      end
+    end
+
+    context "with a database type the mapping does not recognise" do
+      let(:payload) { { :name => :db2, :query => "SELECT * FROM users" } }
+
+      it "names nothing, leaving the SQL sentinel to apply" do
+        is_expected.to be_nil
+      end
+    end
+  end
 end

--- a/spec/lib/appsignal/hooks/active_support_notifications/instrument_shared_examples.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications/instrument_shared_examples.rb
@@ -45,6 +45,31 @@ shared_examples "activesupport instrument override" do
     end
   end
 
+  describe "an ActiveRecord SQL query event with a connection" do
+    let(:connection) { double(:adapter_name => "PostgreSQL") }
+
+    def perform
+      as.instrument("sql.active_record", :sql => "SQL", :connection => connection) { "value" }
+    end
+
+    it "in collector mode", :collector_mode do
+      start_collector_agent
+      transaction = http_request_transaction
+      set_current_transaction(transaction)
+      as.notifier = notifier
+
+      expect(perform).to eq "value"
+      Appsignal::Transaction.complete_current!
+
+      expect(event_spans.size).to eq(1)
+      span = event_spans.find { |s| s.name == "sql.active_record" }
+      expect(span).not_to be_nil
+      # The connection's own adapter name names the engine, rather than the
+      # SQL sentinel every other unrecognized adapter falls back to.
+      expect(span.attributes["db.system.name"]).to eq("postgresql")
+    end
+  end
+
   describe "a Sequel query event (emitted by sequel-rails)" do
     def perform
       as.instrument(

--- a/spec/lib/appsignal/hooks/dry_monitor_spec.rb
+++ b/spec/lib/appsignal/hooks/dry_monitor_spec.rb
@@ -77,7 +77,10 @@ if DependencyHelper.dry_monitor_present?
         expect(span.kind).to eq(:client)
         attrs = span.attributes
         expect(attrs["db.query.text"]).to eq("SELECT * FROM users")
-        expect(attrs["db.system.name"]).to eq("other_sql")
+        # The payload's `name` is Sequel's database_type symbol for the
+        # database ROM is talking to, which the formatter maps to the real
+        # engine name rather than leaving it at the SQL sentinel.
+        expect(attrs["db.system.name"]).to eq("postgresql")
         expect(event_category(span)).to eq("query.rom")
         # ROM emits this event, so it is attributed to ROM rather than to the
         # bus it arrived over.

--- a/spec/lib/appsignal/hooks/dry_monitor_spec.rb
+++ b/spec/lib/appsignal/hooks/dry_monitor_spec.rb
@@ -86,6 +86,48 @@ if DependencyHelper.dry_monitor_present?
       end
     end
 
+    describe "an event whose formatter declares attributes" do
+      let(:event_id) { :attributed }
+      let(:payload) { { :name => "attributed" } }
+
+      # A minimal stand-in for a formatter that both formats an event's body
+      # and names OpenTelemetry attributes for it, such as ROM's SQL
+      # formatter does once it names a real `db.system.name`. This proves
+      # `instrument` calls through to `opentelemetry_attributes`, not only
+      # to `format`.
+      let(:formatter_class) do
+        Class.new(Appsignal::EventFormatter) do
+          def format(_payload)
+            ["attributed.dry", "body", Appsignal::EventFormatter::DEFAULT]
+          end
+
+          def opentelemetry_attributes(_payload)
+            { "db.system.name" => "postgresql" }
+          end
+        end
+      end
+
+      before { Appsignal::EventFormatter.register("attributed.dry", formatter_class) }
+
+      after { Appsignal::EventFormatter.unregister("attributed.dry", formatter_class) }
+
+      def perform
+        notifications.instrument(event_id, payload)
+      end
+
+      it "puts the formatter's attributes on the event's own span", :collector_mode do
+        start_collector_agent
+        transaction = http_request_transaction
+        set_current_transaction(transaction)
+        perform
+        Appsignal::Transaction.complete_current!
+
+        expect(event_spans.size).to eq(1)
+        span = event_spans.first
+        expect(span.attributes["db.system.name"]).to eq("postgresql")
+      end
+    end
+
     describe "an event that another integration records" do
       let(:event_id) { :claimed }
       let(:payload) { { :name => "claimed" } }

--- a/spec/lib/appsignal/hooks/sequel_spec.rb
+++ b/spec/lib/appsignal/hooks/sequel_spec.rb
@@ -1,4 +1,45 @@
 describe Appsignal::Hooks::SequelHook do
+  describe ".sequel_db_attributes" do
+    subject { described_class.sequel_db_attributes(database) }
+
+    context "with a recognised engine and a named database" do
+      let(:database) do
+        double(:database_type => :postgres, :opts => { :database => "app_production" })
+      end
+
+      it "names both the engine and the database" do
+        expect(subject).to eq(
+          "db.system.name" => "postgresql",
+          "db.namespace" => "app_production"
+        )
+      end
+    end
+
+    context "with an in-memory database, which Sequel names with no :database option" do
+      let(:database) { double(:database_type => :sqlite, :opts => {}) }
+
+      it "names the engine without a namespace" do
+        expect(subject).to eq("db.system.name" => "sqlite")
+      end
+    end
+
+    context "with an engine the mapping does not recognise" do
+      let(:database) { double(:database_type => :db2, :opts => {}) }
+
+      it "names neither, leaving the SQL sentinel to apply" do
+        expect(subject).to eq({})
+      end
+    end
+
+    context "with an engine that only the older semantic conventions map" do
+      let(:database) { double(:database_type => :oracle, :opts => {}) }
+
+      it "names the engine with the older semantic conventions value" do
+        expect(subject).to eq("db.system.name" => "oracle")
+      end
+    end
+  end
+
   if DependencyHelper.sequel_present?
     let(:db) do
       if DependencyHelper.running_jruby?
@@ -47,7 +88,12 @@ describe Appsignal::Hooks::SequelHook do
         expect(span).not_to be_nil
         expect(span.kind).to eq(:client)
         expect(span.parent_span_id).to eq(root_span.span_id)
-        expect(span.attributes["db.system.name"]).to eq("other_sql")
+        # The Sequel::Database's own database_type names the engine, rather
+        # than the SQL sentinel every unrecognized engine falls back to.
+        expect(span.attributes["db.system.name"]).to eq("sqlite")
+        # This in-memory database has no :database connection option, so
+        # there is no name to put in db.namespace.
+        expect(span.attributes).not_to have_key("db.namespace")
         expect(span.attributes).not_to have_key("appsignal.body")
         expect(event_category(span)).to eq("sql.sequel")
         expect(scope_of(span)).to eq(["appsignal-ruby/sequel", Appsignal::VERSION])

--- a/spec/lib/appsignal/integrations/data_mapper_spec.rb
+++ b/spec/lib/appsignal/integrations/data_mapper_spec.rb
@@ -60,7 +60,9 @@ describe Appsignal::Hooks::DataMapperLogListener do
         expect(span.parent_span_id).to eq(root_span.span_id)
         attrs = span.attributes
         expect(attrs["db.query.text"]).to eq("SELECT * from users")
-        expect(attrs["db.system.name"]).to eq("other_sql")
+        # The connection class names the engine, rather than the SQL sentinel
+        # every unrecognized SQL_CLASSES entry would fall back to.
+        expect(attrs["db.system.name"]).to eq("sqlite")
         expect(event_category(span)).to eq("query.data_mapper")
         expect(scope_of(span)).to eq(["appsignal-ruby/data_mapper", Appsignal::VERSION])
         expect(attrs).not_to have_key("appsignal.body")

--- a/spec/lib/appsignal/opentelemetry/sql_db_system_spec.rb
+++ b/spec/lib/appsignal/opentelemetry/sql_db_system_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+describe Appsignal::OpenTelemetry::SqlDbSystem do
+  describe ".name_for_active_record" do
+    it "maps ActiveRecord's ADAPTER_NAME to the semantic conventions value" do
+      expect(described_class.name_for_active_record("PostgreSQL")).to eq("postgresql")
+      expect(described_class.name_for_active_record("Mysql2")).to eq("mysql")
+      expect(described_class.name_for_active_record("Trilogy")).to eq("mysql")
+      expect(described_class.name_for_active_record("SQLite")).to eq("sqlite")
+    end
+
+    # activerecord-sqlserver-adapter and activerecord-oracle_enhanced-adapter
+    # are separate gems, but declare ADAPTER_NAME the same way the adapters
+    # Rails bundles do.
+    it "maps activerecord-sqlserver-adapter's ADAPTER_NAME to the older semconv value" do
+      expect(described_class.name_for_active_record("SQLServer")).to eq("mssql")
+    end
+
+    it "maps activerecord-oracle_enhanced-adapter's ADAPTER_NAME to the older semconv value" do
+      expect(described_class.name_for_active_record("OracleEnhanced")).to eq("oracle")
+    end
+
+    it "returns nil for an adapter it does not recognise" do
+      expect(described_class.name_for_active_record("DB2")).to be_nil
+      expect(described_class.name_for_active_record(nil)).to be_nil
+    end
+
+    it "does not recognise Sequel's or DataMapper's vocabulary" do
+      expect(described_class.name_for_active_record(:postgres)).to be_nil
+      expect(described_class.name_for_active_record("DataObjects::Postgres::Connection")).to be_nil
+    end
+  end
+
+  describe ".name_for_sequel" do
+    it "maps Sequel's database_type to the semantic conventions value" do
+      expect(described_class.name_for_sequel(:postgres)).to eq("postgresql")
+      expect(described_class.name_for_sequel(:mysql)).to eq("mysql")
+      expect(described_class.name_for_sequel(:sqlite)).to eq("sqlite")
+    end
+
+    # SQL Server and Oracle map to the older semantic conventions values,
+    # `mssql` and `oracle`, rather than the current registry's
+    # `microsoft.sql_server` and `oracle.db`, because those are what the
+    # AppSignal collector's sanitizer recognizes today.
+    it "maps SQL Server and Oracle to the older semantic conventions values" do
+      expect(described_class.name_for_sequel(:mssql)).to eq("mssql")
+      expect(described_class.name_for_sequel(:oracle)).to eq("oracle")
+    end
+
+    it "returns nil for a database_type it does not recognise" do
+      expect(described_class.name_for_sequel(:db2)).to be_nil
+      expect(described_class.name_for_sequel(nil)).to be_nil
+    end
+
+    it "does not recognise ActiveRecord's or DataMapper's vocabulary" do
+      expect(described_class.name_for_sequel("PostgreSQL")).to be_nil
+      expect(described_class.name_for_sequel("DataObjects::Postgres::Connection")).to be_nil
+    end
+  end
+
+  describe ".name_for_data_mapper" do
+    it "maps DataMapper's DataObjects connection classes to the semantic conventions value" do
+      expect(described_class.name_for_data_mapper("DataObjects::Postgres::Connection"))
+        .to eq("postgresql")
+      expect(described_class.name_for_data_mapper("DataObjects::Mysql::Connection"))
+        .to eq("mysql")
+      expect(described_class.name_for_data_mapper("DataObjects::Sqlite3::Connection"))
+        .to eq("sqlite")
+    end
+
+    # SQL Server maps to the older semantic conventions value, `mssql`,
+    # rather than the current registry's `microsoft.sql_server`, because
+    # that is what the AppSignal collector's sanitizer recognizes today.
+    it "maps SQL Server to the older semantic conventions value" do
+      expect(described_class.name_for_data_mapper("DataObjects::SqlServer::Connection"))
+        .to eq("mssql")
+    end
+
+    it "returns nil for a connection class it does not recognise" do
+      expect(described_class.name_for_data_mapper("DataObjects::Oracle::Connection")).to be_nil
+      expect(described_class.name_for_data_mapper(nil)).to be_nil
+    end
+
+    it "does not recognise ActiveRecord's or Sequel's vocabulary" do
+      expect(described_class.name_for_data_mapper("PostgreSQL")).to be_nil
+      expect(described_class.name_for_data_mapper(:postgres)).to be_nil
+    end
+  end
+end

--- a/spec/lib/appsignal/transaction/opentelemetry_backend_spec.rb
+++ b/spec/lib/appsignal/transaction/opentelemetry_backend_spec.rb
@@ -1481,6 +1481,42 @@ describe Appsignal::Transaction::OpenTelemetryBackend,
           Appsignal::EventFormatter::DEFAULT, 1_000)
         expect(backend.instance_variable_get(:@event_stack)).to be_empty
       end
+
+      it "puts opentelemetry_attributes on the finished span" do
+        backend = create_backend
+        backend.record_event("custom.event", "T", "B",
+          Appsignal::EventFormatter::DEFAULT, 1_000,
+          :opentelemetry_attributes => { "db.system.name" => "postgresql" })
+
+        span = span_exporter.finished_spans.find { |s| s.name == "custom.event (T)" }
+        expect(span.attributes["db.system.name"]).to eq("postgresql")
+      end
+
+      it "lets its own db.system.name win over the SQL sentinel" do
+        backend = create_backend
+        backend.record_event("sql.query", "Q", "SELECT 1",
+          Appsignal::EventFormatter::SQL_BODY_FORMAT, 1_000,
+          :opentelemetry_attributes => { "db.system.name" => "postgresql" })
+
+        span = span_exporter.finished_spans.find { |s| s.name == "sql.query (Q)" }
+        expect(span.attributes["db.system.name"]).to eq("postgresql")
+        expect(span.attributes["db.query.text"]).to eq("SELECT 1")
+      end
+
+      # A caller passing an explicit nil (e.g. a lookup that came back empty)
+      # must not block the sentinel. Attributes.format coerces nil to "", so
+      # the key is present either way; only a non-blank value should count as
+      # naming a real engine. A span left with "" would skip the collector's
+      # sanitizer entirely, unlike other_sql, which the sanitizer recognizes.
+      it "falls back to the SQL sentinel when the engine name is explicitly blank" do
+        backend = create_backend
+        backend.record_event("sql.query", "Q", "SELECT 1",
+          Appsignal::EventFormatter::SQL_BODY_FORMAT, 1_000,
+          :opentelemetry_attributes => { "db.system.name" => nil })
+
+        span = span_exporter.finished_spans.find { |s| s.name == "sql.query (Q)" }
+        expect(span.attributes["db.system.name"]).to eq("other_sql")
+      end
     end
 
     describe "nested events" do

--- a/spec/lib/appsignal/transaction/opentelemetry_backend_spec.rb
+++ b/spec/lib/appsignal/transaction/opentelemetry_backend_spec.rb
@@ -1522,6 +1522,40 @@ describe Appsignal::Transaction::OpenTelemetryBackend,
         expect(attrs).not_to have_key("appsignal.body")
       end
 
+      # This is the bug the fallback guards against: an integration names the
+      # real engine mid-event through `set_attributes` (as
+      # `add_opentelemetry_attributes` does), and the SQL sentinel written at
+      # `finish_event` must not clobber it on the finished span.
+      it "keeps an engine name set mid-event over the SQL sentinel" do
+        backend = create_backend
+        backend.start_event
+        backend.set_attributes("db.system.name" => "postgresql")
+        backend.finish_event("sql.query", "Q", "SELECT 1",
+          Appsignal::EventFormatter::SQL_BODY_FORMAT)
+
+        attrs = span_exporter.finished_spans
+          .find { |s| s.name == "sql.query (Q)" }.attributes
+        expect(attrs["db.system.name"]).to eq("postgresql")
+        expect(attrs["db.query.text"]).to eq("SELECT 1")
+      end
+
+      # Attributes.format coerces an explicit nil to "", so the key is
+      # present on the formatted hash either way. Only a non-blank value
+      # should count as naming a real engine; a blank one must still fall
+      # back to the sentinel; otherwise the span would skip the collector's
+      # sanitizer entirely, unlike other_sql, which the sanitizer recognizes.
+      it "falls back to the SQL sentinel when set_attributes names a blank engine" do
+        backend = create_backend
+        backend.start_event
+        backend.set_attributes("db.system.name" => nil)
+        backend.finish_event("sql.query", "Q", "SELECT 1",
+          Appsignal::EventFormatter::SQL_BODY_FORMAT)
+
+        attrs = span_exporter.finished_spans
+          .find { |s| s.name == "sql.query (Q)" }.attributes
+        expect(attrs["db.system.name"]).to eq("other_sql")
+      end
+
       it "writes appsignal.body for default bodies (no db.* attributes)" do
         backend = create_backend
         backend.start_event

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -4955,7 +4955,8 @@ describe Appsignal::Transaction do
         1,
         1000,
         :opentelemetry_kind => nil,
-        :opentelemetry_scope => nil
+        :opentelemetry_scope => nil,
+        :opentelemetry_attributes => nil
       ).and_call_original
 
       transaction.record_event(
@@ -4975,7 +4976,8 @@ describe Appsignal::Transaction do
         1,
         1000,
         :opentelemetry_kind => nil,
-        :opentelemetry_scope => ["appsignal-ruby/data_mapper", "1.0"]
+        :opentelemetry_scope => ["appsignal-ruby/data_mapper", "1.0"],
+        :opentelemetry_attributes => nil
       ).and_call_original
 
       transaction.record_event(
@@ -4988,6 +4990,28 @@ describe Appsignal::Transaction do
       )
     end
 
+    it "passes the opentelemetry_attributes to the backend" do
+      expect(transaction.backend).to receive(:record_event).with(
+        "name",
+        "title",
+        "body",
+        1,
+        1000,
+        :opentelemetry_kind => nil,
+        :opentelemetry_scope => nil,
+        :opentelemetry_attributes => { "db.system.name" => "postgresql" }
+      ).and_call_original
+
+      transaction.record_event(
+        "name",
+        "title",
+        "body",
+        1000,
+        1,
+        :opentelemetry_attributes => { "db.system.name" => "postgresql" }
+      )
+    end
+
     it "should finish the event in the extension with nil arguments" do
       expect(transaction.backend).to receive(:record_event).with(
         "name",
@@ -4996,7 +5020,8 @@ describe Appsignal::Transaction do
         0,
         1000,
         :opentelemetry_kind => nil,
-        :opentelemetry_scope => nil
+        :opentelemetry_scope => nil,
+        :opentelemetry_attributes => nil
       ).and_call_original
 
       transaction.record_event(


### PR DESCRIPTION
### [Stop the sentinel overwriting db.system.name](https://github.com/appsignal/appsignal-ruby/commit/d0b7f38f)

write_event_body_attributes wrote the other_sql sentinel on every SQL
event unconditionally. finish_event and record_event both call it
after an integration's own attributes are already on the span, so the
sentinel always overwrote whatever engine name the integration had
set. Nothing in the gem sets db.system.name yet, so the bug had no
visible effect, but it would silently undo every integration change
that starts naming a real engine.

The event frame now tracks whether db.system.name was set during the
event, through set_attributes, and the sentinel is only written when
that never happened. record_event has no event frame to track this
on, so it always falls back to the sentinel, which is correct until a
later change gives it a way to pass attributes of its own.

### [Apply formatter attributes to dry-monitor events](https://github.com/appsignal/appsignal-ruby/commit/44316b73)

instrument called Appsignal::EventFormatter.format but never
Appsignal::EventFormatter.opentelemetry_attributes, unlike
ActiveSupportNotificationsIntegration#finish_event, which calls both.
A formatter that only arrives over dry-monitor, such as ROM's SQL
formatter, could define opentelemetry_attributes and it would never
run.

The call is added before finish_event, so the attributes land on the
event's own span rather than on the transaction.

### [Let record_event take opentelemetry_attributes](https://github.com/appsignal/appsignal-ruby/commit/72cab63a)

record_event already accepted opentelemetry_kind and
opentelemetry_scope, but had no way to attach attributes. instrument
callers can add attributes in the window between start_event and
finish_event, but record_event reports a complete event in one call,
so a caller like DataMapper's integration had no way to describe what
it recorded.

The new keyword threads through Transaction#record_event and
OpenTelemetryBackend#record_event, which formats and writes the
attributes to the span before it finishes. ExtensionBackend#record_event
ignores it, the same as the other OpenTelemetry keywords, since agent
mode has no span to put it on. A caller that names its own
db.system.name this way takes priority over the SQL sentinel, the same
as during a normal instrumented event.

record_event is `@!visibility private`, so this needs no signature
changes; sig/ stays clean after regenerating.

### [Name the engine for ActiveRecord, Sequel, ROM](https://github.com/appsignal/appsignal-ruby/commit/41193382)

Every SQL integration recorded a client span with no database
attributes beyond the query text, while Redis, MongoDB and
Elasticsearch already report a full set. The semantic conventions ask
for db.system.name on every database span, but until now every SQL
span got the same "we don't know the dialect" sentinel.

A new Appsignal::OpenTelemetry::SqlDbSystem module maps each library's
own name for its engine onto the semantic conventions value, since
none of the libraries spell it the same way and none of them match the
conventions either. It keeps one map per library rather than one
shared map, because the three libraries' vocabularies do not collide
today only by accident: ActiveRecord's ADAPTER_NAME strings, Sequel's
database_type symbols, and DataMapper's DataObjects class names could
easily overlap in the future, and a flat map would then return a
plausible-looking wrong answer instead of nil. ROM is the one
deliberate exception. Its dry-monitor payload already carries
Sequel's own database_type symbol, so it reuses Sequel's lookup
directly rather than a coincidentally similar one.

ActiveRecord's formatter reads payload[:connection].adapter_name,
covering the Postgres, Mysql2, SQLite and Trilogy adapters Rails
bundles, plus SQL Server and Oracle through the separate
activerecord-sqlserver-adapter and activerecord-oracle_enhanced-adapter
gems, which declare ADAPTER_NAME the same way. Sequel and DataMapper
already named SQL Server, so leaving ActiveRecord's SQL Server users
on the sentinel would have been an oversight rather than a choice.
Sequel's own hook reads database_type directly off the Sequel::Database
the query ran on, since the sql.sequel formatter (used for
sequel-rails compatibility) never sees that object, only the query
text.

This follows the older semantic conventions value set: SQL Server maps
to "mssql" and Oracle maps to "oracle", not the current registry's
"microsoft.sql_server" and "oracle.db", because those are the values
the AppSignal collector's sanitizer recognizes today. A name the map
does not recognise returns nil, so the caller's own other_sql fallback
still applies, the same as for a library this gem has no mapping for
at all.

The Sequel hook also names db.namespace from opts[:database], Sequel's
own option key for the database it connected to. It is a single
documented accessor, so it clears the bar the equivalent ActiveRecord
attribute does not: reaching a connection's database name there goes
through the connection pool's configuration, and the accessor has
moved across the Rails versions this gem supports.

### [Name the real engine for DataMapper](https://github.com/appsignal/appsignal-ruby/commit/d29625e1)

ActiveRecord, Sequel and ROM already name the real db.system.name
instead of the "we don't know the dialect" sentinel. DataMapper's
integration already checks its connection class against SQL_CLASSES
to decide whether a query is SQL at all, so the same class also names
the engine through the shared SqlDbSystem mapping.

This needed record_event's new opentelemetry_attributes keyword,
because DataMapper reports a complete event through record_event in
one call, with no window between start and finish to add an attribute
the way an instrumented event can.

attributes is built as a hash from the start and left empty when there
is nothing to add, rather than threaded through as nil on the branches
that have nothing to report. add_opentelemetry_attributes already
treats an empty hash as a no-op, so there is no need for a value that
exists only to satisfy the variable's later reference.

[skip changeset]
