### PR TITLE
Use `app` as the default service name

### DIFF
--- a/.changesets/default-service-name-to-app.md
+++ b/.changesets/default-service-name-to-app.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Report `app` instead of `unknown` as the OpenTelemetry service name when the `service_name` configuration option is not set and collector mode is in use.

--- a/lib/appsignal/opentelemetry.rb
+++ b/lib/appsignal/opentelemetry.rb
@@ -212,10 +212,12 @@ module Appsignal
 
       # Build the OpenTelemetry Resource that carries AppSignal config to the
       # collector. Attributes whose underlying option is nil or an empty array
-      # are omitted so the collector applies its own defaults.
+      # are omitted so the collector applies its own defaults. The revision,
+      # service name and host name are the exception: they fall back to a
+      # value here, so they are always sent.
       def build_resource(config)
         revision = config[:revision].to_s.empty? ? "unknown" : config[:revision]
-        service_name = config[:service_name].to_s.empty? ? "unknown" : config[:service_name]
+        service_name = config[:service_name].to_s.empty? ? "app" : config[:service_name]
         host_name = config[:hostname].to_s.empty? ? "unknown" : config[:hostname]
 
         attrs = {

--- a/spec/lib/appsignal/opentelemetry_spec.rb
+++ b/spec/lib/appsignal/opentelemetry_spec.rb
@@ -364,7 +364,7 @@ if DependencyHelper.opentelemetry_present?
           .to eq(["IgnoredController#action"])
       end
 
-      it "falls back to 'unknown' for empty revision, service_name, and hostname" do
+      it "falls back to defaults for empty revision, service_name, and hostname" do
         # Other specs in the suite set `ENV["APP_REVISION"]` without clearing
         # it (the spec_helper before-block only resets APPSIGNAL_* and
         # _APPSIGNAL_* prefixed vars). Clear it locally so this test is
@@ -385,7 +385,7 @@ if DependencyHelper.opentelemetry_present?
         attrs = resource_attrs(resource)
 
         expect(attrs["appsignal.config.revision"]).to eq("unknown")
-        expect(attrs["service.name"]).to eq("unknown")
+        expect(attrs["service.name"]).to eq("app")
         expect(attrs["host.name"]).to eq("unknown")
       end
 


### PR DESCRIPTION
The collector turns the service name into names that customers see. A
trace's namespace becomes `{service name}/{namespace}`, so a web
request from an app that does not set `service_name` was filed under
`unknown/web`. A log line's group falls back to the service name on
its own, so those lines were grouped under `unknown`.

Leaving `service_name` unset is the normal case for an app that is a
single service. Nothing about it is actually unknown, so the fallback
now describes what it is. The `revision` and `hostname` fallbacks
still report `unknown`, because those are facts about the running
process that AppSignal really does not have.