### PR TITLE
Detect the revision, hostname and platform in the gem

### DIFF
--- a/.changesets/detect-the-hostname.md
+++ b/.changesets/detect-the-hostname.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+type: add
+---
+
+Detect the hostname of the machine the application runs on. On Heroku this is the name of the dyno, and everywhere else it is the name the host reports for itself. Set the `hostname` configuration option to report a different name.
+
+This affects collector mode, where all data was reported for a host named `unknown` when the hostname was not configured.

--- a/.changesets/detect-the-revision-from-the-platform.md
+++ b/.changesets/detect-the-revision-from-the-platform.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+type: add
+---
+
+Detect the revision that is being deployed from the environment variables set by Heroku, Render, Kamal and Scalingo: `HEROKU_SLUG_COMMIT`, `RENDER_GIT_COMMIT`, `KAMAL_VERSION` and `CONTAINER_VERSION`. Applications deployed on those platforms now report their revision without setting the `revision` configuration option.
+
+This affects collector mode, where deploys were reported as `unknown` when the revision was not configured.

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -727,7 +727,24 @@ module Appsignal
         # environment variable the deployment platform sets.
         revision = detect_revision_from_file || detect_revision_from_platform
         hash[:revision] = revision if revision
+
+        hostname = detect_hostname
+        hash[:hostname] = hostname if hostname
       end
+    end
+
+    # Detect the hostname the way the agent does: the Heroku dyno name first,
+    # then the name the host reports for itself. The agent only detects it for
+    # the data it reports itself, so the gem has to do it for collector mode.
+    def detect_hostname
+      dyno = ENV.fetch("DYNO", nil)
+      return dyno unless dyno.to_s.empty?
+
+      hostname = Socket.gethostname
+      hostname unless hostname.to_s.empty?
+    rescue SystemCallError => e
+      logger.debug "Unable to detect the hostname: #{e.class}: #{e.message}"
+      nil
     end
 
     def detect_revision_from_platform

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -597,6 +597,7 @@ module Appsignal
       ENV["_APPSIGNAL_LOG_LEVEL"]                    = config_hash[:log_level]
       ENV["_APPSIGNAL_LOG_FILE_PATH"]                = log_file_path.to_s if log_file_path
       ENV["_APPSIGNAL_LOGGING_ENDPOINT"]             = config_hash[:logging_endpoint]
+      ENV["_APPSIGNAL_PLATFORM"]                     = config_hash[:platform].to_s
       ENV["_APPSIGNAL_PROCESS_NAME"]                 = $PROGRAM_NAME
       ENV["_APPSIGNAL_PUSH_API_ENDPOINT"]            = config_hash[:endpoint]
       ENV["_APPSIGNAL_PUSH_API_KEY"]                 = config_hash[:push_api_key]
@@ -730,7 +731,21 @@ module Appsignal
 
         hostname = detect_hostname
         hash[:hostname] = hostname if hostname
+
+        platform = detect_platform
+        hash[:platform] = platform if platform
       end
+    end
+
+    # Detect the platform the application is deployed on, the way the agent
+    # does. The agent only detects it for the data it reports itself, so the
+    # gem has to do it for collector mode. There is no config option for it,
+    # because these are the only two platforms that can be recognized.
+    def detect_platform
+      return "dokku" unless ENV.fetch("DOKKU_ROOT", nil).to_s.empty?
+      return "heroku" unless ENV.fetch("DYNO", nil).to_s.empty?
+
+      nil
     end
 
     # Detect the hostname the way the agent does: the Heroku dyno name first,

--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -171,6 +171,18 @@ module Appsignal
       "trace" => ::Logger::DEBUG
     }.freeze
 
+    # Environment variables set by deployment platforms that name the
+    # revision that is being deployed, in the order the agent reads them.
+    # The agent detects the revision this way as well, but only for the data
+    # it sends itself, so the gem has to do it for collector mode.
+    # @!visibility private
+    PLATFORM_REVISION_ENV_VARS = [
+      "HEROKU_SLUG_COMMIT",
+      "RENDER_GIT_COMMIT",
+      "KAMAL_VERSION",
+      "CONTAINER_VERSION" # Scalingo
+    ].freeze
+
     # @!visibility private
     STRING_OPTIONS = {
       :activejob_report_errors => "APPSIGNAL_ACTIVEJOB_REPORT_ERRORS",
@@ -710,11 +722,24 @@ module Appsignal
 
         hash[:enable_at_exit_hook] = "always" if Appsignal::Extension.running_in_container?
 
-        # Set revision from REVISION file if present in project root
-        # This helps with Capistrano and Hatchbox.io deployments
-        revision_from_file = detect_revision_from_file
-        hash[:revision] = revision_from_file if revision_from_file
+        # Set the revision from a REVISION file in the project root, which
+        # helps with Capistrano and Hatchbox.io deployments, or from the
+        # environment variable the deployment platform sets.
+        revision = detect_revision_from_file || detect_revision_from_platform
+        hash[:revision] = revision if revision
       end
+    end
+
+    def detect_revision_from_platform
+      PLATFORM_REVISION_ENV_VARS.each do |env_var|
+        revision = ENV.fetch(env_var, nil)
+        next if revision.to_s.empty?
+
+        logger.debug "Detected revision from the #{env_var} environment variable"
+        return revision
+      end
+
+      nil
     end
 
     def detect_revision_from_file

--- a/lib/appsignal/opentelemetry.rb
+++ b/lib/appsignal/opentelemetry.rb
@@ -226,6 +226,7 @@ module Appsignal
           "appsignal.config.push_api_key" => config[:push_api_key],
           "appsignal.config.revision" => revision,
           "appsignal.config.app_path" => config.root_path&.to_s,
+          "appsignal.config.platform" => config[:platform],
           "appsignal.config.language_integration" => "ruby",
           "service.name" => service_name,
           "host.name" => host_name,

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -28,6 +28,9 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
     let(:app_name) { "TestApp" }
     let(:push_api_key) { "abc" }
     let(:environment) { "production" }
+    # The hostname the CLI will detect while the example runs. Requests to
+    # AppSignal carry it, so the stubs have to expect the same value.
+    let(:hostname) { detected_hostname }
     let(:config) do
       {
         :root_path => root_path,
@@ -35,7 +38,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
         :name => app_name,
         :endpoint => Appsignal::Config::DEFAULT_CONFIG[:endpoint],
         :push_api_key => push_api_key,
-        :hostname => nil
+        :hostname => hostname
       }
     end
     let(:cli_class) { described_class }
@@ -715,6 +718,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
         end
 
         context "when on Heroku" do
+          let(:hostname) { "dyno1" }
           before { recognize_as_heroku { run } }
 
           it "outputs Heroku detection" do
@@ -801,9 +805,13 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
 
         it "transmits validation in report" do
           default_config = hash_with_string_keys(Appsignal::Config::DEFAULT_CONFIG)
-          options = default_config.merge("env" => "", "send_session_data" => true)
+          options = default_config.merge(
+            "env" => "",
+            "send_session_data" => true,
+            "hostname" => hostname
+          )
 
-          system_options = {}
+          system_options = { "hostname" => hostname }
           if Appsignal::Extension.running_in_container?
             options["enable_at_exit_hook"] = "always"
             system_options["enable_at_exit_hook"] = "always"
@@ -1109,7 +1117,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
           final_config = Appsignal.config.config_hash
             .merge(:env => "production")
 
-          system_options = {}
+          system_options = { "hostname" => hostname }
           if Appsignal::Extension.running_in_container?
             final_config["enable_at_exit_hook"] = "always"
             system_options["enable_at_exit_hook"] = "always"
@@ -1154,7 +1162,7 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
           if Appsignal::Extension.running_in_container?
             options = options.merge("enable_at_exit_hook" => "always")
           end
-          system_options = {}
+          system_options = { "hostname" => hostname }
           if Appsignal::Extension.running_in_container?
             system_options["enable_at_exit_hook"] = "always"
           end

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -583,6 +583,53 @@ describe Appsignal::Config do
     end
   end
 
+  describe "system detected platform" do
+    let(:config) { silence { build_config(:env => :none) } }
+
+    # Cleared rather than only restored, so that a platform recognized where
+    # the specs run does not change what the config detects.
+    before do
+      ENV.delete("DOKKU_ROOT")
+      ENV.delete("DYNO")
+    end
+
+    after do
+      ENV.delete("DOKKU_ROOT")
+      ENV.delete("DYNO")
+    end
+
+    it "does not set the platform when it recognizes none" do
+      expect(config.system_config).to_not have_key(:platform)
+    end
+
+    it "recognizes Dokku by its root directory" do
+      ENV["DOKKU_ROOT"] = "~dokku"
+
+      expect(config[:platform]).to eq("dokku")
+      expect(config.system_config).to include(:platform => "dokku")
+    end
+
+    it "recognizes Heroku by the dyno name" do
+      ENV["DYNO"] = "web.1"
+
+      expect(config[:platform]).to eq("heroku")
+    end
+
+    it "recognizes Dokku when the dyno name is set as well" do
+      ENV["DOKKU_ROOT"] = "~dokku"
+      ENV["DYNO"] = "web.1"
+
+      expect(config[:platform]).to eq("dokku")
+    end
+
+    it "ignores variables that are set to an empty string" do
+      ENV["DOKKU_ROOT"] = ""
+      ENV["DYNO"] = ""
+
+      expect(config.system_config).to_not have_key(:platform)
+    end
+  end
+
   describe "loader default config" do
     let(:config) { described_class.new("some-path", "production") }
     before do
@@ -1310,6 +1357,7 @@ describe Appsignal::Config do
       expect(ENV.fetch("_APPSIGNAL_ENABLE_HOST_METRICS", nil)).to eq "true"
       expect(ENV.fetch("_APPSIGNAL_HOSTNAME", nil)).to eq detected_hostname
       expect(ENV.fetch("_APPSIGNAL_HOST_ROLE", nil)).to eq ""
+      expect(ENV.fetch("_APPSIGNAL_PLATFORM", nil)).to eq ""
       expect(ENV.fetch("_APPSIGNAL_PROCESS_NAME", nil)).to include "rspec"
       expect(ENV.fetch("_APPSIGNAL_CA_FILE_PATH", nil))
         .to eq File.join(resources_dir, "cacert.pem")

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -537,6 +537,52 @@ describe Appsignal::Config do
     end
   end
 
+  describe "system detected hostname" do
+    let(:config) { silence { build_config(:env => :none) } }
+
+    # Cleared rather than only restored, so that a dyno name set where the
+    # specs run does not change what the config detects.
+    before { ENV.delete("DYNO") }
+    after { ENV.delete("DYNO") }
+
+    it "sets the hostname to the name the host reports for itself" do
+      expect(config[:hostname]).to eq(Socket.gethostname)
+    end
+
+    it "sets the hostname as loaded through the system" do
+      expect(config.system_config).to include(:hostname => Socket.gethostname)
+    end
+
+    it "prefers the Heroku dyno name" do
+      ENV["DYNO"] = "web.1"
+
+      expect(config[:hostname]).to eq("web.1")
+    end
+
+    it "ignores the dyno name when it is set to an empty string" do
+      ENV["DYNO"] = ""
+
+      expect(config[:hostname]).to eq(Socket.gethostname)
+    end
+
+    context "when the hostname cannot be detected" do
+      before do
+        allow(Socket).to receive(:gethostname)
+          .and_raise(SystemCallError.new("Hostname error"))
+      end
+
+      it "does not set the hostname" do
+        expect(config.system_config).to_not have_key(:hostname)
+      end
+
+      it "logs the error" do
+        logs = capture_logs { build_config(:env => :none) }
+
+        expect(logs).to contains_log(:debug, "Unable to detect the hostname: SystemCallError:")
+      end
+    end
+  end
+
   describe "loader default config" do
     let(:config) { described_class.new("some-path", "production") }
     before do
@@ -1031,6 +1077,7 @@ describe Appsignal::Config do
         :filter_request_payload         => [],
         :filter_request_query_parameters => [],
         :filter_session_data            => [],
+        :hostname                       => detected_hostname,
         :ignore_actions                 => [],
         :ignore_errors                  => [],
         :ignore_logs                    => [],
@@ -1261,7 +1308,7 @@ describe Appsignal::Config do
       expect(ENV.fetch("_APPSIGNAL_IGNORE_NAMESPACES", nil)).to eq "admin,private_namespace"
       expect(ENV.fetch("_APPSIGNAL_RUNNING_IN_CONTAINER", nil)).to eq "false"
       expect(ENV.fetch("_APPSIGNAL_ENABLE_HOST_METRICS", nil)).to eq "true"
-      expect(ENV.fetch("_APPSIGNAL_HOSTNAME", nil)).to eq ""
+      expect(ENV.fetch("_APPSIGNAL_HOSTNAME", nil)).to eq detected_hostname
       expect(ENV.fetch("_APPSIGNAL_HOST_ROLE", nil)).to eq ""
       expect(ENV.fetch("_APPSIGNAL_PROCESS_NAME", nil)).to include "rspec"
       expect(ENV.fetch("_APPSIGNAL_CA_FILE_PATH", nil))

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -466,6 +466,56 @@ describe Appsignal::Config do
         end
       end
 
+      context "when a deployment platform sets a revision environment variable" do
+        before { FileUtils.rm_f(revision_file_path) }
+
+        Appsignal::Config::PLATFORM_REVISION_ENV_VARS.each do |key|
+          it "sets the revision from #{key}" do
+            ENV[key] = "abc123"
+
+            expect(config[:revision]).to eq("abc123")
+          end
+        end
+
+        it "sets the revision as loaded through the system" do
+          ENV["RENDER_GIT_COMMIT"] = "abc123"
+
+          expect(config.system_config).to include(:revision => "abc123")
+        end
+
+        it "reads the variables in the order the agent reads them" do
+          ENV["RENDER_GIT_COMMIT"] = "from-render"
+          ENV["KAMAL_VERSION"] = "from-kamal"
+
+          expect(config[:revision]).to eq("from-render")
+        end
+
+        it "ignores a variable that is set to an empty string" do
+          ENV["HEROKU_SLUG_COMMIT"] = ""
+          ENV["RENDER_GIT_COMMIT"] = "from-render"
+
+          expect(config[:revision]).to eq("from-render")
+        end
+
+        it "logs which variable it read the revision from" do
+          ENV["RENDER_GIT_COMMIT"] = "abc123"
+          logs = capture_logs { build_config(:env => :none, :root_path => tmp_dir) }
+
+          expect(logs).to contains_log(:debug,
+            "Detected revision from the RENDER_GIT_COMMIT environment variable")
+        end
+
+        context "when the REVISION file is present as well" do
+          before { File.write(revision_file_path, "from-file") }
+
+          it "prefers the REVISION file" do
+            ENV["RENDER_GIT_COMMIT"] = "from-render"
+
+            expect(config[:revision]).to eq("from-file")
+          end
+        end
+      end
+
       context "when file reading raises an error" do
         before do
           File.write(revision_file_path, "abc123")

--- a/spec/lib/appsignal/opentelemetry_spec.rb
+++ b/spec/lib/appsignal/opentelemetry_spec.rb
@@ -349,7 +349,8 @@ if DependencyHelper.opentelemetry_present?
               :service_name => "my-service",
               :filter_attributes => ["password"],
               :ignore_actions => ["IgnoredController#action"],
-              :ignore_logs => ["^Started GET"]
+              :ignore_logs => ["^Started GET"],
+              :platform => "heroku"
             }
           )
         )
@@ -359,6 +360,7 @@ if DependencyHelper.opentelemetry_present?
         expect(attrs["appsignal.config.push_api_key"]).to eq("abc")
         expect(attrs["appsignal.config.revision"]).to eq("deadbeef")
         expect(attrs["appsignal.config.app_path"]).to eq("/path/to/app")
+        expect(attrs["appsignal.config.platform"]).to eq("heroku")
         expect(attrs["appsignal.config.language_integration"]).to eq("ruby")
         expect(attrs["service.name"]).to eq("my-service")
         expect(attrs["host.name"]).to eq("host-1")
@@ -427,6 +429,7 @@ if DependencyHelper.opentelemetry_present?
           appsignal.config.filter_request_query_parameters
           appsignal.config.ignore_errors
           appsignal.config.ignore_logs
+          appsignal.config.platform
           appsignal.config.response_headers
           appsignal.config.send_function_parameters
           appsignal.config.send_request_query_parameters

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -148,6 +148,12 @@ RSpec.configure do |config|
     # keys.
     env_keys << "_APPSIGNAL_DIAGNOSE"
     env_keys << "_TEST_APPSIGNAL_EXTENSION_FAILURE"
+    # The config detects the revision from these variables. Clear them so a
+    # revision set where the specs run does not change what the config detects.
+    # DYNO and DOKKU_ROOT are left alone, because specs set those in `around`
+    # hooks, which run before this one.
+    env_keys << "APP_REVISION"
+    env_keys.concat(Appsignal::Config::PLATFORM_REVISION_ENV_VARS)
     env_keys.each do |key|
       # First set the ENV var to an empty string and then delete the key from
       # the env. We set the env var to an empty string first as JRuby doesn't

--- a/spec/support/helpers/api_request_helper.rb
+++ b/spec/support/helpers/api_request_helper.rb
@@ -30,7 +30,11 @@ module ApiRequestHelper
     stub_request(:post, "#{endpoint}/1/#{path}").with(options)
   end
 
+  # A deploy marker is sent by an integration whose config detects the hostname.
+  # A config hash standing in for one does not, so fill in the same value a
+  # config would have detected.
   def stub_marker_request(config = {}, data = {})
+    config = { :hostname => detected_hostname }.merge(config) if config.is_a?(Hash)
     stub_api_request(config, "markers", data)
   end
 

--- a/spec/support/helpers/config_helpers.rb
+++ b/spec/support/helpers/config_helpers.rb
@@ -58,6 +58,12 @@ module ConfigHelpers
     Appsignal.internal_logger = internal_logger if internal_logger
   end
 
+  # The hostname the config detects, so specs can expect what AppSignal will
+  # report without depending on where they run.
+  def detected_hostname
+    ENV.fetch("DYNO", nil) || Socket.gethostname
+  end
+
   def clear_integration_env_vars!
     ENV.delete("RAILS_ENV")
     ENV.delete("RACK_ENV")

--- a/spec/support/helpers/config_helpers.rb
+++ b/spec/support/helpers/config_helpers.rb
@@ -59,9 +59,14 @@ module ConfigHelpers
   end
 
   # The hostname the config detects, so specs can expect what AppSignal will
-  # report without depending on where they run.
+  # report without depending on where they run. Mirrors
+  # `Appsignal::Config#detect_hostname`, minus its rescue: a spec whose
+  # hostname lookup fails has nothing to expect either way.
   def detected_hostname
-    ENV.fetch("DYNO", nil) || Socket.gethostname
+    dyno = ENV.fetch("DYNO", nil)
+    return dyno unless dyno.to_s.empty?
+
+    Socket.gethostname
   end
 
   def clear_integration_env_vars!


### PR DESCRIPTION
Fixes https://github.com/appsignal/appsignal-ruby/issues/1582.
Fixes https://github.com/appsignal/appsignal-ruby/issues/1583.
Fixes https://github.com/appsignal/appsignal-ruby/issues/1586.

Stacked on #1587.

### [Detect the revision from the platform](https://github.com/appsignal/appsignal-ruby/commit/da9c9a308a90776bd041bd2076656f5796df8c24)

The agent reads these same variables, but only for the data it reports
itself. In collector mode the gem puts the revision in a resource
attribute instead, and the collector cannot read it from the
environment, because it runs as its own process and usually on another
host.

### [Detect the hostname](https://github.com/appsignal/appsignal-ruby/commit/c284f909)

The agent detects the hostname the same way, but only for the data it
reports itself. In collector mode the gem puts the hostname in a
resource attribute instead, and the collector cannot detect it, because
it runs as its own process and usually on another host.

The agent reads the gem's hostname before detecting one itself, so it
now uses the value detected here. Both detect it the same way, so the
reported hostname stays the same.

### [Detect the platform and send it](https://github.com/appsignal/appsignal-ruby/commit/8a82b0b1)

The agent detects the platform the same way, but only for the data it
reports itself. In collector mode the gem has to put it in a resource
attribute, and the collector cannot detect it, because DOKKU_ROOT and
DYNO are set in the application's environment while the collector runs
as its own process, usually on another host.

There is no config option for the platform. The detected value reaches
the agent through the private environment variable that its own
detection already reads first.

### [Update diagnose tests for the hostname](https://github.com/appsignal/appsignal-ruby/commit/bdb5f6c524ea9f9bb849b2a3cea68fb70223bdb9)

The diagnose output lists every config option and every config source,
so the diagnose test expectations have to include the hostname the gem
now detects. Point the submodule at the diagnose_tests commit that adds
it.

That commit sits on the diagnose_tests default branch. The submodule
used to point at a branch commit from before that branch was merged, so
this also brings the diagnose test dependencies up to date.

The matching change is https://github.com/appsignal/diagnose_tests/pull/157,
which has been merged. The submodule points at the merge commit on the
diagnose_tests default branch.
