### PR TITLE
Load the Rails app before running demo

### DIFF
--- a/.changesets/load-rails-app-in-demo-command.md
+++ b/.changesets/load-rails-app-in-demo-command.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+type: fix
+---
+
+Load the host Rails application before the `appsignal demo` command reads the
+AppSignal configuration. This matches the behavior of `appsignal diagnose`.
+
+Thanks [@Guflly](https://github.com/Guflly) for your contribution!

--- a/lib/appsignal/cli/demo.rb
+++ b/lib/appsignal/cli/demo.rb
@@ -40,6 +40,8 @@ module Appsignal
     # @see https://docs.appsignal.com/support/debugging.html
     #   Debugging AppSignal guide
     class Demo
+      extend CLI::Helpers
+
       class << self
         # @param options [Hash]
         # @option options :environment [String] environment to load
@@ -47,6 +49,9 @@ module Appsignal
         # @return [void]
         def run(options = {})
           ENV["APPSIGNAL_APP_ENV"] = options[:environment] if options[:environment]
+          # Load the host Rails app, if any, so that the AppSignal config file
+          # can use the application when it is read.
+          require_rails_app_if_present(options[:environment])
 
           puts "Sending demonstration sample data..."
           if Appsignal::Demo.transmit

--- a/lib/appsignal/cli/diagnose.rb
+++ b/lib/appsignal/cli/diagnose.rb
@@ -189,10 +189,15 @@ module Appsignal
 
         def configure_appsignal(options)
           env_option = options.fetch(:environment, nil)
+          # Mark app as Rails app
+          data[:app][:rails] = true if rails_present?
           # Try and load the Rails app, if any.
           # This will configure AppSignal through the config file or an
           # initializer.
-          require_rails_app_if_present(env_option)
+          require_rails_app_if_present(env_option) do |error|
+            data[:app][:load_error] =
+              "#{error.class}: #{error.message}\n#{error.backtrace.join("\n")}"
+          end
 
           # No config loaded yet, try loading as normal
           Appsignal._load_config!(env_option) unless Appsignal.config
@@ -626,43 +631,6 @@ module Appsignal
 
           puts "    Read error: #{path[:read_error]}"
           print_empty_line
-        end
-
-        def print_empty_line
-          puts "\n"
-        end
-
-        def require_rails_app_if_present(env_option)
-          return unless rails_present?
-
-          # Set the environment given as an option to the diagnose CLI so the
-          # Rails app uses it when loaded.
-          ENV["_APPSIGNAL_CONFIG_FILE_ENV"] = env_option
-          # Mark app as Rails app
-          data[:app][:rails] = true
-          # Manually require the railtie, because it wasn't loaded when the CLI
-          # started and AppSignal loaded, because the `Rails` constant wasn't
-          # present.
-          require "appsignal/integrations/railtie"
-          # Start the Rails app, including railties and initializers.
-          require Appsignal::Utils::RailsHelper.environment_config_path
-        rescue LoadError, StandardError => error
-          print_empty_line
-          puts "ERROR: Error encountered while loading the Rails app"
-          puts "#{error.class}: #{error.message}"
-          puts error.backtrace
-          data[:app][:load_error] =
-            "#{error.class}: #{error.message}\n#{error.backtrace.join("\n")}"
-        ensure
-          ENV.delete("_APPSIGNAL_CONFIG_FILE_ENV")
-        end
-
-        def rails_present?
-          # Try and load the Rails gem
-          require "rails"
-          true
-        rescue LoadError
-          false
         end
       end
     end

--- a/lib/appsignal/cli/helpers.rb
+++ b/lib/appsignal/cli/helpers.rb
@@ -36,6 +36,44 @@ module Appsignal
         "\e[#{color_code}m#{text}\e[#{reset_color_code}m"
       end
 
+      def print_empty_line
+        puts "\n"
+      end
+
+      def rails_present?
+        require "rails"
+        true
+      rescue LoadError
+        false
+      end
+
+      def load_rails_app(environment)
+        # Pass the environment given as a command line option to the app, so
+        # that the AppSignal config file uses it when the app loads it.
+        ENV["_APPSIGNAL_CONFIG_FILE_ENV"] = environment
+        # Require the railtie manually. It was not loaded when AppSignal
+        # loaded, because the `Rails` constant was not present at that point.
+        require "appsignal/integrations/railtie"
+        # Start the Rails app, including its railties and initializers.
+        require Appsignal::Utils::RailsHelper.environment_config_path
+      ensure
+        ENV.delete("_APPSIGNAL_CONFIG_FILE_ENV")
+      end
+
+      # Yields the error when the app fails to load, so that a command can
+      # report it in its own way.
+      def require_rails_app_if_present(environment)
+        return unless rails_present?
+
+        load_rails_app(environment)
+      rescue LoadError, StandardError => error
+        print_empty_line
+        puts "ERROR: Error encountered while loading the Rails app"
+        puts "#{error.class}: #{error.message}"
+        puts error.backtrace
+        yield error if block_given?
+      end
+
       def periods
         3.times do
           print "."

--- a/lib/appsignal/cli/helpers.rb
+++ b/lib/appsignal/cli/helpers.rb
@@ -47,6 +47,13 @@ module Appsignal
         false
       end
 
+      # The Rails gem being loadable says nothing about the directory the
+      # command runs in, so check for the app itself as well.
+      def rails_app_present?
+        rails_present? &&
+          File.exist?(Appsignal::Utils::RailsHelper.environment_config_path)
+      end
+
       def load_rails_app(environment)
         # Pass the environment given as a command line option to the app, so
         # that the AppSignal config file uses it when the app loads it.
@@ -63,7 +70,7 @@ module Appsignal
       # Yields the error when the app fails to load, so that a command can
       # report it in its own way.
       def require_rails_app_if_present(environment)
-        return unless rails_present?
+        return unless rails_app_present?
 
         load_rails_app(environment)
       rescue LoadError, StandardError => error

--- a/spec/lib/appsignal/cli/demo_spec.rb
+++ b/spec/lib/appsignal/cli/demo_spec.rb
@@ -43,4 +43,29 @@ describe Appsignal::CLI::Demo do
       expect(output).to include("Demonstration sample data sent!")
     end
   end
+
+  if DependencyHelper.rails_present?
+    context "with a Rails app" do
+      let(:root_path) { File.join(tmp_dir, "demo_test_app_#{SecureRandom.uuid}") }
+      before { FileUtils.cp_r(rails_project_with_config_rb_fixture_path, root_path) }
+      after { FileUtils.rm_rf(root_path) }
+
+      # Run the command in a process of its own. This test suite loads Rails
+      # itself, so a `config/appsignal.rb` file that uses Rails would work here
+      # even when the command does not load the app. Booting a Rails app in
+      # this process also disturbs the specs that run after it.
+      def run_demo_command
+        binary = File.join(DirectoryHelper.project_dir, "bin/appsignal")
+        env = { "BUNDLE_GEMFILE" => Bundler.default_gemfile.to_s }
+        options = { :chdir => root_path, :err => [:child, :out] }
+        Bundler.with_unbundled_env do
+          IO.popen([env, "bundle", "exec", binary, "demo", "--environment=test", options], &:read)
+        end
+      end
+
+      it "loads the app, so its config file can use the application" do
+        expect(run_demo_command).to include("Demonstration sample data sent!")
+      end
+    end
+  end
 end

--- a/spec/lib/appsignal/cli/helpers_spec.rb
+++ b/spec/lib/appsignal/cli/helpers_spec.rb
@@ -63,6 +63,38 @@ describe Appsignal::CLI::Helpers do
     end
   end
 
+  describe ".rails_app_present?" do
+    let(:root_path) { File.join(tmp_dir, SecureRandom.uuid) }
+    before do
+      allow(Appsignal::Utils::RailsHelper).to receive(:environment_config_path)
+        .and_return(File.join(root_path, "config/environment.rb"))
+    end
+    after { FileUtils.rm_rf(root_path) }
+
+    context "when the Rails gem is not present" do
+      before { allow(cli).to receive(:rails_present?).and_return(false) }
+
+      it "returns false" do
+        expect(cli.send(:rails_app_present?)).to be(false)
+      end
+    end
+
+    context "when the Rails gem is present" do
+      before { allow(cli).to receive(:rails_present?).and_return(true) }
+
+      it "returns true when the directory holds a Rails app" do
+        FileUtils.mkdir_p(File.join(root_path, "config"))
+        FileUtils.touch(File.join(root_path, "config/environment.rb"))
+
+        expect(cli.send(:rails_app_present?)).to be(true)
+      end
+
+      it "returns false when the directory holds no Rails app" do
+        expect(cli.send(:rails_app_present?)).to be(false)
+      end
+    end
+  end
+
   describe ".load_rails_app" do
     let(:environment_path) { File.join(tmp_dir, "config/environment.rb") }
     before do
@@ -92,8 +124,8 @@ describe Appsignal::CLI::Helpers do
   end
 
   describe ".require_rails_app_if_present" do
-    context "when the Rails gem is not present" do
-      before { allow(cli).to receive(:rails_present?).and_return(false) }
+    context "when there is no Rails app" do
+      before { allow(cli).to receive(:rails_app_present?).and_return(false) }
 
       it "does not load the app" do
         expect(cli).to_not receive(:load_rails_app)
@@ -102,8 +134,8 @@ describe Appsignal::CLI::Helpers do
       end
     end
 
-    context "when the Rails gem is present" do
-      before { allow(cli).to receive(:rails_present?).and_return(true) }
+    context "when there is a Rails app" do
+      before { allow(cli).to receive(:rails_app_present?).and_return(true) }
 
       it "loads the app with the given environment" do
         expect(cli).to receive(:load_rails_app).with("staging")

--- a/spec/lib/appsignal/cli/helpers_spec.rb
+++ b/spec/lib/appsignal/cli/helpers_spec.rb
@@ -49,6 +49,102 @@ describe Appsignal::CLI::Helpers do
     end
   end
 
+  describe ".rails_present?" do
+    it "returns true when the Rails gem can be loaded" do
+      expect(cli).to receive(:require).with("rails")
+
+      expect(cli.send(:rails_present?)).to be(true)
+    end
+
+    it "returns false when the Rails gem cannot be loaded" do
+      expect(cli).to receive(:require).with("rails").and_raise(LoadError)
+
+      expect(cli.send(:rails_present?)).to be(false)
+    end
+  end
+
+  describe ".load_rails_app" do
+    let(:environment_path) { File.join(tmp_dir, "config/environment.rb") }
+    before do
+      allow(Appsignal::Utils::RailsHelper).to receive(:environment_config_path)
+        .and_return(environment_path)
+    end
+
+    it "loads the railtie and the app with the given environment" do
+      expect(cli).to receive(:require)
+        .with("appsignal/integrations/railtie").ordered
+      expect(cli).to receive(:require).with(environment_path).ordered do
+        expect(ENV.fetch("_APPSIGNAL_CONFIG_FILE_ENV", nil)).to eq("staging")
+      end
+
+      cli.send(:load_rails_app, "staging")
+
+      expect(ENV).to_not have_key("_APPSIGNAL_CONFIG_FILE_ENV")
+    end
+
+    it "clears the given environment when the app fails to load" do
+      allow(cli).to receive(:require).and_raise(LoadError)
+
+      expect { cli.send(:load_rails_app, "staging") }.to raise_error(LoadError)
+
+      expect(ENV).to_not have_key("_APPSIGNAL_CONFIG_FILE_ENV")
+    end
+  end
+
+  describe ".require_rails_app_if_present" do
+    context "when the Rails gem is not present" do
+      before { allow(cli).to receive(:rails_present?).and_return(false) }
+
+      it "does not load the app" do
+        expect(cli).to_not receive(:load_rails_app)
+
+        cli.send(:require_rails_app_if_present, "staging")
+      end
+    end
+
+    context "when the Rails gem is present" do
+      before { allow(cli).to receive(:rails_present?).and_return(true) }
+
+      it "loads the app with the given environment" do
+        expect(cli).to receive(:load_rails_app).with("staging")
+
+        cli.send(:require_rails_app_if_present, "staging")
+      end
+
+      context "when the app fails to load" do
+        let(:error) do
+          ExampleStandardError.new("error message").tap do |raised_error|
+            raised_error.set_backtrace(["line 1", "line 2"])
+          end
+        end
+        before { allow(cli).to receive(:load_rails_app).and_raise(error) }
+
+        it "prints the error" do
+          capture_stdout(out_stream) do
+            cli.send(:require_rails_app_if_present, "staging")
+          end
+
+          expect(output).to include(
+            "ERROR: Error encountered while loading the Rails app\n" \
+              "ExampleStandardError: error message\n" \
+              "line 1\nline 2\n"
+          )
+        end
+
+        it "yields the error" do
+          yielded_error = nil
+          capture_stdout(out_stream) do
+            cli.send(:require_rails_app_if_present, "staging") do |raised_error|
+              yielded_error = raised_error
+            end
+          end
+
+          expect(yielded_error).to be(error)
+        end
+      end
+    end
+  end
+
   describe ".periods" do
     it "prints three periods" do
       capture_stdout(out_stream) { cli.send :periods }

--- a/spec/support/fixtures/projects/valid_with_rails_app_with_config_rb/config/appsignal.rb
+++ b/spec/support/fixtures/projects/valid_with_rails_app_with_config_rb/config/appsignal.rb
@@ -1,3 +1,7 @@
+# The demo and diagnose commands have to load this Rails application before they
+# read this file. Referencing a Rails constant here fails when they do not.
+Rails.application
+
 Appsignal.configure do |config|
   config.activate_if_environment(:production, :development, :test)
   config.name = "TestApp"


### PR DESCRIPTION
Backport of #1584 for the 4.x series of the Ruby gem.

### [Move the Rails app loading to the CLI helpers](https://github.com/appsignal/appsignal-ruby/commit/9199d046)

The diagnose command loads the host Rails application before it reads
the AppSignal configuration. The demo command needs to do the same, so
the code that does it moves to the helper module both commands already
extend.

While it loads the app, diagnose also records in its report whether
this is a Rails app and what error the app raised. A shared helper
cannot know about that report, so it yields the error and diagnose sets
both fields at the call site.

### [Load the Rails app before running demo](https://github.com/appsignal/appsignal-ruby/commit/f6cdbbb3)

The `config/appsignal.rb` file is read by both the demo and the diagnose
command. Diagnose loads the host Rails application first and demo did
not, so a config file that reads application state worked under one
command and raised `NameError` under the other. Reading application
state is how an app tells AppSignal something only the app knows, such
as which of two tiers it is when both run with `RAILS_ENV=production`.

The spec runs the command in a process of its own. This test suite loads
Rails itself, so a config file that uses Rails would work here even when
the command never loads the app. Booting a Rails app in the test suite
process also breaks the specs that run after it.

### [Only load a Rails app when there is one](https://github.com/appsignal/appsignal-ruby/commit/26233cd6)

Whether the Rails gem can be loaded says nothing about the directory the
command runs in. A command run from a subdirectory of a Rails app, or
from a gem that carries Rails in its bundle, tried to load an
application that is not there. It then reported the resulting
`LoadError` with a full backtrace.

That reads as a failure when nothing failed, and the demo command makes
it worse, because it sends its sample data successfully either way.
Both commands now look for the `config/environment.rb` file before they
load anything, so a directory without an application is no longer
treated as an error.

[skip review] because these commits were already reviewed and approved on `main`.
