### PR TITLE
Report Delayed Job jobs that fail to load

### DIFF
--- a/.changesets/report-delayed-job-jobs-that-fail-to-load.md
+++ b/.changesets/report-delayed-job-jobs-that-fail-to-load.md
@@ -1,0 +1,13 @@
+---
+bump: patch
+type: fix
+---
+
+Report Delayed Job jobs that fail to load. Before this change, a job whose
+payload could not be deserialized was not reported to AppSignal at all.
+
+This can happen when a deploy removes or renames a job class while jobs of that
+class are still queued. Those jobs are now reported as failed, with the
+`Delayed::DeserializationError` they raised, and are named after the class
+recorded in the job's handler. When even that cannot be read, they are named
+`DelayedJobInternal`.

--- a/lib/appsignal/integrations/delayed_job_plugin.rb
+++ b/lib/appsignal/integrations/delayed_job_plugin.rb
@@ -63,16 +63,26 @@ module Appsignal
           transaction.set_error(error)
           raise
         ensure
-          payload = job.payload_object
-          if payload.respond_to? :job_data
-            # ActiveJob
-            job_data = payload.job_data
-            transaction.set_action_if_nil("#{job_data["job_class"]}#perform")
-            transaction.add_params_if_nil(job_data.fetch("arguments", {}))
-          else
-            # Delayed Job
-            transaction.set_action_if_nil(action_name_from_payload(payload, job.name))
-            transaction.add_params_if_nil(extract_value(payload, :args, {}))
+          # Delayed Job raises when a job's handler will not deserialize, and it
+          # raises again on every further attempt to read it. Reading the payload
+          # here without a guard therefore replaces the error the job already
+          # failed with, and skips the rest of this block, so the transaction is
+          # never completed and the failure is never reported.
+          begin
+            payload = job.payload_object
+            if payload.respond_to? :job_data
+              # ActiveJob
+              job_data = payload.job_data
+              transaction.set_action_if_nil("#{job_data["job_class"]}#perform")
+              transaction.add_params_if_nil(job_data.fetch("arguments", {}))
+            else
+              # Delayed Job
+              transaction.set_action_if_nil(action_name_from_payload(payload, job.name))
+              transaction.add_params_if_nil(extract_value(payload, :args, {}))
+            end
+          rescue => error
+            warn_unreadable_payload_once(error)
+            transaction.set_action_if_nil(action_name_without_payload(job))
           end
 
           transaction.add_tags(
@@ -88,14 +98,67 @@ module Appsignal
         end
       end
 
+      # The name Delayed Job derives from the raw handler when the payload will
+      # not deserialize. It reads the class name out of the handler with a
+      # regular expression, which covers the job class a deploy removed. That
+      # expression raises for a handler it does not match, and it is skipped
+      # altogether when the payload raised something Delayed Job does not wrap,
+      # so fall back to a name that says the failure came from inside Delayed
+      # Job. The failure is then reported under a name that can be found, and
+      # every job this happens to is grouped together.
+      def self.action_name_without_payload(job)
+        with_perform_suffix(job.name)
+      rescue
+        "DelayedJobInternal"
+      end
+
+      # Guards the check-and-set below, so two threads that read an unreadable
+      # payload at the same time cannot both warn. A constant so it is created
+      # once at load time, because creating it lazily would race in turn.
+      WARN_ONCE_LOCK = Mutex.new
+
+      # A deploy that removes a job class leaves every job of that class unable
+      # to deserialize, so this can be reached once per job. Each of those jobs
+      # reports its own error to AppSignal, so the log only has to say once that
+      # it is happening.
+      def self.warn_unreadable_payload_once(error)
+        should_warn = WARN_ONCE_LOCK.synchronize do
+          next false if @warned_unreadable_payload
+
+          @warned_unreadable_payload = true
+        end
+        return unless should_warn
+
+        Appsignal.internal_logger.warn(
+          "Unable to read a Delayed Job job's payload: #{error.class}: " \
+            "#{error.message}. Jobs whose payload cannot be read are reported " \
+            "without parameters. They are named after the class in their raw " \
+            "handler, or DelayedJobInternal when that cannot be read either."
+        )
+      end
+
+      # @!visibility private
+      #
+      # Resets the warn-once state. Only used to keep test runs isolated.
+      def self.reset_unreadable_payload_warning!
+        WARN_ONCE_LOCK.synchronize { @warned_unreadable_payload = false }
+      end
+
       def self.action_name_from_payload(payload, default_name)
         # Attempt to find appsignal_name override
         class_and_method_name = extract_value(payload, :appsignal_name, nil)
         return class_and_method_name if class_and_method_name.is_a?(String)
-        return default_name if default_name.split("#").length == 2
-        return default_name if default_name.split(".").length == 2
 
-        "#{default_name}#perform"
+        with_perform_suffix(default_name)
+      end
+
+      # An action name is a class and a method. A name that already names both,
+      # separated either way, is left alone.
+      def self.with_perform_suffix(name)
+        return name if name.split("#").length == 2
+        return name if name.split(".").length == 2
+
+        "#{name}#perform"
       end
 
       # rubocop:disable Style/OptionalBooleanParameter

--- a/lib/appsignal/integrations/delayed_job_plugin.rb
+++ b/lib/appsignal/integrations/delayed_job_plugin.rb
@@ -11,6 +11,18 @@ module Appsignal
           enqueue_with_instrumentation(job, block)
         end
 
+        # Delayed Job asks a job for its own maximum run time before it invokes
+        # it, and answering that question reads the job's payload. A job whose
+        # payload will not deserialize therefore raises inside the worker and
+        # never reaches `invoke_job`, so the callback below does not run and the
+        # failure goes unreported. This callback sits one step further out, on
+        # the worker's whole run of the job, which is where such a job can still
+        # be seen.
+        lifecycle.around(:perform) do |worker, job, &block|
+          report_job_that_cannot_be_loaded(job)
+          block.call(worker, job)
+        end
+
         lifecycle.around(:invoke_job) do |job, &block|
           invoke_with_instrumentation(job, block)
         end
@@ -51,6 +63,34 @@ module Appsignal
         job.name
       end
 
+      # Reports a job whose payload cannot be read, and does nothing at all for
+      # a job that loads. That is what keeps every ordinary job instrumented by
+      # the `:invoke_job` callback alone: no transaction is opened here, so an
+      # ordinary job's reported duration and its reported error are exactly
+      # what they were before this callback existed.
+      #
+      # Reading the payload here reads it a moment before the worker would have
+      # read it anyway. Delayed Job memoizes a payload that loads, so a job
+      # that is fine is deserialized once either way.
+      #
+      # Nothing is re-raised. The worker reads the same payload immediately
+      # after this returns, raises the same error, and fails the job as it
+      # always has. Raising here instead would move that error out of the
+      # worker's own handling and into the loop that reserves jobs.
+      def self.report_job_that_cannot_be_loaded(job)
+        job.payload_object
+        nil
+      rescue Exception => error
+        warn_unreadable_payload_once(error)
+
+        transaction =
+          Appsignal::Transaction.create(Appsignal::Transaction::BACKGROUND_JOB)
+        transaction.set_action_if_nil(action_name_without_payload(job))
+        transaction.set_error(error)
+        add_job_metadata(transaction, job)
+        Appsignal::Transaction.complete_current!
+      end
+
       def self.invoke_with_instrumentation(job, block)
         transaction =
           Appsignal::Transaction.create(Appsignal::Transaction::BACKGROUND_JOB)
@@ -85,17 +125,21 @@ module Appsignal
             transaction.set_action_if_nil(action_name_without_payload(job))
           end
 
-          transaction.add_tags(
-            :id => extract_value(job, :id, nil, true),
-            :queue => extract_value(job, :queue),
-            :priority => extract_value(job, :priority, 0),
-            :attempts => extract_value(job, :attempts, 0)
-          )
-
-          transaction.set_queue_start(extract_value(job, :run_at)&.to_i&.* 1_000)
+          add_job_metadata(transaction, job)
 
           Appsignal::Transaction.complete_current!
         end
+      end
+
+      def self.add_job_metadata(transaction, job)
+        transaction.add_tags(
+          :id => extract_value(job, :id, nil, true),
+          :queue => extract_value(job, :queue),
+          :priority => extract_value(job, :priority, 0),
+          :attempts => extract_value(job, :attempts, 0)
+        )
+
+        transaction.set_queue_start(extract_value(job, :run_at)&.to_i&.* 1_000)
       end
 
       # The name Delayed Job derives from the raw handler when the payload will

--- a/spec/lib/appsignal/integrations/delayed_job_plugin_spec.rb
+++ b/spec/lib/appsignal/integrations/delayed_job_plugin_spec.rb
@@ -37,6 +37,15 @@ if DependencyHelper.delayed_job_present?
       job.invoke_job
     end
 
+    # Runs the queued job the way a worker does. `work_off` is the only path
+    # that runs the `:perform` lifecycle callbacks, and it is also the path that
+    # reads a job's payload before invoking it and swallows the job's exception
+    # afterwards. Calling `invoke_job` directly does neither, so an example that
+    # needs either of those has to go through here.
+    def work_off_one_job
+      Delayed::Worker.new(:quiet => true).work_off(1)
+    end
+
     describe "enqueueing a job" do
       context "with an active transaction" do
         it "records an enqueue event titled after the job" do
@@ -280,6 +289,158 @@ if DependencyHelper.delayed_job_present?
             expect(transaction).to have_namespace("background_job")
             expect(transaction).to have_action("DelayedActiveJob#perform")
             expect(transaction).to include_params(["arg"])
+          end
+        end
+      end
+
+      # Every example above performs the job by calling `invoke_job` directly,
+      # which is what Delayed Job does when `delay_jobs` is false. A worker
+      # takes a different path. It reads the job's payload before it invokes the
+      # job, so a job that cannot be read never reaches `invoke_job` at all. It
+      # also catches the job's exception instead of letting it out, so an error
+      # report that only worked because the exception reached the integration
+      # would report nothing here. Neither is visible from `invoke_job`, which
+      # is why these examples drive the worker itself.
+      context "when a worker runs the job" do
+        before do
+          stub_const("DelayedWorkerErrorJob", Class.new do
+            def perform
+              raise ExampleException, "uh oh"
+            end
+          end)
+
+          # A job that has no attempts left, so Delayed Job marks it failed
+          # instead of rescheduling it. That runs a different set of its
+          # callbacks than a job that will be retried.
+          stub_const("DelayedLastAttemptJob", Class.new do
+            def max_attempts
+              1
+            end
+
+            def perform
+              raise ExampleException, "last try"
+            end
+          end)
+
+          # A job that outlives its own maximum run time. Delayed Job passes
+          # that number to `Timeout.timeout` as an integer, so one second is the
+          # shortest limit it can express.
+          stub_const("DelayedSlowJob", Class.new do
+            def max_run_time
+              1
+            end
+
+            def perform
+              sleep 1.1
+            end
+          end)
+        end
+
+        it "reports a job that loads exactly once" do
+          start_agent
+          Delayed::Job.enqueue(DelayedTestJob.new, :queue => "dj-queue")
+
+          keep_transactions { work_off_one_job }
+
+          expect(created_transactions.count).to eq(1)
+          transaction = last_transaction
+          expect(transaction).to be_completed
+          expect(transaction).to have_action("DelayedTestJob#perform")
+          expect(transaction).to_not have_error
+        end
+
+        # The worker catches the job's exception, so nothing is raised here.
+        # This example fails if the integration ever comes to depend on the
+        # exception reaching it, which is what would happen if the transaction
+        # were opened around the worker's whole run of the job instead of
+        # around `invoke_job`.
+        it "reports the job's own error, once" do
+          start_agent
+          Delayed::Job.enqueue(DelayedWorkerErrorJob.new)
+
+          keep_transactions { work_off_one_job }
+
+          expect(created_transactions.count).to eq(1)
+          transaction = last_transaction
+          expect(transaction).to be_completed
+          expect(transaction).to have_action("DelayedWorkerErrorJob#perform")
+          expect(transaction).to have_error("ExampleException", "uh oh")
+        end
+
+        # Delayed Job marks this job failed rather than rescheduling it, which
+        # runs its failure callbacks on top of its error callbacks. Both of
+        # those are places a second report could come from.
+        it "reports a job on its last attempt once" do
+          start_agent
+          Delayed::Job.enqueue(DelayedLastAttemptJob.new)
+
+          keep_transactions { work_off_one_job }
+
+          expect(created_transactions.count).to eq(1)
+          transaction = last_transaction
+          expect(transaction).to be_completed
+          expect(transaction).to have_action("DelayedLastAttemptJob#perform")
+          expect(transaction).to have_error("ExampleException", "last try")
+        end
+
+        it "reports a job that runs longer than its maximum run time" do
+          start_agent
+          Delayed::Job.enqueue(DelayedSlowJob.new)
+
+          keep_transactions { work_off_one_job }
+
+          expect(created_transactions.count).to eq(1)
+          transaction = last_transaction
+          expect(transaction).to be_completed
+          expect(transaction).to have_error("Delayed::WorkerTimeout", /execution expired/)
+        end
+
+        context "with a job whose payload cannot be deserialized" do
+          before do
+            Delayed::Backend::Test::Job.create(
+              :handler => "--- !ruby/object:TotallyMissingJobClass {}\n"
+            )
+          end
+
+          it "reports the job with its deserialization error" do
+            start_agent
+
+            keep_transactions { work_off_one_job }
+
+            expect(created_transactions.count).to eq(1)
+            transaction = last_transaction
+            expect(transaction).to be_completed
+            expect(transaction).to have_namespace("background_job")
+            expect(transaction).to have_error(
+              "Delayed::DeserializationError", /TotallyMissingJobClass/
+            )
+            expect(transaction).to have_action("TotallyMissingJobClass#perform")
+            expect(transaction).to include_tags("attempts" => 0, "priority" => 0)
+          end
+        end
+
+        # Delayed Job cannot name this job either, and its own failure handling
+        # raises while trying to, so the worker's run of the job ends in an
+        # error rather than in the job being marked failed. That happens whether
+        # or not AppSignal is loaded. What matters here is that the job is
+        # reported before it happens.
+        context "when the handler cannot be parsed for a class name either" do
+          before do
+            Delayed::Backend::Test::Job.create(:handler => "--- {\n")
+          end
+
+          it "names the job after Delayed Job" do
+            start_agent
+
+            keep_transactions do
+              expect { work_off_one_job }.to raise_error(NoMethodError)
+            end
+
+            expect(created_transactions.count).to eq(1)
+            transaction = last_transaction
+            expect(transaction).to be_completed
+            expect(transaction).to have_error("Delayed::DeserializationError", /./)
+            expect(transaction).to have_action("DelayedJobInternal")
           end
         end
       end

--- a/spec/lib/appsignal/integrations/delayed_job_plugin_spec.rb
+++ b/spec/lib/appsignal/integrations/delayed_job_plugin_spec.rb
@@ -20,6 +20,10 @@ if DependencyHelper.delayed_job_present?
       Delayed::Worker.plugins << Appsignal::Integrations::DelayedJobPlugin
       Delayed::Worker.setup_lifecycle
 
+      # The unreadable-payload warning is emitted once per process, so it has to
+      # be reset or only the first example to reach it would see it.
+      Appsignal::Integrations::DelayedJobPlugin.reset_unreadable_payload_warning!
+
       stub_const("DelayedTestJob", Class.new do
         def perform
         end
@@ -149,6 +153,83 @@ if DependencyHelper.delayed_job_present?
           expect(transaction).to have_namespace("background_job")
           expect(transaction).to have_action("DelayedErrorJob#perform")
           expect(transaction).to have_error("ExampleException", "uh oh")
+        end
+      end
+
+      # What a deploy that removes a job class leaves behind: jobs whose stored
+      # handler names a class that is gone. Created straight through the backend,
+      # because `Delayed::Job.enqueue` stores the live object next to the handler
+      # and Delayed Job then never parses the handler at all.
+      context "with a job whose payload cannot be deserialized" do
+        let(:job) do
+          Delayed::Backend::Test::Job.create(
+            :handler => "--- !ruby/object:TotallyMissingJobClass {}\n"
+          )
+        end
+
+        it "reports the job with its deserialization error" do
+          start_agent
+
+          keep_transactions do
+            expect { perform_job(job) }.to raise_error(
+              Delayed::DeserializationError, /TotallyMissingJobClass/
+            )
+          end
+
+          transaction = last_transaction
+          expect(transaction).to be_completed
+          expect(transaction).to have_namespace("background_job")
+          expect(transaction).to have_error(
+            "Delayed::DeserializationError", /TotallyMissingJobClass/
+          )
+          # Delayed Job reads the class name out of the raw handler when the
+          # payload will not load, so the job is still named after its class.
+          expect(transaction).to have_action("TotallyMissingJobClass#perform")
+          expect(transaction).to include_tags("attempts" => 0, "priority" => 0)
+        end
+
+        it "logs that the payload could not be read, once per process" do
+          start_agent
+          other_job = Delayed::Backend::Test::Job.create(:handler => job.handler)
+
+          logs = capture_logs do
+            keep_transactions do
+              [job, other_job].each do |unreadable_job|
+                expect { perform_job(unreadable_job) }
+                  .to raise_error(Delayed::DeserializationError)
+              end
+            end
+          end
+
+          expect(logs).to contains_log(
+            :warn, "Unable to read a Delayed Job job's payload"
+          )
+          # Both jobs failed, but a deploy that removes a job class can leave
+          # very many of them, so the warning is only worth logging once.
+          expect(logs.scan("Unable to read a Delayed Job").count).to eq(1)
+        end
+
+        # A handler that defeats the class-name expression Delayed Job falls back
+        # to, so the job's own class cannot be named.
+        context "when the handler cannot be parsed for a class name either" do
+          let(:job) { Delayed::Backend::Test::Job.create(:handler => "--- {\n") }
+
+          it "names the job after Delayed Job" do
+            start_agent
+
+            keep_transactions do
+              expect { perform_job(job) }
+                .to raise_error(Delayed::DeserializationError)
+            end
+
+            transaction = last_transaction
+            expect(transaction).to be_completed
+            expect(transaction).to have_error("Delayed::DeserializationError", /./)
+            # Named after Delayed Job itself, so the failure is reported under a
+            # name that can be found rather than under none.
+            expect(transaction).to have_action("DelayedJobInternal")
+            expect(transaction).to include_tags("attempts" => 0, "priority" => 0)
+          end
         end
       end
 


### PR DESCRIPTION
### [Report Delayed Job jobs that fail to load](https://github.com/appsignal/appsignal-ruby/commit/6f2a837131dc5af7eafac7fb6cfdf69ac8f16f60)

The Delayed Job integration reads a job's payload after performing it,
to name the transaction and record the job's parameters. Delayed Job
raises when a job's handler no longer deserializes, and raises again on
every further read, so that read raises inside the `ensure` block. The
transaction is therefore never completed and the failure never reaches
AppSignal, even though the error is already set on it. The payload read
is now guarded, and a job whose payload cannot be read is named after
the class recorded in its raw handler, or after Delayed Job itself when
the handler does not record one either.

### [Report Delayed Job jobs the worker cannot load](https://github.com/appsignal/appsignal-ruby/commit/06d99afb41a60e37437e4749c45ae9dfefc49966)

The plugin instruments a job from Delayed Job's `invoke_job` callback.
Delayed Job reads a job's payload before it invokes it, because it asks
the job for its own maximum run time, so a job whose payload will not
deserialize raises inside the worker and never reaches `invoke_job`.
The worker fails that job on its own and nothing is reported. The
`perform` callback runs for every job the worker takes, including that
one, so reading the payload there is what gets the failure reported.

The transaction stays on `invoke_job`. `Delayed::Worker#run` rescues
every exception a job raises, so a transaction opened around it would
never see the job's error, and error reporting would stop for every
failing job with nothing to show that it had.
