### PR TITLE
Record Active Job bulk enqueues as one event

### DIFF
--- a/.changesets/record-active-job-bulk-enqueues-as-one-event.md
+++ b/.changesets/record-active-job-bulk-enqueues-as-one-event.md
@@ -1,0 +1,14 @@
+---
+bump: patch
+type: fix
+---
+
+Record a single event for a bulk enqueue of Active Job jobs. Before this change,
+enqueuing jobs with `ActiveJob.perform_all_later` would record an event for the
+batch and, if the adapter was instrumented with AppSignal, another event for each
+job in it. A job that slices a large collection and enqueues it in batches was
+therefore reported with an event per job enqueued, where before version 4.9.0 it
+had one event per batch.
+
+A bulk enqueue is now recorded as a single `enqueue_all.active_job` event, named
+after the job class when every job in the batch shares one.

--- a/lib/appsignal/hooks/active_job.rb
+++ b/lib/appsignal/hooks/active_job.rb
@@ -21,6 +21,59 @@ module Appsignal
         defined?(::ActiveJob)
       end
 
+      # The parameters of the Active Job method this hook wraps to record a
+      # bulk enqueue. The wrapper reads the array of jobs out of the second
+      # one, so it is only safe to wrap a method that still takes these.
+      EXPECTED_INSTRUMENT_ENQUEUE_ALL_PARAMETERS = [
+        [:req, :queue_adapter],
+        [:req, :jobs]
+      ].freeze
+
+      # Whether Active Job records a bulk enqueue through a method at all. It
+      # only does so from version 7.1 on. Checking for the method, rather than
+      # for the version, keeps us from wrapping one on a version that has no
+      # bulk enqueue path to instrument.
+      def self.instrument_enqueue_all_defined?
+        ::ActiveJob.singleton_class.private_method_defined?(:instrument_enqueue_all)
+      end
+
+      # Whether that method still takes the arguments the wrapper reads.
+      #
+      # The method is private, so a later version of Active Job can change
+      # what it takes. Wrapping one that takes something else raises an
+      # ArgumentError inside every `ActiveJob.perform_all_later` call an
+      # application makes, which breaks enqueuing and not just its
+      # instrumentation. Refusing to wrap it is therefore the safe direction,
+      # whatever the refusal costs us.
+      def self.instrument_enqueue_all_parameters_match?
+        instrument_enqueue_all_parameters == EXPECTED_INSTRUMENT_ENQUEUE_ALL_PARAMETERS
+      end
+
+      # Active Job's own definition of the method, looked up past the wrapper
+      # this hook prepends. Installing twice would otherwise find that wrapper
+      # rather than the method it wraps, and so check it against itself. Only
+      # the wrapper is skipped, so a version of Active Job that defines the
+      # method somewhere else is still found.
+      def self.instrument_enqueue_all_method
+        method = ::ActiveJob.singleton_class.instance_method(:instrument_enqueue_all)
+        method = method.super_method while method&.owner == ActiveJobBulkEnqueueInstrumentation
+        method
+      end
+
+      def self.instrument_enqueue_all_parameters
+        instrument_enqueue_all_method&.parameters
+      end
+
+      # Names both sides of the mismatch, so a log line is enough to tell what
+      # Active Job changed and what the wrapper was written against.
+      def self.instrument_enqueue_all_mismatch_message
+        "Not instrumenting Active Job bulk enqueues: " \
+          "`ActiveJob.instrument_enqueue_all` takes " \
+          "#{instrument_enqueue_all_parameters.inspect} in this version of " \
+          "Active Job, where AppSignal expects " \
+          "#{EXPECTED_INSTRUMENT_ENQUEUE_ALL_PARAMETERS.inspect}."
+      end
+
       def dependencies_present?
         self.class.dependencies_present? && Appsignal.config &&
           Appsignal.config[:instrument_active_job]
@@ -32,6 +85,32 @@ module Appsignal
             .extend ::Appsignal::Hooks::ActiveJobHook::ActiveJobClassInstrumentation
           ::ActiveJob::Base
             .prepend ::Appsignal::Hooks::ActiveJobHook::ActiveJobEnqueueInstrumentation
+
+          # Wrap the method Active Job records a bulk enqueue through, but only
+          # when it is still the method the wrapper knows how to read. When it
+          # is not, the batch goes unrecorded: Rails' own notification stays
+          # suppressed, because a worse event is not worth reporting in place
+          # of the one we set out to report.
+          if !Appsignal::Hooks::ActiveJobHook.instrument_enqueue_all_defined?
+            # Nothing to instrument on a version with no bulk enqueue path, so
+            # there is nothing to report either.
+            Appsignal.internal_logger.debug(
+              "Not instrumenting Active Job bulk enqueues: this version of " \
+                "Active Job does not record them through " \
+                "`ActiveJob.instrument_enqueue_all`."
+            )
+          elsif !Appsignal::Hooks::ActiveJobHook.instrument_enqueue_all_parameters_match?
+            # A bulk enqueue path exists, but not one that can be wrapped
+            # without breaking `ActiveJob.perform_all_later` for the whole
+            # application. Report that at a level someone will see, because a
+            # batch that used to be recorded no longer is.
+            Appsignal.internal_logger.warn(
+              Appsignal::Hooks::ActiveJobHook.instrument_enqueue_all_mismatch_message
+            )
+          else
+            ::ActiveJob.singleton_class
+              .prepend ::Appsignal::Hooks::ActiveJobHook::ActiveJobBulkEnqueueInstrumentation
+          end
 
           next unless Appsignal::Hooks::ActiveJobHook.version_7_1_or_higher?
 
@@ -77,6 +156,67 @@ module Appsignal
               super
             end
           end
+        end
+      end
+
+      # Records an `enqueue_all.active_job` event when a batch of jobs is
+      # enqueued with `ActiveJob.perform_all_later`, so the batch shows up on the
+      # active transaction's timeline as one event.
+      #
+      # This wraps `instrument_enqueue_all` rather than `perform_all_later`, for
+      # two reasons. It is the method that records the batch, so it is called
+      # once for each queue adapter the batch spans, which is the same event
+      # count as the native notification it replaces. And it runs inside
+      # `perform_all_later`, after Active Job has split off the jobs it defers
+      # until the database transaction commits, so each of those halves is
+      # recorded when it is really enqueued.
+      #
+      # @!visibility private
+      module ActiveJobBulkEnqueueInstrumentation
+        private
+
+        def instrument_enqueue_all(_queue_adapter, jobs)
+          # Skip recording the event when enqueue events are suppressed, which is
+          # also the case when enqueue instrumentation is disabled. Same check as
+          # the single-job path above.
+          if Appsignal::Transaction.current? &&
+              Appsignal::Transaction.current.job_enqueue_events_suppressed?
+            return super
+          end
+
+          Appsignal.instrument("enqueue_all.active_job", bulk_enqueue_title(jobs)) do
+            # A bulk enqueue does not go through `ActiveJob::Base#enqueue`, so
+            # nothing has suppressed the adapter (Sidekiq, Resque, ...) yet, and
+            # its own enqueue instrumentation would record an event for every job
+            # in the batch. Suppress it so the batch is recorded once, as this
+            # event.
+            if Appsignal::Transaction.current?
+              Appsignal::Transaction.current.suppress_job_enqueue_events { super }
+            else
+              super
+            end
+          end
+        end
+
+        # The batch's job class, when every job in it has the same one. Active
+        # Job groups the jobs it enqueues by queue adapter rather than by class,
+        # so a batch can mix classes, and then there is no one class to name.
+        def bulk_enqueue_title(jobs)
+          job_class = shared_across(jobs) { |job| job.class.name }
+          return "bulk enqueue jobs" unless job_class
+
+          "bulk enqueue #{job_class} jobs"
+        end
+
+        # The one value every job in the batch shares, or nil when they differ
+        # or the batch is empty. Stops at the first job that disagrees, because
+        # a batch is as large as the caller made it and a single mismatch is
+        # enough to know.
+        def shared_across(jobs)
+          return if jobs.empty?
+
+          first = yield(jobs.first)
+          jobs.all? { |job| yield(job) == first } ? first : nil
         end
       end
 

--- a/lib/appsignal/integrations/active_support_notifications.rb
+++ b/lib/appsignal/integrations/active_support_notifications.rb
@@ -9,10 +9,15 @@ module Appsignal
 
         # Events a dedicated AppSignal integration already records, so the
         # generic notifications path must not record them a second time. The
-        # ActiveJob hook owns `enqueue.active_job` (it wraps the enqueue in its
-        # own event, with Rails' native notification nested inside), and the
+        # ActiveJob hook owns `enqueue.active_job` and `enqueue_all.active_job`.
+        # It records its own event for a single enqueue, and one event for a
+        # whole batch, with Rails' native notification nested inside. The
         # Faraday integration owns `request.faraday`.
-        SUPPRESSED_EVENT_NAMES = ["enqueue.active_job", "request.faraday"].freeze
+        SUPPRESSED_EVENT_NAMES = [
+          "enqueue.active_job",
+          "enqueue_all.active_job",
+          "request.faraday"
+        ].freeze
 
         def start_event(name)
           return unless record_event?(name)

--- a/spec/lib/appsignal/hooks/activejob_spec.rb
+++ b/spec/lib/appsignal/hooks/activejob_spec.rb
@@ -37,6 +37,86 @@ if DependencyHelper.active_job_present?
         expect(path).to end_with("/lib/appsignal/hooks/active_job.rb")
       end
     end
+
+    describe "the bulk enqueue notification" do
+      let(:integration) do
+        Appsignal::Integrations::ActiveSupportNotificationsIntegration
+      end
+
+      # Suppressed whether or not this hook ends up recording the batch
+      # itself. When it cannot, the batch goes unrecorded rather than falling
+      # back to Rails' own notification, which is the worse event the hook
+      # exists to replace.
+      it "is never recorded by the notifications path" do
+        expect(integration.record_event?("enqueue_all.active_job")).to be(false)
+      end
+    end
+
+    describe "wrapping the bulk enqueue method" do
+      let(:instrumentation) do
+        Appsignal::Hooks::ActiveJobHook::ActiveJobBulkEnqueueInstrumentation
+      end
+
+      if DependencyHelper.rails7_1_present?
+        # The wrapper reads the array of jobs out of the second argument of a
+        # private Active Job method, so it is written against that method's
+        # parameters. Pin them, so a version of Active Job that changes them
+        # fails here, naming both sides, instead of reaching an application as
+        # an ArgumentError from inside `perform_all_later`.
+        it "is written against the parameters Active Job has today" do
+          expect(described_class.instrument_enqueue_all_parameters)
+            .to eq(described_class::EXPECTED_INSTRUMENT_ENQUEUE_ALL_PARAMETERS)
+        end
+      end
+
+      # Asserted as a message never sent, rather than as an absence from the
+      # ancestors, because an earlier example in the suite may already have
+      # installed the hook for real.
+      it "does not wrap it when Active Job does not define it" do
+        start_agent
+        allow(::ActiveJob.singleton_class)
+          .to receive(:private_method_defined?).and_call_original
+        allow(::ActiveJob.singleton_class)
+          .to receive(:private_method_defined?)
+          .with(:instrument_enqueue_all)
+          .and_return(false)
+
+        expect(::ActiveJob.singleton_class)
+          .to_not receive(:prepend).with(instrumentation)
+
+        logs = capture_logs { described_class.new.install }
+
+        expect(logs).to contains_log(
+          :debug,
+          "Not instrumenting Active Job bulk enqueues: this version of " \
+            "Active Job does not record them through " \
+            "`ActiveJob.instrument_enqueue_all`."
+        )
+      end
+
+      it "does not wrap it when its parameters are not the ones expected" do
+        start_agent
+        allow(described_class)
+          .to receive(:instrument_enqueue_all_defined?).and_return(true)
+        allow(described_class)
+          .to receive(:instrument_enqueue_all_parameters)
+          .and_return([[:req, :queue_adapter], [:req, :jobs], [:key, :batch]])
+
+        expect(::ActiveJob.singleton_class)
+          .to_not receive(:prepend).with(instrumentation)
+
+        logs = capture_logs { described_class.new.install }
+
+        expect(logs).to contains_log(
+          :warn,
+          "Not instrumenting Active Job bulk enqueues: " \
+            "`ActiveJob.instrument_enqueue_all` takes " \
+            "[[:req, :queue_adapter], [:req, :jobs], [:key, :batch]] in this " \
+            "version of Active Job, where AppSignal expects " \
+            "[[:req, :queue_adapter], [:req, :jobs]]."
+        )
+      end
+    end
   end
 
   describe Appsignal::Hooks::ActiveJobHook::ActiveJobClassInstrumentation do
@@ -409,6 +489,145 @@ if DependencyHelper.active_job_present?
             transaction.to_h["events"].select { |event| event["name"] == "enqueue.active_job" }
           expect(enqueue_events).to be_empty
           expect(ActiveJob::Base.queue_adapter.enqueued_jobs.count).to eq(1)
+        end
+      end
+    end
+
+    if DependencyHelper.rails7_1_present?
+      context "when enqueuing jobs in bulk" do
+        before { ActiveJob::Base.queue_adapter = :test }
+
+        let(:jobs) { Array.new(3) { ActiveJobTestJob.new } }
+
+        def bulk_enqueue_events(transaction)
+          transaction.to_h["events"]
+            .select { |event| event["name"] == "enqueue_all.active_job" }
+        end
+
+        context "with an active transaction" do
+          it "records a single enqueue_all.active_job event on the transaction" do
+            transaction = http_request_transaction
+            set_current_transaction(transaction)
+
+            ActiveJob.perform_all_later(jobs)
+
+            # Exactly one event for the batch: ours. Rails' native
+            # `enqueue_all.active_job` notification is suppressed so it isn't
+            # recorded a second time.
+            events = bulk_enqueue_events(transaction)
+            expect(events.size).to eq(1)
+            expect(events.first["title"]).to eq("bulk enqueue ActiveJobTestJob jobs")
+            expect(ActiveJob::Base.queue_adapter.enqueued_jobs.count).to eq(3)
+          end
+
+          it "records no per-job enqueue events alongside it" do
+            transaction = http_request_transaction
+            set_current_transaction(transaction)
+
+            ActiveJob.perform_all_later(jobs)
+
+            event_names = transaction.to_h["events"].map { |event| event["name"] }
+            expect(event_names).to_not include("enqueue.active_job")
+          end
+        end
+
+        context "with jobs of more than one class" do
+          # Active Job groups the jobs it enqueues by queue adapter rather than
+          # by class, so one batch can cover several classes.
+          let(:jobs) { [ActiveJobTestJob.new, ActiveJobCustomQueueTestJob.new] }
+
+          it "records the event without naming a job class" do
+            transaction = http_request_transaction
+            set_current_transaction(transaction)
+
+            ActiveJob.perform_all_later(jobs)
+
+            events = bulk_enqueue_events(transaction)
+            expect(events.size).to eq(1)
+            expect(events.first["title"]).to eq("bulk enqueue jobs")
+          end
+        end
+
+        context "with an active transaction" do
+          it "suppresses nested adapter enqueue events while enqueuing" do
+            transaction = http_request_transaction
+            set_current_transaction(transaction)
+
+            # The window in which a nested adapter integration (Sidekiq, Resque,
+            # ...) would record an event per job in the batch, which Active Job
+            # suppresses so the batch is recorded once.
+            suppressed_during_enqueue = []
+            adapter = ActiveJob::Base.queue_adapter
+            allow(adapter).to receive(:enqueue).and_wrap_original do |method, *args|
+              suppressed_during_enqueue <<
+                Appsignal::Transaction.current.job_enqueue_events_suppressed?
+              method.call(*args)
+            end
+
+            ActiveJob.perform_all_later(jobs)
+
+            expect(suppressed_during_enqueue).to eq([true, true, true])
+          end
+        end
+
+        # The `:test` adapter has no `enqueue_all`, so a bulk enqueue through it
+        # falls back to enqueuing each job on its own. Sidekiq's adapter does
+        # have one, and that is the path the duplicated events were reported on,
+        # so it needs covering too.
+        context "with an adapter that enqueues the batch itself" do
+          before do
+            stub_const(
+              "ActiveJobBulkTestAdapter",
+              Class.new(ActiveJob::QueueAdapters::TestAdapter) do
+                attr_reader :enqueue_all_calls, :suppressed_during_enqueue_all
+
+                def enqueue_all(jobs)
+                  @enqueue_all_calls = (@enqueue_all_calls || 0) + 1
+                  @suppressed_during_enqueue_all =
+                    Appsignal::Transaction.current.job_enqueue_events_suppressed?
+                  jobs.each { |job| enqueue(job) }
+                  jobs.size
+                end
+              end
+            )
+            ActiveJob::Base.queue_adapter = ActiveJobBulkTestAdapter.new
+          end
+
+          it "records one event and suppresses the adapter's own" do
+            transaction = http_request_transaction
+            set_current_transaction(transaction)
+
+            ActiveJob.perform_all_later(jobs)
+
+            adapter = ActiveJob::Base.queue_adapter
+            expect(adapter.enqueue_all_calls).to eq(1)
+            expect(adapter.suppressed_during_enqueue_all).to be(true)
+            expect(bulk_enqueue_events(transaction).size).to eq(1)
+          end
+        end
+
+        context "without an active transaction" do
+          it "is a transparent pass-through that still enqueues the jobs" do
+            expect do
+              ActiveJob.perform_all_later(jobs)
+            end.to_not(change { created_transactions.count })
+
+            expect(ActiveJob::Base.queue_adapter.enqueued_jobs.count).to eq(3)
+          end
+        end
+
+        context "when enqueue instrumentation is disabled" do
+          let(:options) { { :enable_job_enqueue_instrumentation => false } }
+
+          it "does not record an event but still enqueues the jobs" do
+            transaction = http_request_transaction
+            set_current_transaction(transaction)
+
+            ActiveJob.perform_all_later(jobs)
+
+            expect(bulk_enqueue_events(transaction)).to be_empty
+            expect(ActiveJob::Base.queue_adapter.enqueued_jobs.count).to eq(3)
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes https://github.com/appsignal/appsignal-ruby/issues/1578.

Active Job's `perform_all_later` does not enqueue through
`ActiveJob::Base#enqueue`, so the wrapper that records an enqueue once
never runs for a batch. Nothing suppresses the queue adapter's own
enqueue instrumentation, and a batch of three jobs is therefore recorded
as Rails' native batch notification plus one adapter event per job. The
batch is now recorded as a single event, with the adapter's own events
suppressed while it is enqueued. The method wrapped to do that is
private, because it is the only point that covers both the adapters that
enqueue a batch themselves and the ones Active Job falls back to
enqueuing job by job.

The wrapper reads the batch out of that method's second argument, and
the method being private means a later version of Active Job can change
what it takes. Wrapping a method that takes something else raises an
`ArgumentError` inside every `ActiveJob.perform_all_later` call an
application makes, which breaks enqueuing and not just its
instrumentation. It is therefore wrapped only while its parameters are
the ones the wrapper was written against. A batch that cannot be
recorded that way goes unrecorded, because Rails' own notification is
the worse event this hook set out to replace.
