### PR TITLE
Read Active Job trace context from the Active Job layer

### DIFF
--- a/gemfiles/delayed_job.gemfile
+++ b/gemfiles/delayed_job.gemfile
@@ -3,4 +3,8 @@ source "https://rubygems.org"
 gem "delayed_job"
 gem "ostruct"
 
+# The Active Job adapter for Delayed Job, so the Active Job paths through this
+# integration are covered.
+gem "activejob"
+
 gemspec :path => "../"

--- a/gemfiles/que-1.gemfile
+++ b/gemfiles/que-1.gemfile
@@ -3,4 +3,8 @@ source "https://rubygems.org"
 gem "ostruct"
 gem "que", "~> 1.0"
 
+# The Active Job adapter for Que, so the Active Job paths through this
+# integration are covered.
+gem "activejob"
+
 gemspec :path => "../"

--- a/gemfiles/que-2.gemfile
+++ b/gemfiles/que-2.gemfile
@@ -3,4 +3,8 @@ source "https://rubygems.org"
 gem "ostruct"
 gem "que", "~> 2.0"
 
+# The Active Job adapter for Que, so the Active Job paths through this
+# integration are covered.
+gem "activejob"
+
 gemspec :path => "../"

--- a/gemfiles/resque-2.gemfile
+++ b/gemfiles/resque-2.gemfile
@@ -3,4 +3,8 @@ source 'https://rubygems.org'
 gem 'resque', "~> 2.0"
 gem 'sinatra'
 
+# The Active Job adapter for Resque, so the Active Job paths through this
+# integration are covered.
+gem 'activejob'
+
 gemspec :path => '../'

--- a/gemfiles/resque-3.gemfile
+++ b/gemfiles/resque-3.gemfile
@@ -3,4 +3,8 @@ source 'https://rubygems.org'
 gem 'resque', "~> 3.0"
 gem 'sinatra'
 
+# The Active Job adapter for Resque, so the Active Job paths through this
+# integration are covered.
+gem 'activejob'
+
 gemspec :path => '../'

--- a/gemfiles/shoryuken-6.gemfile
+++ b/gemfiles/shoryuken-6.gemfile
@@ -5,4 +5,8 @@ gem "shoryuken", "~> 6.0"
 # installed separately.
 gem "aws-sdk-sqs"
 
+# The Active Job adapter for Shoryuken, so the Active Job paths through this
+# integration are covered.
+gem "activejob"
+
 gemspec :path => "../"

--- a/gemfiles/shoryuken-7.gemfile
+++ b/gemfiles/shoryuken-7.gemfile
@@ -2,4 +2,8 @@ source "https://rubygems.org"
 
 gem "shoryuken", "~> 7.0"
 
+# The Active Job adapter for Shoryuken, so the Active Job paths through this
+# integration are covered.
+gem "activejob"
+
 gemspec :path => "../"

--- a/lib/appsignal/integrations/delayed_job_plugin.rb
+++ b/lib/appsignal/integrations/delayed_job_plugin.rb
@@ -107,15 +107,41 @@ module Appsignal
       rescue Exception => error
         warn_unreadable_payload_once(error)
 
-        transaction = create_perform_transaction(job)
+        # No trace context: the payload the context would come from is the one
+        # that just failed to load.
+        transaction = create_perform_transaction(job, nil)
         transaction.set_action_if_nil(action_name_without_payload(job))
         transaction.set_error(error)
         add_job_metadata(transaction, job)
         Appsignal::Transaction.complete_current!
       end
 
+      # The trace context to continue. Delayed Job has no carrier of its own,
+      # because a job's handler is a YAML dump of the object to run with nowhere
+      # to put a header, so an Active Job job is the only kind that arrives with
+      # one.
+      def self.extract_context(job)
+        Appsignal::OpenTelemetry.extract_active_job_context(active_job_data(job))
+      end
+
+      # The serialized Active Job job data inside a Delayed Job job, or nil when
+      # this is not an Active Job job. The Active Job adapter wraps the job data
+      # in an object that exposes it as `job_data`.
+      #
+      # Reading it means deserializing the handler, which raises for a job whose
+      # class is gone, so a job that cannot be read gets no context. Delayed Job
+      # remembers a payload it read successfully, so doing this before the job
+      # runs costs no extra work later.
+      def self.active_job_data(job)
+        payload = job.payload_object
+        payload.job_data if payload.respond_to?(:job_data)
+      rescue => error
+        warn_unreadable_payload_once(error)
+        nil
+      end
+
       def self.invoke_with_instrumentation(job, block)
-        transaction = create_perform_transaction(job)
+        transaction = create_perform_transaction(job, extract_context(job))
 
         begin
           Appsignal.instrument(
@@ -161,10 +187,13 @@ module Appsignal
       end
 
       # The transaction a performed job is reported under. Shared by the two
-      # callbacks that can report a job, so both describe it the same way.
-      def self.create_perform_transaction(job)
+      # callbacks that can report a job, so both describe it the same way. The
+      # trace context is passed in rather than read here, because the payload it
+      # would be read from is the one a job that cannot be loaded failed on.
+      def self.create_perform_transaction(job, context)
         transaction = Appsignal::Transaction.create(
           Appsignal::Transaction::BACKGROUND_JOB,
+          :opentelemetry_context => context,
           :opentelemetry_scope => ["appsignal-ruby/delayed_job", Appsignal::VERSION],
           :opentelemetry_kind => :consumer,
           :opentelemetry_relationship => :both

--- a/lib/appsignal/integrations/que.rb
+++ b/lib/appsignal/integrations/que.rb
@@ -93,6 +93,36 @@ module Appsignal
         Array(tags).include?(BULK_TAG)
       end
 
+      # The class the Active Job adapter enqueues, with the serialized job data
+      # as its only argument. Que records the name in the job's `job_class`, and
+      # the name is fixed, because it is stored in every job record the adapter
+      # has ever written.
+      ACTIVE_JOB_WRAPPER = "ActiveJob::QueueAdapters::QueAdapter::JobWrapper"
+
+      # The trace context to continue: the Active Job layer when this is an
+      # Active Job job, the job's own tags otherwise. See `Appsignal::OpenTelemetry.extract_active_job_context`
+      # for why that layer wins.
+      # Que's tags are a carrier with a hard limit: five per job, shared with
+      # whatever the user puts there.
+      def extract_context(attrs, tags)
+        Appsignal::OpenTelemetry.extract_active_job_context(active_job_data(attrs)) ||
+          extract(tags)
+      end
+
+      # The serialized Active Job job data inside a Que job, or nil when this is
+      # not an Active Job job.
+      #
+      # Que reads a job's arguments out of JSONB with symbol keys and only turns
+      # them back into strings on the way into Active Job, so they are
+      # stringified here too. Only the outer keys need it: the headers below them
+      # are an array of pairs of strings, which Que leaves alone.
+      def active_job_data(attrs)
+        return unless attrs[:job_class] == ACTIVE_JOB_WRAPPER
+
+        job_data = Array(attrs[:args]).first
+        job_data.transform_keys(&:to_s) if job_data.is_a?(Hash)
+      end
+
       def within_limits?(tags)
         tags.length <= MAX_TAGS_COUNT && tags.all? { |tag| tag.length <= MAX_TAG_LENGTH }
       end
@@ -118,7 +148,7 @@ module Appsignal
         transaction =
           Appsignal::Transaction.create(
             Appsignal::Transaction::BACKGROUND_JOB,
-            :opentelemetry_context => QueTraceContext.extract(tags),
+            :opentelemetry_context => QueTraceContext.extract_context(local_attrs, tags),
             :opentelemetry_scope => ["appsignal-ruby/que", Appsignal::VERSION],
             :opentelemetry_kind => :consumer,
             :opentelemetry_relationship => relationship

--- a/lib/appsignal/integrations/resque.rb
+++ b/lib/appsignal/integrations/resque.rb
@@ -9,7 +9,7 @@ module Appsignal
         # enqueuer. No-op outside collector mode.
         transaction = Appsignal::Transaction.create(
           Appsignal::Transaction::BACKGROUND_JOB,
-          :opentelemetry_context => Appsignal::OpenTelemetry.extract_job_context(payload),
+          :opentelemetry_context => ResqueHelpers.extract_context(payload),
           :opentelemetry_scope => ["appsignal-ruby/resque", Appsignal::VERSION],
           :opentelemetry_kind => :consumer,
           :opentelemetry_relationship => :both
@@ -93,13 +93,34 @@ module Appsignal
 
     # @!visibility private
     class ResqueHelpers
+      # The class the Active Job adapter enqueues, with the serialized job data
+      # as its only argument.
+      ACTIVE_JOB_WRAPPER = "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper"
+
       def self.arguments(payload)
         case payload["class"]
-        when "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper"
+        when ACTIVE_JOB_WRAPPER
           nil # Set in the ActiveJob integration
         else
           payload["args"]
         end
+      end
+
+      # The serialized Active Job job data inside a Resque job, or nil when this
+      # is not an Active Job job.
+      def self.active_job_data(payload)
+        return unless payload["class"] == ACTIVE_JOB_WRAPPER
+
+        job_data = payload["args"]&.first
+        job_data if job_data.is_a?(Hash)
+      end
+
+      # The trace context to continue: the Active Job layer when this is an
+      # Active Job job, the Resque job itself otherwise. See `Appsignal::OpenTelemetry.extract_active_job_context`
+      # for why that layer wins.
+      def self.extract_context(payload)
+        Appsignal::OpenTelemetry.extract_active_job_context(active_job_data(payload)) ||
+          Appsignal::OpenTelemetry.extract_job_context(payload)
       end
     end
   end

--- a/lib/appsignal/integrations/shoryuken.rb
+++ b/lib/appsignal/integrations/shoryuken.rb
@@ -77,7 +77,7 @@ module Appsignal
         # links back to the enqueuer. A batch carries messages from multiple
         # traces with no single parent, so only single messages link back.
         # No-op outside collector mode.
-        context = ShoryukenTraceContext.extract(sqs_msg.message_attributes) unless batch
+        context = extract_context(sqs_msg, body) unless batch
 
         transaction = Appsignal::Transaction.create(
           Appsignal::Transaction::BACKGROUND_JOB,
@@ -126,6 +126,21 @@ module Appsignal
       end
 
       private
+
+      # The trace context to continue: the Active Job layer when this is an
+      # Active Job job, the message's own attributes otherwise. See `Appsignal::OpenTelemetry.extract_active_job_context`
+      # for why that layer wins.
+      # SQS allows ten message attributes per message, shared with whatever the
+      # user puts there.
+      #
+      # The Active Job adapter registers a worker that parses the message body as
+      # JSON, so an Active Job job's body arrives here as its serialized job
+      # data. Nothing checks that it is one: a body with no readable trace
+      # context in it reads as "nothing here" on its own.
+      def extract_context(sqs_msg, body)
+        Appsignal::OpenTelemetry.extract_active_job_context(body) ||
+          ShoryukenTraceContext.extract(sqs_msg.message_attributes)
+      end
 
       def fetch_attributes(batch, sqs_msg)
         if batch

--- a/lib/appsignal/integrations/sidekiq.rb
+++ b/lib/appsignal/integrations/sidekiq.rb
@@ -178,7 +178,7 @@ module Appsignal
         # enqueuer. No-op outside collector mode.
         transaction = Appsignal::Transaction.create(
           Appsignal::Transaction::BACKGROUND_JOB,
-          :opentelemetry_context => Appsignal::OpenTelemetry.extract_job_context(item),
+          :opentelemetry_context => extract_context(item),
           :opentelemetry_scope => ["appsignal-ruby/sidekiq", Appsignal::VERSION],
           :opentelemetry_kind => :consumer,
           :opentelemetry_relationship => :both
@@ -245,6 +245,25 @@ module Appsignal
       end
 
       private
+
+      # The trace context to continue: the Active Job layer when this is an
+      # Active Job job, the Sidekiq job itself otherwise. See `Appsignal::OpenTelemetry.extract_active_job_context`
+      # for why that layer wins.
+      def extract_context(item)
+        Appsignal::OpenTelemetry.extract_active_job_context(active_job_data(item)) ||
+          Appsignal::OpenTelemetry.extract_job_context(item)
+      end
+
+      # The serialized Active Job job data inside a Sidekiq job, or nil when this
+      # is not an Active Job job. Both Active Job adapters for Sidekiq, the one in
+      # Rails and the one in the Sidekiq gem, enqueue a wrapper class with the
+      # job data as its only argument and name the real job class in `wrapped`.
+      def active_job_data(item)
+        return unless item["wrapped"]
+
+        job_data = item["args"]&.first
+        job_data if job_data.is_a?(Hash)
+      end
 
       def increment_counter(key, value, tags = {})
         Appsignal.increment_counter "sidekiq_#{key}", value, tags

--- a/lib/appsignal/opentelemetry.rb
+++ b/lib/appsignal/opentelemetry.rb
@@ -166,9 +166,8 @@ module Appsignal
       def extract_job_context(item)
         if_started do
           carrier = item
-          nested = item["__otel_headers"]
-          nested = nested.to_h if otel_header_pairs?(nested)
-          carrier = item.merge(nested) if nested.is_a?(Hash)
+          nested = otel_headers_hash(item["__otel_headers"])
+          carrier = item.merge(nested) if nested
           # Extract onto an empty context rather than the default
           # `Context.current`, for the same reason as `extract_rack_context`:
           # a job with no injected trace context must not inherit an ambient
@@ -179,6 +178,62 @@ module Appsignal
             :context => ::OpenTelemetry::Context.empty
           )
         end
+      end
+
+      # Read the trace context off the serialized Active Job job data that a
+      # queue adapter's job wraps, so the transaction the adapter creates links
+      # back to the enqueuer.
+      #
+      # Every adapter wraps the job data as the single argument of its own job
+      # wrapper, but each keeps it somewhere different, so finding the job data
+      # is the adapter integration's business and reading a context out of it is
+      # this method's.
+      #
+      # This is the layer every integration prefers. Active Job owns the job
+      # whichever adapter carries it, its carrier survives an adapter that has
+      # nowhere of its own to put a header, and it does not compete with the
+      # user's own data for a carrier with a hard limit on what fits.
+      #
+      # Returns `nil` when the SDK has not booted, when this is not Active Job
+      # job data, and when the job data carries no usable context. A caller reads
+      # that `nil` as "nothing here" and falls back to its own native carrier.
+      # That fallback matters twice over: it is where a job enqueued by a service
+      # that instruments only the adapter carries its context, and it is the only
+      # carrier a job that is not an Active Job job has at all.
+      def extract_active_job_context(job_data)
+        return unless job_data.is_a?(Hash)
+
+        if_started do
+          headers = otel_headers_hash(job_data["__otel_headers"])
+          next unless headers
+
+          # Extract onto an empty context, for the same reason as
+          # `extract_job_context` above.
+          context = ::OpenTelemetry.propagation.extract(
+            headers,
+            :context => ::OpenTelemetry::Context.empty
+          )
+          context if remote_span_context(context)
+        end
+      end
+
+      # The remote parent's SpanContext from an incoming OTel context, or `nil`
+      # when there is no context or the span in it is invalid.
+      #
+      # `propagation.extract` returns a context whether or not the carrier held
+      # anything, so this is what tells "read a context" apart from "read
+      # nothing". A caller that can fall back to another carrier uses it to
+      # decide whether to, and a caller that parents or links a span uses it to
+      # decide between doing that and starting a plain root span.
+      #
+      # Only ever called with a context that came from the OpenTelemetry SDK, so
+      # it does not gate on the SDK having booted the way the extract methods do.
+      def remote_span_context(opentelemetry_context)
+        return unless opentelemetry_context
+
+        span_context =
+          ::OpenTelemetry::Trace.current_span(opentelemetry_context).context
+        span_context if span_context.valid?
       end
 
       # Run `block` only when the OpenTelemetry SDK has booted (collector mode),
@@ -282,10 +337,20 @@ module Appsignal
         Class.new(base) { include ProxiedExporter }
       end
 
+      # A `__otel_headers` value as a hash carrier, or `nil` when there is no
+      # usable one. Active Job puts the headers through its argument serializer,
+      # which turns the hash into an array of `[key, value]` pairs, so both
+      # shapes arrive. Anything else, including a malformed array, gives `nil`
+      # rather than raising on `to_h` inside a job perform.
+      def otel_headers_hash(value)
+        return value if value.is_a?(Hash)
+        return value.to_h if otel_header_pairs?(value)
+
+        nil
+      end
+
       # Whether a `__otel_headers` value is the array-of-`[key, value]`-pairs
-      # shape produced by ActiveJob's argument serializer, so it can be turned
-      # into a hash carrier. Anything else (including a malformed array) is left
-      # alone rather than raising on `to_h` inside a job perform.
+      # shape produced by ActiveJob's argument serializer.
       def otel_header_pairs?(value)
         value.is_a?(Array) && value.all? { |pair| pair.is_a?(Array) && pair.size == 2 }
       end

--- a/lib/appsignal/transaction/opentelemetry_backend.rb
+++ b/lib/appsignal/transaction/opentelemetry_backend.rb
@@ -686,7 +686,7 @@ module Appsignal
       # to a plain root span, since there is nothing to parent or link to.
       def start_transaction_span(namespace, kind, relationship, opentelemetry_context)
         name = placeholder_span_name(namespace)
-        remote = remote_span_context(opentelemetry_context)
+        remote = Appsignal::OpenTelemetry.remote_span_context(opentelemetry_context)
         tracer = tracer_for(@scope)
 
         # With no incoming context (or an invalid remote span) there is nothing
@@ -733,16 +733,6 @@ module Appsignal
       def option_caller_location
         frames = caller
         frames.find { |frame| !frame.include?("/lib/appsignal/") } || frames.first
-      end
-
-      # The remote parent's SpanContext from an incoming OTel context, or nil
-      # when there is no context or the remote span is invalid -- in which case
-      # callers fall back to a plain root span.
-      def remote_span_context(opentelemetry_context)
-        return unless opentelemetry_context
-
-        context = ::OpenTelemetry::Trace.current_span(opentelemetry_context).context
-        context if context.valid?
       end
 
       def display_namespace(namespace)

--- a/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
+++ b/spec/lib/appsignal/hooks/active_support_notifications_spec.rb
@@ -1,5 +1,13 @@
 require_relative "active_support_notifications/instrument_shared_examples"
 
+# Some gemfiles install Active Support as a dependency of another gem and
+# never require this part of it, so ask for it rather than relying on
+# something else having loaded it.
+if DependencyHelper.active_support_present?
+  require "active_support"
+  require "active_support/notifications"
+end
+
 describe Appsignal::Hooks::ActiveSupportNotificationsHook do
   if active_support_present?
     let(:notifier) { ActiveSupport::Notifications::Fanout.new }

--- a/spec/lib/appsignal/hooks/activejob_spec.rb
+++ b/spec/lib/appsignal/hooks/activejob_spec.rb
@@ -1,4 +1,7 @@
-if DependencyHelper.active_job_present?
+# This spec branches on the Rails version throughout, so it needs the whole
+# framework rather than Active Job on its own. Some gemfiles install Active
+# Job by itself, to cover the Active Job paths through a queue integration.
+if DependencyHelper.active_job_present? && DependencyHelper.rails_present?
   require "active_job"
   require "action_mailer"
 

--- a/spec/lib/appsignal/integrations/delayed_job_plugin_spec.rb
+++ b/spec/lib/appsignal/integrations/delayed_job_plugin_spec.rb
@@ -139,7 +139,7 @@ if DependencyHelper.delayed_job_present?
         end
       end
 
-      if DependencyHelper.active_job_present?
+      if DependencyHelper.active_job_delayed_job_adapter_present?
         context "when wrapped by Active Job" do
           # Active Job records its own `enqueue.active_job` event and suppresses
           # the backend's, so no duplicate is recorded here.
@@ -268,6 +268,103 @@ if DependencyHelper.delayed_job_present?
           event = root_span.events.find { |e| e.name == "exception" }
           expect(event.attributes["exception.type"]).to eq("ExampleException")
           expect(event.attributes["exception.message"]).to eq("uh oh")
+        end
+      end
+
+      if DependencyHelper.active_job_delayed_job_adapter_present?
+        # A full round trip through real Active Job and the real Delayed Job
+        # adapter. The enqueue writes the trace context onto the job, Active Job
+        # serializes it, Delayed Job stores that in the handler, and the perform
+        # reads it back. No part of the job's shape is written by hand here, so
+        # this fails if any assumption about that shape is wrong.
+        context "with a job enqueued through real Active Job" do
+          before do
+            require "active_job"
+            ActiveJob::Base.queue_adapter = :delayed_job
+            ActiveJob::Base.logger = nil
+
+            stub_const("DelayedRoundTripJob", Class.new(ActiveJob::Base) do
+              def perform(*)
+              end
+            end)
+          end
+
+          # Enqueue inside a transaction and perform outside it, because
+          # performing while the enqueuing transaction is still open would leave
+          # the job sharing it instead of creating its own.
+          def enqueue_then_perform
+            set_current_transaction(http_request_transaction)
+            DelayedRoundTripJob.perform_later("foo")
+            Appsignal::Transaction.complete_current!
+
+            perform_job(Delayed::Backend::Test::Job.all.last)
+          end
+
+          it "in collector mode", :collector_mode do
+            start_collector_agent
+
+            enqueue_then_perform
+
+            producer = event_span_for("enqueue.active_job")
+            consumer = span_exporter.finished_spans.find do |span|
+              span.kind == :consumer
+            end
+            expect(consumer).to_not be_nil
+            expect(consumer.attributes["appsignal.action_name"])
+              .to eq("DelayedRoundTripJob#perform")
+            # The job continues the enqueuer's trace as a child of the producer
+            # span, and links back to it.
+            expect(consumer.hex_trace_id).to eq(producer.hex_trace_id)
+            expect(consumer.parent_span_id).to eq(producer.span_id)
+            expect(consumer.links.map { |link| link.span_context.hex_span_id })
+              .to eq([producer.hex_span_id])
+          end
+        end
+      end
+
+      # Delayed Job has no carrier of its own, so an Active Job job is the only
+      # kind whose trace can be continued here. The adapter wraps the serialized
+      # job data in an object that exposes it as `job_data`.
+      context "with an Active Job job carrying incoming trace context" do
+        let(:trace_id_hex) { "0af7651916cd43dd8448eb211c80319c" }
+        let(:span_id_hex) { "b7ad6b7169203331" }
+        let(:traceparent) { "00-#{trace_id_hex}-#{span_id_hex}-01" }
+        let(:job_data) do
+          {
+            "job_class" => "DelayedActiveJob",
+            "arguments" => [],
+            "__otel_headers" => [["traceparent", traceparent]]
+          }
+        end
+        let(:job) do
+          wrapper = Struct.new(:job_data) do
+            def perform
+            end
+          end
+          Delayed::Job.enqueue(wrapper.new(job_data))
+        end
+
+        it "in agent mode", :agent_mode do
+          start_agent
+
+          keep_transactions { perform_job(job) }
+
+          transaction = last_transaction
+          expect(transaction).to be_completed
+          expect(transaction).to have_action("DelayedActiveJob#perform")
+          # The trace header doesn't leak into the transaction as a tag.
+          expect(transaction).to_not include_tags("traceparent" => traceparent)
+        end
+
+        it "in collector mode", :collector_mode do
+          start_collector_agent
+
+          perform_job(job)
+
+          expect(root_span.kind).to eq(:consumer)
+          expect(root_span.hex_trace_id).to eq(trace_id_hex)
+          expect(root_span.parent_span_id.unpack1("H*")).to eq(span_id_hex)
+          expect(root_span.links.size).to eq(1)
         end
       end
 
@@ -411,7 +508,7 @@ if DependencyHelper.delayed_job_present?
         end
       end
 
-      if DependencyHelper.active_job_present?
+      if DependencyHelper.active_job_delayed_job_adapter_present?
         context "when wrapped by Active Job" do
           before do
             require "active_job"

--- a/spec/lib/appsignal/integrations/que_spec.rb
+++ b/spec/lib/appsignal/integrations/que_spec.rb
@@ -364,6 +364,176 @@ if DependencyHelper.que_present?
         end
       end
 
+      # The Active Job adapter enqueues a wrapper class with the serialized job
+      # data as its only argument, so an Active Job job carries its context
+      # there rather than in the job's tags. That works on every Que version,
+      # including the ones with no tags to carry a context in at all.
+      context "with incoming trace context from an Active Job job" do
+        let(:trace_id_hex) { "0af7651916cd43dd8448eb211c80319c" }
+        let(:span_id_hex) { "b7ad6b7169203331" }
+        let(:traceparent) { "00-#{trace_id_hex}-#{span_id_hex}-01" }
+        # Que reads a job's arguments back out of JSONB with symbol keys, so
+        # that is the shape the integration has to read.
+        let(:job_attrs) do
+          super().merge(
+            :job_class => Appsignal::Integrations::QueTraceContext::ACTIVE_JOB_WRAPPER,
+            :args => [
+              {
+                :job_class => "MyActiveJob",
+                :arguments => [],
+                :__otel_headers => [["traceparent", traceparent]]
+              }
+            ]
+          )
+        end
+        let(:job) do
+          Class.new(::Que::Job) do
+            def run(job_data)
+            end
+          end
+        end
+
+        def perform
+          perform_que_job(instance)
+        end
+
+        it "in agent mode", :agent_mode do
+          start_agent
+          expect { perform }.to change { created_transactions.length }.by(1)
+          expect(last_transaction).to be_completed
+        end
+
+        it "in collector mode", :collector_mode do
+          start_collector_agent
+          perform
+
+          expect(root_span.kind).to eq(:consumer)
+          expect(root_span.hex_trace_id).to eq(trace_id_hex)
+          expect(root_span.parent_span_id.unpack1("H*")).to eq(span_id_hex)
+          expect(root_span.links.size).to eq(1)
+        end
+      end
+
+      if DependencyHelper.active_job_present? && DependencyHelper.que2_present?
+        # A round trip through real Active Job and the real Que adapter. The
+        # enqueue writes the trace context onto the job and Active Job
+        # serializes it; the arguments are then put through Que's own JSON
+        # round trip, which is what turns their keys into symbols on the way
+        # back out of the database. That symbol-keyed shape is the one the
+        # integration has to read, and it is not obvious from the enqueue side,
+        # so it is worth producing rather than assuming.
+        context "with a job enqueued through real Active Job" do
+          before do
+            require "active_job"
+            # Que ships the adapter but only requires it from its railtie.
+            require "que/active_job/extensions"
+            ActiveJob::Base.queue_adapter = :que
+            ActiveJob::Base.logger = nil
+
+            stub_const("QueRoundTripJob", Class.new(ActiveJob::Base) do
+              def perform(*)
+              end
+            end)
+          end
+
+          let(:job) do
+            Class.new(::Que::Job) do
+              def run(job_data)
+              end
+            end
+          end
+
+          # Enqueues with a real Active Job job, captures the arguments Que would
+          # have inserted, and hands them back in the shape Que reads them in.
+          def enqueue_then_perform
+            enqueued = nil
+            allow(::Que).to receive(:execute) do |_command, values = nil|
+              enqueued ||= values
+              # Que builds the job it returns from the inserted row, and the
+              # adapter reads an id off it.
+              [{ :id => 1 }]
+            end
+
+            set_current_transaction(http_request_transaction)
+            QueRoundTripJob.perform_later("foo")
+            Appsignal::Transaction.complete_current!
+
+            # Que stores the arguments as JSONB and reads them back with
+            # symbolized keys. Use Que's own serializer so the shape is Que's,
+            # not this example's idea of it.
+            args_json = enqueued.find do |value|
+              value.is_a?(String) && value.start_with?("[")
+            end
+            args = ::Que.deserialize_json(args_json)
+            attrs = job_attrs.merge(
+              :job_class => Appsignal::Integrations::QueTraceContext::ACTIVE_JOB_WRAPPER,
+              :args => args
+            )
+            perform_que_job(job.new(attrs))
+            args
+          end
+
+          it "in collector mode", :collector_mode do
+            start_collector_agent
+
+            args = enqueue_then_perform
+
+            producer = event_span_for("enqueue.active_job")
+
+            # The shape the integration reads, as Active Job, the Que adapter and
+            # Que's own JSON round trip really produce it. The examples that
+            # construct this shape by hand are only valid as long as this holds.
+            expect(args.size).to eq(1)
+            expect(args.first[:__otel_headers]).to eq(
+              [["traceparent", "00-#{producer.hex_trace_id}-#{producer.hex_span_id}-01"]]
+            )
+
+            consumer = span_exporter.finished_spans.find do |span|
+              span.kind == :consumer
+            end
+            expect(consumer).to_not be_nil
+            expect(consumer.hex_trace_id).to eq(producer.hex_trace_id)
+            expect(consumer.parent_span_id).to eq(producer.span_id)
+          end
+        end
+      end
+
+      # A job enqueued by a service that instruments Que but not Active Job has
+      # no Active Job carrier to read, so the job's tags are what the trace has
+      # to be continued from.
+      context "with an Active Job job carrying only a tag context",
+        :if => DependencyHelper.que1_present? do
+        let(:trace_id_hex) { "0af7651916cd43dd8448eb211c80319c" }
+        let(:span_id_hex) { "b7ad6b7169203331" }
+        let(:job_attrs) do
+          super().merge(
+            :job_class => Appsignal::Integrations::QueTraceContext::ACTIVE_JOB_WRAPPER,
+            :args => [{ :job_class => "MyActiveJob", :arguments => [] }],
+            :data => {
+              :tags => ["traceparent:00-#{trace_id_hex}-#{span_id_hex}-01"]
+            }
+          )
+        end
+        let(:job) do
+          Class.new(::Que::Job) do
+            def run(job_data)
+            end
+          end
+        end
+
+        def perform
+          perform_que_job(instance)
+        end
+
+        it "in collector mode", :collector_mode do
+          start_collector_agent
+          perform
+
+          expect(root_span.hex_trace_id).to eq(trace_id_hex)
+          expect(root_span.parent_span_id.unpack1("H*")).to eq(span_id_hex)
+        end
+      end
+
       # Only Que 2's `bulk_enqueue` writes the bulk tag, but reading it back is
       # the same on every version that has tags, so this runs on Que 1 too.
       context "with incoming trace context from a bulk enqueue",

--- a/spec/lib/appsignal/integrations/resque_spec.rb
+++ b/spec/lib/appsignal/integrations/resque_spec.rb
@@ -112,6 +112,149 @@ if DependencyHelper.resque_present?
         # The trace header doesn't leak into the trace as a tag.
         expect(root_span.attributes).to_not have_key("appsignal.tag.traceparent")
       end
+
+      # The Active Job adapter enqueues a wrapper class with the serialized job
+      # data as its only argument, so an Active Job job carries its context one
+      # level in, rather than on the Resque job itself.
+      context "with an Active Job job carrying the context in its job data" do
+        let(:wrapper) { Appsignal::Integrations::ResqueHelpers::ACTIVE_JOB_WRAPPER }
+        let(:job_data) do
+          {
+            "job_class" => "ResqueTestJob",
+            "arguments" => [],
+            "__otel_headers" => [["traceparent", traceparent]]
+          }
+        end
+
+        before do
+          stub_const(wrapper, Class.new do
+            def self.perform(*)
+            end
+          end)
+        end
+
+        def perform
+          perform_rescue_job(wrapper, "args" => [job_data])
+        end
+
+        it "in agent mode", :agent_mode do
+          start_agent(**start_agent_args)
+          expect(Appsignal).to receive(:stop)
+          perform
+
+          expect(last_transaction).to_not include_tags(
+            "traceparent" => traceparent
+          )
+        end
+
+        it "in collector mode", :collector_mode do
+          start_collector_agent
+          expect(Appsignal).to receive(:stop)
+          perform
+
+          expect(root_span.kind).to eq(:consumer)
+          expect(root_span.hex_trace_id).to eq(trace_id_hex)
+          expect(root_span.parent_span_id.unpack1("H*")).to eq(span_id_hex)
+          expect(root_span.links.size).to eq(1)
+        end
+      end
+
+      if DependencyHelper.active_job_present?
+        # A round trip through real Active Job and the real Resque adapter. The
+        # enqueue writes the trace context onto the job, Active Job serializes
+        # it, and the adapter wraps that as the payload's only argument. The
+        # payload is captured where Resque would hand it to Redis, so this uses
+        # the shape Active Job and Resque really produce, JSON round trip
+        # included, without needing a Redis to talk to.
+        context "with a job enqueued through real Active Job" do
+          before do
+            require "active_job"
+            ActiveJob::Base.queue_adapter = :resque
+            ActiveJob::Base.logger = nil
+
+            stub_const("ResqueRoundTripJob", Class.new(ActiveJob::Base) do
+              def perform(*)
+              end
+            end)
+          end
+
+          # Enqueue inside a transaction and perform outside it, because
+          # performing while the enqueuing transaction is still open would leave
+          # the job sharing it instead of creating its own.
+          def enqueue_then_perform
+            captured = nil
+            allow(::Resque.data_store).to receive(:push_to_queue) do |_queue, encoded|
+              captured = ::Resque.decode(encoded)
+            end
+
+            set_current_transaction(http_request_transaction)
+            ResqueRoundTripJob.perform_later("foo")
+            Appsignal::Transaction.complete_current!
+
+            keep_transactions { ::Resque::Job.new(queue, captured).perform }
+            captured
+          end
+
+          it "in collector mode", :collector_mode do
+            start_collector_agent
+            expect(Appsignal).to receive(:stop)
+
+            payload = enqueue_then_perform
+
+            producer = event_span_for("enqueue.active_job")
+
+            # The shape the integration reads, as Active Job and the Resque
+            # adapter really produce it: the adapter's wrapper class, and the
+            # serialized job data as its only argument with the trace context
+            # inside. The examples that construct this shape by hand to isolate
+            # one carrier are only valid as long as this holds.
+            expect(payload["class"])
+              .to eq(Appsignal::Integrations::ResqueHelpers::ACTIVE_JOB_WRAPPER)
+            expect(payload["args"].size).to eq(1)
+            expect(payload["args"].first["__otel_headers"]).to eq(
+              [["traceparent", "00-#{producer.hex_trace_id}-#{producer.hex_span_id}-01"]]
+            )
+
+            consumer = span_exporter.finished_spans.find do |span|
+              span.kind == :consumer
+            end
+            expect(consumer).to_not be_nil
+            expect(consumer.hex_trace_id).to eq(producer.hex_trace_id)
+            expect(consumer.parent_span_id).to eq(producer.span_id)
+          end
+        end
+      end
+
+      # A job enqueued by a service that instruments Resque but not Active Job
+      # has no Active Job carrier to read, so the Resque job's own header is what
+      # the trace has to be continued from.
+      context "with an Active Job job carrying only a Resque-level context" do
+        let(:wrapper) { Appsignal::Integrations::ResqueHelpers::ACTIVE_JOB_WRAPPER }
+
+        before do
+          stub_const(wrapper, Class.new do
+            def self.perform(*)
+            end
+          end)
+        end
+
+        def perform
+          perform_rescue_job(
+            wrapper,
+            "args" => [{ "job_class" => "ResqueTestJob", "arguments" => [] }],
+            "traceparent" => traceparent
+          )
+        end
+
+        it "in collector mode", :collector_mode do
+          start_collector_agent
+          expect(Appsignal).to receive(:stop)
+          perform
+
+          expect(root_span.hex_trace_id).to eq(trace_id_hex)
+          expect(root_span.parent_span_id.unpack1("H*")).to eq(span_id_hex)
+        end
+      end
     end
 
     describe "tracks the error on the transaction" do

--- a/spec/lib/appsignal/integrations/shoryuken_spec.rb
+++ b/spec/lib/appsignal/integrations/shoryuken_spec.rb
@@ -237,6 +237,132 @@ describe Appsignal::Integrations::ShoryukenMiddleware do
         expect(root_span.attributes).to_not have_key("appsignal.tag.traceparent")
       end
     end
+
+    # The Active Job adapter registers a worker that parses the message body as
+    # JSON, so an Active Job job's body arrives as its serialized job data, with
+    # the trace context inside it.
+    context "with an Active Job job carrying the context in its body" do
+      let(:sqs_msg) do
+        double(:message_id => "msg1", :attributes => {}, :message_attributes => {})
+      end
+      let(:body) do
+        {
+          "job_class" => "ShoryukenActiveJob",
+          "arguments" => [],
+          "__otel_headers" => [["traceparent", traceparent]]
+        }
+      end
+
+      it "in agent mode", :agent_mode do
+        start_agent(**start_agent_args)
+        perform_shoryuken_job
+
+        expect(last_transaction).to_not include_tags("traceparent" => traceparent)
+      end
+
+      it "in collector mode", :collector_mode do
+        start_collector_agent
+        perform_shoryuken_job
+
+        expect(root_span.kind).to eq(:consumer)
+        expect(root_span.hex_trace_id).to eq(trace_id_hex)
+        expect(root_span.parent_span_id.unpack1("H*")).to eq(span_id_hex)
+        expect(root_span.links.size).to eq(1)
+      end
+    end
+
+    # Gated on Shoryuken itself as well as Active Job: the rest of this file
+    # works from doubles and so runs under every gemfile, but a round trip needs
+    # the real adapter, which only the Shoryuken gemfiles install.
+    if DependencyHelper.active_job_present? && DependencyHelper.shoryuken_present?
+      # A round trip through real Active Job and the real Shoryuken adapter. The
+      # enqueue writes the trace context onto the job and Active Job serializes
+      # it into the message body. The body is captured where the adapter would
+      # hand it to SQS, so this uses the shape Active Job and Shoryuken really
+      # produce without needing a queue to talk to.
+      context "with a job enqueued through real Active Job" do
+        before do
+          require "active_job"
+          # Shoryuken 7 ships its Active Job adapter and its job extensions as
+          # `active_job` files. Version 6 keeps both under
+          # `shoryuken/extensions`. The extensions are what give a job the
+          # `sqs_send_message_parameters` the adapter sends it with.
+          if Gem.loaded_specs["shoryuken"].version >= Gem::Version.new("7.0.0")
+            require "active_job/extensions"
+            require "active_job/queue_adapters/shoryuken_adapter"
+          else
+            require "shoryuken/extensions/active_job_extensions"
+            require "shoryuken/extensions/active_job_adapter"
+          end
+          ActiveJob::Base.queue_adapter = :shoryuken
+          ActiveJob::Base.logger = nil
+
+          stub_const("ShoryukenRoundTripJob", Class.new(ActiveJob::Base) do
+            def perform(*)
+            end
+          end)
+        end
+
+        # Enqueue inside a transaction and perform outside it, because performing
+        # while the enqueuing transaction is still open would leave the job
+        # sharing it instead of creating its own.
+        def enqueue_then_perform
+          sent = nil
+          sqs_queue = double(:fifo? => false)
+          allow(sqs_queue).to receive(:send_message) { |options| sent = options }
+          allow(::Shoryuken::Client).to receive(:queues).and_return(sqs_queue)
+
+          set_current_transaction(http_request_transaction)
+          ShoryukenRoundTripJob.perform_later("foo")
+          Appsignal::Transaction.complete_current!
+
+          described_class.new.call(
+            worker_instance, queue, sqs_msg, sent[:message_body]
+          ) { nil }
+          sent
+        end
+
+        it "in collector mode", :collector_mode do
+          start_collector_agent
+
+          sent = enqueue_then_perform
+
+          producer = event_span_for("enqueue.active_job")
+
+          # The shape the integration reads, as Active Job and the Shoryuken
+          # adapter really produce it: the serialized job data as the message
+          # body, with the trace context inside. The examples that construct this
+          # shape by hand are only valid as long as this holds.
+          expect(sent[:message_body]["__otel_headers"]).to eq(
+            [["traceparent", "00-#{producer.hex_trace_id}-#{producer.hex_span_id}-01"]]
+          )
+
+          consumer = span_exporter.finished_spans.find do |span|
+            span.kind == :consumer
+          end
+          expect(consumer).to_not be_nil
+          expect(consumer.hex_trace_id).to eq(producer.hex_trace_id)
+          expect(consumer.parent_span_id).to eq(producer.span_id)
+        end
+      end
+    end
+
+    # A message sent by a service that instruments the AWS SDK but not Active
+    # Job has no Active Job carrier to read, so the message attributes are what
+    # the trace has to be continued from.
+    context "with an Active Job job carrying only a message attribute context" do
+      let(:body) do
+        { "job_class" => "ShoryukenActiveJob", "arguments" => [] }
+      end
+
+      it "in collector mode", :collector_mode do
+        start_collector_agent
+        perform_shoryuken_job
+
+        expect(root_span.hex_trace_id).to eq(trace_id_hex)
+        expect(root_span.parent_span_id.unpack1("H*")).to eq(span_id_hex)
+      end
+    end
   end
 
   context "with exception" do

--- a/spec/lib/appsignal/integrations/sidekiq_spec.rb
+++ b/spec/lib/appsignal/integrations/sidekiq_spec.rb
@@ -666,6 +666,85 @@ if DependencyHelper.sidekiq_present?
           expect_parented_and_linked_to_remote
         end
       end
+
+      # The shape an Active Job job really arrives in. Both Active Job adapters
+      # for Sidekiq enqueue a wrapper class with the serialized job data as its
+      # only argument, so the headers are nested one level deeper than the
+      # context above, inside `args`.
+      context "with an Active Job job carrying the context in its job data" do
+        let(:item) do
+          super().merge(
+            "wrapped" => "ActiveJobTestJob",
+            "args" => [
+              {
+                "job_class" => "ActiveJobTestJob",
+                "arguments" => [],
+                "__otel_headers" => [["traceparent", traceparent]]
+              }
+            ]
+          )
+        end
+
+        it "in agent mode", :agent_mode do
+          start_agent(**start_agent_args)
+          perform_sidekiq_job
+
+          expect(transaction.to_h["metadata"].keys).to_not include("__otel_headers")
+        end
+
+        it "in collector mode", :collector_mode do
+          start_collector_agent
+          perform_sidekiq_job
+
+          expect_parented_and_linked_to_remote
+        end
+      end
+
+      # A job enqueued by a service that instruments Sidekiq but not Active Job
+      # has no Active Job carrier to read, so the Sidekiq job's own header is
+      # what the trace has to be continued from.
+      context "with an Active Job job carrying only a Sidekiq-level context" do
+        let(:item) do
+          super().merge(
+            "traceparent" => traceparent,
+            "wrapped" => "ActiveJobTestJob",
+            "args" => [{ "job_class" => "ActiveJobTestJob", "arguments" => [] }]
+          )
+        end
+
+        it "in collector mode", :collector_mode do
+          start_collector_agent
+          perform_sidekiq_job
+
+          expect_parented_and_linked_to_remote
+        end
+      end
+
+      # Both carriers present is what a job enqueued by an older version of this
+      # gem looks like, and what a rolling deploy therefore produces. The two
+      # hold the same context, so either one continues the same trace.
+      context "with an Active Job job carrying both contexts" do
+        let(:item) do
+          super().merge(
+            "traceparent" => traceparent,
+            "wrapped" => "ActiveJobTestJob",
+            "args" => [
+              {
+                "job_class" => "ActiveJobTestJob",
+                "arguments" => [],
+                "__otel_headers" => [["traceparent", traceparent]]
+              }
+            ]
+          )
+        end
+
+        it "in collector mode", :collector_mode do
+          start_collector_agent
+          perform_sidekiq_job
+
+          expect_parented_and_linked_to_remote
+        end
+      end
     end
 
     context "with parameter filtering" do
@@ -1189,6 +1268,60 @@ if DependencyHelper.sidekiq_present?
         # We test somewhere else if the middleware is installed properly.
         Sidekiq::Testing.server_middleware do |chain|
           chain.add Appsignal::Integrations::SidekiqMiddleware
+        end
+      end
+
+      # A full round trip through real Active Job and the real Sidekiq adapter.
+      # The enqueue writes the trace context onto the job, Active Job serializes
+      # it into the job data, Sidekiq stores that as the wrapper's argument, and
+      # the perform reads it back. No part of the job's shape is written by hand
+      # here, so this fails if any assumption about that shape is wrong.
+      describe "carrying trace context from the enqueue to the perform" do
+        # Enqueue inside a transaction and perform outside it, because draining
+        # while the enqueuing transaction is still open would leave the job
+        # sharing it instead of creating its own. Yields the stored Sidekiq job
+        # between the enqueue and the perform.
+        def enqueue_then_perform
+          Sidekiq::Testing.fake! do
+            with_rails_error_reporter do
+              set_current_transaction(http_request_transaction)
+              ActiveJobSidekiqTestJob.perform_later("foo")
+              Appsignal::Transaction.complete_current!
+
+              yield Sidekiq::Queues["default"].first if block_given?
+
+              Timecop.freeze(time) { Sidekiq::Worker.drain_all }
+            end
+          end
+        end
+
+        it "in collector mode", :collector_mode do
+          start_collector_agent
+
+          stored = nil
+          enqueue_then_perform { |item| stored = item }
+
+          producer = event_span_for("enqueue.active_job")
+
+          # The shape the integration reads, as Active Job and the Sidekiq
+          # adapter really produce it: the real job class in `wrapped`, and the
+          # serialized job data as the wrapper's only argument, with the trace
+          # context inside it. The examples that construct this shape by hand to
+          # isolate one carrier are only valid as long as this holds.
+          expect(stored["wrapped"]).to eq("ActiveJobSidekiqTestJob")
+          expect(stored["args"].size).to eq(1)
+          expect(stored["args"].first["__otel_headers"]).to eq(
+            [["traceparent", "00-#{producer.hex_trace_id}-#{producer.hex_span_id}-01"]]
+          )
+
+          consumer = span_exporter.finished_spans.find { |span| span.kind == :consumer }
+          expect(consumer).to_not be_nil
+          # The job continues the enqueuer's trace as a child of the producer
+          # span, and links back to it.
+          expect(consumer.hex_trace_id).to eq(producer.hex_trace_id)
+          expect(consumer.parent_span_id).to eq(producer.span_id)
+          expect(consumer.links.map { |link| link.span_context.hex_span_id })
+            .to eq([producer.hex_span_id])
         end
       end
 

--- a/spec/lib/appsignal/opentelemetry_spec.rb
+++ b/spec/lib/appsignal/opentelemetry_spec.rb
@@ -402,6 +402,84 @@ if DependencyHelper.opentelemetry_present?
       end
     end
 
+    describe ".extract_active_job_context" do
+      let(:traceparent) do
+        "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+      end
+      let(:job_data) { { "__otel_headers" => { "traceparent" => traceparent } } }
+
+      it "returns nil when the SDK has not booted" do
+        expect(described_class.started?).to be(false)
+        expect(described_class.extract_active_job_context(job_data)).to be_nil
+      end
+
+      context "when the SDK has booted", :collector_mode do
+        before { start_collector_agent }
+
+        def extracted_trace_id(job_data)
+          context = described_class.extract_active_job_context(job_data)
+          return if context.nil?
+
+          ::OpenTelemetry::Trace.current_span(context).context.hex_trace_id
+        end
+
+        it "reads the context out of __otel_headers" do
+          expect(extracted_trace_id(job_data))
+            .to eq("0af7651916cd43dd8448eb211c80319c")
+        end
+
+        # Active Job puts the headers through its argument serializer, which
+        # turns the hash into an array of pairs. That is the shape a job that
+        # travelled over the wire arrives with.
+        it "reads the serialized array-of-pairs shape" do
+          serialized = { "__otel_headers" => [["traceparent", traceparent]] }
+
+          expect(extracted_trace_id(serialized))
+            .to eq("0af7651916cd43dd8448eb211c80319c")
+        end
+
+        # A nil return is how a caller learns to fall back to its own native
+        # carrier, so each of these has to give nil rather than a context with
+        # no usable span in it.
+        it "returns nil for job data with no headers" do
+          expect(described_class.extract_active_job_context({})).to be_nil
+        end
+
+        it "returns nil for headers that carry no trace context" do
+          expect(
+            described_class.extract_active_job_context("__otel_headers" => {})
+          ).to be_nil
+        end
+
+        it "returns nil for an invalid traceparent" do
+          expect(
+            described_class.extract_active_job_context(
+              "__otel_headers" => { "traceparent" => "nonsense" }
+            )
+          ).to be_nil
+        end
+
+        it "returns nil for a malformed headers value" do
+          expect(
+            described_class.extract_active_job_context("__otel_headers" => ["oops"])
+          ).to be_nil
+        end
+
+        it "returns nil for anything that is not job data" do
+          expect(described_class.extract_active_job_context(nil)).to be_nil
+          expect(described_class.extract_active_job_context("string")).to be_nil
+        end
+
+        # Same reason as the job and Rack carriers: a job with no context of its
+        # own must not pick up whatever span happens to be on the fiber.
+        it "does not inherit the ambient span" do
+          with_leaked_ambient_context do
+            expect(described_class.extract_active_job_context({})).to be_nil
+          end
+        end
+      end
+    end
+
     describe ".if_started" do
       it "does not run the block and returns nil when the SDK has not booted" do
         expect(described_class.started?).to be(false)

--- a/spec/support/helpers/dependency_helper.rb
+++ b/spec/support/helpers/dependency_helper.rb
@@ -119,6 +119,18 @@ module DependencyHelper
     dependency_present? "activejob"
   end
 
+  # Whether the Active Job adapter for Delayed Job can be loaded. Delayed Job
+  # ships an adapter that subclasses `ActiveJob::QueueAdapters::AbstractAdapter`,
+  # which Active Job only has from 7.2 on. Active Job ships an adapter of the
+  # same name, so which of the two a `require` finds depends on the load order,
+  # and the Delayed Job one raises below 7.2. Only drive the adapter on versions
+  # where it loads whichever wins.
+  def active_job_delayed_job_adapter_present?
+    return false unless active_job_present? && delayed_job_present?
+
+    Gem.loaded_specs["activejob"].version >= Gem::Version.new("7.2.0")
+  end
+
   def active_support_present?
     dependency_present? "activesupport"
   end


### PR DESCRIPTION
Stacked on #1592.

### [Read trace context from Active Job job data](https://github.com/appsignal/appsignal-ruby/commit/839967fa299e1a6c2023b7c606085b294914fee2)

Every queue adapter wraps the serialized Active Job job data as the
single argument of its own job wrapper, and Active Job carries the trace
context inside that data under `__otel_headers`. An adapter integration
that wants to read it therefore needs somewhere to send the job data
once it has found it, which is what `extract_active_job_context` is for.
It returns nil rather than an empty context when the data carries
nothing usable, so a caller can tell "read a context" from "read
nothing" and fall back to its own native carrier. Deciding that needs
the check the OpenTelemetry backend already had for choosing between a
parented and a root span, so that moves next to it.

### [Read the Active Job carrier in Sidekiq](https://github.com/appsignal/appsignal-ruby/commit/dc353f530a5a454a98bc1748a99a83d87694706b)

The Sidekiq server middleware creates the transaction for an Active Job
job, before Active Job's own hook runs, and that hook then skips reading
the trace context because a transaction already exists. So the Sidekiq
job's own `traceparent` was the only carrier ever read, and the context
Active Job writes into the job data went unread. Read that one first,
and keep the Sidekiq header as the fallback it now is: that is where a
job enqueued by a service running only OpenTelemetry's Sidekiq
instrumentation carries its context, and where a job enqueued by an
earlier version of this gem carries a copy of the same context.

### [Read the Active Job carrier in Resque](https://github.com/appsignal/appsignal-ruby/commit/69597733c8f6731f22eee5eb8898ff44aec45193)

The Resque integration creates the transaction for an Active Job job,
before Active Job's own hook runs, and that hook then skips reading the
trace context because a transaction already exists. So the Resque job's
own `traceparent` was the only carrier ever read, and the context Active
Job writes into the job data went unread. Read that one first, and keep
the Resque header as the fallback it now is: that is where a job
enqueued by a service running only OpenTelemetry's Resque
instrumentation carries its context. The wrapper class name that says a
Resque job is an Active Job job was already spelled out here to skip its
arguments, so it becomes a constant that both readers share.

Covering those paths needs Active Job in the Resque gemfiles, and
installing it installs Active Support alongside. Two specs gate on those
gems being present rather than on the whole framework, so they started
loading in a bundle with no Rails in it. The Active Job hook spec
branches on the Rails version throughout and now asks for Rails, and the
Active Support notifications spec now requires the part of Active
Support it uses rather than relying on another gem to have loaded it.

### [Read the Active Job carrier in Que](https://github.com/appsignal/appsignal-ruby/commit/1fbc382ee26e39a346297f7079cb7363d26aaa4b)

The Que integration creates the transaction for an Active Job job,
before Active Job's own hook runs, and that hook then skips reading the
trace context because a transaction already exists. So the job's tags
were the only carrier ever read, and the context Active Job writes into
the job data went unread. Read that one first, and keep the tags as the
fallback they now are, for a job enqueued by a service running only
OpenTelemetry's Que instrumentation and for a Que job that is not an
Active Job job at all. Reading the Active Job carrier also gives Que 0.x
propagation for the first time, because that version has no tags to
carry a trace context in.

### [Read the Active Job carrier in Shoryuken](https://github.com/appsignal/appsignal-ruby/commit/8e040d9ab4412453cf285b0e5f82889deb536fed)

The Shoryuken middleware creates the transaction for an Active Job job,
before Active Job's own hook runs, and that hook then skips reading the
trace context because a transaction already exists. So the message's own
attributes were the only carrier ever read, and the context Active Job
writes into the job data went unread. Read that one first, and keep the
message attributes as the fallback they now are, for a message sent by a
service running only OpenTelemetry's aws-sdk instrumentation and for a
Shoryuken job that is not an Active Job job at all. Reading the Active
Job carrier also gives bulk Active Job enqueues propagation for the
first time, because those go out through Shoryuken's batch send, which
runs no client middleware and so injects nothing into the message
attributes.

### [Read the Active Job carrier in Delayed Job](https://github.com/appsignal/appsignal-ruby/commit/76e1c557f98b9d3880d4fc82ec01208107cd5fba)

Delayed Job stores a job as a YAML dump of the object to run, which has
nowhere to put a trace header, so this integration created its consumer
transaction without ever passing a context. An Active Job job does carry
one, in the job data the adapter wraps, and this integration already
read that job data at the end of a job to name the action. Read it
before the transaction is created as well, so an Active Job job
performed through Delayed Job links back to whatever enqueued it.
Delayed Job remembers a payload it read successfully, so reading it
earlier costs no extra work, and a handler that will not deserialize is
already handled.

Covering those paths needs Active Job in the Delayed Job gemfile, which
makes this file's Active Job specs run for the first time. Delayed Job
ships its own Active Job adapter, and that adapter subclasses
`ActiveJob::QueueAdapters::AbstractAdapter`, which Active Job only has
from version 7.2 on. Active Job ships an adapter of the same name, so
which of the two a require finds depends on the load order, and below
7.2 the Delayed Job one raises. Those specs therefore only run from 7.2
up.

[skip changeset]

