### PR TITLE
Support Active Job bulk enqueues, with trace context

### DIFF
--- a/.changesets/record-active-job-bulk-enqueues-as-one-event.md
+++ b/.changesets/record-active-job-bulk-enqueues-as-one-event.md
@@ -1,0 +1,14 @@
+---
+bump: patch
+type: fix
+---
+
+Record a single event for a bulk enqueue of Active Job jobs. Before this change,
+enqueuing jobs with `ActiveJob.perform_all_later` would record an event for the
+batch and, if the adapter was instrumented with AppSignal, another event for each
+job in it. A job that slices a large collection and enqueues it in batches was
+therefore reported with an event per job enqueued, where before version 4.9.0 it
+had one event per batch.
+
+A bulk enqueue is now recorded as a single `enqueue_all.active_job` event, named
+after the job class when every job in the batch shares one.

--- a/lib/appsignal/hooks/active_job.rb
+++ b/lib/appsignal/hooks/active_job.rb
@@ -192,6 +192,7 @@ module Appsignal
                 :batch_size => jobs.size
               )
             )
+            inject_context_into(jobs)
             # A bulk enqueue does not go through `ActiveJob::Base#enqueue`, so
             # nothing has suppressed the adapter (Sidekiq, Resque, ...) yet, and
             # its own enqueue instrumentation would record an event for every job
@@ -202,6 +203,21 @@ module Appsignal
             else
               super
             end
+          end
+        end
+
+        # Writes this producer span's context onto every job in the batch, and
+        # marks each one as part of a batch, so the jobs that perform later link
+        # back to this span. A bulk enqueue never goes through
+        # `ActiveJob::Base#enqueue`, so the injection the single-job path does
+        # never runs for these jobs. The adapter serializes each job after this,
+        # and the `serialize` patch carries the headers to the wire from there.
+        # A no-op outside collector mode.
+        def inject_context_into(jobs)
+          jobs.each do |job|
+            headers = job.__otel_headers
+            Appsignal::OpenTelemetry.inject_context(headers)
+            Appsignal::OpenTelemetry.mark_active_job_batch(headers)
           end
         end
 

--- a/lib/appsignal/hooks/active_job.rb
+++ b/lib/appsignal/hooks/active_job.rb
@@ -22,6 +22,14 @@ module Appsignal
         Appsignal::EventFormatter::RecordedElsewhere
       )
 
+      # Claimed for the same reason as the single enqueue above: this integration
+      # records the batch itself, as one producer event, and Active Job's own
+      # `enqueue_all.active_job` notification fires nested inside it.
+      Appsignal::EventFormatter.register(
+        "enqueue_all.active_job",
+        Appsignal::EventFormatter::RecordedElsewhere
+      )
+
       def self.version_7_1_or_higher?
         @version_7_1_or_higher ||=
           if dependencies_present?
@@ -35,6 +43,59 @@ module Appsignal
 
       def self.dependencies_present?
         defined?(::ActiveJob)
+      end
+
+      # The parameters of the Active Job method this hook wraps to record a
+      # bulk enqueue. The wrapper reads the array of jobs out of the second
+      # one, so it is only safe to wrap a method that still takes these.
+      EXPECTED_INSTRUMENT_ENQUEUE_ALL_PARAMETERS = [
+        [:req, :queue_adapter],
+        [:req, :jobs]
+      ].freeze
+
+      # Whether Active Job records a bulk enqueue through a method at all. It
+      # only does so from version 7.1 on. Checking for the method, rather than
+      # for the version, keeps us from wrapping one on a version that has no
+      # bulk enqueue path to instrument.
+      def self.instrument_enqueue_all_defined?
+        ::ActiveJob.singleton_class.private_method_defined?(:instrument_enqueue_all)
+      end
+
+      # Whether that method still takes the arguments the wrapper reads.
+      #
+      # The method is private, so a later version of Active Job can change
+      # what it takes. Wrapping one that takes something else raises an
+      # ArgumentError inside every `ActiveJob.perform_all_later` call an
+      # application makes, which breaks enqueuing and not just its
+      # instrumentation. Refusing to wrap it is therefore the safe direction,
+      # whatever the refusal costs us.
+      def self.instrument_enqueue_all_parameters_match?
+        instrument_enqueue_all_parameters == EXPECTED_INSTRUMENT_ENQUEUE_ALL_PARAMETERS
+      end
+
+      # Active Job's own definition of the method, looked up past the wrapper
+      # this hook prepends. Installing twice would otherwise find that wrapper
+      # rather than the method it wraps, and so check it against itself. Only
+      # the wrapper is skipped, so a version of Active Job that defines the
+      # method somewhere else is still found.
+      def self.instrument_enqueue_all_method
+        method = ::ActiveJob.singleton_class.instance_method(:instrument_enqueue_all)
+        method = method.super_method while method&.owner == ActiveJobBulkEnqueueInstrumentation
+        method
+      end
+
+      def self.instrument_enqueue_all_parameters
+        instrument_enqueue_all_method&.parameters
+      end
+
+      # Names both sides of the mismatch, so a log line is enough to tell what
+      # Active Job changed and what the wrapper was written against.
+      def self.instrument_enqueue_all_mismatch_message
+        "Not instrumenting Active Job bulk enqueues: " \
+          "`ActiveJob.instrument_enqueue_all` takes " \
+          "#{instrument_enqueue_all_parameters.inspect} in this version of " \
+          "Active Job, where AppSignal expects " \
+          "#{EXPECTED_INSTRUMENT_ENQUEUE_ALL_PARAMETERS.inspect}."
       end
 
       def dependencies_present?
@@ -52,6 +113,32 @@ module Appsignal
           ::ActiveJob::Base
             .prepend ::Appsignal::Hooks::ActiveJobHook::ActiveJobTraceContext
 
+          # Wrap the method Active Job records a bulk enqueue through, but only
+          # when it is still the method the wrapper knows how to read. When it
+          # is not, the batch goes unrecorded: the claim above stands, because
+          # a worse event is not worth reporting in place of the one we set out
+          # to report.
+          if !Appsignal::Hooks::ActiveJobHook.instrument_enqueue_all_defined?
+            # Nothing to instrument on a version with no bulk enqueue path, so
+            # there is nothing to report either.
+            Appsignal.internal_logger.debug(
+              "Not instrumenting Active Job bulk enqueues: this version of " \
+                "Active Job does not record them through " \
+                "`ActiveJob.instrument_enqueue_all`."
+            )
+          elsif !Appsignal::Hooks::ActiveJobHook.instrument_enqueue_all_parameters_match?
+            # A bulk enqueue path exists, but not one that can be wrapped
+            # without breaking `ActiveJob.perform_all_later` for the whole
+            # application. Report that at a level someone will see, because a
+            # batch that used to be recorded no longer is.
+            Appsignal.internal_logger.warn(
+              Appsignal::Hooks::ActiveJobHook.instrument_enqueue_all_mismatch_message
+            )
+          else
+            ::ActiveJob.singleton_class
+              .prepend ::Appsignal::Hooks::ActiveJobHook::ActiveJobBulkEnqueueInstrumentation
+          end
+
           next unless Appsignal::Hooks::ActiveJobHook.version_7_1_or_higher?
 
           # Only works on Active Job 7.1 and newer
@@ -60,6 +147,90 @@ module Appsignal
 
             Appsignal::Transaction.current.set_error(exception)
           end
+        end
+      end
+
+      # Records an `enqueue_all.active_job` event when a batch of jobs is
+      # enqueued with `ActiveJob.perform_all_later`, so the batch shows up on the
+      # active transaction's timeline as one event, and as one producer span in
+      # collector mode.
+      #
+      # This wraps `instrument_enqueue_all` rather than `perform_all_later`, for
+      # two reasons. It is the method that records the batch, so it is called
+      # once for each queue adapter the batch spans, which is the same event
+      # count as the native notification it replaces. And it runs inside
+      # `perform_all_later`, after Active Job has split off the jobs it defers
+      # until the database transaction commits, so each of those halves is
+      # recorded when it is really enqueued.
+      #
+      # @!visibility private
+      module ActiveJobBulkEnqueueInstrumentation
+        private
+
+        def instrument_enqueue_all(_queue_adapter, jobs)
+          # When enqueue instrumentation is disabled, record nothing, the same as
+          # the single-job path.
+          return super if Appsignal.config && !Appsignal.config[:enable_job_enqueue_instrumentation]
+
+          # Another enqueue integration is already recording this enqueue, so
+          # don't record it a second time.
+          if Appsignal::Transaction.current? &&
+              Appsignal::Transaction.current.job_enqueue_events_suppressed?
+            return super
+          end
+
+          Appsignal.instrument(
+            "enqueue_all.active_job",
+            bulk_enqueue_title(jobs),
+            :opentelemetry_kind => :producer,
+            :opentelemetry_scope => ["appsignal-ruby/active_job", Appsignal::VERSION]
+          ) do
+            Appsignal::Transaction.current.add_opentelemetry_attributes(
+              Appsignal::OpenTelemetry::Messaging.enqueue_attributes(
+                "active_job",
+                :destination => bulk_enqueue_destination(jobs),
+                :batch_size => jobs.size
+              )
+            )
+            # A bulk enqueue does not go through `ActiveJob::Base#enqueue`, so
+            # nothing has suppressed the adapter (Sidekiq, Resque, ...) yet, and
+            # its own enqueue instrumentation would record an event for every job
+            # in the batch. Suppress it so the batch is recorded once, as this
+            # event.
+            if Appsignal::Transaction.current?
+              Appsignal::Transaction.current.suppress_job_enqueue_events { super }
+            else
+              super
+            end
+          end
+        end
+
+        # The batch's job class, when every job in it has the same one. Active
+        # Job groups the jobs it enqueues by queue adapter rather than by class,
+        # so a batch can mix classes, and then there is no one class to name.
+        def bulk_enqueue_title(jobs)
+          job_class = shared_across(jobs) { |job| job.class.name }
+          return "bulk enqueue jobs" unless job_class
+
+          "bulk enqueue #{job_class} jobs"
+        end
+
+        # The queue the batch went to, when every job in it is on the same one.
+        # Grouping is by queue adapter and not by queue, so a batch can span
+        # queues, and then there is no one queue to name as the destination.
+        def bulk_enqueue_destination(jobs)
+          shared_across(jobs, &:queue_name)
+        end
+
+        # The one value every job in the batch shares, or nil when they differ
+        # or the batch is empty. Stops at the first job that disagrees, because
+        # a batch is as large as the caller made it and a single mismatch is
+        # enough to know.
+        def shared_across(jobs)
+          return if jobs.empty?
+
+          first = yield(jobs.first)
+          jobs.all? { |job| yield(job) == first } ? first : nil
         end
       end
 

--- a/lib/appsignal/hooks/active_job.rb
+++ b/lib/appsignal/hooks/active_job.rb
@@ -283,7 +283,8 @@ module Appsignal
                 :opentelemetry_context => Appsignal::OpenTelemetry.extract_job_context(job),
                 :opentelemetry_scope => ["appsignal-ruby/active_job", Appsignal::VERSION],
                 :opentelemetry_kind => :consumer,
-                :opentelemetry_relationship => :both
+                :opentelemetry_relationship =>
+                  Appsignal::OpenTelemetry.active_job_relationship(job)
               )
             end
 

--- a/lib/appsignal/integrations/delayed_job_plugin.rb
+++ b/lib/appsignal/integrations/delayed_job_plugin.rb
@@ -107,8 +107,8 @@ module Appsignal
       rescue Exception => error
         warn_unreadable_payload_once(error)
 
-        # No trace context: the payload the context would come from is the one
-        # that just failed to load.
+        # No job data: the payload it would have been read from is the one that
+        # just failed to load.
         transaction = create_perform_transaction(job, nil)
         transaction.set_action_if_nil(action_name_without_payload(job))
         transaction.set_error(error)
@@ -116,17 +116,13 @@ module Appsignal
         Appsignal::Transaction.complete_current!
       end
 
-      # The trace context to continue. Delayed Job has no carrier of its own,
-      # because a job's handler is a YAML dump of the object to run with nowhere
-      # to put a header, so an Active Job job is the only kind that arrives with
-      # one.
-      def self.extract_context(job)
-        Appsignal::OpenTelemetry.extract_active_job_context(active_job_data(job))
-      end
-
       # The serialized Active Job job data inside a Delayed Job job, or nil when
       # this is not an Active Job job. The Active Job adapter wraps the job data
       # in an object that exposes it as `job_data`.
+      #
+      # Delayed Job has no carrier of its own, because a job's handler is a YAML
+      # dump of the object to run with nowhere to put a header, so an Active Job
+      # job is the only kind that arrives with a trace context at all.
       #
       # Reading it means deserializing the handler, which raises for a job whose
       # class is gone, so a job that cannot be read gets no context. Delayed Job
@@ -141,7 +137,8 @@ module Appsignal
       end
 
       def self.invoke_with_instrumentation(job, block)
-        transaction = create_perform_transaction(job, extract_context(job))
+        job_data = active_job_data(job)
+        transaction = create_perform_transaction(job, job_data)
 
         begin
           Appsignal.instrument(
@@ -188,15 +185,17 @@ module Appsignal
 
       # The transaction a performed job is reported under. Shared by the two
       # callbacks that can report a job, so both describe it the same way. The
-      # trace context is passed in rather than read here, because the payload it
+      # job data is passed in rather than read here, because the payload it
       # would be read from is the one a job that cannot be loaded failed on.
-      def self.create_perform_transaction(job, context)
+      def self.create_perform_transaction(job, job_data)
         transaction = Appsignal::Transaction.create(
           Appsignal::Transaction::BACKGROUND_JOB,
-          :opentelemetry_context => context,
+          :opentelemetry_context =>
+            Appsignal::OpenTelemetry.extract_active_job_context(job_data),
           :opentelemetry_scope => ["appsignal-ruby/delayed_job", Appsignal::VERSION],
           :opentelemetry_kind => :consumer,
-          :opentelemetry_relationship => :both
+          :opentelemetry_relationship =>
+            Appsignal::OpenTelemetry.active_job_relationship(job_data)
         )
         transaction.add_opentelemetry_attributes(
           Appsignal::OpenTelemetry::Messaging

--- a/lib/appsignal/integrations/que.rb
+++ b/lib/appsignal/integrations/que.rb
@@ -104,9 +104,8 @@ module Appsignal
       # for why that layer wins.
       # Que's tags are a carrier with a hard limit: five per job, shared with
       # whatever the user puts there.
-      def extract_context(attrs, tags)
-        Appsignal::OpenTelemetry.extract_active_job_context(active_job_data(attrs)) ||
-          extract(tags)
+      def extract_context(job_data, tags)
+        Appsignal::OpenTelemetry.extract_active_job_context(job_data) || extract(tags)
       end
 
       # The serialized Active Job job data inside a Que job, or nil when this is
@@ -134,21 +133,24 @@ module Appsignal
         local_attrs = respond_to?(:que_attrs) ? que_attrs : attrs
         tags = local_attrs.dig(:data, :tags)
 
-        # A job enqueued on its own is the only job its producer span produced, so
-        # it can be a child of that span as well as link to it. Every job in a
-        # batch shares one producer span, and a span can only have one parent, so
-        # parenting a batch would hang the whole batch off that single span. Only
-        # link those, which is what the OpenTelemetry messaging conventions ask
-        # for: they use links as the default, and allow the producer to be the
-        # parent only when it produced a single message.
-        relationship = QueTraceContext.bulk?(tags) ? :link : :both
+        job_data = QueTraceContext.active_job_data(local_attrs)
+        # A Que batch says so with a tag, and an Active Job batch says so in the
+        # job data, so both have to be asked. See
+        # `Appsignal::OpenTelemetry.active_job_relationship` for why a batch
+        # links back rather than parenting under the span that enqueued it.
+        relationship =
+          if QueTraceContext.bulk?(tags)
+            :link
+          else
+            Appsignal::OpenTelemetry.active_job_relationship(job_data)
+          end
 
         # Read the incoming trace context off the job's tags so the transaction
         # links back to the enqueuer. No-op outside collector mode.
         transaction =
           Appsignal::Transaction.create(
             Appsignal::Transaction::BACKGROUND_JOB,
-            :opentelemetry_context => QueTraceContext.extract_context(local_attrs, tags),
+            :opentelemetry_context => QueTraceContext.extract_context(job_data, tags),
             :opentelemetry_scope => ["appsignal-ruby/que", Appsignal::VERSION],
             :opentelemetry_kind => :consumer,
             :opentelemetry_relationship => relationship

--- a/lib/appsignal/integrations/resque.rb
+++ b/lib/appsignal/integrations/resque.rb
@@ -7,12 +7,14 @@ module Appsignal
       def perform
         # Read trace context off the job so the transaction links back to the
         # enqueuer. No-op outside collector mode.
+        job_data = ResqueHelpers.active_job_data(payload)
         transaction = Appsignal::Transaction.create(
           Appsignal::Transaction::BACKGROUND_JOB,
-          :opentelemetry_context => ResqueHelpers.extract_context(payload),
+          :opentelemetry_context => ResqueHelpers.extract_context(payload, job_data),
           :opentelemetry_scope => ["appsignal-ruby/resque", Appsignal::VERSION],
           :opentelemetry_kind => :consumer,
-          :opentelemetry_relationship => :both
+          :opentelemetry_relationship =>
+            Appsignal::OpenTelemetry.active_job_relationship(job_data)
         )
         # Describes this span as a job being performed. The messaging system is
         # what the trace timeline reads to recognize background job work, and
@@ -118,8 +120,8 @@ module Appsignal
       # The trace context to continue: the Active Job layer when this is an
       # Active Job job, the Resque job itself otherwise. See `Appsignal::OpenTelemetry.extract_active_job_context`
       # for why that layer wins.
-      def self.extract_context(payload)
-        Appsignal::OpenTelemetry.extract_active_job_context(active_job_data(payload)) ||
+      def self.extract_context(payload, job_data)
+        Appsignal::OpenTelemetry.extract_active_job_context(job_data) ||
           Appsignal::OpenTelemetry.extract_job_context(payload)
       end
     end

--- a/lib/appsignal/integrations/shoryuken.rb
+++ b/lib/appsignal/integrations/shoryuken.rb
@@ -84,7 +84,11 @@ module Appsignal
           :opentelemetry_context => context,
           :opentelemetry_scope => ["appsignal-ruby/shoryuken", Appsignal::VERSION],
           :opentelemetry_kind => :consumer,
-          :opentelemetry_relationship => :both
+          # A message batch is a batch on the receiving side, and carries no
+          # context to relate to at all, so the body it reads here is the single
+          # message's job data or nothing.
+          :opentelemetry_relationship =>
+            Appsignal::OpenTelemetry.active_job_relationship(batch ? nil : body)
         )
         # Describes this span as a job being performed. The messaging system is
         # what the trace timeline reads to recognize background job work.

--- a/lib/appsignal/integrations/sidekiq.rb
+++ b/lib/appsignal/integrations/sidekiq.rb
@@ -176,12 +176,14 @@ module Appsignal
         action_name = formatted_action_name(item)
         # Read trace context off the job so the transaction links back to the
         # enqueuer. No-op outside collector mode.
+        job_data = active_job_data(item)
         transaction = Appsignal::Transaction.create(
           Appsignal::Transaction::BACKGROUND_JOB,
-          :opentelemetry_context => extract_context(item),
+          :opentelemetry_context => extract_context(item, job_data),
           :opentelemetry_scope => ["appsignal-ruby/sidekiq", Appsignal::VERSION],
           :opentelemetry_kind => :consumer,
-          :opentelemetry_relationship => :both
+          :opentelemetry_relationship =>
+            Appsignal::OpenTelemetry.active_job_relationship(job_data)
         )
         transaction.add_opentelemetry_attributes(
           Appsignal::OpenTelemetry::Messaging
@@ -249,8 +251,8 @@ module Appsignal
       # The trace context to continue: the Active Job layer when this is an
       # Active Job job, the Sidekiq job itself otherwise. See `Appsignal::OpenTelemetry.extract_active_job_context`
       # for why that layer wins.
-      def extract_context(item)
-        Appsignal::OpenTelemetry.extract_active_job_context(active_job_data(item)) ||
+      def extract_context(item, job_data)
+        Appsignal::OpenTelemetry.extract_active_job_context(job_data) ||
           Appsignal::OpenTelemetry.extract_job_context(item)
       end
 

--- a/lib/appsignal/opentelemetry.rb
+++ b/lib/appsignal/opentelemetry.rb
@@ -15,6 +15,11 @@ require "appsignal/opentelemetry/sql_db_system"
 module Appsignal
   # @!visibility private
   module OpenTelemetry
+    # The carrier key that marks an Active Job job as one of a batch. Not a W3C
+    # trace context header, and deliberately not named like one, so no
+    # propagator reads it as one.
+    ACTIVE_JOB_BATCH_HEADER = "appsignal-batch"
+
     class << self
       # Configure the global OpenTelemetry SDK to export OTLP/HTTP protobuf to
       # the collector endpoint in `config[:collector_endpoint]`.
@@ -215,6 +220,38 @@ module Appsignal
           )
           context if remote_span_context(context)
         end
+      end
+
+      # Marks an outgoing Active Job carrier as belonging to a batch, so the
+      # integration that later performs the job can tell the two enqueue paths
+      # apart. Every job in a batch shares the one producer span, and a span can
+      # have only one parent, so a batch has to link back rather than parent
+      # under it -- and only the enqueue side knows it was a batch.
+      #
+      # The marker rides in the same carrier as the trace context.
+      # `propagation.extract` ignores a key it does not recognise, so it is
+      # invisible to every other reader of that carrier, including
+      # OpenTelemetry's own Active Job instrumentation.
+      #
+      # Does nothing to a carrier nothing was injected into. Without a context
+      # there is no producer span to link back to, so the marker would have
+      # nothing to say.
+      def mark_active_job_batch(headers)
+        return if headers.empty?
+
+        headers[ACTIVE_JOB_BATCH_HEADER] = "1"
+      end
+
+      # Whether Active Job job data says the job was enqueued as part of a batch.
+      # An integration reads this to choose between linking the performed job
+      # back to the enqueuer and also parenting it under them.
+      def active_job_batch?(job_data)
+        return false unless job_data.is_a?(Hash)
+
+        headers = otel_headers_hash(job_data["__otel_headers"])
+        return false unless headers
+
+        headers[ACTIVE_JOB_BATCH_HEADER] == "1"
       end
 
       # The remote parent's SpanContext from an incoming OTel context, or `nil`

--- a/lib/appsignal/opentelemetry.rb
+++ b/lib/appsignal/opentelemetry.rb
@@ -254,6 +254,19 @@ module Appsignal
         headers[ACTIVE_JOB_BATCH_HEADER] == "1"
       end
 
+      # How a performed job should relate to the span that enqueued it.
+      #
+      # A job enqueued on its own is the only job its producer span produced, so
+      # it can be a child of that span as well as link to it. Every job in a
+      # batch shares one producer span, and a span can have only one parent, so
+      # parenting a batch would hang the whole batch off that single span. Only
+      # link those, which is what the OpenTelemetry messaging conventions ask
+      # for: they use links as the default, and allow the producer to be the
+      # parent only when it produced a single message.
+      def active_job_relationship(job_data)
+        active_job_batch?(job_data) ? :link : :both
+      end
+
       # The remote parent's SpanContext from an incoming OTel context, or `nil`
       # when there is no context or the span in it is invalid.
       #

--- a/spec/lib/appsignal/hooks/activejob_spec.rb
+++ b/spec/lib/appsignal/hooks/activejob_spec.rb
@@ -41,6 +41,122 @@ if DependencyHelper.active_job_present? && DependencyHelper.rails_present?
       end
     end
 
+    describe "the enqueue_all.active_job event" do
+      # The event formatter registry is shared by the whole test suite, so put
+      # back whatever these examples change. Loading the hook file below also
+      # re-registers it in the hooks registry, so put that back too.
+      around do |example|
+        formatters = Appsignal::EventFormatter.formatters.dup
+        formatter_classes = Appsignal::EventFormatter.formatter_classes.dup
+        hooks = Appsignal::Hooks.hooks.dup
+        example.run
+      ensure
+        Appsignal::EventFormatter.formatters.replace(formatters)
+        Appsignal::EventFormatter.formatter_classes.replace(formatter_classes)
+        Appsignal::Hooks.hooks.replace(hooks)
+      end
+
+      # The hook file claims the event as soon as it is required, before
+      # anything knows whether the batch can be recorded, and nothing ever
+      # gives the claim back. Force the event to unclaimed and load the file
+      # again, so that what is asserted below is the claim this file makes
+      # rather than one an earlier example left behind.
+      it "is claimed when the gem loads" do
+        Appsignal::EventFormatter.unregister(
+          "enqueue_all.active_job",
+          Appsignal::EventFormatter::RecordedElsewhere
+        )
+        expect(Appsignal::EventFormatter.record?("enqueue_all.active_job"))
+          .to be(true)
+
+        load "appsignal/hooks/active_job.rb"
+
+        expect(Appsignal::EventFormatter.record?("enqueue_all.active_job"))
+          .to be(false)
+      end
+
+      if DependencyHelper.rails7_1_present?
+        # The wrapper reads the array of jobs out of the second argument of a
+        # private Active Job method, so it is written against that method's
+        # parameters. Pin them, so a version of Active Job that changes them
+        # fails here, naming both sides, instead of reaching an application as
+        # an ArgumentError from inside `perform_all_later`.
+        it "is wrapped against the parameters Active Job has today" do
+          expect(described_class.instrument_enqueue_all_parameters)
+            .to eq(described_class::EXPECTED_INSTRUMENT_ENQUEUE_ALL_PARAMETERS)
+        end
+      end
+
+      # Active Job records a bulk enqueue through a method that only exists
+      # from version 7.1 on, and this hook wraps that method to record the
+      # batch itself. Without it there is nothing to record the batch with,
+      # and the claim stands anyway: Active Job's own notification is the
+      # worse event this hook set out to replace, so nothing records the
+      # batch instead.
+      it "stays claimed when Active Job does not define the wrapped method" do
+        start_agent
+        # `install` does its work inside an `ActiveSupport.on_load(:active_job)`
+        # block, which only runs once `ActiveJob::Base` is loaded. Load it here
+        # so this example does not rely on an earlier one having loaded it.
+        _base = ::ActiveJob::Base
+
+        allow(::ActiveJob.singleton_class)
+          .to receive(:private_method_defined?).and_call_original
+        allow(::ActiveJob.singleton_class)
+          .to receive(:private_method_defined?)
+          .with(:instrument_enqueue_all)
+          .and_return(false)
+
+        # Asserted as a message never sent, rather than as an absence from the
+        # ancestors, because an earlier example may already have installed the
+        # hook for real.
+        expect(::ActiveJob.singleton_class)
+          .to_not receive(:prepend).with(bulk_enqueue_instrumentation)
+
+        logs = capture_logs { described_class.new.install }
+
+        expect(Appsignal::EventFormatter.record?("enqueue_all.active_job"))
+          .to be(false)
+        expect(logs).to contains_log(
+          :debug,
+          "Not instrumenting Active Job bulk enqueues: this version of " \
+            "Active Job does not record them through " \
+            "`ActiveJob.instrument_enqueue_all`."
+        )
+      end
+
+      it "stays claimed when the wrapped method takes other parameters" do
+        start_agent
+        _base = ::ActiveJob::Base
+
+        allow(described_class)
+          .to receive(:instrument_enqueue_all_defined?).and_return(true)
+        allow(described_class)
+          .to receive(:instrument_enqueue_all_parameters)
+          .and_return([[:req, :queue_adapter], [:req, :jobs], [:key, :batch]])
+
+        expect(::ActiveJob.singleton_class)
+          .to_not receive(:prepend).with(bulk_enqueue_instrumentation)
+
+        logs = capture_logs { described_class.new.install }
+
+        expect(Appsignal::EventFormatter.record?("enqueue_all.active_job"))
+          .to be(false)
+        expect(logs).to contains_log(
+          :warn,
+          "Not instrumenting Active Job bulk enqueues: " \
+            "`ActiveJob.instrument_enqueue_all` takes " \
+            "[[:req, :queue_adapter], [:req, :jobs], [:key, :batch]] in this " \
+            "version of Active Job, where AppSignal expects " \
+            "[[:req, :queue_adapter], [:req, :jobs]]."
+        )
+      end
+
+      def bulk_enqueue_instrumentation
+        Appsignal::Hooks::ActiveJobHook::ActiveJobBulkEnqueueInstrumentation
+      end
+    end
+
     describe "claiming the enqueue.active_job event" do
       # The event formatter registry is shared by the whole test suite, so
       # put back whatever this example changes. Reloading the hook file
@@ -796,6 +912,216 @@ if DependencyHelper.active_job_present? && DependencyHelper.rails_present?
           expect(event_spans_for("enqueue.active_job")).to be_empty
           expect(job.serialize).to_not have_key("__otel_headers")
           expect(ActiveJob::Base.queue_adapter.enqueued_jobs.count).to eq(1)
+        end
+      end
+    end
+
+    if DependencyHelper.rails7_1_present?
+      context "when enqueuing jobs in bulk" do
+        before { ActiveJob::Base.queue_adapter = :test }
+
+        let(:jobs) { Array.new(3) { ActiveJobTestJob.new } }
+
+        # Returns the enqueuing transaction so the example can read its events.
+        def bulk_enqueue_within_transaction
+          transaction = http_request_transaction
+          set_current_transaction(transaction)
+          ActiveJob.perform_all_later(jobs)
+          transaction
+        end
+
+        def bulk_enqueue_events(transaction)
+          transaction.to_h["events"]
+            .select { |event| event["name"] == "enqueue_all.active_job" }
+        end
+
+        describe "records the batch as one event" do
+          it "in agent mode", :agent_mode do
+            start_agent(**start_agent_args)
+            transaction = bulk_enqueue_within_transaction
+
+            # Exactly one event for the batch: ours. Active Job's native
+            # `enqueue_all.active_job` notification is claimed so it isn't
+            # recorded a second time.
+            events = bulk_enqueue_events(transaction)
+            expect(events.size).to eq(1)
+            expect(events.first["title"]).to eq("bulk enqueue ActiveJobTestJob jobs")
+            # And no per-job enqueue event alongside it.
+            event_names = transaction.to_h["events"].map { |event| event["name"] }
+            expect(event_names).to_not include("enqueue.active_job")
+            expect(ActiveJob::Base.queue_adapter.enqueued_jobs.count).to eq(3)
+          end
+
+          it "in collector mode", :collector_mode do
+            start_collector_agent
+            bulk_enqueue_within_transaction
+            Appsignal::Transaction.complete_current!
+
+            producer = event_span_for("enqueue_all.active_job")
+            expect(producer.name).to eq(
+              "enqueue_all.active_job (bulk enqueue ActiveJobTestJob jobs)"
+            )
+            expect(producer.kind).to eq(:producer)
+            expect(scope_of(producer))
+              .to eq(["appsignal-ruby/active_job", Appsignal::VERSION])
+            expect(producer.attributes["messaging.system"]).to eq("active_job")
+            expect(producer.attributes["messaging.operation.name"]).to eq("enqueue")
+            expect(producer.attributes["messaging.operation.type"]).to eq("send")
+            expect(producer.attributes["messaging.destination.name"]).to eq("default")
+            # The batch count is what marks this span as covering more than one
+            # message. A single enqueue must not carry it.
+            expect(producer.attributes["messaging.batch.message_count"]).to eq(3)
+            expect(producer.parent_span_id).to eq(root_span.span_id)
+            expect(event_spans_for("enqueue.active_job")).to be_empty
+          end
+        end
+
+        # Active Job groups the jobs it enqueues by queue adapter rather than by
+        # class or by queue, so one batch can cover several of each, and then
+        # there is no one class to name it after and no one queue to report.
+        context "with jobs of more than one class and queue" do
+          let(:jobs) { [ActiveJobTestJob.new, ActiveJobCustomQueueTestJob.new] }
+
+          describe "records the batch without naming a class or a queue" do
+            it "in agent mode", :agent_mode do
+              start_agent(**start_agent_args)
+              transaction = bulk_enqueue_within_transaction
+
+              events = bulk_enqueue_events(transaction)
+              expect(events.size).to eq(1)
+              expect(events.first["title"]).to eq("bulk enqueue jobs")
+            end
+
+            it "in collector mode", :collector_mode do
+              start_collector_agent
+              bulk_enqueue_within_transaction
+              Appsignal::Transaction.complete_current!
+
+              producer = event_span_for("enqueue_all.active_job")
+              expect(producer.name).to eq("enqueue_all.active_job (bulk enqueue jobs)")
+              expect(producer.attributes).to_not have_key("messaging.destination.name")
+              expect(producer.attributes["messaging.batch.message_count"]).to eq(2)
+            end
+          end
+        end
+
+        describe "suppresses nested adapter enqueue events while enqueuing" do
+          # The window in which a nested adapter integration (Sidekiq, Resque,
+          # ...) would record an event per job in the batch, which Active Job
+          # suppresses so the batch is recorded once.
+          def suppressed_during_enqueue
+            captured = []
+            adapter = ActiveJob::Base.queue_adapter
+            allow(adapter).to receive(:enqueue).and_wrap_original do |method, *args|
+              captured << Appsignal::Transaction.current.job_enqueue_events_suppressed?
+              method.call(*args)
+            end
+            bulk_enqueue_within_transaction
+            captured
+          end
+
+          it "in agent mode", :agent_mode do
+            start_agent(**start_agent_args)
+
+            expect(suppressed_during_enqueue).to eq([true, true, true])
+          end
+
+          it "in collector mode", :collector_mode do
+            start_collector_agent
+
+            expect(suppressed_during_enqueue).to eq([true, true, true])
+          end
+        end
+
+        # The `:test` adapter has no `enqueue_all`, so a bulk enqueue through it
+        # falls back to enqueuing each job on its own. Sidekiq's adapter does
+        # have one, and that is the path the duplicated events were reported on,
+        # so it needs covering too.
+        context "with an adapter that enqueues the batch itself" do
+          before do
+            stub_const(
+              "ActiveJobBulkTestAdapter",
+              Class.new(ActiveJob::QueueAdapters::TestAdapter) do
+                attr_reader :enqueue_all_calls, :suppressed_during_enqueue_all
+
+                def enqueue_all(jobs)
+                  @enqueue_all_calls = (@enqueue_all_calls || 0) + 1
+                  @suppressed_during_enqueue_all =
+                    Appsignal::Transaction.current.job_enqueue_events_suppressed?
+                  jobs.each { |job| enqueue(job) }
+                  jobs.size
+                end
+              end
+            )
+            ActiveJob::Base.queue_adapter = ActiveJobBulkTestAdapter.new
+          end
+
+          describe "records one event and suppresses the adapter's own" do
+            it "in agent mode", :agent_mode do
+              start_agent(**start_agent_args)
+              transaction = bulk_enqueue_within_transaction
+
+              adapter = ActiveJob::Base.queue_adapter
+              expect(adapter.enqueue_all_calls).to eq(1)
+              expect(adapter.suppressed_during_enqueue_all).to be(true)
+              expect(bulk_enqueue_events(transaction).size).to eq(1)
+            end
+
+            it "in collector mode", :collector_mode do
+              start_collector_agent
+              bulk_enqueue_within_transaction
+              Appsignal::Transaction.complete_current!
+
+              adapter = ActiveJob::Base.queue_adapter
+              expect(adapter.enqueue_all_calls).to eq(1)
+              expect(adapter.suppressed_during_enqueue_all).to be(true)
+              expect(event_spans_for("enqueue_all.active_job").size).to eq(1)
+            end
+          end
+        end
+
+        describe "is a transparent pass-through without an active transaction" do
+          it "in agent mode", :agent_mode do
+            start_agent(**start_agent_args)
+
+            expect do
+              ActiveJob.perform_all_later(jobs)
+            end.to_not(change { created_transactions.count })
+
+            expect(ActiveJob::Base.queue_adapter.enqueued_jobs.count).to eq(3)
+          end
+
+          it "in collector mode", :collector_mode do
+            start_collector_agent
+
+            ActiveJob.perform_all_later(jobs)
+
+            expect(event_spans_for("enqueue_all.active_job")).to be_empty
+            expect(ActiveJob::Base.queue_adapter.enqueued_jobs.count).to eq(3)
+          end
+        end
+
+        context "when enqueue instrumentation is disabled" do
+          let(:options) { { :enable_job_enqueue_instrumentation => false } }
+
+          describe "records no event but still enqueues the jobs" do
+            it "in agent mode", :agent_mode do
+              start_agent(**start_agent_args)
+              transaction = bulk_enqueue_within_transaction
+
+              expect(bulk_enqueue_events(transaction)).to be_empty
+              expect(ActiveJob::Base.queue_adapter.enqueued_jobs.count).to eq(3)
+            end
+
+            it "in collector mode", :collector_mode do
+              start_collector_agent
+              bulk_enqueue_within_transaction
+              Appsignal::Transaction.complete_current!
+
+              expect(event_spans_for("enqueue_all.active_job")).to be_empty
+              expect(ActiveJob::Base.queue_adapter.enqueued_jobs.count).to eq(3)
+            end
+          end
         end
       end
     end

--- a/spec/lib/appsignal/hooks/activejob_spec.rb
+++ b/spec/lib/appsignal/hooks/activejob_spec.rb
@@ -976,6 +976,61 @@ if DependencyHelper.active_job_present? && DependencyHelper.rails_present?
           end
         end
 
+        describe "writes the producer span's context onto every job" do
+          it "in collector mode", :collector_mode do
+            start_collector_agent
+            bulk_enqueue_within_transaction
+            Appsignal::Transaction.complete_current!
+
+            producer = event_span_for("enqueue_all.active_job")
+            expected_traceparent =
+              "00-#{producer.hex_trace_id}-#{producer.hex_span_id}-01"
+
+            enqueued = ActiveJob::Base.queue_adapter.enqueued_jobs
+            expect(enqueued.size).to eq(3)
+            # Every job in the batch carries the one producer span's context,
+            # plus the marker that says it came from a batch. That marker is what
+            # tells the performing job to link back rather than parent under a
+            # span it shares with every other job in the batch.
+            enqueued.each do |job|
+              expect(job["__otel_headers"]).to eq(
+                [
+                  ["traceparent", expected_traceparent],
+                  [Appsignal::OpenTelemetry::ACTIVE_JOB_BATCH_HEADER, "1"]
+                ]
+              )
+            end
+          end
+
+          it "writes nothing onto the jobs in agent mode", :agent_mode do
+            start_agent(**start_agent_args)
+            bulk_enqueue_within_transaction
+
+            ActiveJob::Base.queue_adapter.enqueued_jobs.each do |job|
+              expect(job).to_not have_key("__otel_headers")
+            end
+          end
+        end
+
+        context "when enqueue instrumentation is disabled for the batch" do
+          let(:options) { { :enable_job_enqueue_instrumentation => false } }
+
+          # Without an enqueue event there is no producer span, so the context
+          # that would be written is whatever span is current, such as the
+          # surrounding web request. The jobs would then link back to a span that
+          # is not a producer, so nothing is written at all.
+          it "writes no trace context onto the jobs", :collector_mode do
+            start_collector_agent
+            bulk_enqueue_within_transaction
+            Appsignal::Transaction.complete_current!
+
+            expect(event_spans_for("enqueue_all.active_job")).to be_empty
+            ActiveJob::Base.queue_adapter.enqueued_jobs.each do |job|
+              expect(job).to_not have_key("__otel_headers")
+            end
+          end
+        end
+
         # Active Job groups the jobs it enqueues by queue adapter rather than by
         # class or by queue, so one batch can cover several of each, and then
         # there is no one class to name it after and no one queue to report.

--- a/spec/lib/appsignal/hooks/activejob_spec.rb
+++ b/spec/lib/appsignal/hooks/activejob_spec.rb
@@ -867,6 +867,43 @@ if DependencyHelper.active_job_present? && DependencyHelper.rails_present?
         end
       end
 
+      # This is the standalone path, for a queue adapter with no AppSignal
+      # integration of its own to start the transaction.
+      describe "linking a bulk-enqueued job back to the enqueuer" do
+        # A job from a bulk enqueue carries a marker alongside its trace
+        # context, because every job in the batch shares one producer span.
+        def perform_with_batch_context
+          job_data = ActiveJobTestJob.new.serialize.merge(
+            "__otel_headers" => [
+              ["traceparent", traceparent],
+              [Appsignal::OpenTelemetry::ACTIVE_JOB_BATCH_HEADER, "1"]
+            ]
+          )
+          perform_active_job { ActiveJob::Base.execute(job_data) }
+        end
+
+        it "in collector mode", :collector_mode do
+          start_collector_agent
+          perform_with_batch_context
+
+          # Every job in the batch shares the one producer span, so the job only
+          # links back to it. It gets its own trace instead of hanging the whole
+          # batch off that span.
+          expect(root_span.kind).to eq(:consumer)
+          expect(root_span.parent_span_id).to eq(::OpenTelemetry::Trace::INVALID_SPAN_ID)
+          expect(root_span.hex_trace_id).to_not eq(trace_id_hex)
+          expect(root_span.links.size).to eq(1)
+          expect(root_span.links.first.span_context.hex_trace_id).to eq(trace_id_hex)
+        end
+
+        it "in agent mode", :agent_mode do
+          start_agent(**start_agent_args)
+          perform_with_batch_context
+
+          expect(last_transaction.to_h["metadata"].keys).to_not include("__otel_headers")
+        end
+      end
+
       context "when enqueue instrumentation is disabled" do
         let(:options) { { :enable_job_enqueue_instrumentation => false } }
         before { ActiveJob::Base.queue_adapter = :test }

--- a/spec/lib/appsignal/integrations/delayed_job_plugin_spec.rb
+++ b/spec/lib/appsignal/integrations/delayed_job_plugin_spec.rb
@@ -368,6 +368,47 @@ if DependencyHelper.delayed_job_present?
         end
       end
 
+      # A job from an Active Job bulk enqueue carries a marker alongside its
+      # trace context, because every job in the batch shares one producer span.
+      context "with an Active Job job from a bulk enqueue" do
+        let(:trace_id_hex) { "0af7651916cd43dd8448eb211c80319c" }
+        let(:span_id_hex) { "b7ad6b7169203331" }
+        let(:traceparent) { "00-#{trace_id_hex}-#{span_id_hex}-01" }
+        let(:job) do
+          wrapper = Struct.new(:job_data) do
+            def perform
+            end
+          end
+          Delayed::Job.enqueue(
+            wrapper.new(
+              {
+                "job_class" => "DelayedActiveJob",
+                "arguments" => [],
+                "__otel_headers" => [
+                  ["traceparent", traceparent],
+                  [Appsignal::OpenTelemetry::ACTIVE_JOB_BATCH_HEADER, "1"]
+                ]
+              }
+            )
+          )
+        end
+
+        it "in collector mode", :collector_mode do
+          start_collector_agent
+
+          perform_job(job)
+
+          # Every job in the batch shares the one producer span, so the job
+          # only links back to it. It gets its own trace instead of hanging the
+          # whole batch off that span.
+          expect(root_span.kind).to eq(:consumer)
+          expect(root_span.parent_span_id).to eq(::OpenTelemetry::Trace::INVALID_SPAN_ID)
+          expect(root_span.hex_trace_id).to_not eq(trace_id_hex)
+          expect(root_span.links.size).to eq(1)
+          expect(root_span.links.first.span_context.hex_trace_id).to eq(trace_id_hex)
+        end
+      end
+
       # What a deploy that removes a job class leaves behind: jobs whose stored
       # handler names a class that is gone. Created straight through the backend,
       # because `Delayed::Job.enqueue` stores the live object next to the handler

--- a/spec/lib/appsignal/integrations/que_spec.rb
+++ b/spec/lib/appsignal/integrations/que_spec.rb
@@ -498,6 +498,53 @@ if DependencyHelper.que_present?
         end
       end
 
+      # A job from an Active Job bulk enqueue carries a marker alongside its
+      # trace context, because every job in the batch shares one producer span.
+      context "with incoming trace context from an Active Job bulk enqueue" do
+        let(:trace_id_hex) { "0af7651916cd43dd8448eb211c80319c" }
+        let(:span_id_hex) { "b7ad6b7169203331" }
+        let(:traceparent) { "00-#{trace_id_hex}-#{span_id_hex}-01" }
+        let(:job_attrs) do
+          super().merge(
+            :job_class => Appsignal::Integrations::QueTraceContext::ACTIVE_JOB_WRAPPER,
+            :args => [
+              {
+                :job_class => "MyActiveJob",
+                :arguments => [],
+                :__otel_headers => [
+                  ["traceparent", traceparent],
+                  [Appsignal::OpenTelemetry::ACTIVE_JOB_BATCH_HEADER, "1"]
+                ]
+              }
+            ]
+          )
+        end
+        let(:job) do
+          Class.new(::Que::Job) do
+            def run(job_data)
+            end
+          end
+        end
+
+        def perform
+          perform_que_job(instance)
+        end
+
+        it "in collector mode", :collector_mode do
+          start_collector_agent
+          perform
+
+          # Every job in the batch shares the one producer span, so the job
+          # only links back to it. It gets its own trace instead of hanging the
+          # whole batch off that span.
+          expect(root_span.kind).to eq(:consumer)
+          expect(root_span.parent_span_id).to eq(::OpenTelemetry::Trace::INVALID_SPAN_ID)
+          expect(root_span.hex_trace_id).to_not eq(trace_id_hex)
+          expect(root_span.links.size).to eq(1)
+          expect(root_span.links.first.span_context.hex_trace_id).to eq(trace_id_hex)
+        end
+      end
+
       # A job enqueued by a service that instruments Que but not Active Job has
       # no Active Job carrier to read, so the job's tags are what the trace has
       # to be continued from.

--- a/spec/lib/appsignal/integrations/resque_spec.rb
+++ b/spec/lib/appsignal/integrations/resque_spec.rb
@@ -225,6 +225,50 @@ if DependencyHelper.resque_present?
         end
       end
 
+      # A job from an Active Job bulk enqueue carries a marker alongside its
+      # trace context, because every job in the batch shares one producer span.
+      context "with an Active Job job from a bulk enqueue" do
+        let(:wrapper) { Appsignal::Integrations::ResqueHelpers::ACTIVE_JOB_WRAPPER }
+
+        before do
+          stub_const(wrapper, Class.new do
+            def self.perform(*)
+            end
+          end)
+        end
+
+        def perform
+          perform_rescue_job(
+            wrapper,
+            "args" => [
+              {
+                "job_class" => "ResqueTestJob",
+                "arguments" => [],
+                "__otel_headers" => [
+                  ["traceparent", traceparent],
+                  [Appsignal::OpenTelemetry::ACTIVE_JOB_BATCH_HEADER, "1"]
+                ]
+              }
+            ]
+          )
+        end
+
+        it "in collector mode", :collector_mode do
+          start_collector_agent
+          expect(Appsignal).to receive(:stop)
+          perform
+
+          # Every job in the batch shares the one producer span, so the job
+          # only links back to it. It gets its own trace instead of hanging the
+          # whole batch off that span.
+          expect(root_span.kind).to eq(:consumer)
+          expect(root_span.parent_span_id).to eq(::OpenTelemetry::Trace::INVALID_SPAN_ID)
+          expect(root_span.hex_trace_id).to_not eq(trace_id_hex)
+          expect(root_span.links.size).to eq(1)
+          expect(root_span.links.first.span_context.hex_trace_id).to eq(trace_id_hex)
+        end
+      end
+
       # A job enqueued by a service that instruments Resque but not Active Job
       # has no Active Job carrier to read, so the Resque job's own header is what
       # the trace has to be continued from.

--- a/spec/lib/appsignal/integrations/shoryuken_spec.rb
+++ b/spec/lib/appsignal/integrations/shoryuken_spec.rb
@@ -347,6 +347,38 @@ describe Appsignal::Integrations::ShoryukenMiddleware do
       end
     end
 
+    # A job from an Active Job bulk enqueue carries a marker alongside its trace
+    # context, because every job in the batch shares one producer span.
+    context "with an Active Job job from a bulk enqueue" do
+      let(:sqs_msg) do
+        double(:message_id => "msg1", :attributes => {}, :message_attributes => {})
+      end
+      let(:body) do
+        {
+          "job_class" => "ShoryukenActiveJob",
+          "arguments" => [],
+          "__otel_headers" => [
+            ["traceparent", traceparent],
+            [Appsignal::OpenTelemetry::ACTIVE_JOB_BATCH_HEADER, "1"]
+          ]
+        }
+      end
+
+      it "in collector mode", :collector_mode do
+        start_collector_agent
+        perform_shoryuken_job
+
+        # Every job in the batch shares the one producer span, so the job
+        # only links back to it. It gets its own trace instead of hanging the
+        # whole batch off that span.
+        expect(root_span.kind).to eq(:consumer)
+        expect(root_span.parent_span_id).to eq(::OpenTelemetry::Trace::INVALID_SPAN_ID)
+        expect(root_span.hex_trace_id).to_not eq(trace_id_hex)
+        expect(root_span.links.size).to eq(1)
+        expect(root_span.links.first.span_context.hex_trace_id).to eq(trace_id_hex)
+      end
+    end
+
     # A message sent by a service that instruments the AWS SDK but not Active
     # Job has no Active Job carrier to read, so the message attributes are what
     # the trace has to be continued from.

--- a/spec/lib/appsignal/integrations/sidekiq_spec.rb
+++ b/spec/lib/appsignal/integrations/sidekiq_spec.rb
@@ -700,6 +700,47 @@ if DependencyHelper.sidekiq_present?
         end
       end
 
+      # A job from an Active Job bulk enqueue carries a marker alongside its
+      # trace context, because every job in the batch shares one producer span.
+      context "with an Active Job job from a bulk enqueue" do
+        let(:item) do
+          super().merge(
+            "wrapped" => "ActiveJobTestJob",
+            "args" => [
+              {
+                "job_class" => "ActiveJobTestJob",
+                "arguments" => [],
+                "__otel_headers" => [
+                  ["traceparent", traceparent],
+                  [Appsignal::OpenTelemetry::ACTIVE_JOB_BATCH_HEADER, "1"]
+                ]
+              }
+            ]
+          )
+        end
+
+        it "in agent mode", :agent_mode do
+          start_agent(**start_agent_args)
+          perform_sidekiq_job
+
+          expect(transaction.to_h["metadata"].keys).to_not include("__otel_headers")
+        end
+
+        it "in collector mode", :collector_mode do
+          start_collector_agent
+          perform_sidekiq_job
+
+          # Every job in the batch shares the one producer span, so the job
+          # only links back to it. It gets its own trace instead of hanging the
+          # whole batch off that span.
+          expect(root_span.kind).to eq(:consumer)
+          expect(root_span.parent_span_id).to eq(::OpenTelemetry::Trace::INVALID_SPAN_ID)
+          expect(root_span.hex_trace_id).to_not eq(trace_id_hex)
+          expect(root_span.links.size).to eq(1)
+          expect(root_span.links.first.span_context.hex_trace_id).to eq(trace_id_hex)
+        end
+      end
+
       # A job enqueued by a service that instruments Sidekiq but not Active Job
       # has no Active Job carrier to read, so the Sidekiq job's own header is
       # what the trace has to be continued from.

--- a/spec/lib/appsignal/opentelemetry_spec.rb
+++ b/spec/lib/appsignal/opentelemetry_spec.rb
@@ -480,6 +480,49 @@ if DependencyHelper.opentelemetry_present?
       end
     end
 
+    describe ".mark_active_job_batch and .active_job_batch?" do
+      let(:header) { Appsignal::OpenTelemetry::ACTIVE_JOB_BATCH_HEADER }
+
+      it "marks a carrier that something was injected into" do
+        headers = { "traceparent" => "00-x-y-01" }
+        described_class.mark_active_job_batch(headers)
+
+        expect(headers[header]).to eq("1")
+      end
+
+      # No context means no producer span to link back to, so the marker would
+      # have nothing to say.
+      it "leaves an empty carrier alone" do
+        headers = {}
+        described_class.mark_active_job_batch(headers)
+
+        expect(headers).to be_empty
+      end
+
+      it "reads the marker back off job data" do
+        expect(
+          described_class.active_job_batch?("__otel_headers" => { header => "1" })
+        ).to be(true)
+      end
+
+      # The serialized array-of-pairs shape a job arrives in over the wire.
+      it "reads the marker off the serialized shape" do
+        expect(
+          described_class.active_job_batch?("__otel_headers" => [[header, "1"]])
+        ).to be(true)
+      end
+
+      it "is false for a job that was not part of a batch" do
+        expect(
+          described_class.active_job_batch?(
+            "__otel_headers" => [["traceparent", "00-x-y-01"]]
+          )
+        ).to be(false)
+        expect(described_class.active_job_batch?({})).to be(false)
+        expect(described_class.active_job_batch?(nil)).to be(false)
+      end
+    end
+
     describe ".if_started" do
       it "does not run the block and returns nil when the SDK has not booted" do
         expect(described_class.started?).to be(false)


### PR DESCRIPTION
Fixes https://github.com/appsignal/appsignal-ruby/issues/1578 on the 5.x line. The
same fix for 4.x is #1591.

Stacked on #1593.

### [Record Active Job bulk enqueues as one event](https://github.com/appsignal/appsignal-ruby/commit/1116111ee6c1637e2fa5a0401fb1be69bdedf809)

Active Job's `perform_all_later` does not enqueue through
`ActiveJob::Base#enqueue`, so the wrapper that records an enqueue once
never runs for a batch. Nothing suppresses the queue adapter's own
enqueue instrumentation, and a batch of three jobs is therefore recorded
as Active Job's native batch notification plus one adapter event per
job. The batch is now recorded as a single producer event, with the
adapter's own events suppressed while it is enqueued, and it reports how
many jobs it covers. The method wrapped to do that is private, because
it is the only point that covers both the adapters that enqueue a batch
themselves and the ones Active Job falls back to enqueuing job by job.

The wrapper reads the batch out of that method's second argument, and
the method being private means a later version of Active Job can change
what it takes. Wrapping a method that takes something else raises an
`ArgumentError` inside every `ActiveJob.perform_all_later` call an
application makes, which breaks enqueuing and not just its
instrumentation. It is therefore wrapped only while its parameters are
the ones the wrapper was written against. A batch that cannot be
recorded that way goes unrecorded, because Active Job's own notification
is the worse event this hook set out to replace.

### [Carry trace context through a bulk enqueue](https://github.com/appsignal/appsignal-ruby/commit/08cae91305e03d05fdfb5cc4121768249ce2da76)

A bulk enqueue never goes through `ActiveJob::Base#enqueue`, so the
injection that writes the producer span's context onto a job never runs
for one, and a batch of jobs reached the worker carrying nothing. Write
the context onto every job in the batch from inside the batch's producer
event, which the adapter then serializes to the wire along with the rest
of the job. Each job is also marked as one of a batch, because the two
enqueue paths are indistinguishable by the time a job is performed, and
a batch has to be linked back to rather than parented under: every job
in it shares the one producer span, and a span can have only one parent.
The marker rides in the same carrier as the context, where no propagator
will read it as a trace header.

### [Link a bulk-enqueued job instead of parenting it](https://github.com/appsignal/appsignal-ruby/commit/1b3bfea551e77294ba3364e38f33cad9c3fbab19)

Every integration parents an Active Job job under the span that enqueued
it and links back to it as well. That is right for a job enqueued on its
own, which is the only job its producer span produced, but every job in
a bulk enqueue shares one producer span, and a span can have only one
parent, so parenting a whole batch would hang all of it off that single
span. Read the marker the enqueue side now writes and only link those.
Que already made this distinction for its own `bulk_enqueue`, from a
tag, so it now asks both. The rule itself lives next to the marker
rather than in each of the five integrations that needs it.

