### PR TITLE
Turn the agent's OpenTelemetry listener off

### DIFF
--- a/lib/appsignal/config.rb
+++ b/lib/appsignal/config.rb
@@ -581,6 +581,10 @@ module Appsignal
       ENV["_APPSIGNAL_ENABLE_HOST_METRICS"]          = config_hash[:enable_host_metrics].to_s
       ENV["_APPSIGNAL_ENABLE_STATSD"]                = config_hash[:enable_statsd].to_s
       ENV["_APPSIGNAL_ENABLE_NGINX_METRICS"]         = config_hash[:enable_nginx_metrics].to_s
+      # The gem never sends OpenTelemetry data to the agent, so it has no
+      # reason to listen for it. Written out rather than left to the agent's
+      # own default, so a value set in the environment cannot turn it on.
+      ENV["_APPSIGNAL_ENABLE_OPENTELEMETRY_HTTP"]    = "false"
       ENV["_APPSIGNAL_APP_ENV"]                      = env
       ENV["_APPSIGNAL_FILES_WORLD_ACCESSIBLE"]       = config_hash[:files_world_accessible].to_s
       ENV["_APPSIGNAL_FILTER_PARAMETERS"]            = config_hash[:filter_parameters].join(",")

--- a/spec/lib/appsignal/config_spec.rb
+++ b/spec/lib/appsignal/config_spec.rb
@@ -1355,6 +1355,7 @@ describe Appsignal::Config do
       expect(ENV.fetch("_APPSIGNAL_IGNORE_NAMESPACES", nil)).to eq "admin,private_namespace"
       expect(ENV.fetch("_APPSIGNAL_RUNNING_IN_CONTAINER", nil)).to eq "false"
       expect(ENV.fetch("_APPSIGNAL_ENABLE_HOST_METRICS", nil)).to eq "true"
+      expect(ENV.fetch("_APPSIGNAL_ENABLE_OPENTELEMETRY_HTTP", nil)).to eq "false"
       expect(ENV.fetch("_APPSIGNAL_HOSTNAME", nil)).to eq detected_hostname
       expect(ENV.fetch("_APPSIGNAL_HOST_ROLE", nil)).to eq ""
       expect(ENV.fetch("_APPSIGNAL_PLATFORM", nil)).to eq ""


### PR DESCRIPTION
The gem sends no OpenTelemetry data to the agent in either mode, so the
agent has no reason to listen for it. It does not listen today either,
because the setting defaults to off, but that default lives in the
agent and a value set in the environment reaches it before the gem
writes anything.

Writing the setting out makes the gem decide it. The port it binds is
also the collector's default port, so an agent listening on it next to
a collector on the same host is a conflict waiting to happen.

AppSignal for Python does the same as part of appsignal/appsignal-python#280.

[skip changeset]