### PR TITLE
Send collector data through the CA file and proxy

### DIFF
--- a/.changesets/apply-ca-file-path-and-http-proxy-in-collector-mode.md
+++ b/.changesets/apply-ca-file-path-and-http-proxy-in-collector-mode.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+The `ca_file_path` and `http_proxy` options now apply to the data sent to the collector in collector mode. Before this change they only applied to the data sent by the agent, so a custom certificate authority file or a proxy had no effect in collector mode.

--- a/lib/appsignal/opentelemetry.rb
+++ b/lib/appsignal/opentelemetry.rb
@@ -8,6 +8,7 @@ require "appsignal/opentelemetry/http_method"
 require "appsignal/opentelemetry/http_response"
 require "appsignal/opentelemetry/http_server_request"
 require "appsignal/opentelemetry/messaging"
+require "appsignal/opentelemetry/proxied_exporter"
 require "appsignal/opentelemetry/rendering"
 require "appsignal/opentelemetry/sql_db_system"
 
@@ -55,14 +56,16 @@ module Appsignal
         # resource for the tracer provider to keep all three in sync.
         resource = ::OpenTelemetry::SDK::Resources::Resource.default.merge(build_resource(config))
 
+        span_exporter = build_exporter(
+          ::OpenTelemetry::Exporter::OTLP::Exporter,
+          config,
+          :endpoint => "#{endpoint}/v1/traces"
+        )
+
         ::OpenTelemetry::SDK.configure do |c|
           c.resource = resource
           c.add_span_processor(
-            ::OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
-              ::OpenTelemetry::Exporter::OTLP::Exporter.new(
-                :endpoint => "#{endpoint}/v1/traces"
-              )
-            )
+            ::OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(span_exporter)
           )
         end
 
@@ -72,22 +75,26 @@ module Appsignal
         # `force_flush` is a no-op.
         ::OpenTelemetry.meter_provider =
           ::OpenTelemetry::SDK::Metrics::MeterProvider.new(:resource => resource)
+        metrics_exporter = build_exporter(
+          ::OpenTelemetry::Exporter::OTLP::Metrics::MetricsExporter,
+          config,
+          :endpoint => "#{endpoint}/v1/metrics"
+        )
         ::OpenTelemetry.meter_provider.add_metric_reader(
           ::OpenTelemetry::SDK::Metrics::Export::PeriodicMetricReader.new(
-            :exporter => ::OpenTelemetry::Exporter::OTLP::Metrics::MetricsExporter.new(
-              :endpoint => "#{endpoint}/v1/metrics"
-            )
+            :exporter => metrics_exporter
           )
         )
 
+        logs_exporter = build_exporter(
+          ::OpenTelemetry::Exporter::OTLP::Logs::LogsExporter,
+          config,
+          :endpoint => "#{endpoint}/v1/logs"
+        )
         ::OpenTelemetry.logger_provider =
           ::OpenTelemetry::SDK::Logs::LoggerProvider.new(:resource => resource)
         ::OpenTelemetry.logger_provider.add_log_record_processor(
-          ::OpenTelemetry::SDK::Logs::Export::BatchLogRecordProcessor.new(
-            ::OpenTelemetry::Exporter::OTLP::Logs::LogsExporter.new(
-              :endpoint => "#{endpoint}/v1/logs"
-            )
-          )
+          ::OpenTelemetry::SDK::Logs::Export::BatchLogRecordProcessor.new(logs_exporter)
         )
 
         @started = true
@@ -253,6 +260,27 @@ module Appsignal
       end
 
       private
+
+      # Build one OTLP exporter, applying the `ca_file_path` and `http_proxy`
+      # options to the requests it sends. The certificate file is a keyword
+      # argument the exporters accept; the proxy is not, so an exporter that
+      # needs one is a subclass that applies it to its own connection.
+      def build_exporter(base, config, **kwargs)
+        certificate_file = config[:ca_file_path].to_s
+        kwargs[:certificate_file] = certificate_file unless certificate_file.empty?
+
+        http_proxy = config[:http_proxy].to_s
+        return base.new(**kwargs) if http_proxy.empty?
+
+        proxied_exporter_class(base).new(:appsignal_http_proxy => http_proxy, **kwargs)
+      end
+
+      # A subclass of an OTLP exporter that routes its requests through a
+      # proxy. Built here rather than declared, because the exporter gems are
+      # only loaded once collector mode is configured.
+      def proxied_exporter_class(base)
+        Class.new(base) { include ProxiedExporter }
+      end
 
       # Whether a `__otel_headers` value is the array-of-`[key, value]`-pairs
       # shape produced by ActiveJob's argument serializer, so it can be turned

--- a/lib/appsignal/opentelemetry/proxied_exporter.rb
+++ b/lib/appsignal/opentelemetry/proxied_exporter.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "uri"
+
+module Appsignal
+  module OpenTelemetry
+    # @!visibility private
+    #
+    # Routes an OTLP exporter's requests through the proxy in the
+    # `http_proxy` config option.
+    #
+    # The exporters accept no proxy and expose no way to reach the connection
+    # they build. They do build it in one method, `http_connection`, which
+    # this module overrides to configure the connection it returns.
+    #
+    # This module is included into a subclass rather than prepended onto the
+    # exporter itself, so that an application using the OpenTelemetry gems for
+    # its own exporting is unaffected.
+    #
+    # That method is not part of the exporters' public API, so a later version
+    # can rename it, stop calling it, or return something other than a
+    # `Net::HTTP` from it. This module does not try to predict which of those
+    # happened by inspecting the method. It records whether it managed to
+    # configure a connection, and {#initialize} reports it when it did not, so
+    # a version we cannot proxy through is visible in the log rather than
+    # silently sending around the proxy.
+    module ProxiedExporter
+      def initialize(appsignal_http_proxy:, **kwargs)
+        @appsignal_http_proxy = appsignal_http_proxy
+        @appsignal_proxy_applied = false
+
+        # The exporters build their connection while they initialize, so by
+        # the time this returns the override below has either run or never
+        # will.
+        super(**kwargs)
+
+        return if @appsignal_proxy_applied
+
+        Appsignal.internal_logger.error(
+          "Not sending #{self.class.superclass} data through the proxy in " \
+            "the `http_proxy` option: this version of the OpenTelemetry " \
+            "exporters does not build its connection where AppSignal " \
+            "configures the proxy."
+        )
+      end
+
+      # Whether the proxy was applied to the connection this exporter sends
+      # through. False means the exporter sends straight to its endpoint.
+      def appsignal_proxy_applied?
+        @appsignal_proxy_applied
+      end
+
+      private
+
+      # Accepts and forwards whatever the exporter calls this with, because
+      # none of the arguments are read here. A version that adds an argument,
+      # positional or keyword, is passed straight through instead of raising
+      # on the way to `super`.
+      def http_connection(*args, **kwargs)
+        apply_appsignal_proxy(super)
+      end
+
+      # Point a connection at the proxy. Returns the connection either way, so
+      # an exporter whose connection cannot be proxied still sends its data.
+      def apply_appsignal_proxy(http)
+        return http unless http.respond_to?(:proxy_from_env=)
+
+        proxy = URI.parse(@appsignal_http_proxy)
+
+        # `Net::HTTP#proxy?` reads the address only when the connection is not
+        # taking its proxy from the environment, which it does by default.
+        http.proxy_from_env = false
+        http.proxy_address = proxy.host
+        http.proxy_port = proxy.port
+        http.proxy_user = proxy.user
+        http.proxy_pass = proxy.password
+
+        @appsignal_proxy_applied = true
+        http
+      end
+    end
+  end
+end

--- a/spec/integration/collector_mode_proxy_spec.rb
+++ b/spec/integration/collector_mode_proxy_spec.rb
@@ -1,0 +1,58 @@
+if DependencyHelper.opentelemetry_present?
+  describe "AppSignal collector mode proxy" do
+    before do
+      OTLPCollectorServer.clear
+      HTTPProxyServer.clear
+    end
+
+    it "sends every signal through the proxy in the http_proxy option" do
+      runner = Runner.new(
+        "collector_mode_emit",
+        :env => OTLPCollectorServer.env.merge(HTTPProxyServer.env)
+      )
+      runner.run
+
+      # A request sent through a proxy carries the whole URL in its request
+      # line, where one sent straight to the server carries only the path.
+      request_lines = Array.new(3) { HTTPProxyServer.listen[:line] }
+
+      expect(request_lines).to contain_exactly(
+        "POST #{OTLPCollectorServer.endpoint}/v1/traces HTTP/1.1",
+        "POST #{OTLPCollectorServer.endpoint}/v1/metrics HTTP/1.1",
+        "POST #{OTLPCollectorServer.endpoint}/v1/logs HTTP/1.1"
+      )
+
+      # The mock proxy answers requests itself rather than forwarding them,
+      # so nothing reaching the collector proves nothing went around it.
+      expect(OTLPCollectorServer.received.values.map(&:size)).to all(be_zero)
+    end
+
+    it "sends the credentials in the proxy address" do
+      proxy_with_credentials =
+        HTTPProxyServer.address.sub("http://", "http://user:secret@")
+      runner = Runner.new(
+        "collector_mode_emit",
+        :env => OTLPCollectorServer.env
+          .merge("APPSIGNAL_HTTP_PROXY" => proxy_with_credentials)
+      )
+      runner.run
+
+      authorizations = Array.new(3) { HTTPProxyServer.listen[:authorization] }
+
+      expect(authorizations)
+        .to eq(["Basic #{["user:secret"].pack("m0")}"] * 3)
+    end
+
+    it "sends straight to the collector when no proxy is configured" do
+      runner = Runner.new("collector_mode_emit", :env => OTLPCollectorServer.env)
+      runner.run
+
+      # Wait for every signal to reach the collector before asserting that the
+      # proxy saw none of them, so that an empty proxy cannot mean "not sent
+      # yet" rather than "not sent through the proxy".
+      OTLPCollectorServer::PATHS.each { |path| OTLPCollectorServer.listen_to(path) }
+
+      expect(HTTPProxyServer.received_count).to be_zero
+    end
+  end
+end

--- a/spec/lib/appsignal/opentelemetry_spec.rb
+++ b/spec/lib/appsignal/opentelemetry_spec.rb
@@ -176,6 +176,90 @@ if DependencyHelper.opentelemetry_present?
           )
         end
       end
+
+      describe "the certificate authority file" do
+        # The exporters take the certificate file as a keyword argument and
+        # apply it to their own connection, so all that is left to test here
+        # is that AppSignal hands it to them.
+        it "gives each exporter the file in the ca_file_path option" do
+          certificate_files = capture_exporter_option(:certificate_file) do
+            with_config(:ca_file_path => "/path/to/cacert.pem") do |ca_config|
+              described_class.configure(ca_config)
+            end
+          end
+
+          expect(certificate_files).to eq(["/path/to/cacert.pem"] * 3)
+        end
+      end
+
+      describe "the HTTP proxy" do
+        # The exporters take no proxy argument, so each one is subclassed and
+        # the connection it builds is configured through a method that is not
+        # part of its public API. This asserts the proxy reached all three
+        # connections, so a version of the exporters that builds its
+        # connection somewhere else fails here, naming the exporter, rather
+        # than sending around the proxy unnoticed.
+        #
+        # Whether those requests then really go through a proxy is covered end
+        # to end against a mock proxy in
+        # `spec/integration/collector_mode_proxy_spec.rb`.
+        it "applies the proxy in the http_proxy option to each exporter" do
+          exporters = capture_built_exporters do
+            with_config(:http_proxy => "http://proxy.example.com:8080") do |proxy_config|
+              described_class.configure(proxy_config)
+            end
+          end
+
+          expect(exporters.size).to eq(3)
+          expect(exporters.map(&:appsignal_proxy_applied?)).to eq([true] * 3)
+        end
+      end
+    end
+
+    # Run the block and return the value each OTLP exporter was built with for
+    # `option`, in the order they were built.
+    def capture_exporter_option(option)
+      values = []
+      [
+        ::OpenTelemetry::Exporter::OTLP::Exporter,
+        ::OpenTelemetry::Exporter::OTLP::Metrics::MetricsExporter,
+        ::OpenTelemetry::Exporter::OTLP::Logs::LogsExporter
+      ].each do |klass|
+        allow(klass).to receive(:new).and_wrap_original do |original, **kwargs|
+          values << kwargs[option]
+          original.call(**kwargs)
+        end
+      end
+
+      yield
+
+      values
+    end
+
+    # Run the block and return each OTLP exporter it built, in the order they
+    # were built. Captured where AppSignal builds them, rather than by stubbing
+    # the exporter classes, because a proxied exporter is an instance of a
+    # subclass built at configure time.
+    def capture_built_exporters
+      exporters = []
+      allow(described_class).to receive(:build_exporter)
+        .and_wrap_original do |original, *args, **kwargs|
+          original.call(*args, **kwargs).tap { |exporter| exporters << exporter }
+        end
+
+      yield
+
+      exporters
+    end
+
+    def with_config(options)
+      yield build_config(
+        :options => {
+          :name => "collector-mode-spec",
+          :push_api_key => "abc",
+          :collector_endpoint => "http://127.0.0.1:9090"
+        }.merge(options)
+      )
     end
 
     describe ".started?" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,15 +99,21 @@ RSpec.configure do |config|
   end
 
   config.before :suite do
-    # The OTLP mock server is only needed by collector-mode specs, which only
-    # run when the OpenTelemetry gems are installed. Always disable real network
-    # connections; when those specs run, relax the rule just enough to reach the
-    # mock server bound by `OTLPCollectorServer`.
+    # The mock servers are only needed by collector-mode specs, which only run
+    # when the OpenTelemetry gems are installed. Always disable real network
+    # connections; when those specs run, relax the rule just enough to reach
+    # the servers bound by `OTLPCollectorServer` and `HTTPProxyServer`.
     if DependencyHelper.opentelemetry_present?
-      # Boot first: the server binds an OS-assigned port, so its address is only
-      # known afterwards.
+      # Boot first: each server binds an OS-assigned port, so its address is
+      # only known afterwards.
       OTLPCollectorServer.boot!
-      WebMock.disable_net_connect!(:allow => "127.0.0.1:#{OTLPCollectorServer.port}")
+      HTTPProxyServer.boot!
+      WebMock.disable_net_connect!(
+        :allow => [
+          "127.0.0.1:#{OTLPCollectorServer.port}",
+          "127.0.0.1:#{HTTPProxyServer.port}"
+        ]
+      )
     else
       WebMock.disable_net_connect!
     end
@@ -115,6 +121,7 @@ RSpec.configure do |config|
 
   config.after do
     OTLPCollectorServer.clear if defined?(OTLPCollectorServer)
+    HTTPProxyServer.clear if defined?(HTTPProxyServer)
     Appsignal::OpenTelemetry.reset!
   end
 

--- a/spec/support/helpers/http_proxy_server.rb
+++ b/spec/support/helpers/http_proxy_server.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "socket"
+require "timeout"
+
+# A mock HTTP proxy used by the collector-mode proxy integration spec.
+#
+# It records the request line and the proxy authorization of everything sent
+# to it, and answers each request with an empty 200. It never forwards
+# anything on: the spec asserts on what reached the proxy, and on the mock
+# collector having received nothing as a result.
+#
+# A request sent through a proxy carries the whole URL in its request line,
+# where one sent straight to the server carries only the path. That is what
+# tells the two apart.
+#
+# Hand-rolled on top of `TCPServer` for the same reason as
+# {OTLPCollectorServer}: so the spec suite doesn't drag a web server gem into
+# every framework gemfile.
+module HTTPProxyServer
+  @received = Queue.new
+  @booted = false
+  @port = nil
+
+  class << self
+    # The port the mock proxy is bound to. Assigned by `boot!`, which binds to
+    # an OS-assigned free port rather than a fixed one, so concurrent suite
+    # runs on the same machine don't collide. `nil` until booted.
+    attr_reader :port
+
+    def address
+      "http://127.0.0.1:#{port}"
+    end
+
+    # Env vars that point a spawned runner's AppSignal config at this mock
+    # proxy. Returns a plain Hash so callers can merge in other env vars.
+    def env
+      { "APPSIGNAL_HTTP_PROXY" => address }
+    end
+
+    # Pop one received request, waiting for it to arrive. Returns a Hash with
+    # `:line` and `:authorization`.
+    def listen(timeout: 10)
+      Timeout.timeout(timeout) { @received.pop }
+    rescue Timeout::Error
+      raise "Timed out after #{timeout}s waiting for a request to the proxy."
+    end
+
+    def received_count
+      @received.size
+    end
+
+    def clear
+      @received.clear
+    end
+
+    def boot!
+      return if @booted
+
+      @server = TCPServer.new("127.0.0.1", 0)
+      @port = @server.addr[1]
+      @booted = true
+      @thread = Thread.new do
+        Thread.current.abort_on_exception = false
+        accept_loop
+      end
+    end
+
+    private
+
+    def accept_loop
+      loop do
+        client = @server.accept
+        Thread.new(client) { |c| handle(c) }
+      end
+    rescue IOError, Errno::EBADF
+      # Server socket was closed; exit the loop.
+    end
+
+    def handle(client)
+      request_line = client.gets
+      return unless request_line
+
+      headers = read_headers(client)
+      length = headers["content-length"].to_i
+      # Read the body, so the client is not left writing to a socket that
+      # closed before it finished.
+      client.read(length) if length.positive?
+
+      @received << {
+        :line => request_line.strip,
+        :authorization => headers["proxy-authorization"]
+      }
+
+      write_response(client)
+    rescue StandardError
+      # Swallow per-connection errors so a malformed request doesn't bring
+      # down the accept loop for the rest of the suite.
+    ensure
+      begin
+        client&.close
+      rescue StandardError
+        # ignore
+      end
+    end
+
+    def read_headers(client)
+      headers = {}
+      while (line = client.gets) && line != "\r\n"
+        key, _, value = line.strip.partition(":")
+        headers[key.downcase] = value.strip
+      end
+      headers
+    end
+
+    def write_response(client)
+      client.write("HTTP/1.1 200 OK\r\n")
+      client.write("Content-Type: application/x-protobuf\r\n")
+      client.write("Content-Length: 0\r\n")
+      client.write("Connection: close\r\n")
+      client.write("\r\n")
+    end
+  end
+end


### PR DESCRIPTION
The OTLP exporters are built with an endpoint and nothing else, so the
`ca_file_path` and `http_proxy` options do not reach the data sent in
collector mode. They do reach the data the agent sends, so a proxy or a
private certificate authority works in one mode and not the other.

The certificate file is a keyword argument the exporters accept. The
proxy is not, and they expose no way to reach the connection they send
through, so an exporter that needs a proxy is a subclass that applies
it to the connection its own `http_connection` returns.

That method is private, and the version range in `REQUIRED_GEMS` allows
a version that changes it to reach us. The override forwards whatever it
is called with, so an argument added to it does not raise on the way
through. It also records whether it managed to configure a connection,
so a version that no longer builds one there is reported in the log
instead of quietly sending around the proxy. A spec asserts the proxy
reached all three exporters, and an integration spec runs an application
against a mock proxy to check that the requests really go through one.

The same change for AppSignal for Python is in appsignal/appsignal-python#281.
