### PR TITLE
Report errored transactions with no action

### DIFF
--- a/lib/appsignal/transaction/opentelemetry_backend.rb
+++ b/lib/appsignal/transaction/opentelemetry_backend.rb
@@ -14,6 +14,12 @@ module Appsignal
     class OpenTelemetryBackend < BaseBackend
       TRACER_NAME = "appsignal-ruby"
 
+      # The action name given to a transaction that recorded an error without
+      # ever setting one. Bracketed so it reads as a marker rather than as a
+      # class the application defines, and so it sorts apart from real action
+      # names.
+      UNNAMED_ACTION = "[unnamed action]"
+
       # Guards the process-wide warn-once state, which transactions touch
       # concurrently on threaded servers. A constant so it is created once at
       # load time rather than lazily (which would race).
@@ -125,6 +131,7 @@ module Appsignal
         @start_time = Time.now
         @action_set = false
         @action = nil
+        @error_set = false
         @allocation_start = current_allocation_count
         @root_child_allocation_count = 0
 
@@ -317,6 +324,7 @@ module Appsignal
       # become their own incident. Each cause carries only the part of its
       # backtrace that is not shared (see `trim_shared_tail`).
       def set_error(class_name, message, backtrace, causes, _root_cause_missing)
+        @error_set = true
         span = current_span
         error_lines = Array(backtrace)
 
@@ -392,12 +400,12 @@ module Appsignal
         # `teardown` sets `@completed`, so this guard also makes the body
         # idempotent across a double `complete`, and skips it on `discard`.
         unless @completed
-          # Aggregate metrics are only emitted for a transaction that set an
-          # action to group by. An actionless transaction is never reported in
-          # agent mode, so it must contribute to no aggregate here either.
-          emit_queue_duration_metric if @action_set
+          # Settle the action first, because the allocation count metric below
+          # tags by `@action`, and this is what fills it in for a transaction
+          # the application never named.
+          resolve_missing_action
+          emit_queue_duration_metric if should_report?
           report_allocation_count
-          ignore_subtrace_without_action
         end
         teardown
       end
@@ -450,15 +458,38 @@ module Appsignal
         @span&.finish
       end
 
-      # A transaction that never set an action has nothing to group by, and agent
-      # mode does not report one at all. Collector mode cannot represent "no
-      # action", so the subtrace is flagged for the collector to drop instead,
-      # the same way `discard` does. The flag has to be set before `teardown`
-      # finishes the span, because attributes set on an ended span are dropped.
-      def ignore_subtrace_without_action
+      # Whether this transaction is reported at all. One that set an action is
+      # reported so it can be grouped under it. One that recorded an error is
+      # reported even without an action, because the failure is worth reporting
+      # even when we cannot say what failed. The agent draws the line in the
+      # same place: it drops a transaction only when it has neither.
+      def should_report?
+        @action_set || @error_set
+      end
+
+      # Decides what to do about a transaction that never set an action, which
+      # has nothing to group by. Collector mode cannot represent "no action", so
+      # it needs a name for the ones it reports and a way to drop the rest.
+      #
+      # A reported one is named after the marker. Leaving the action unset would
+      # not report nothing: the collector fills an empty action in from the span
+      # name, which here is the placeholder this backend opened the span with,
+      # and that reads as though it were the application's own action.
+      #
+      # The rest are noise, such as serving assets in development, so their
+      # subtrace is flagged for the collector to drop, the same way `discard`
+      # does.
+      #
+      # Both branches have to run before `teardown` finishes the span, because
+      # attributes set on an ended span are dropped.
+      def resolve_missing_action
         return if @action_set
 
-        @span&.set_attribute("appsignal.ignore_subtrace", true)
+        if should_report?
+          set_action(UNNAMED_ACTION)
+        else
+          @span&.set_attribute("appsignal.ignore_subtrace", true)
+        end
       end
 
       # Emits the queue duration as a distribution metric in both the
@@ -505,7 +536,7 @@ module Appsignal
           count - @root_child_allocation_count
         )
 
-        return unless @action_set && count.positive?
+        return unless should_report? && count.positive?
 
         namespace = display_namespace(@namespace)
         Appsignal::Metrics::OpenTelemetryBackend.increment_counter(

--- a/spec/lib/appsignal/integrations/railtie_spec.rb
+++ b/spec/lib/appsignal/integrations/railtie_spec.rb
@@ -422,7 +422,9 @@ if DependencyHelper.rails_present?
               expect(root_span.kind).to eq(:server)
               expect(root_span.attributes["appsignal.namespace"])
                 .to eq("web")
-              expect(root_span.attributes).to_not have_key("appsignal.action_name")
+              # Reported without an action, so it is named after the marker.
+              expect(root_span.attributes["appsignal.action_name"])
+                .to eq("[unnamed action]")
               event = root_span.events.find { |e| e.name == "exception" }
               expect(event).not_to be_nil
               expect(event.attributes["exception.type"]).to eq("ExampleStandardError")
@@ -788,7 +790,9 @@ if DependencyHelper.rails_present?
 
               expect(root_span.kind).to eq(:server)
               expect(root_span.attributes["appsignal.namespace"]).to eq("runner")
-              expect(root_span.attributes).to_not have_key("appsignal.action_name")
+              # Reported without an action, so it is named after the marker.
+              expect(root_span.attributes["appsignal.action_name"])
+                .to eq("[unnamed action]")
               event = root_span.events.find { |e| e.name == "exception" }
               expect(event).not_to be_nil
               expect(event.attributes["exception.type"]).to eq("ExampleStandardError")

--- a/spec/lib/appsignal/transaction/opentelemetry_backend_spec.rb
+++ b/spec/lib/appsignal/transaction/opentelemetry_backend_spec.rb
@@ -672,6 +672,26 @@ describe Appsignal::Transaction::OpenTelemetryBackend,
       backend.complete
     end
 
+    # A transaction reported under the unnamed action marker tags by the marker.
+    # The action is settled before the metrics are emitted, so the tag carries it
+    # rather than the nil the transaction had until then.
+    it "emits the allocation count metric under the unnamed action marker" do
+      @allocations = 100
+      backend = create_backend
+      @allocations = 300
+
+      expect(metrics).to receive(:increment_counter).with(
+        "transaction_allocation_count", 200, :namespace => "web"
+      )
+      expect(metrics).to receive(:increment_counter).with(
+        "transaction_allocation_count", 200,
+        :namespace => "web", :action => "[unnamed action]"
+      )
+
+      backend.set_error("ExampleException", "uh oh", ["line 1"], [], false)
+      backend.complete
+    end
+
     it "does not emit the allocation count metric when no action was set" do
       @allocations = 100
       backend = create_backend
@@ -1283,6 +1303,64 @@ describe Appsignal::Transaction::OpenTelemetryBackend,
         finished = finished_span(span)
         expect(finished.attributes["appsignal.action_name"]).to eq("PagesController#show")
         expect(finished.attributes).to_not have_key("appsignal.ignore_subtrace")
+      end
+    end
+
+    # The agent drops a transaction only when it has neither an action nor an
+    # error, so a failure is reported even when we cannot say what failed.
+    # Collector mode has to draw the line in the same place.
+    context "when an error was set but no action" do
+      it "names it after the unnamed action marker" do
+        backend = create_backend
+        backend.set_error("ExampleException", "uh oh", ["line 1"], [], false)
+        span = backend.instance_variable_get(:@span)
+        backend.complete
+
+        finished = finished_span(span)
+        expect(finished.attributes).to_not have_key("appsignal.ignore_subtrace")
+        expect(finished.attributes["appsignal.action_name"]).to eq("[unnamed action]")
+        # The collector reads an empty action from the span name, so the marker
+        # has to reach the name too. Otherwise the placeholder the span opened
+        # with would be reported as the action.
+        expect(finished.name).to eq("[unnamed action]")
+        event = finished.events.find { |e| e.name == "exception" }
+        expect(event.attributes["exception.type"]).to eq("ExampleException")
+      end
+
+      # The transaction is reported, so it aggregates like any other reported
+      # one. The metrics gate on an action being set, and the marker is one.
+      it "emits the aggregate metrics under the marker" do
+        backend = create_backend("background_job")
+        start_time = backend.instance_variable_get(:@start_time)
+
+        expect(Appsignal::Metrics::OpenTelemetryBackend)
+          .to receive(:add_distribution_value).with(
+            "transaction_queue_duration", be_within(1_000).of(5_000),
+            :namespace => "background"
+          )
+        expect(Appsignal::Metrics::OpenTelemetryBackend)
+          .to receive(:add_distribution_value).with(
+            "transaction_queue_duration", be_within(1_000).of(5_000),
+            :namespace => "background", :hostname => an_instance_of(String)
+          )
+
+        backend.set_queue_start(((start_time.to_f * 1000) - 5_000).round)
+        backend.set_error("ExampleException", "uh oh", ["line 1"], [], false)
+        backend.complete
+      end
+    end
+
+    # A transaction with neither an action nor an error is noise, such as serving
+    # assets in development, and stays dropped.
+    context "when neither an action nor an error was set" do
+      it "flags the subtrace as ignored" do
+        backend = create_backend
+        span = backend.instance_variable_get(:@span)
+        backend.complete
+
+        finished = finished_span(span)
+        expect(finished.attributes["appsignal.ignore_subtrace"]).to be(true)
+        expect(finished.attributes).to_not have_key("appsignal.action_name")
       end
     end
   end

--- a/spec/lib/appsignal_spec.rb
+++ b/spec/lib/appsignal_spec.rb
@@ -2327,7 +2327,10 @@ describe Appsignal do
           expect(root_span.kind).to eq(:server)
           expect(root_span.attributes["appsignal.namespace"])
             .to eq("web")
-          expect(root_span.attributes).not_to have_key("appsignal.action_name")
+          # `send_error` never sets an action, so the transaction is named after
+          # the marker rather than reported under the span's placeholder name.
+          expect(root_span.attributes["appsignal.action_name"])
+            .to eq("[unnamed action]")
 
           event = root_span.events.find { |e| e.name == "exception" }
           expect(event).not_to be_nil


### PR DESCRIPTION
Collector mode flags a transaction that never set an action with
`appsignal.ignore_subtrace`, so the collector drops it, on the grounds
that agent mode does not report one either. That is only half true. The
agent drops a transaction when it has neither an action nor an error, to
leave out noise like asset requests in development, and an error exempts
it. So a failure that AppSignal could not name was reported in agent
mode and thrown away in collector mode. Draw the line where the agent
draws it, and keep flagging a transaction that recorded neither.

Reporting one needs a name to report it under, and an action left unset
does not stay empty. The collector fills an empty action in from the
span name, which here is the placeholder the transaction span opened
with, and that reads as though it were the application's own action. So
these are named `[unnamed action]`, which says what it is. The aggregate
metrics were gated on an action having been set, standing in for the
transaction being reported at all, and they gate on that directly now.
The name is settled before they run, because they tag by it.

[skip changeset]
