### PR TITLE
Audit spec coverage across the build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 # This is a generated file by the `rake build_matrix:github:generate` task.
 # See `build_matrix.yml` for the build matrix.
 # Generate this file with `rake build_matrix:github:generate`.
-# Generated job count: 432
+# Generated job count: 433
 ---
 name: Ruby gem CI
 'on':
@@ -15046,3 +15046,40 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/no_dependencies.gemfile
+  spec_coverage_audit:
+    name: Spec coverage audit
+    needs: validation
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 180
+    permissions:
+      actions: read
+      contents: read
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.4'
+    - name: Wait for the test jobs to upload their example lists
+      env:
+        GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      run: |
+        jobs="repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs"
+        filter='.jobs[]
+          | select(.name != "Spec coverage audit")
+          | select(.status != "completed")
+          | .name'
+        while :; do
+          pending=$(gh api --paginate "$jobs?per_page=100" --jq "$filter" | wc -l)
+          if [ "$pending" -eq 0 ]; then break; fi
+          echo "Waiting for $pending jobs."
+          sleep 60
+        done
+    - name: Download example lists
+      uses: actions/download-artifact@v4
+      with:
+        path: artifacts
+    - name: Audit spec coverage
+      run: ruby script/audit_spec_coverage.rb artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,14 @@ jobs:
       run: "./script/bundler_wrapper exec rake test"
     - name: Run tests without extension
       run: "./script/bundler_wrapper exec rake test:failure"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -155,6 +163,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *1
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__no_dependencies-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -183,6 +199,14 @@ jobs:
     - &2
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__capistrano2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -209,6 +233,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *2
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__capistrano2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -237,6 +269,14 @@ jobs:
     - &3
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__capistrano3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -263,6 +303,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *3
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__capistrano3-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -291,6 +339,14 @@ jobs:
     - &4
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__code_ownership_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -317,6 +373,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *4
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__code_ownership-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -345,6 +409,14 @@ jobs:
     - &5
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__delayed_job_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -371,6 +443,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *5
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__delayed_job-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -399,6 +479,14 @@ jobs:
     - &6
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__dry-monitor_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -425,6 +513,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *6
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__dry-monitor-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -453,6 +549,14 @@ jobs:
     - &7
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__excon_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -479,6 +583,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *7
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__excon-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -507,6 +619,14 @@ jobs:
     - &8
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__faraday-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -533,6 +653,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *8
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__faraday-1-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -561,6 +689,14 @@ jobs:
     - &9
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__faraday-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -587,6 +723,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *9
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__faraday-2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -615,6 +759,14 @@ jobs:
     - &10
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__grape-3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -641,6 +793,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *10
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__grape-3-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -669,6 +829,14 @@ jobs:
     - &11
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__http5_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -695,6 +863,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *11
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__http5-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -723,6 +899,14 @@ jobs:
     - &12
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__http6_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -749,6 +933,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *12
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__http6-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -777,6 +969,14 @@ jobs:
     - &13
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__mongo_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -803,6 +1003,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *13
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__mongo-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -831,6 +1039,14 @@ jobs:
     - &14
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__ownership_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -857,6 +1073,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *14
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__ownership-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -885,6 +1109,14 @@ jobs:
     - &15
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__psych-3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -911,6 +1143,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *15
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__psych-3-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -939,6 +1179,14 @@ jobs:
     - &16
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__psych-4_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -965,6 +1213,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *16
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__psych-4-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -993,6 +1249,14 @@ jobs:
     - &17
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__que-0-14_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1019,6 +1283,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *17
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__que-0-14-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1047,6 +1319,14 @@ jobs:
     - &18
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__que-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1073,6 +1353,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *18
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__que-1-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1101,6 +1389,14 @@ jobs:
     - &19
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__que-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1127,6 +1423,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *19
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__que-2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1155,6 +1459,14 @@ jobs:
     - &20
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__rails-7-0_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1181,6 +1493,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *20
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__rails-7-0-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1209,6 +1529,14 @@ jobs:
     - &21
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__rails-7-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1235,6 +1563,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *21
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__rails-7-1-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1263,6 +1599,14 @@ jobs:
     - &22
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__rails-7-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1289,6 +1633,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *22
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__rails-7-2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1317,6 +1669,14 @@ jobs:
     - &23
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__rails-8-0_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1343,6 +1703,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *23
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__rails-8-0-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1371,6 +1739,14 @@ jobs:
     - &24
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__resque-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1397,6 +1773,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *24
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__resque-2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1425,6 +1809,14 @@ jobs:
     - &25
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__resque-3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1451,6 +1843,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *25
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__resque-3-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1479,6 +1879,14 @@ jobs:
     - &26
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__sequel_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1505,6 +1913,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *26
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__sequel-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1533,6 +1949,14 @@ jobs:
     - &27
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__shoryuken-7_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1559,6 +1983,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *27
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__shoryuken-7-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1587,6 +2019,14 @@ jobs:
     - &28
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__sinatra_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1613,6 +2053,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *28
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__sinatra-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1641,6 +2089,14 @@ jobs:
     - &29
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__webmachine2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1667,6 +2123,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *29
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__webmachine2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1695,6 +2159,14 @@ jobs:
     - &30
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__redis-4_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1721,6 +2193,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *30
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__redis-4-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1749,6 +2229,14 @@ jobs:
     - &31
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__redis-5_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1775,6 +2263,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *31
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__redis-5-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1803,6 +2299,14 @@ jobs:
     - &32
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__sidekiq-7_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1829,6 +2333,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *32
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__sidekiq-7-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1857,6 +2369,14 @@ jobs:
     - &33
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__sidekiq-8_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1883,6 +2403,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *33
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__sidekiq-8-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1912,6 +2440,14 @@ jobs:
       run: "./script/bundler_wrapper exec rake test"
     - name: Run tests without extension
       run: "./script/bundler_wrapper exec rake test:failure"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0_macos-14
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1942,6 +2478,14 @@ jobs:
       run: "./script/bundler_wrapper exec rake test"
     - name: Run tests without extension
       run: "./script/bundler_wrapper exec rake test:failure"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1968,6 +2512,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *34
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__no_dependencies-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -1996,6 +2548,14 @@ jobs:
     - &35
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__capistrano2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2022,6 +2582,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *35
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__capistrano2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2050,6 +2618,14 @@ jobs:
     - &36
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__capistrano3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2076,6 +2652,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *36
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__capistrano3-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2104,6 +2688,14 @@ jobs:
     - &37
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__code_ownership_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2130,6 +2722,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *37
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__code_ownership-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2158,6 +2758,14 @@ jobs:
     - &38
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__delayed_job_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2184,6 +2792,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *38
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__delayed_job-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2212,6 +2828,14 @@ jobs:
     - &39
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__dry-monitor_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2238,6 +2862,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *39
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__dry-monitor-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2266,6 +2898,14 @@ jobs:
     - &40
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__excon_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2292,6 +2932,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *40
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__excon-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2320,6 +2968,14 @@ jobs:
     - &41
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__faraday-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2346,6 +3002,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *41
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__faraday-1-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2374,6 +3038,14 @@ jobs:
     - &42
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__faraday-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2400,6 +3072,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *42
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__faraday-2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2428,6 +3108,14 @@ jobs:
     - &43
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__grape-3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2454,6 +3142,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *43
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__grape-3-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2482,6 +3178,14 @@ jobs:
     - &44
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__hanami-2-0_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2508,6 +3212,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *44
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__hanami-2-0-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2536,6 +3248,14 @@ jobs:
     - &45
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__hanami-2-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2562,6 +3282,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *45
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__hanami-2-1-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2590,6 +3318,14 @@ jobs:
     - &46
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__hanami-2-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2616,6 +3352,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *46
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__hanami-2-2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2644,6 +3388,14 @@ jobs:
     - &47
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__http5_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2670,6 +3422,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *47
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__http5-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2698,6 +3458,14 @@ jobs:
     - &48
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__http6_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2724,6 +3492,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *48
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__http6-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2752,6 +3528,14 @@ jobs:
     - &49
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__mongo_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2778,6 +3562,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *49
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__mongo-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2806,6 +3598,14 @@ jobs:
     - &50
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__ownership_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2832,6 +3632,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *50
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__ownership-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2860,6 +3668,14 @@ jobs:
     - &51
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__padrino_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2886,6 +3702,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *51
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__padrino-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2914,6 +3738,14 @@ jobs:
     - &52
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__psych-3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2940,6 +3772,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *52
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__psych-3-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2968,6 +3808,14 @@ jobs:
     - &53
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__psych-4_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -2994,6 +3842,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *53
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__psych-4-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3022,6 +3878,14 @@ jobs:
     - &54
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__que-0-14_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3048,6 +3912,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *54
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__que-0-14-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3076,6 +3948,14 @@ jobs:
     - &55
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__que-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3102,6 +3982,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *55
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__que-1-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3130,6 +4018,14 @@ jobs:
     - &56
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__que-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3156,6 +4052,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *56
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__que-2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3184,6 +4088,14 @@ jobs:
     - &57
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__rails-7-0_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3210,6 +4122,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *57
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__rails-7-0-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3238,6 +4158,14 @@ jobs:
     - &58
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__rails-7-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3264,6 +4192,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *58
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__rails-7-1-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3292,6 +4228,14 @@ jobs:
     - &59
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__rails-7-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3318,6 +4262,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *59
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__rails-7-2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3346,6 +4298,14 @@ jobs:
     - &60
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__rails-8-0_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3372,6 +4332,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *60
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__rails-8-0-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3400,6 +4368,14 @@ jobs:
     - &61
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__rails-8-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3426,6 +4402,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *61
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__rails-8-1-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3454,6 +4438,14 @@ jobs:
     - &62
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__resque-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3480,6 +4472,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *62
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__resque-2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3508,6 +4508,14 @@ jobs:
     - &63
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__resque-3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3534,6 +4542,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *63
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__resque-3-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3562,6 +4578,14 @@ jobs:
     - &64
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__sequel_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3588,6 +4612,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *64
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__sequel-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3616,6 +4648,14 @@ jobs:
     - &65
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__shoryuken-7_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3642,6 +4682,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *65
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__shoryuken-7-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3670,6 +4718,14 @@ jobs:
     - &66
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__sinatra_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3696,6 +4752,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *66
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__sinatra-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3724,6 +4788,14 @@ jobs:
     - &67
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__webmachine2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3750,6 +4822,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *67
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__webmachine2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3778,6 +4858,14 @@ jobs:
     - &68
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__redis-4_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3804,6 +4892,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *68
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__redis-4-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3832,6 +4928,14 @@ jobs:
     - &69
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__redis-5_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3858,6 +4962,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *69
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__redis-5-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3886,6 +4998,14 @@ jobs:
     - &70
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__sidekiq-7_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3912,6 +5032,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *70
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__sidekiq-7-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3940,6 +5068,14 @@ jobs:
     - &71
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__sidekiq-8_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3966,6 +5102,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *71
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__sidekiq-8-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -3995,6 +5139,14 @@ jobs:
       run: "./script/bundler_wrapper exec rake test"
     - name: Run tests without extension
       run: "./script/bundler_wrapper exec rake test:failure"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1_macos-14
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4025,6 +5177,14 @@ jobs:
       run: "./script/bundler_wrapper exec rake test"
     - name: Run tests without extension
       run: "./script/bundler_wrapper exec rake test:failure"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4051,6 +5211,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *72
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__no_dependencies-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4079,6 +5247,14 @@ jobs:
     - &73
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__capistrano2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4105,6 +5281,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *73
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__capistrano2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4133,6 +5317,14 @@ jobs:
     - &74
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__capistrano3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4159,6 +5351,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *74
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__capistrano3-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4187,6 +5387,14 @@ jobs:
     - &75
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__code_ownership_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4213,6 +5421,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *75
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__code_ownership-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4241,6 +5457,14 @@ jobs:
     - &76
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__delayed_job_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4267,6 +5491,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *76
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__delayed_job-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4295,6 +5527,14 @@ jobs:
     - &77
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__dry-monitor_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4321,6 +5561,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *77
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__dry-monitor-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4349,6 +5597,14 @@ jobs:
     - &78
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__excon_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4375,6 +5631,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *78
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__excon-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4403,6 +5667,14 @@ jobs:
     - &79
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__faraday-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4429,6 +5701,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *79
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__faraday-1-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4457,6 +5737,14 @@ jobs:
     - &80
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__faraday-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4483,6 +5771,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *80
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__faraday-2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4511,6 +5807,14 @@ jobs:
     - &81
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__grape-3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4537,6 +5841,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *81
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__grape-3-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4565,6 +5877,14 @@ jobs:
     - &82
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__hanami-2-0_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4591,6 +5911,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *82
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__hanami-2-0-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4619,6 +5947,14 @@ jobs:
     - &83
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__hanami-2-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4645,6 +5981,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *83
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__hanami-2-1-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4673,6 +6017,14 @@ jobs:
     - &84
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__hanami-2-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4699,6 +6051,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *84
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__hanami-2-2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4727,6 +6087,14 @@ jobs:
     - &85
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__http5_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4753,6 +6121,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *85
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__http5-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4781,6 +6157,14 @@ jobs:
     - &86
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__http6_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4807,6 +6191,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *86
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__http6-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4835,6 +6227,14 @@ jobs:
     - &87
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__mongo_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4861,6 +6261,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *87
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__mongo-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4889,6 +6297,14 @@ jobs:
     - &88
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__ownership_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4915,6 +6331,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *88
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__ownership-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4943,6 +6367,14 @@ jobs:
     - &89
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__padrino_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4969,6 +6401,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *89
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__padrino-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -4997,6 +6437,14 @@ jobs:
     - &90
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__psych-3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5023,6 +6471,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *90
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__psych-3-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5051,6 +6507,14 @@ jobs:
     - &91
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__psych-4_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5077,6 +6541,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *91
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__psych-4-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5105,6 +6577,14 @@ jobs:
     - &92
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__que-0-14_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5131,6 +6611,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *92
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__que-0-14-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5159,6 +6647,14 @@ jobs:
     - &93
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__que-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5185,6 +6681,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *93
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__que-1-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5213,6 +6717,14 @@ jobs:
     - &94
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__que-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5239,6 +6751,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *94
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__que-2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5267,6 +6787,14 @@ jobs:
     - &95
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__rails-6-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5293,6 +6821,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *95
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__rails-6-1-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5321,6 +6857,14 @@ jobs:
     - &96
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__rails-7-0_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5347,6 +6891,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *96
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__rails-7-0-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5375,6 +6927,14 @@ jobs:
     - &97
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__rails-7-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5401,6 +6961,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *97
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__rails-7-1-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5429,6 +6997,14 @@ jobs:
     - &98
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__rails-7-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5455,6 +7031,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *98
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__rails-7-2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5483,6 +7067,14 @@ jobs:
     - &99
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__rails-8-0_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5509,6 +7101,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *99
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__rails-8-0-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5537,6 +7137,14 @@ jobs:
     - &100
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__rails-8-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5563,6 +7171,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *100
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__rails-8-1-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5591,6 +7207,14 @@ jobs:
     - &101
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__resque-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5617,6 +7241,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *101
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__resque-2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5645,6 +7277,14 @@ jobs:
     - &102
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__resque-3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5671,6 +7311,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *102
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__resque-3-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5699,6 +7347,14 @@ jobs:
     - &103
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__sequel_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5725,6 +7381,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *103
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__sequel-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5753,6 +7417,14 @@ jobs:
     - &104
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__shoryuken-7_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5779,6 +7451,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *104
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__shoryuken-7-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5807,6 +7487,14 @@ jobs:
     - &105
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__sinatra_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5833,6 +7521,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *105
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__sinatra-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5861,6 +7557,14 @@ jobs:
     - &106
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__webmachine2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5887,6 +7591,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *106
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__webmachine2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5915,6 +7627,14 @@ jobs:
     - &107
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__redis-4_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5941,6 +7661,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *107
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__redis-4-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5969,6 +7697,14 @@ jobs:
     - &108
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__redis-5_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -5995,6 +7731,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *108
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__redis-5-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6024,6 +7768,14 @@ jobs:
       run: "./script/bundler_wrapper exec rake test"
     - name: Run tests without extension
       run: "./script/bundler_wrapper exec rake test:failure"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4_macos-14
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6054,6 +7806,14 @@ jobs:
       run: "./script/bundler_wrapper exec rake test"
     - name: Run tests without extension
       run: "./script/bundler_wrapper exec rake test:failure"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6080,6 +7840,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *109
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__no_dependencies-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6108,6 +7876,14 @@ jobs:
     - &110
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__capistrano2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6134,6 +7910,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *110
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__capistrano2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6162,6 +7946,14 @@ jobs:
     - &111
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__capistrano3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6188,6 +7980,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *111
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__capistrano3-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6216,6 +8016,14 @@ jobs:
     - &112
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__delayed_job_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6242,6 +8050,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *112
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__delayed_job-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6270,6 +8086,14 @@ jobs:
     - &113
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__dry-monitor_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6296,6 +8120,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *113
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__dry-monitor-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6324,6 +8156,14 @@ jobs:
     - &114
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__excon_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6350,6 +8190,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *114
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__excon-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6378,6 +8226,14 @@ jobs:
     - &115
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__faraday-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6404,6 +8260,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *115
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__faraday-1-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6432,6 +8296,14 @@ jobs:
     - &116
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__faraday-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6458,6 +8330,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *116
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__faraday-2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6486,6 +8366,14 @@ jobs:
     - &117
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__grape-3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6512,6 +8400,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *117
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__grape-3-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6540,6 +8436,14 @@ jobs:
     - &118
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__hanami-2-0_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6566,6 +8470,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *118
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__hanami-2-0-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6594,6 +8506,14 @@ jobs:
     - &119
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__hanami-2-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6620,6 +8540,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *119
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__hanami-2-1-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6648,6 +8576,14 @@ jobs:
     - &120
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__hanami-2-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6674,6 +8610,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *120
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__hanami-2-2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6702,6 +8646,14 @@ jobs:
     - &121
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__http5_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6728,6 +8680,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *121
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__http5-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6756,6 +8716,14 @@ jobs:
     - &122
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__http6_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6782,6 +8750,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *122
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__http6-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6810,6 +8786,14 @@ jobs:
     - &123
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__mongo_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6836,6 +8820,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *123
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__mongo-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6864,6 +8856,14 @@ jobs:
     - &124
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__ownership_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6890,6 +8890,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *124
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__ownership-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6918,6 +8926,14 @@ jobs:
     - &125
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__padrino_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6944,6 +8960,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *125
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__padrino-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6972,6 +8996,14 @@ jobs:
     - &126
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__psych-3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -6998,6 +9030,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *126
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__psych-3-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7026,6 +9066,14 @@ jobs:
     - &127
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__psych-4_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7052,6 +9100,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *127
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__psych-4-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7080,6 +9136,14 @@ jobs:
     - &128
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__que-0-14_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7106,6 +9170,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *128
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__que-0-14-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7134,6 +9206,14 @@ jobs:
     - &129
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__que-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7160,6 +9240,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *129
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__que-1-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7188,6 +9276,14 @@ jobs:
     - &130
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__que-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7214,6 +9310,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *130
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__que-2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7242,6 +9346,14 @@ jobs:
     - &131
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__rails-6-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7268,6 +9380,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *131
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__rails-6-1-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7296,6 +9416,14 @@ jobs:
     - &132
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__rails-7-0_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7322,6 +9450,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *132
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__rails-7-0-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7350,6 +9486,14 @@ jobs:
     - &133
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__rails-7-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7376,6 +9520,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *133
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__rails-7-1-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7404,6 +9556,14 @@ jobs:
     - &134
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__rails-7-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7430,6 +9590,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *134
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__rails-7-2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7458,6 +9626,14 @@ jobs:
     - &135
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__rails-8-0_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7484,6 +9660,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *135
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__rails-8-0-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7512,6 +9696,14 @@ jobs:
     - &136
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__rails-8-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7538,6 +9730,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *136
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__rails-8-1-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7566,6 +9766,14 @@ jobs:
     - &137
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__resque-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7592,6 +9800,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *137
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__resque-2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7620,6 +9836,14 @@ jobs:
     - &138
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__resque-3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7646,6 +9870,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *138
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__resque-3-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7674,6 +9906,14 @@ jobs:
     - &139
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__sequel_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7700,6 +9940,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *139
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__sequel-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7728,6 +9976,14 @@ jobs:
     - &140
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__shoryuken-7_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7754,6 +10010,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *140
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__shoryuken-7-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7782,6 +10046,14 @@ jobs:
     - &141
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__sinatra_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7808,6 +10080,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *141
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__sinatra-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7836,6 +10116,14 @@ jobs:
     - &142
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__webmachine2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7862,6 +10150,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *142
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__webmachine2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7890,6 +10186,14 @@ jobs:
     - &143
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__redis-4_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7916,6 +10220,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *143
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__redis-4-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7944,6 +10256,14 @@ jobs:
     - &144
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__redis-5_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7970,6 +10290,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *144
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5__redis-5-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -7999,6 +10327,14 @@ jobs:
       run: "./script/bundler_wrapper exec rake test"
     - name: Run tests without extension
       run: "./script/bundler_wrapper exec rake test:failure"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-2-5_macos-14
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8029,6 +10365,14 @@ jobs:
       run: "./script/bundler_wrapper exec rake test"
     - name: Run tests without extension
       run: "./script/bundler_wrapper exec rake test:failure"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8055,6 +10399,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *145
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__no_dependencies-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8083,6 +10435,14 @@ jobs:
     - &146
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__capistrano2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8109,6 +10469,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *146
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__capistrano2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8137,6 +10505,14 @@ jobs:
     - &147
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__capistrano3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8163,6 +10539,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *147
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__capistrano3-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8191,6 +10575,14 @@ jobs:
     - &148
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__delayed_job_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8217,6 +10609,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *148
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__delayed_job-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8245,6 +10645,14 @@ jobs:
     - &149
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__dry-monitor_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8271,6 +10679,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *149
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__dry-monitor-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8299,6 +10715,14 @@ jobs:
     - &150
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__excon_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8325,6 +10749,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *150
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__excon-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8353,6 +10785,14 @@ jobs:
     - &151
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__faraday-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8379,6 +10819,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *151
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__faraday-1-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8407,6 +10855,14 @@ jobs:
     - &152
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__faraday-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8433,6 +10889,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *152
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__faraday-2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8461,6 +10925,14 @@ jobs:
     - &153
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__grape-3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8487,6 +10959,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *153
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__grape-3-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8515,6 +10995,14 @@ jobs:
     - &154
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__hanami-2-0_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8541,6 +11029,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *154
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__hanami-2-0-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8569,6 +11065,14 @@ jobs:
     - &155
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__hanami-2-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8595,6 +11099,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *155
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__hanami-2-1-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8623,6 +11135,14 @@ jobs:
     - &156
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__hanami-2-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8649,6 +11169,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *156
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__hanami-2-2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8677,6 +11205,14 @@ jobs:
     - &157
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__http5_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8703,6 +11239,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *157
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__http5-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8731,6 +11275,14 @@ jobs:
     - &158
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__mongo_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8757,6 +11309,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *158
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__mongo-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8785,6 +11345,14 @@ jobs:
     - &159
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__ownership_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8811,6 +11379,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *159
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__ownership-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8839,6 +11415,14 @@ jobs:
     - &160
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__padrino_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8865,6 +11449,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *160
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__padrino-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8893,6 +11485,14 @@ jobs:
     - &161
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__psych-3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8919,6 +11519,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *161
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__psych-3-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8947,6 +11555,14 @@ jobs:
     - &162
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__psych-4_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -8973,6 +11589,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *162
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__psych-4-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9001,6 +11625,14 @@ jobs:
     - &163
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__que-0-14_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9027,6 +11659,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *163
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__que-0-14-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9055,6 +11695,14 @@ jobs:
     - &164
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__que-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9081,6 +11729,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *164
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__que-1-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9109,6 +11765,14 @@ jobs:
     - &165
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__que-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9135,6 +11799,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *165
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__que-2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9163,6 +11835,14 @@ jobs:
     - &166
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__rails-6-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9189,6 +11869,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *166
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__rails-6-1-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9217,6 +11905,14 @@ jobs:
     - &167
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__rails-7-0_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9243,6 +11939,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *167
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__rails-7-0-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9271,6 +11975,14 @@ jobs:
     - &168
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__rails-7-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9297,6 +12009,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *168
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__rails-7-1-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9325,6 +12045,14 @@ jobs:
     - &169
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__rails-7-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9351,6 +12079,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *169
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__rails-7-2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9379,6 +12115,14 @@ jobs:
     - &170
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__resque-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9405,6 +12149,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *170
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__resque-2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9433,6 +12185,14 @@ jobs:
     - &171
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__resque-3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9459,6 +12219,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *171
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__resque-3-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9487,6 +12255,14 @@ jobs:
     - &172
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__sequel_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9513,6 +12289,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *172
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__sequel-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9541,6 +12325,14 @@ jobs:
     - &173
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__shoryuken-6_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9567,6 +12359,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *173
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__shoryuken-6-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9595,6 +12395,14 @@ jobs:
     - &174
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__sinatra_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9621,6 +12429,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *174
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__sinatra-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9649,6 +12465,14 @@ jobs:
     - &175
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__webmachine2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9675,6 +12499,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *175
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__webmachine2-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9703,6 +12535,14 @@ jobs:
     - &176
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__redis-4_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9729,6 +12569,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *176
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__redis-4-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9757,6 +12605,14 @@ jobs:
     - &177
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__redis-5_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9783,6 +12639,14 @@ jobs:
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
     - *177
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6__redis-5-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9812,6 +12676,14 @@ jobs:
       run: "./script/bundler_wrapper exec rake test"
     - name: Run tests without extension
       run: "./script/bundler_wrapper exec rake test:failure"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-1-6_macos-14
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9841,6 +12713,14 @@ jobs:
       run: "./script/bundler_wrapper exec rake test"
     - name: Run tests without extension
       run: "./script/bundler_wrapper exec rake test:failure"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9868,6 +12748,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__capistrano2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9895,6 +12783,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__capistrano3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9922,6 +12818,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__delayed_job_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9949,6 +12853,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__dry-monitor_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -9976,6 +12888,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__excon_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10003,6 +12923,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__faraday-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10030,6 +12958,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__faraday-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10057,6 +12993,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__grape-3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10084,6 +13028,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__hanami-2-0_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10111,6 +13063,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__hanami-2-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10138,6 +13098,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__http5_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10165,6 +13133,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__mongo_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10192,6 +13168,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__ownership_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10219,6 +13203,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__padrino_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10246,6 +13238,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__psych-3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10273,6 +13273,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__psych-4_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10300,6 +13308,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__que-0-14_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10327,6 +13343,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__que-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10354,6 +13378,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__que-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10381,6 +13413,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__rails-6-0_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10408,6 +13448,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__rails-6-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10435,6 +13483,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__rails-7-0_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10462,6 +13518,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__rails-7-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10489,6 +13553,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__resque-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10516,6 +13588,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__resque-3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10543,6 +13623,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__sequel_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10570,6 +13658,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__shoryuken-6_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10597,6 +13693,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__sinatra_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10624,6 +13728,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__webmachine2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10651,6 +13763,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__redis-4_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10678,6 +13798,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7__redis-5_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10707,6 +13835,14 @@ jobs:
       run: "./script/bundler_wrapper exec rake test"
     - name: Run tests without extension
       run: "./script/bundler_wrapper exec rake test:failure"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-0-7_macos-14
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10736,6 +13872,14 @@ jobs:
       run: "./script/bundler_wrapper exec rake test"
     - name: Run tests without extension
       run: "./script/bundler_wrapper exec rake test:failure"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10763,6 +13907,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8__capistrano2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10790,6 +13942,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8__capistrano3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10817,6 +13977,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8__delayed_job_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10844,6 +14012,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8__excon_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10871,6 +14047,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8__faraday-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10898,6 +14082,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8__grape-3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10925,6 +14117,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8__http5_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10952,6 +14152,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8__mongo_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -10979,6 +14187,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8__ownership_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -11006,6 +14222,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8__padrino_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -11033,6 +14257,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8__psych-3_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -11060,6 +14292,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8__psych-4_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -11087,6 +14327,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8__que-0-14_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -11114,6 +14362,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8__que-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -11141,6 +14397,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8__que-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -11168,6 +14432,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8__rails-6-0_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -11195,6 +14467,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8__rails-6-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -11222,6 +14502,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8__rails-7-0_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -11249,6 +14537,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8__resque-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -11276,6 +14572,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8__sequel_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -11303,6 +14607,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8__shoryuken-6_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -11330,6 +14642,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8__sinatra_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -11357,6 +14677,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8__webmachine2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -11384,6 +14712,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8__redis-4_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -11411,6 +14747,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8__redis-5_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -11440,6 +14784,14 @@ jobs:
       run: "./script/bundler_wrapper exec rake test"
     - name: Run tests without extension
       run: "./script/bundler_wrapper exec rake test:failure"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_2-7-8_macos-14
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -11469,6 +14821,14 @@ jobs:
       run: "./script/bundler_wrapper exec rake test"
     - name: Run tests without extension
       run: "./script/bundler_wrapper exec rake test:failure"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_jruby-9-4-7-0_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -11496,6 +14856,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_jruby-9-4-7-0__rails-6-0_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -11523,6 +14891,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_jruby-9-4-7-0__rails-6-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -11550,6 +14926,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_jruby-9-4-7-0__rails-7-0_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -11577,6 +14961,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_jruby-9-4-7-0__rails-7-1_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -11604,6 +14996,14 @@ jobs:
         found'"
     - name: Run tests
       run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_jruby-9-4-7-0__rails-7-2_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''
@@ -11633,6 +15033,14 @@ jobs:
       run: "./script/bundler_wrapper exec rake test"
     - name: Run tests without extension
       run: "./script/bundler_wrapper exec rake test:failure"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_jruby-9-4-7-0_macos-14
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
     env:
       RAILS_ENV: test
       JRUBY_OPTS: ''

--- a/Rakefile
+++ b/Rakefile
@@ -448,14 +448,25 @@ begin
   excludes << "spec/lib/appsignal/extension/jruby_spec.rb" unless is_jruby
   exclude_pattern = "--exclude-pattern=#{excludes.join(",")}" if excludes.any?
 
+  # Written alongside the human-readable output so the coverage audit can tell
+  # which examples this Ruby and gemfile combination actually ran. Every CI job
+  # uploads its list. Nothing else reveals that a dependency guard is false in
+  # every combination, because a guarded example is then never defined at all.
+  def example_list_opts(name)
+    "--format json --out tmp/examples-#{name}.json"
+  end
+
   desc "Run the AppSignal gem test suite."
   RSpec::Core::RakeTask.new :test do |t|
-    t.rspec_opts = "#{exclude_pattern} --format documentation"
+    t.rspec_opts = "#{exclude_pattern} --format documentation " \
+      "#{example_list_opts("test")}"
   end
 
   namespace :test do
     RSpec::Core::RakeTask.new :rspec_failure do |t|
-      t.rspec_opts = "#{exclude_pattern} --tag extension_installation_failure"
+      t.rspec_opts = "#{exclude_pattern} --format documentation " \
+        "--tag extension_installation_failure " \
+        "#{example_list_opts("failure")}"
     end
 
     desc "Intentionally fail the extension installation"

--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,8 @@ VERSION_MANAGERS = {
   }
 }.freeze
 
+SPEC_COVERAGE_AUDIT_JOB_NAME = "Spec coverage audit"
+
 def build_job(ruby_version, ruby_gem: nil, runs_on: DEFAULT_RUNS_ON)
   name = "Ruby #{ruby_version}"
   name = "#{name} - #{ruby_gem}" if ruby_gem
@@ -72,6 +74,71 @@ def example_list_upload_step(key)
       "if-no-files-found" => "error",
       "retention-days" => 1
     }
+  }
+end
+
+# Compares the examples defined in the source against the union of every job's
+# example list.
+#
+# It cannot wait for the test jobs through `needs`. Naming all 426 of them puts
+# the workflow over a limit on how many dependency edges GitHub accepts, and
+# GitHub then refuses to create the run without reporting anything: no run
+# appears, the pull request shows no checks, and the runs API stays empty.
+# Grouping the dependencies behind intermediate jobs does not help, because the
+# same number of edges still has to exist. So this job starts with the others
+# and waits by polling the run it belongs to.
+def spec_coverage_audit_job
+  {
+    "name" => SPEC_COVERAGE_AUDIT_JOB_NAME,
+    "needs" => "validation",
+    "runs-on" => DEFAULT_RUNS_ON,
+    # Reports without failing the build. The examples it currently finds are
+    # covered by separate work; removing this line is what makes it enforcing.
+    "continue-on-error" => true,
+    # Long enough for the whole matrix, and short enough that a stuck job does
+    # not hold a runner for the six hours GitHub would otherwise allow.
+    "timeout-minutes" => 180,
+    "permissions" => {
+      "actions" => "read",
+      "contents" => "read"
+    },
+    "steps" => [
+      {
+        "name" => "Check out repository",
+        "uses" => "actions/checkout@v4"
+      },
+      {
+        "name" => "Install Ruby",
+        "uses" => "ruby/setup-ruby@v1",
+        "with" => { "ruby-version" => "3.4" }
+      },
+      {
+        "name" => "Wait for the test jobs to upload their example lists",
+        "env" => { "GH_TOKEN" => "${{ secrets.GITHUB_TOKEN }}" },
+        "run" => <<~SHELL
+          jobs="repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs"
+          filter='.jobs[]
+            | select(.name != "#{SPEC_COVERAGE_AUDIT_JOB_NAME}")
+            | select(.status != "completed")
+            | .name'
+          while :; do
+            pending=$(gh api --paginate "$jobs?per_page=100" --jq "$filter" | wc -l)
+            if [ "$pending" -eq 0 ]; then break; fi
+            echo "Waiting for $pending jobs."
+            sleep 60
+          done
+        SHELL
+      },
+      {
+        "name" => "Download example lists",
+        "uses" => "actions/download-artifact@v4",
+        "with" => { "path" => "artifacts" }
+      },
+      {
+        "name" => "Audit spec coverage",
+        "run" => "ruby script/audit_spec_coverage.rb artifacts"
+      }
+    ]
   }
 end
 
@@ -214,6 +281,8 @@ namespace :build_matrix do
         job["steps"] << example_list_upload_step(macos_key)
         builds[macos_key] = job
       end
+
+      builds["spec_coverage_audit"] = spec_coverage_audit_job
 
       github["jobs"] = github["jobs"].merge(builds)
 

--- a/Rakefile
+++ b/Rakefile
@@ -57,6 +57,24 @@ def build_job(ruby_version, ruby_gem: nil, runs_on: DEFAULT_RUNS_ON)
   }
 end
 
+# Every test job uploads the example list its run wrote, named after the job so
+# the audit can say which combination is missing one. Uploaded even when the run
+# fails, because the list is written either way and the audit needs to tell a
+# crashed job apart from a combination that legitimately runs nothing.
+def example_list_upload_step(key)
+  {
+    "name" => "Upload example list",
+    "if" => "always()",
+    "uses" => "actions/upload-artifact@v4",
+    "with" => {
+      "name" => key,
+      "path" => "tmp/examples-*.json",
+      "if-no-files-found" => "error",
+      "retention-days" => 1
+    }
+  }
+end
+
 def build_matrix_key(ruby_version, ruby_gem: nil, runs_on: DEFAULT_RUNS_ON)
   base = "ruby_#{ruby_version}"
   base = "#{base}__#{ruby_gem}" if ruby_gem
@@ -150,11 +168,14 @@ namespace :build_matrix do
               "name" => "Run tests without extension",
               "run" => "./script/bundler_wrapper exec rake test:failure"
             }
+            job["steps"] << example_list_upload_step(build_matrix_key(ruby["ruby"]))
             builds[build_matrix_key(ruby["ruby"])] = job
           else
             job["needs"] = build_matrix_key(ruby["ruby"])
             job["steps"] << test_step
-            builds[build_matrix_key(ruby["ruby"], :ruby_gem => ruby_gem["gem"])] = job
+            gem_key = build_matrix_key(ruby["ruby"], :ruby_gem => ruby_gem["gem"])
+            job["steps"] << example_list_upload_step(gem_key)
+            builds[gem_key] = job
           end
 
           # On collector-capable Rubies, additionally run the gem's
@@ -169,8 +190,9 @@ namespace :build_matrix do
             .merge("BUNDLE_GEMFILE" => "gemfiles/#{collector_gem}.gemfile")
           collector_job["needs"] = build_matrix_key(ruby["ruby"])
           collector_job["steps"] << test_step
-          builds[build_matrix_key(ruby["ruby"], :ruby_gem => collector_gem)] =
-            collector_job
+          collector_key = build_matrix_key(ruby["ruby"], :ruby_gem => collector_gem)
+          collector_job["steps"] << example_list_upload_step(collector_key)
+          builds[collector_key] = collector_job
         end
 
         # Add build for macOS
@@ -188,7 +210,9 @@ namespace :build_matrix do
           "name" => "Run tests without extension",
           "run" => "./script/bundler_wrapper exec rake test:failure"
         }
-        builds[build_matrix_key(ruby["ruby"], :runs_on => runs_on)] = job
+        macos_key = build_matrix_key(ruby["ruby"], :runs_on => runs_on)
+        job["steps"] << example_list_upload_step(macos_key)
+        builds[macos_key] = job
       end
 
       github["jobs"] = github["jobs"].merge(builds)

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -293,7 +293,6 @@ matrix:
           - "3.4.1"
           - "3.3.4"
           - "3.2.5"
-    - gem: "mongo"
     - gem: "resque-2"
     - gem: "resque-3"
       only:

--- a/script/audit_spec_coverage.rb
+++ b/script/audit_spec_coverage.rb
@@ -1,0 +1,307 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Checks that every example defined in the suite is actually run by some
+# combination in the build matrix.
+#
+# An example inside a false dependency guard is never defined, so it appears in
+# no run and in no report. That cannot be detected from inside RSpec, because
+# there is nothing to compare against: the guard removed the example before
+# RSpec ever saw it. So this reads the source with Prism to learn what exists,
+# and compares that against the example lists every CI job uploads.
+#
+# Usage: bundle exec ruby script/audit_spec_coverage.rb <artifacts-directory>
+#
+# The directory is expected to hold one subdirectory per CI job, named after the
+# job, each containing that job's `examples-*.json`.
+
+require "json"
+require "prism"
+require "yaml"
+
+WORKFLOW = ".github/workflows/ci.yml"
+
+# Example-defining methods, from rspec-core's `example_group.rb`. RSpec records
+# each of these at the line where its block opens.
+RSPEC_EXAMPLE_METHODS = %w[
+  example it specify
+  focus fexample fit fspecify
+  xexample xit xspecify
+  skip pending
+].freeze
+
+# This suite's own example-defining helpers, mapped to how many examples one
+# call defines. They pass `:caller` so that RSpec records the call site rather
+# than the helper, and Ruby's `caller` reports the line where the call starts,
+# so they anchor differently from the methods above.
+#
+# The count is matched with `===`, so a range works wherever an exact number
+# does. Only reach for one when a call site legitimately reports more, which
+# happens when one line is used by more than one inclusion: a loop around the
+# call, or the call living in a shared example group included from several
+# places. Note what widening costs. `2..` also accepts two inclusions that each
+# ran one of their two examples, which is the very thing this count checks for.
+CALLER_ANCHORED_METHODS = { "it_in_both_modes" => 2 }.freeze
+
+# A built-in example method defines one example per call, but one call can be
+# reported many times over when it sits in a shared example group, so the only
+# safe expectation is that it ran at least once.
+BUILT_IN_EXAMPLE_COUNT = (1..).freeze
+
+# Methods that never run an example body, so a pending result from them is
+# deliberate rather than a condition that is met everywhere. RSpec gives each a
+# fixed pending message.
+DELIBERATE_SKIP_MESSAGE =
+  /\ATemporarily skipped with x(it|example|specify|describe|context)\z/.freeze
+
+# Each definition is a path and the lines RSpec might record it at. A built-in
+# example method can be recorded at either of two lines when its description
+# wraps, because the call and its block then start on different lines and which
+# one RSpec uses depends on the Ruby version: 3.1 to 3.3 report the call, while
+# 3.4 and later report the block. A helper that passes `:caller` has only one
+# possible line on every version, so listing a second one for it would treat a
+# line RSpec can never report as accounted for.
+#
+# An example method called inside a `def` is a helper defining examples for its
+# callers, and the call sites are what we check, so those are not counted.
+def example_definitions_in(path)
+  result = Prism.parse_file(path)
+  # Prism returns a tree even when it could not parse the file, so without this
+  # a file it choked on would contribute no definitions at all and the audit
+  # would quietly conclude that fewer examples exist than really do.
+  abort "Could not parse #{path}: #{result.errors.first.message}" if result.failure?
+
+  found = []
+  collect_examples(result.value, found, path)
+  found
+end
+
+def collect_examples(node, found, path, in_method: false)
+  return unless node.is_a?(Prism::Node)
+
+  in_method = true if node.is_a?(Prism::DefNode)
+
+  if node.is_a?(Prism::CallNode) && node.block && node.receiver.nil? && !in_method
+    name = node.name.to_s
+    if RSPEC_EXAMPLE_METHODS.include?(name)
+      lines = [node.location.start_line, node.block.location.start_line].uniq
+      found << { :path => path, :lines => lines, :expected => BUILT_IN_EXAMPLE_COUNT }
+    elsif CALLER_ANCHORED_METHODS.key?(name)
+      found << {
+        :path => path,
+        :lines => [node.location.start_line],
+        :expected => CALLER_ANCHORED_METHODS.fetch(name)
+      }
+    end
+  end
+
+  node.compact_child_nodes.each do |child|
+    collect_examples(child, found, path, :in_method => in_method)
+  end
+end
+
+def defined_examples
+  paths = Dir.glob("spec/**/*.rb").reject do |path|
+    path.start_with?("spec/integration/diagnose/")
+  end
+  paths.flat_map { |path| example_definitions_in(path) }.uniq
+end
+
+# Every job that runs tests, and the example lists it is expected to upload.
+# Read from the generated workflow rather than from `build_matrix.yml`, because
+# the workflow is the literal list of jobs and CI already checks that the two
+# agree.
+def expected_jobs
+  workflow = YAML.safe_load_file(WORKFLOW, :aliases => true)
+  workflow.fetch("jobs").each_with_object({}) do |(name, job), expected|
+    next unless job.dig("env", "BUNDLE_GEMFILE")
+
+    steps = job["steps"] || []
+    runs_failure_leg = steps.any? { |step| step["run"].to_s.include?("rake test:failure") }
+
+    lists = ["examples-test.json"]
+    lists << "examples-failure.json" if runs_failure_leg
+    expected[name] = lists
+  end
+end
+
+def read_reported_examples(directory)
+  # Keyed by file and description rather than by line, because the line an
+  # example is reported at varies by Ruby version and a per-line key would split
+  # one example's results into two partial sets.
+  reported = {}
+  descriptions = {}
+  incomplete = []
+
+  Dir.glob(File.join(directory, "*")).sort.each do |job_directory|
+    next unless File.directory?(job_directory)
+
+    job = File.basename(job_directory)
+    Dir.glob(File.join(job_directory, "*.json")).sort.each do |file|
+      examples = parse_example_list(file)
+      if examples.nil? || examples.empty?
+        incomplete << "#{job}/#{File.basename(file)}"
+        next
+      end
+
+      examples.each do |example|
+        path = example["file_path"].sub(%r{\A\./}, "")
+        line = example["line_number"]
+        description = example["full_description"]
+        ((descriptions[path] ||= {})[line] ||= []) << description
+        key = [path, description]
+        entry = reported[key] ||= { :path => path, :line => line, :results => [] }
+        entry[:results] << [example["status"], example["pending_message"]]
+      end
+    end
+  end
+
+  descriptions.each_value { |lines| lines.each_value(&:uniq!) }
+  [reported, descriptions, incomplete]
+end
+
+def parse_example_list(file)
+  JSON.parse(File.read(file))["examples"]
+rescue JSON::ParserError
+  nil
+end
+
+def source_line(path, line)
+  File.readlines(path)[line - 1].to_s.strip
+rescue StandardError
+  ""
+end
+
+def report(title, explanation, entries)
+  puts
+  puts "#{title} (#{entries.length})"
+  puts explanation
+  puts
+  entries.each { |line| puts "  #{line}" }
+end
+
+directory = ARGV[0]
+abort "Usage: bundle exec ruby #{$PROGRAM_NAME} <artifacts-directory>" if directory.nil?
+abort "No such directory: #{directory}" unless File.directory?(directory)
+
+defined = defined_examples
+reported, reported_descriptions, incomplete = read_reported_examples(directory)
+
+# A reported line is accounted for when some definition in that file could have
+# been recorded at it.
+known_lines = {}
+defined.each do |definition|
+  (known_lines[definition[:path]] ||= []).concat(definition[:lines])
+end
+reported_lines = reported_descriptions.transform_values(&:keys)
+
+# How many distinct examples the matrix reported for one definition, counted
+# across both of the lines it could have been recorded at.
+ran_count = lambda do |definition|
+  lines = reported_descriptions[definition[:path]] || {}
+  definition[:lines].flat_map { |line| lines[line] || [] }.uniq.length
+end
+
+failures = []
+
+# A missing or empty list means a job did not finish, and its examples would
+# then look unreachable. The JSON formatter writes its document only when the
+# run ends, so a crashed job leaves nothing at all behind.
+missing = expected_jobs.flat_map do |job, lists|
+  lists.reject { |list| File.file?(File.join(directory, job, list)) }
+    .map { |list| "#{job}/#{list}" }
+end
+
+if missing.any? || incomplete.any?
+  entries = missing.map { |list| "#{list} (missing)" } +
+    incomplete.map { |list| "#{list} (no examples)" }
+  report(
+    "Incomplete example lists",
+    "These jobs uploaded no usable list, so the audit cannot draw any conclusion.\n" \
+      "Re-run once the matrix is green.",
+    entries
+  )
+  failures << :incomplete
+end
+
+unparsed = reported_lines.flat_map do |path, lines|
+  (lines - (known_lines[path] || [])).map { |line| [path, line] }
+end
+if unparsed.any?
+  report(
+    "Reported by RSpec but not found in the source",
+    "The parser in this script does not know about a helper that defines examples.\n" \
+      "Add it to RSPEC_EXAMPLE_METHODS or CALLER_ANCHORED_METHODS. Until then the\n" \
+      "audit undercounts and its other findings cannot be trusted.",
+    unparsed.sort.map { |path, line| "#{path}:#{line}" }
+  )
+  failures << :unparsed
+end
+
+if failures.empty?
+  counted = defined.map { |definition| [definition, ran_count.call(definition)] }
+    # rubocop:disable Style/CaseEquality
+    .reject { |definition, count| definition[:expected] === count }
+  # rubocop:enable Style/CaseEquality
+  never_run, partly_run = counted.partition { |_, count| count.zero? }
+
+  if never_run.any?
+    report(
+      "Defined but never run",
+      "No combination in the build matrix runs these examples. Either a dependency\n" \
+        "guard cannot be true anywhere, or the matrix is missing a combination.",
+      never_run.map do |definition, _|
+        path = definition[:path]
+        line = definition[:lines].first
+        "#{path}:#{line}  #{source_line(path, line)}"
+      end.sort
+    )
+    failures << :never_run
+  end
+
+  if partly_run.any?
+    report(
+      "Ran a different number of examples than the source defines",
+      "A helper such as `it_in_both_modes` defines more than one example per call,\n" \
+        "and they share a line, so one of them never running is invisible to the\n" \
+        "check above. Running fewer than expected means a combination that should\n" \
+        "cover one of them does not. Running more means the line is used by more\n" \
+        "than one inclusion, and the count in CALLER_ANCHORED_METHODS needs to be a\n" \
+        "range. Read the note there first, because widening it gives something up.",
+      partly_run.map do |definition, count|
+        path = definition[:path]
+        line = definition[:lines].first
+        "#{path}:#{line}  expected #{definition[:expected]}, ran #{count}"
+      end.sort
+    )
+    failures << :count_mismatch
+  end
+
+  always_pending = reported.each_value.select do |entry|
+    entry[:results].all? do |status, message|
+      status == "pending" && !DELIBERATE_SKIP_MESSAGE.match?(message.to_s)
+    end
+  end
+
+  if always_pending.any?
+    report(
+      "Pending everywhere",
+      "These examples are skipped in every combination that runs them, so they never\n" \
+        "assert anything. Deliberate markers such as `xit` are not reported here.",
+      always_pending.map do |entry|
+        message = entry[:results].map(&:last).compact.uniq.join(", ")
+        "#{entry[:path]}:#{entry[:line]}  #{message}"
+      end.sort
+    )
+    failures << :always_pending
+  end
+end
+
+puts
+if failures.empty?
+  puts "All #{defined.length} defined examples run in at least one combination."
+  exit 0
+end
+
+puts "Spec coverage audit failed: #{failures.join(", ")}."
+exit 1

--- a/spec/support/helpers/mode_helpers.rb
+++ b/spec/support/helpers/mode_helpers.rb
@@ -10,12 +10,19 @@ module ModeHelpers
   # NOT start the agent itself, and any mode-dependent arrangement (e.g.
   # `set_current_transaction`, building a transaction) belongs inside the block
   # — which runs after the start — rather than in a `before` hook.
+  #
+  # Each example wraps the given block in a new one, so RSpec would record this
+  # helper as the location of every example it defines. Passing `:caller` makes
+  # RSpec record the call site instead, which is what `rspec <file>:<line>`
+  # needs to select the right example.
   def it_in_both_modes(description = nil, &block)
-    it([description, "in agent mode"].compact.join(" "), :agent_mode) do
+    callsite = caller
+    it([description, "in agent mode"].compact.join(" "), :agent_mode, :caller => callsite) do
       start_agent(**(defined?(start_agent_args) ? start_agent_args : {}))
       instance_exec(&block)
     end
-    it([description, "in collector mode"].compact.join(" "), :collector_mode) do
+    it([description, "in collector mode"].compact.join(" "), :collector_mode,
+      :caller => callsite) do
       start_collector_agent
       instance_exec(&block)
     end


### PR DESCRIPTION
### [Record dual-mode examples at their call site](https://github.com/appsignal/appsignal-ruby/commit/70ec4b40)

The `it_in_both_modes` helper wraps the given block in a new one, so
RSpec records the helper itself as the location of every example the
helper defines. Pointing `rspec` at a call site then selects whichever
example RSpec resolves that line to, which is a different one, so a
single dual-mode example cannot be run on its own. Passing `:caller`
makes RSpec record the call site instead.

### [Write an example list from every test run](https://github.com/appsignal/appsignal-ruby/commit/31447604)

The suite reports which examples ran, but nothing records which
examples exist. An example inside a false dependency guard is never
defined, so it appears in no run and in no report, and no single run
can reveal that: the guard removed it before RSpec saw it. Write a
JSON list of the examples each run covered, so a later check can union
the lists from every Ruby and gemfile combination and compare them
against the source.

### [Add a spec coverage audit](https://github.com/appsignal/appsignal-ruby/commit/b9d27320)

Nothing currently notices when no build matrix combination runs an
example. The Delayed Job specs have two examples behind an Active Job
guard, and no gemfile pairs Delayed Job with Active Job, so they have
never run. Read the source with Prism to learn which examples exist,
union the example lists the CI jobs write, and report four things: an
example that no combination runs, a call site where the matrix ran a
different number of examples than the source defines, an example RSpec
reported at a line the parser did not find, and an example skipped in
every combination that runs it. The third of those keeps the others
honest, because a parser that does not know a test helper would
otherwise undercount in silence.

### [Upload the example list from every test job](https://github.com/appsignal/appsignal-ruby/commit/8c56a996)

The audit needs the example lists from every combination at once, and a
single job only ever has its own. Upload each job's list as an artifact
named after the job, so the audit can name the combination whose list is
missing. Uploaded even when the run fails, because the list is written
either way and a crashed job has to be distinguishable from one that
legitimately ran nothing.

### [Run the spec coverage audit on CI](https://github.com/appsignal/appsignal-ruby/commit/e1e3771e)

The audit needs every combination's example list at once, so a job that
waits for the test jobs has to name them in `needs`. Naming all 426 puts
the workflow over a limit on how many dependency edges GitHub accepts,
and GitHub then refuses to create the run without reporting it: no run
appears, the pull request shows no checks, and the runs API returns
nothing. Grouping the dependencies behind intermediate jobs does not
help, because the same number of edges still has to exist. So the job
starts alongside the others and waits by polling the run it belongs to.
That keeps it inside the CI workflow, where it appears as a check on
every pull request.

### [Remove the duplicate mongo build matrix entry](https://github.com/appsignal/appsignal-ruby/commit/edf4071d)

The build matrix lists the `mongo` gemset twice. The workflow generator
keys jobs by Ruby version and gemset, so the second entry overwrites the
job the first one built and the generated workflow is identical either
way. Anything else that reads the matrix counts the gemset twice, which
is a trap for the next reader rather than a bug today. The entry removed
here is the one that also breaks the alphabetical order of the list.

[skip changeset]
