### PR TITLE
Update agent to version 0.37.0

### DIFF
--- a/.changesets/fix-events-showing-as-unknown-in-long-running-applications.md
+++ b/.changesets/fix-events-showing-as-unknown-in-long-running-applications.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+type: fix
+integrations:
+- ruby
+---
+
+Fix events showing as unknown in long-running applications. An application process that kept running for thirty days without restarting could lose the names and queries of the events it recorded, both in slow traces and in the "Slow events" panel.

--- a/.changesets/handle-high-traffic-apps.md
+++ b/.changesets/handle-high-traffic-apps.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+type: change
+integrations: all
+---
+
+Update the agent to handle high traffic apps. On high-traffic apps that would exceed the maximum accepted internal payload size, send data to the Push API more frequently.

--- a/.changesets/prevent-gc-events-in-slow-events-panel.md
+++ b/.changesets/prevent-gc-events-in-slow-events-panel.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+type: fix
+integrations: ruby
+---
+
+Prevent `gc` events from appearing in the "Slow events" panel.

--- a/.changesets/update-the-agent-from-0-35-19-to-0-37-0.md
+++ b/.changesets/update-the-agent-from-0-35-19-to-0-37-0.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+type: change
+integrations: ruby
+---
+
+Update the agent from version 0.35.19 to version 0.37.0. The 3.x series of the Ruby gem was several agent releases behind, so this update also brings the improvements from every agent release in between. Those include better sanitisation of SQL queries, host metric collection that keeps working when a disk mount is frozen, and no more leftover `[timeout]` processes on Alpine Linux containers.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ name: Ruby gem CI
     branches:
     - main
     - develop
+    - "*-stable"
   pull_request:
     types:
     - opened

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -2,7 +2,7 @@ github:
   name: Ruby gem CI
   "on":
     push:
-      branches: ["main", "develop"]
+      branches: ["main", "develop", "*-stable"]
     pull_request:
       types: [opened, reopened, synchronize]
     schedule:

--- a/ext/agent.rb
+++ b/ext/agent.rb
@@ -1,144 +1,144 @@
 # frozen_string_literal: true
 
 # DO NOT EDIT
-# This is a generated file by the `rake ship` family of tasks in the
+# This is a generated file by the `rake publish` family of tasks in the
 # appsignal-agent repository.
 # Modifications to this file will be overwritten with the next agent release.
 
 APPSIGNAL_AGENT_CONFIG = {
-  "version" => "0.35.19",
+  "version" => "0.37.0",
   "mirrors" => [
-    "https://appsignal-agent-releases.global.ssl.fastly.net",
-    "https://d135dj0rjqvssy.cloudfront.net"
+    "https://d135dj0rjqvssy.cloudfront.net",
+    "https://appsignal-agent-releases.global.ssl.fastly.net"
   ],
   "triples" => {
     "x86_64-darwin" => {
       "static" => {
-        "checksum" => "0d465ca77500f7e9675d262a5ccd277fc3428821ac96f973b9941ad49a300ea9",
+        "checksum" => "1c05ef4cd4f0d0646bbc00a61568448cafd6c8cd23e152a4d7e22bab7e733cf1",
         "filename" => "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "ff1b90c3c52e5b765dc8c43b2c0fe376a06101134ec5879d581642ed6837603e",
+        "checksum" => "0c74689a0bc204e0ce462c875f46ea458aa63705956f1adb9daa72dbce47e736",
         "filename" => "appsignal-x86_64-darwin-all-dynamic.tar.gz"
       }
     },
     "universal-darwin" => {
       "static" => {
-        "checksum" => "0d465ca77500f7e9675d262a5ccd277fc3428821ac96f973b9941ad49a300ea9",
+        "checksum" => "1c05ef4cd4f0d0646bbc00a61568448cafd6c8cd23e152a4d7e22bab7e733cf1",
         "filename" => "appsignal-x86_64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "ff1b90c3c52e5b765dc8c43b2c0fe376a06101134ec5879d581642ed6837603e",
+        "checksum" => "0c74689a0bc204e0ce462c875f46ea458aa63705956f1adb9daa72dbce47e736",
         "filename" => "appsignal-x86_64-darwin-all-dynamic.tar.gz"
       }
     },
     "aarch64-darwin" => {
       "static" => {
-        "checksum" => "7c735e7490d9d5313e76a0e0508f85983c98caceb0507afa3d8d34bb3b740627",
+        "checksum" => "031d0f3c32302271274d1e602c9cecb2b037e9dd338001901ff4ed4d0e457075",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "c29689978f56904771c6caa151a35d8bea3ba4002b6e767ddc102f82d9909fa2",
+        "checksum" => "5aadc22281991a97250bd6bf12dd5dd764ffc4da72301d745f86d63542159436",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "arm64-darwin" => {
       "static" => {
-        "checksum" => "7c735e7490d9d5313e76a0e0508f85983c98caceb0507afa3d8d34bb3b740627",
+        "checksum" => "031d0f3c32302271274d1e602c9cecb2b037e9dd338001901ff4ed4d0e457075",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "c29689978f56904771c6caa151a35d8bea3ba4002b6e767ddc102f82d9909fa2",
+        "checksum" => "5aadc22281991a97250bd6bf12dd5dd764ffc4da72301d745f86d63542159436",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "arm-darwin" => {
       "static" => {
-        "checksum" => "7c735e7490d9d5313e76a0e0508f85983c98caceb0507afa3d8d34bb3b740627",
+        "checksum" => "031d0f3c32302271274d1e602c9cecb2b037e9dd338001901ff4ed4d0e457075",
         "filename" => "appsignal-aarch64-darwin-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "c29689978f56904771c6caa151a35d8bea3ba4002b6e767ddc102f82d9909fa2",
+        "checksum" => "5aadc22281991a97250bd6bf12dd5dd764ffc4da72301d745f86d63542159436",
         "filename" => "appsignal-aarch64-darwin-all-dynamic.tar.gz"
       }
     },
     "aarch64-linux" => {
       "static" => {
-        "checksum" => "6ed44186487547614b1a2d4f1c2fea4676f2b5829c8949ad86ca61a66db716e7",
+        "checksum" => "48499ed06fda433dc7347a4a3d23944d0bfb31604e5d7f52db0a0bbe437f8e03",
         "filename" => "appsignal-aarch64-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "775399b3b559f1c8bd931fb835a88dee012fb62d580584b8e6f4d40ea24f6a0a",
+        "checksum" => "d943b05951cce5d797c0fe7aeacafc9b6870a0d72aa7869b9aa16f5add82fcc6",
         "filename" => "appsignal-aarch64-linux-all-dynamic.tar.gz"
       }
     },
     "i686-linux" => {
       "static" => {
-        "checksum" => "608b8de770ddc9cbc9cae16f793c630079d640b3b77f3af2f854de474e8ef5de",
+        "checksum" => "41600ba4171cb8549ff9c8b675e9b4ef100eb7ef0a001a970964af04dc209738",
         "filename" => "appsignal-i686-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "87e893f27ec2128d953c65c46dd0136a0dfab50eab18ec2a3a47cfff8068ca89",
+        "checksum" => "ada062a08dc531421141330764e4a0b9a05b34b52b922c1c705ffbac604eb332",
         "filename" => "appsignal-i686-linux-all-dynamic.tar.gz"
       }
     },
     "x86-linux" => {
       "static" => {
-        "checksum" => "608b8de770ddc9cbc9cae16f793c630079d640b3b77f3af2f854de474e8ef5de",
+        "checksum" => "41600ba4171cb8549ff9c8b675e9b4ef100eb7ef0a001a970964af04dc209738",
         "filename" => "appsignal-i686-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "87e893f27ec2128d953c65c46dd0136a0dfab50eab18ec2a3a47cfff8068ca89",
+        "checksum" => "ada062a08dc531421141330764e4a0b9a05b34b52b922c1c705ffbac604eb332",
         "filename" => "appsignal-i686-linux-all-dynamic.tar.gz"
       }
     },
     "x86_64-linux" => {
       "static" => {
-        "checksum" => "4499818ce89075c7754e26c8915b452352a155619f2ce648232fad6480638f34",
+        "checksum" => "8240c494573360ad147aa56a973fe809bf1f3976383b8cd990fc0824e5554913",
         "filename" => "appsignal-x86_64-linux-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "70b60e4af4c17c569869293680f5d71ea3c3ab2be8a64dfa02421b431f6a5b7b",
+        "checksum" => "ec07ea8188c3589c7c9a401d7555b51fdd052f07b05fc62e3801288493f85ca8",
         "filename" => "appsignal-x86_64-linux-all-dynamic.tar.gz"
       }
     },
     "x86_64-linux-musl" => {
       "static" => {
-        "checksum" => "ed3a557d8ae6aeb15597ff40dce3739c350053a24d163ddc362af20e7e9d4e1c",
+        "checksum" => "39de4602e300f701ed28748bd1c523bedf44f2d0f6241fffe370485185a895cc",
         "filename" => "appsignal-x86_64-linux-musl-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "594cb5216a260f315481e1c6d56af978716f2736653374c3ea52270a355e673d",
+        "checksum" => "8a9fd74a6a7589b842a8297025656e7ccc995c9df40c09cf45b39382d3d4a507",
         "filename" => "appsignal-x86_64-linux-musl-all-dynamic.tar.gz"
       }
     },
     "aarch64-linux-musl" => {
       "static" => {
-        "checksum" => "f18731c7c549cf635ec8b040c3dbd3cdc3285f0e240c2790a8c8003e0ff7cbee",
+        "checksum" => "13fa41ad765a9c79f374dad4d131e7860afb8760c11508af1de982580798a3bc",
         "filename" => "appsignal-aarch64-linux-musl-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "e7bb93dba7975920539e7d270752c690de9e1e292da5f9b2c0e66863b0c8caf7",
+        "checksum" => "8193f5925818164390aac737d15a3d86706fce7aad81c4d5e84a3b0552b407a5",
         "filename" => "appsignal-aarch64-linux-musl-all-dynamic.tar.gz"
       }
     },
     "x86_64-freebsd" => {
       "static" => {
-        "checksum" => "fa2c007ca5cb40ac75b7c147d18460edcb0d948648286debc03d4f5afda469f1",
+        "checksum" => "c519b132c7a1de2a8dbb8c36d87fe91b4c0451d2c65d8bd4f44b748bb2ad2904",
         "filename" => "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "e0e3b59374e7b32eefcc7877a81d0d4d3bcf0d756d7e8cbff3a44444506fa00c",
+        "checksum" => "fb5ea3aac557543de74842d668c66ede00d125e1e86f601fa5ffe002edbd6c62",
         "filename" => "appsignal-x86_64-freebsd-all-dynamic.tar.gz"
       }
     },
     "amd64-freebsd" => {
       "static" => {
-        "checksum" => "fa2c007ca5cb40ac75b7c147d18460edcb0d948648286debc03d4f5afda469f1",
+        "checksum" => "c519b132c7a1de2a8dbb8c36d87fe91b4c0451d2c65d8bd4f44b748bb2ad2904",
         "filename" => "appsignal-x86_64-freebsd-all-static.tar.gz"
       },
       "dynamic" => {
-        "checksum" => "e0e3b59374e7b32eefcc7877a81d0d4d3bcf0d756d7e8cbff3a44444506fa00c",
+        "checksum" => "fb5ea3aac557543de74842d668c66ede00d125e1e86f601fa5ffe002edbd6c62",
         "filename" => "appsignal-x86_64-freebsd-all-dynamic.tar.gz"
       }
     }

--- a/gemfiles/grape.gemfile
+++ b/gemfiles/grape.gemfile
@@ -1,5 +1,9 @@
 source "https://rubygems.org"
 
-gem "grape"
+# The Grape middleware here is written against Grape 2, and the
+# ActiveSupport::Notifications hook against ActiveSupport 7.1. Cap both,
+# because an unpinned Grape pulls in newer versions of each.
+gem "grape", "< 3"
+gem "activesupport", "< 7.2"
 
 gemspec :path => "../"

--- a/gemfiles/rails-6.0.gemfile
+++ b/gemfiles/rails-6.0.gemfile
@@ -3,6 +3,10 @@ source "https://rubygems.org"
 gem "rails", "~> 6.0.0"
 gem "sidekiq"
 
+# concurrent-ruby 1.3.5 stopped requiring logger, which this version of
+# ActiveSupport relies on it doing.
+gem "concurrent-ruby", "< 1.3.5"
+
 # Fix install issue for jruby on gem 3.1.8.
 # No java stub is published.
 gem "bigdecimal", "3.1.7" if RUBY_PLATFORM == "java"

--- a/gemfiles/rails-6.1.gemfile
+++ b/gemfiles/rails-6.1.gemfile
@@ -4,6 +4,10 @@ gem "net-smtp", :require => false
 gem "rails", "~> 6.1.0"
 gem "sidekiq"
 
+# concurrent-ruby 1.3.5 stopped requiring logger, which this version of
+# ActiveSupport relies on it doing.
+gem "concurrent-ruby", "< 1.3.5"
+
 # Fix install issue for jruby on gem 3.1.8.
 # No java stub is published.
 gem "bigdecimal", "3.1.7" if RUBY_PLATFORM == "java"

--- a/gemfiles/rails-7.1.gemfile
+++ b/gemfiles/rails-7.1.gemfile
@@ -2,7 +2,8 @@ source "https://rubygems.org"
 
 gem "rails", "~> 7.1.0"
 gem "rake", "> 12.2"
-gem "sidekiq"
+# The Sidekiq probe specs stub Sidekiq with a mock of its version 7 API.
+gem "sidekiq", "< 8"
 
 # JRuby activates the jar-dependencies it ships with before Bundler
 # resolves the newer one that psych asks for.

--- a/gemfiles/rails-7.1.gemfile
+++ b/gemfiles/rails-7.1.gemfile
@@ -4,6 +4,10 @@ gem "rails", "~> 7.1.0"
 gem "rake", "> 12.2"
 gem "sidekiq"
 
+# JRuby activates the jar-dependencies it ships with before Bundler
+# resolves the newer one that psych asks for.
+gem "jar-dependencies", "0.4.1" if RUBY_PLATFORM == "java"
+
 # Fix install issue for jruby on gem 3.1.8.
 # No java stub is published.
 gem "bigdecimal", "3.1.7" if RUBY_PLATFORM == "java"

--- a/spec/lib/appsignal/cli/diagnose_spec.rb
+++ b/spec/lib/appsignal/cli/diagnose_spec.rb
@@ -466,6 +466,15 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
       end
 
       context "when the extension returns invalid JSON" do
+        # The JSON gem reworded this error in version 2.10. Accept the wording
+        # from before that release and the wording from after it.
+        let(:parse_error) do
+          Regexp.union(
+            "unexpected token at 'invalid agent\njson'",
+            "unexpected character: 'invalid' at line 1 column 1"
+          )
+        end
+
         before do
           expect(Appsignal::Extension).to receive(:diagnose).and_return("invalid agent\njson")
           run
@@ -476,12 +485,11 @@ describe Appsignal::CLI::Diagnose, :api_stub => true, :send_report => :yes_cli_i
             "Agent diagnostics",
             "  Error while parsing agent diagnostics report:",
             "    Output: invalid agent\njson"
-          expect(output).to match(/Error:( \d+:)? unexpected token at 'invalid agent\njson'/)
+          expect(output).to match(/Error:( \d+:)? #{parse_error}/)
         end
 
         it "adds the output to the report" do
-          expect(received_report["agent"]["error"])
-            .to match(/unexpected token at 'invalid agent\njson'/)
+          expect(received_report["agent"]["error"]).to match(parse_error)
           expect(received_report["agent"]["output"]).to eq(["invalid agent", "json"])
         end
       end

--- a/spec/support/helpers/config_helpers.rb
+++ b/spec/support/helpers/config_helpers.rb
@@ -20,7 +20,7 @@ module ConfigHelpers
       config_file
     )
   end
-  module_function :project_fixture_config, :project_fixture_path
+  module_function :project_fixture_config
 
   def start_agent(env = "production")
     Appsignal._config = project_fixture_config(env)


### PR DESCRIPTION
Backport of #1599 for the 3.x series of the Ruby gem.

The first commit is the backport itself. The second is the CI trigger change from `4.x-stable`, which used to be #1602. The remaining six are all CI repair. This branch had not been built in a long time, and its unpinned gemfiles resolve versions of Grape, Sidekiq, ActiveSupport, concurrent-ruby and the JSON gem that it predates. None of them touch the gem's own code. Every check passes now.

### [Update agent to version 0.37.0](https://github.com/appsignal/appsignal-ruby/commit/59d83f9b)

The 3.x series pins agent version 0.35.19. Agent 0.37.0 sends every
event's name and body inside the payload that refers to it, and marks
that payload `event_details_complete`. That flag is the signal the
processing side needs before it can stop resolving digests against
separately stored details, and it is why this branch skips ahead this
many agent releases instead of waiting for a release of its own.

### [Run CI on pushes to stable branches](https://github.com/appsignal/appsignal-ruby/commit/6894699e)

The push trigger on this branch lists only `main` and `develop`, so
pushes to `3.x-stable` build nothing. A push event uses the workflow
file from the branch being pushed, so the trigger that matches
`*-stable` takes effect only on a branch that carries it, and this
branch has to carry its own copy.

### [Drop a duplicate module_function symbol](https://github.com/appsignal/appsignal-ruby/commit/1e74221f)

The `ConfigHelpers` module makes `project_fixture_path` a module
function on its own line, and then names it a second time in the
`module_function` call for `project_fixture_config`. RuboCop's
`Style/AccessModifierDeclarations` accepts the inline form for a single
symbol but not for a list of them, so that second mention is the only
reason the linter fails on this branch.

### [Match the JSON gem's reworded parse error](https://github.com/appsignal/appsignal-ruby/commit/7342958e)

Two examples assert the exact wording of the error the JSON gem raises
for input it cannot parse. Version 2.10 of that gem reworded it from
`unexpected token at '...'` to `unexpected character: '...' at line 1
column 1`, so both examples fail wherever a current JSON gem resolves.
The assertions now accept either wording.

### [Keep concurrent-ruby below 1.3.5 on Rails 6](https://github.com/appsignal/appsignal-ruby/commit/9a5444b3)

The Rails 6 gemfiles take whichever concurrent-ruby version is current.
Version 1.3.5 stopped requiring `logger`, and this version of
ActiveSupport relies on it doing so, so loading Rails raises
`NameError: uninitialized constant
ActiveSupport::LoggerThreadSafeLevel::Logger` before a single example
runs.

### [Pin jar-dependencies for JRuby on Rails 7.1](https://github.com/appsignal/appsignal-ruby/commit/9f51d905)

JRuby 9.4.7.0 ships jar-dependencies 0.4.1 as a default gem and
activates it while it boots. The java build of `psych` depends on
`jar-dependencies (>= 0.1.7)`, which Bundler resolves to 0.5.7, and the
mismatch raises `Gem::LoadError` before the suite loads.

### [Cap Grape and ActiveSupport in the Grape gemfile](https://github.com/appsignal/appsignal-ruby/commit/2aa95d34)

The Grape gemfile takes whichever version of Grape is current, and Grape
pulls in ActiveSupport alongside it. Grape 3 reworked `Endpoint#call!`,
so the middleware specs get a nil app, and ActiveSupport 8 records
nothing through the `instrument` override, so the notification hook
specs see no events. Neither is supported on this branch.

### [Cap Sidekiq below version 8 on Rails 7.1](https://github.com/appsignal/appsignal-ruby/commit/33cabd72)

The Sidekiq probe specs replace `Sidekiq` with a mock of its version 7
API. Sidekiq 8 calls `Sidekiq.loader` while `sidekiq/api` loads, which
that mock does not answer, so requiring the probe raises
`NoMethodError`. Sidekiq 8 needs Ruby 3.2, which is why only the two
newest Rubies in the matrix resolve it.

### Notes on the version jump

This branch was more than twenty agent releases behind, so the update brings everything in between. I read through the diff looking for behaviour that turns on by default. These are the changes worth knowing about before this ships.

- Agent 0.37.0 removes GC instrumentation. The `run.gc` event metric and the per-event and per-transaction GC durations are gone. The C extension API and the wire format are unchanged, so nothing breaks, but GC time no longer shows up in samples. This reaches `main` and the 4.x series too.
- Every payload now carries every event detail it refers to, so payloads get bigger. Agent 0.37.0 handles that by transmitting early once a payload passes the soft size limit, at most once per second per app. High traffic apps will make more requests to the Push API than they do today. This reaches `main` and the 4.x series too.
- Agent 0.36.1 delays each agent reboot by an extra second and gives up after ten attempts. An app whose agent keeps dying used to respawn it forever. It now stops reporting instead, which is the intent, but it turns a loud failure into a quiet one.
- The `sql_lexer` crate goes from 0.9.7 to 0.9.9. That is the sanitizer which runs on SQL events recorded through the extension, so some query bodies change shape and may regroup in the interface.
- `CONTAINER_VERSION` is now read as the app revision, which is how Scalingo reports it.
- The error rate counts transactions that have an error rather than counting errors, so it can no longer go above 100%.

I confirmed that agent 0.37.0 still reads every configuration option this gem writes, that the new `nginx_port` option defaults to the port 0.35.19 had hardcoded, and that the 3.x extension compiles and links against agent 0.37.0. For comparison, the same agent update on the 4.x series is #1600.

### One gap this backport leaves open

The gem sends no OpenTelemetry data to the agent, so #1595 made `main` write `_APPSIGNAL_ENABLE_OPENTELEMETRY_HTTP` out as `false`, which stops a value in the environment from turning the agent's listener on. This branch does not write it. The agent's own default is off in both 0.35.19 and 0.37.0, so this update changes nothing there, but the gap is worth a separate backport.
