### PR TITLE
Run CI on pushes to stable branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ name: Ruby gem CI
     branches:
     - main
     - develop
+    - "*-stable"
   pull_request:
     types:
     - opened

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -2,7 +2,7 @@ github:
   name: Ruby gem CI
   "on":
     push:
-      branches: ["main", "develop"]
+      branches: ["main", "develop", "*-stable"]
     pull_request:
       types: [opened, reopened, synchronize]
     schedule:


### PR DESCRIPTION
Backport of the CI trigger change on `4.x-stable` ([`32cadcaa`](https://github.com/appsignal/appsignal-ruby/commit/32cadcaa)) for the 3.x series of the Ruby gem.

The push trigger on this branch lists only `main` and `develop`, so
pushes to `3.x-stable` build nothing. A push event uses the workflow
file from the branch being pushed, so the trigger that matches
`*-stable` takes effect only on a branch that carries it, and this
branch has to carry its own copy.

[skip changeset]