### PR TITLE
Report the request environment in collector mode

### DIFF
--- a/.changesets/report-the-request-environment.md
+++ b/.changesets/report-the-request-environment.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+type: add
+---
+
+Report the request environment in collector mode. The `request_headers` configuration option is an allowlist of Rack environment names, and some of those names are not request headers. Those values are now reported as `appsignal.environment.*` OpenTelemetry attributes and shown in the request's Environment panel, instead of being left out.
+
+Values that describe the request itself are not repeated there, because they are already reported as the request's method, path, host, port and protocol version.

--- a/.changesets/report-the-request-host.md
+++ b/.changesets/report-the-request-host.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Report the host, the port and the HTTP version of an incoming web request in collector mode. These are sent as the `server.address`, `server.port` and `network.protocol.version` OpenTelemetry attributes. The host is read from the `Forwarded` and `X-Forwarded-Host` headers when a proxy sets them, so it is the host the client used rather than the one the proxy connected to.

--- a/lib/appsignal/integrations/webmachine.rb
+++ b/lib/appsignal/integrations/webmachine.rb
@@ -30,15 +30,19 @@ module Appsignal
           # Set here, where the transaction is created, so they land on the
           # transaction's own span rather than on the event started below.
           #
-          # Webmachine isn't Rack: the path, scheme and query string come off the
-          # request's `URI` rather than from Rack's readers. The request's own
-          # `query` is the parsed form, so the URI is where the string itself is.
+          # Webmachine isn't Rack: the path, scheme, query string, host and port
+          # come off the request's `URI` rather than from Rack's readers. The
+          # request's own `query` is the parsed form, so the URI is where the
+          # string itself is. Webmachine has no environment to read the protocol
+          # version from, so that one is left undescribed.
           transaction.add_opentelemetry_attributes(
             Appsignal::OpenTelemetry::HttpServerRequest.attributes_for(
               :method => request.method,
               :path => request.uri&.path,
               :scheme => request.uri&.scheme,
-              :query => request.uri&.query
+              :query => request.uri&.query,
+              :host => request.uri&.host,
+              :port => request.uri&.port
             )
           )
         end

--- a/lib/appsignal/opentelemetry/http_server_request.rb
+++ b/lib/appsignal/opentelemetry/http_server_request.rb
@@ -21,6 +21,15 @@ module Appsignal
     # collector filters it with the `filter_request_query_parameters` option, and
     # builds the request's query parameters out of it.
     #
+    # The host and the port describe where the client addressed the request. The
+    # conventions ask for the host the client used, so a caller reads it through
+    # the `Forwarded` and `X-Forwarded-Host` headers before falling back to the
+    # `Host` header and then to the server's own name. That is the order
+    # `Rack::Request#hostname` already follows. The port is only reported
+    # alongside a host, which is the condition the conventions put on it.
+    #
+    # The protocol version is the version out of `HTTP/1.1`, without the name.
+    #
     # Every value is optional, because reading any of them from the request can
     # fail. An attribute we have no value for is left out rather than sent
     # empty.
@@ -28,16 +37,41 @@ module Appsignal
       PATH_ATTRIBUTE = "url.path"
       SCHEME_ATTRIBUTE = "url.scheme"
       QUERY_ATTRIBUTE = "url.query"
+      ADDRESS_ATTRIBUTE = "server.address"
+      PORT_ATTRIBUTE = "server.port"
+      PROTOCOL_VERSION_ATTRIBUTE = "network.protocol.version"
 
       class << self
         # The attributes describing the given request, as a Hash to pass to
         # `add_opentelemetry_attributes`.
-        def attributes_for(method:, path: nil, scheme: nil, query: nil)
+        def attributes_for( # rubocop:disable Metrics/ParameterLists
+          method:, path: nil, scheme: nil, query: nil, host: nil, port: nil, protocol: nil
+        )
           attributes = HttpMethod.attributes_for(method)
           attributes[PATH_ATTRIBUTE] = path.to_s unless path.to_s.empty?
           attributes[SCHEME_ATTRIBUTE] = scheme.to_s unless scheme.to_s.empty?
           attributes[QUERY_ATTRIBUTE] = query.to_s unless query.to_s.empty?
+
+          unless host.to_s.empty?
+            attributes[ADDRESS_ATTRIBUTE] = host.to_s
+            port = Integer(port, :exception => false)
+            attributes[PORT_ATTRIBUTE] = port if port
+          end
+
+          version = protocol_version_for(protocol)
+          attributes[PROTOCOL_VERSION_ATTRIBUTE] = version if version
+
           attributes
+        end
+
+        private
+
+        # `network.protocol.name` is asked for alongside the version only when
+        # the protocol is not HTTP. A value shaped any other way than `HTTP/x`
+        # is one we cannot name, so it is left out entirely rather than sent as
+        # a version with no name to go with it.
+        def protocol_version_for(protocol)
+          protocol.to_s[%r{\AHTTP/(.+)\z}, 1]
         end
       end
     end

--- a/lib/appsignal/rack.rb
+++ b/lib/appsignal/rack.rb
@@ -47,6 +47,32 @@ module Appsignal
         nil
       end
 
+      # Fetch a value from the request environment, for the values that are only
+      # available there.
+      #
+      # The request class is configurable, so it may have no environment at all,
+      # which is not worth logging about. Reading from one can still raise, and
+      # that is logged. Either way the caller gets nil and skips whatever it
+      # needed the value for.
+      #
+      # @param request [Rack::Request] Request object.
+      # @param key [String] Name of the environment key to read.
+      # @return [Object, NilClass]
+      def self.request_env_value_from(request, key)
+        return unless request.respond_to?(:env)
+
+        env = request.env
+        return unless env
+
+        env[key]
+      rescue => error
+        Appsignal.internal_logger.error(
+          "Exception while fetching the HTTP request environment #{key}: " \
+            "#{error.class}: #{error}"
+        )
+        nil
+      end
+
       # Fetch the queue start time from the request environment.
       #
       # @since 3.11.0

--- a/lib/appsignal/rack/abstract_middleware.rb
+++ b/lib/appsignal/rack/abstract_middleware.rb
@@ -98,7 +98,10 @@ module Appsignal
             :method => Appsignal::Rack::Utils.request_method_from(request),
             :path => Appsignal::Rack::Utils.request_value_from(request, :path),
             :scheme => Appsignal::Rack::Utils.request_value_from(request, :scheme),
-            :query => Appsignal::Rack::Utils.request_value_from(request, :query_string)
+            :query => Appsignal::Rack::Utils.request_value_from(request, :query_string),
+            :host => Appsignal::Rack::Utils.request_value_from(request, :hostname),
+            :port => Appsignal::Rack::Utils.request_value_from(request, :port),
+            :protocol => Appsignal::Rack::Utils.request_env_value_from(request, "SERVER_PROTOCOL")
           )
         )
       end

--- a/lib/appsignal/rack/event_handler.rb
+++ b/lib/appsignal/rack/event_handler.rb
@@ -81,7 +81,11 @@ module Appsignal
               :method => Appsignal::Rack::Utils.request_method_from(request),
               :path => Appsignal::Rack::Utils.request_value_from(request, :path),
               :scheme => Appsignal::Rack::Utils.request_value_from(request, :scheme),
-              :query => Appsignal::Rack::Utils.request_value_from(request, :query_string)
+              :query => Appsignal::Rack::Utils.request_value_from(request, :query_string),
+              :host => Appsignal::Rack::Utils.request_value_from(request, :hostname),
+              :port => Appsignal::Rack::Utils.request_value_from(request, :port),
+              :protocol =>
+                Appsignal::Rack::Utils.request_env_value_from(request, "SERVER_PROTOCOL")
             )
           )
           transaction.start_event(

--- a/lib/appsignal/transaction/opentelemetry_backend.rb
+++ b/lib/appsignal/transaction/opentelemetry_backend.rb
@@ -103,10 +103,22 @@ module Appsignal
       UNPREFIXED_HEADER_KEYS = %w[CONTENT_LENGTH CONTENT_TYPE].freeze
 
       # `HTTP_VERSION` is a CGI variable holding the same value as
-      # `SERVER_PROTOCOL`, not a header. A client that sends a `Version` header
-      # arrives under the same key, so this drops that header too. That is the
-      # better trade, because `Version` is not a registered HTTP header.
+      # `SERVER_PROTOCOL`, not a header. A client that sends a real `Version`
+      # header arrives under the same key, so that header is reported as an
+      # environment value rather than as a header. `Version` is not a registered
+      # HTTP header, so that is the cheaper of the two mistakes.
       NON_HEADER_KEYS = %w[HTTP_VERSION].freeze
+
+      # The environment keys the Rack and Webmachine instrumentation already
+      # describes with a semantic convention attribute, which it reads from the
+      # request itself. Reporting them as environment values as well would say
+      # the same thing twice, in a worse form: `PATH_INFO` drops the mount
+      # prefix that `url.path` keeps, and `SERVER_NAME` ignores the forwarded
+      # host that `server.address` follows.
+      TRANSLATED_ENV_KEYS = %w[
+        PATH_INFO REQUEST_METHOD REQUEST_PATH SERVER_NAME SERVER_PORT
+        SERVER_PROTOCOL
+      ].freeze
 
       # One open event on the event stack. Holds the OpenTelemetry span and the
       # context token attached for it, plus the allocation bookkeeping for the
@@ -740,13 +752,20 @@ module Appsignal
       # The transaction's "environment" sample data is a Rack/CGI env allowlist
       # mixing true HTTP headers (HTTP_*, plus CONTENT_LENGTH/CONTENT_TYPE) with
       # non-header CGI vars (REQUEST_METHOD, REQUEST_PATH, PATH_INFO, SERVER_*).
-      # Only the true headers map to the OTel `http.request.header.*` convention
-      # the collector and trace UI read, so emit those (normalized to lowercase,
-      # dashed header names) and drop everything else.
+      #
+      # A true header becomes `http.request.header.*`, normalized to the
+      # lowercase dashed name that convention uses. Everything else keeps its
+      # own environment name under `appsignal.environment.*`, except for the
+      # keys in `TRANSLATED_ENV_KEYS`, which the instrumentation already
+      # describes from the request itself.
       def write_request_headers(headers)
         headers.each do |key, value|
           name = otel_header_name(key)
-          @span.set_attribute("http.request.header.#{name}", value.to_s) if name
+          if name
+            @span.set_attribute("http.request.header.#{name}", value.to_s)
+          elsif !TRANSLATED_ENV_KEYS.include?(key)
+            @span.set_attribute("appsignal.environment.#{key}", value.to_s)
+          end
         end
       end
 

--- a/lib/appsignal/transaction/opentelemetry_backend.rb
+++ b/lib/appsignal/transaction/opentelemetry_backend.rb
@@ -98,6 +98,16 @@ module Appsignal
       # queue duration when `queue_start_ms > 946_681_200_000`.
       QUEUE_START_MIN = 946_681_200_000
 
+      # The only two request headers Rack passes without the `HTTP_` prefix,
+      # because CGI reserves the prefixed spelling of them.
+      UNPREFIXED_HEADER_KEYS = %w[CONTENT_LENGTH CONTENT_TYPE].freeze
+
+      # `HTTP_VERSION` is a CGI variable holding the same value as
+      # `SERVER_PROTOCOL`, not a header. A client that sends a `Version` header
+      # arrives under the same key, so this drops that header too. That is the
+      # better trade, because `Version` is not a registered HTTP header.
+      NON_HEADER_KEYS = %w[HTTP_VERSION].freeze
+
       # One open event on the event stack. Holds the OpenTelemetry span and the
       # context token attached for it, plus the allocation bookkeeping for the
       # event. `allocation_start` is the allocation counter when the event began
@@ -741,9 +751,11 @@ module Appsignal
       end
 
       def otel_header_name(env_key)
+        return if NON_HEADER_KEYS.include?(env_key)
+
         if env_key.start_with?("HTTP_")
           env_key.delete_prefix("HTTP_").downcase.tr("_", "-")
-        elsif env_key.start_with?("CONTENT_")
+        elsif UNPREFIXED_HEADER_KEYS.include?(env_key)
           env_key.downcase.tr("_", "-")
         end
       end

--- a/spec/lib/appsignal/integrations/webmachine_spec.rb
+++ b/spec/lib/appsignal/integrations/webmachine_spec.rb
@@ -89,12 +89,20 @@ if DependencyHelper.webmachine_present?
           expect(root_span.attributes["url.scheme"]).to eq("http")
           expect(root_span.attributes["url.query"])
             .to eq("param1=value1&param2=value2")
+          # The host and port come off the same URI.
+          expect(root_span.attributes["server.address"]).to eq("google.com")
+          expect(root_span.attributes["server.port"]).to eq(80)
+          # Webmachine has no request environment to read the protocol version
+          # from, so it is left undescribed rather than guessed at.
+          expect(root_span.attributes).to_not have_key("network.protocol.version")
           expect(event_spans).to_not be_empty
           event_spans.each do |span|
             expect(span.attributes).to_not have_key("http.request.method")
             expect(span.attributes).to_not have_key("url.path")
             expect(span.attributes).to_not have_key("url.scheme")
             expect(span.attributes).to_not have_key("url.query")
+            expect(span.attributes).to_not have_key("server.address")
+            expect(span.attributes).to_not have_key("server.port")
           end
         end
       end

--- a/spec/lib/appsignal/opentelemetry/http_server_request_spec.rb
+++ b/spec/lib/appsignal/opentelemetry/http_server_request_spec.rb
@@ -29,6 +29,48 @@ describe Appsignal::OpenTelemetry::HttpServerRequest do
       )
     end
 
+    it "describes the host, the port and the protocol version" do
+      expect(
+        described_class.attributes_for(
+          :method => "GET",
+          :path => "/",
+          :host => "example.com",
+          :port => 443,
+          :protocol => "HTTP/1.1"
+        )
+      ).to eq(
+        "http.request.method" => "GET",
+        "url.path" => "/",
+        "server.address" => "example.com",
+        "server.port" => 443,
+        "network.protocol.version" => "1.1"
+      )
+    end
+
+    # Rack reads the port out of the request authority, so it can arrive as the
+    # String it was written as. The conventions ask for a number.
+    it "reports the port as a number" do
+      expect(
+        described_class.attributes_for(:method => "GET", :host => "example.com", :port => "8080")
+      ).to include("server.port" => 8080)
+    end
+
+    # The conventions ask for the port only alongside the host, because a port
+    # on its own describes nothing.
+    it "leaves out the port when there is no host" do
+      expect(described_class.attributes_for(:method => "GET", :port => 443)).to eq(
+        "http.request.method" => "GET"
+      )
+    end
+
+    # A protocol that is not HTTP needs `network.protocol.name` to go with the
+    # version, so a value we cannot name is left out altogether.
+    it "leaves out a protocol it cannot name" do
+      expect(described_class.attributes_for(:method => "GET", :protocol => "SPDY")).to eq(
+        "http.request.method" => "GET"
+      )
+    end
+
     # The method goes through the same normalization as anywhere else, so an
     # unknown method is reported as `_OTHER` with the original kept.
     it "normalizes the request method" do

--- a/spec/lib/appsignal/rack/event_handler_spec.rb
+++ b/spec/lib/appsignal/rack/event_handler_spec.rb
@@ -151,13 +151,36 @@ describe Appsignal::Rack::EventHandler do
         # This environment carries no scheme, so there is nothing to report and
         # the attribute is left out rather than sent empty.
         expect(root_span.attributes).to_not have_key("url.scheme")
+        # This environment names no host and no protocol either, so those are
+        # left out as well.
+        expect(root_span.attributes).to_not have_key("server.address")
+        expect(root_span.attributes).to_not have_key("server.port")
+        expect(root_span.attributes).to_not have_key("network.protocol.version")
         expect(event_spans).to_not be_empty
         event_spans.each do |span|
           expect(span.attributes).to_not have_key("http.request.method")
           expect(span.attributes).to_not have_key("url.path")
           expect(span.attributes).to_not have_key("url.scheme")
           expect(span.attributes).to_not have_key("url.query")
+          expect(span.attributes).to_not have_key("server.address")
+          expect(span.attributes).to_not have_key("server.port")
+          expect(span.attributes).to_not have_key("network.protocol.version")
         end
+      end
+
+      it "reads the host, port and protocol version off the request", :collector_mode do
+        env["SERVER_NAME"] = "example.com"
+        env["SERVER_PORT"] = "8080"
+        env["SERVER_PROTOCOL"] = "HTTP/1.1"
+        start_collector_agent
+        on_start
+        Appsignal::Transaction.complete_current!
+
+        expect(root_span.attributes["server.address"]).to eq("example.com")
+        expect(root_span.attributes["server.port"]).to eq(8080)
+        # The environment holds `HTTP/1.1`. The conventions want the version
+        # without the protocol name in front of it.
+        expect(root_span.attributes["network.protocol.version"]).to eq("1.1")
       end
 
       it "reads the scheme off the request", :collector_mode do

--- a/spec/lib/appsignal/rack/instrumentation_middleware_spec.rb
+++ b/spec/lib/appsignal/rack/instrumentation_middleware_spec.rb
@@ -53,6 +53,9 @@ describe Appsignal::Rack::InstrumentationMiddleware do
           expect(span.attributes).to_not have_key("url.path")
           expect(span.attributes).to_not have_key("url.scheme")
           expect(span.attributes).to_not have_key("url.query")
+          expect(span.attributes).to_not have_key("server.address")
+          expect(span.attributes).to_not have_key("server.port")
+          expect(span.attributes).to_not have_key("network.protocol.version")
         end
       end
 
@@ -61,6 +64,36 @@ describe Appsignal::Rack::InstrumentationMiddleware do
         make_request(Rack::MockRequest.env_for("/some/path", :method => "POST"))
 
         expect(root_span.attributes["http.request.method"]).to eq("POST")
+      end
+
+      it "reads the host, port and protocol version off the request", :collector_mode do
+        start_collector_agent
+        make_request(
+          Rack::MockRequest.env_for(
+            "https://example.com/other/path",
+            "SERVER_PROTOCOL" => "HTTP/1.1"
+          )
+        )
+
+        expect(root_span.attributes["server.address"]).to eq("example.com")
+        expect(root_span.attributes["server.port"]).to eq(443)
+        # The environment holds `HTTP/1.1`. The conventions want the version
+        # without the protocol name in front of it.
+        expect(root_span.attributes["network.protocol.version"]).to eq("1.1")
+      end
+
+      # The conventions ask for the host the client used, which behind a proxy is
+      # the one the proxy forwards rather than the one it connected to.
+      it "prefers the forwarded host over the server's own name", :collector_mode do
+        start_collector_agent
+        make_request(
+          Rack::MockRequest.env_for(
+            "http://internal.local/some/path",
+            "HTTP_X_FORWARDED_HOST" => "www.example.com"
+          )
+        )
+
+        expect(root_span.attributes["server.address"]).to eq("www.example.com")
       end
 
       it "reads the path, scheme and query string off the request", :collector_mode do

--- a/spec/lib/appsignal/rack_spec.rb
+++ b/spec/lib/appsignal/rack_spec.rb
@@ -60,6 +60,47 @@ describe Appsignal::Rack::Utils do
       it_should_behave_like "HTTP queue start"
     end
   end
+
+  describe ".request_env_value_from" do
+    it "reads the value from the request environment" do
+      request = Rack::Request.new(
+        Rack::MockRequest.env_for("/", "SERVER_PROTOCOL" => "HTTP/1.1")
+      )
+
+      expect(described_class.request_env_value_from(request, "SERVER_PROTOCOL"))
+        .to eq("HTTP/1.1")
+    end
+
+    # The request class is configurable, so the object we are given may have no
+    # environment at all.
+    it "returns nil when the request has no environment" do
+      expect(described_class.request_env_value_from(Object.new, "SERVER_PROTOCOL")).to be_nil
+    end
+
+    # A request class can carry the method and no environment behind it. That is
+    # the same "no environment" case as the one above, so it logs nothing.
+    it "returns nil when the request environment is nil" do
+      request = double(:env => nil)
+      logs = capture_logs do
+        expect(described_class.request_env_value_from(request, "SERVER_PROTOCOL")).to be_nil
+      end
+
+      expect(logs).to be_empty
+    end
+
+    it "logs and returns nil when reading the environment raises" do
+      request = double
+      allow(request).to receive(:respond_to?).with(:env).and_return(true)
+      allow(request).to receive(:env).and_raise(ExampleStandardError, "uh oh")
+      logs = capture_logs { expect(described_class.request_env_value_from(request, "X")).to be_nil }
+
+      expect(logs).to contains_log(
+        :error,
+        "Exception while fetching the HTTP request environment X: " \
+          "ExampleStandardError: uh oh"
+      )
+    end
+  end
 end
 
 describe Appsignal::Rack::ApplyRackRequest do

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -2370,6 +2370,67 @@ describe Appsignal::Transaction do
         end
       end
     end
+
+    context "with request_headers options allowing keys that are not headers" do
+      let(:options) do
+        { :request_headers => %w[CONTENT_LENGTH CONTENT_TYPE CONTENT_FOO HTTP_VERSION] }
+      end
+
+      describe "only sending the two headers Rack passes without the HTTP_ prefix" do
+        def perform
+          transaction.add_headers(
+            "CONTENT_LENGTH" => "12",
+            "CONTENT_TYPE" => "application/json",
+            "CONTENT_FOO" => "bar"
+          )
+        end
+
+        it "in agent mode", :agent_mode do
+          start_agent(**start_agent_args)
+          perform
+          transaction._sample
+
+          expect(transaction).to include_environment(
+            "CONTENT_LENGTH" => "12",
+            "CONTENT_TYPE" => "application/json",
+            "CONTENT_FOO" => "bar"
+          )
+        end
+
+        it "in collector mode", :collector_mode do
+          start_collector_agent
+          perform
+          transaction.complete
+
+          expect(root_span.attributes["http.request.header.content-length"]).to eq("12")
+          expect(root_span.attributes["http.request.header.content-type"])
+            .to eq("application/json")
+          expect(root_span.attributes).to_not have_key("http.request.header.content-foo")
+        end
+      end
+
+      describe "not sending HTTP_VERSION, which is a CGI variable and not a header" do
+        def perform
+          transaction.add_headers("HTTP_VERSION" => "HTTP/1.1")
+        end
+
+        it "in agent mode", :agent_mode do
+          start_agent(**start_agent_args)
+          perform
+          transaction._sample
+
+          expect(transaction).to include_environment("HTTP_VERSION" => "HTTP/1.1")
+        end
+
+        it "in collector mode", :collector_mode do
+          start_collector_agent
+          perform
+          transaction.complete
+
+          expect(root_span.attributes).to_not have_key("http.request.header.version")
+        end
+      end
+    end
   end
 
   describe "#add_headers_if_nil" do

--- a/spec/lib/appsignal/transaction_spec.rb
+++ b/spec/lib/appsignal/transaction_spec.rb
@@ -2211,10 +2211,12 @@ describe Appsignal::Transaction do
         perform
         transaction.complete
 
-        # True headers normalized to the OTel convention; non-header CGI vars
-        # dropped.
+        # True headers normalized to the OTel convention. `PATH_INFO` is not a
+        # header, and the instrumentation already describes it as `url.path`, so
+        # it is reported neither as a header nor as an environment value.
         expect(root_span.attributes["http.request.header.accept"]).to eq("text/html")
         expect(root_span.attributes).to_not have_key("http.request.header.path-info")
+        expect(root_span.attributes).to_not have_key("appsignal.environment.PATH_INFO")
       end
     end
 
@@ -2373,7 +2375,13 @@ describe Appsignal::Transaction do
 
     context "with request_headers options allowing keys that are not headers" do
       let(:options) do
-        { :request_headers => %w[CONTENT_LENGTH CONTENT_TYPE CONTENT_FOO HTTP_VERSION] }
+        {
+          :request_headers => %w[
+            CONTENT_LENGTH CONTENT_TYPE CONTENT_FOO HTTP_VERSION QUERY_STRING
+            SCRIPT_NAME REQUEST_METHOD REQUEST_PATH PATH_INFO SERVER_NAME
+            SERVER_PORT SERVER_PROTOCOL
+          ]
+        }
       end
 
       describe "only sending the two headers Rack passes without the HTTP_ prefix" do
@@ -2406,10 +2414,13 @@ describe Appsignal::Transaction do
           expect(root_span.attributes["http.request.header.content-type"])
             .to eq("application/json")
           expect(root_span.attributes).to_not have_key("http.request.header.content-foo")
+          # Not a header, and nothing describes it, so it keeps its environment
+          # name.
+          expect(root_span.attributes["appsignal.environment.CONTENT_FOO"]).to eq("bar")
         end
       end
 
-      describe "not sending HTTP_VERSION, which is a CGI variable and not a header" do
+      describe "not calling HTTP_VERSION a header, because it is a CGI variable" do
         def perform
           transaction.add_headers("HTTP_VERSION" => "HTTP/1.1")
         end
@@ -2428,6 +2439,75 @@ describe Appsignal::Transaction do
           transaction.complete
 
           expect(root_span.attributes).to_not have_key("http.request.header.version")
+          expect(root_span.attributes["appsignal.environment.HTTP_VERSION"])
+            .to eq("HTTP/1.1")
+        end
+      end
+
+      describe "keeping the environment name of a value that is not a header" do
+        def perform
+          transaction.add_headers("QUERY_STRING" => "page=2", "SCRIPT_NAME" => "/admin")
+        end
+
+        it "in agent mode", :agent_mode do
+          start_agent(**start_agent_args)
+          perform
+          transaction._sample
+
+          expect(transaction).to include_environment(
+            "QUERY_STRING" => "page=2",
+            "SCRIPT_NAME" => "/admin"
+          )
+        end
+
+        it "in collector mode", :collector_mode do
+          start_collector_agent
+          perform
+          transaction.complete
+
+          expect(root_span.attributes["appsignal.environment.QUERY_STRING"]).to eq("page=2")
+          expect(root_span.attributes["appsignal.environment.SCRIPT_NAME"]).to eq("/admin")
+        end
+      end
+
+      describe "not repeating a value the instrumentation already describes" do
+        def perform
+          transaction.add_headers(
+            "REQUEST_METHOD" => "GET",
+            "REQUEST_PATH" => "/users",
+            "PATH_INFO" => "/users",
+            "SERVER_NAME" => "example.com",
+            "SERVER_PORT" => "443",
+            "SERVER_PROTOCOL" => "HTTP/1.1"
+          )
+        end
+
+        it "in agent mode", :agent_mode do
+          start_agent(**start_agent_args)
+          perform
+          transaction._sample
+
+          expect(transaction).to include_environment(
+            "REQUEST_METHOD" => "GET",
+            "REQUEST_PATH" => "/users",
+            "PATH_INFO" => "/users",
+            "SERVER_NAME" => "example.com",
+            "SERVER_PORT" => "443",
+            "SERVER_PROTOCOL" => "HTTP/1.1"
+          )
+        end
+
+        # The Rack and Webmachine instrumentation reads these off the request
+        # and sends them as `http.request.method`, `url.path`, `server.address`,
+        # `server.port` and `network.protocol.version`, from better sources than
+        # this blob has.
+        it "in collector mode", :collector_mode do
+          start_collector_agent
+          perform
+          transaction.complete
+
+          environment_keys = root_span.attributes.keys.grep(/\Aappsignal\.environment\./)
+          expect(environment_keys).to be_empty
         end
       end
     end


### PR DESCRIPTION
A customer reported that the request host had disappeared from their error and
performance traces. Working out why turned into a change across four repositories.
The thread it came from is [here](https://appsignal.slack.com/archives/C7XHXQ7N0/p1788338538223539?thread_ts=1788257649.503859&cid=C7XHXQ7N0).


### [Stop mapping non-headers to header attributes](https://github.com/appsignal/appsignal-ruby/commit/baf5d1d084d055b42bf5f12488a67853d45811aa)

The OpenTelemetry backend turns the transaction's environment sample
data into `http.request.header.*` attributes, and decides what counts
as a header by prefix: any `HTTP_` key and any `CONTENT_` key. Rack
passes only two headers without the `HTTP_` prefix, `CONTENT_LENGTH`
and `CONTENT_TYPE`, and `HTTP_VERSION` is a CGI variable holding the
value of `SERVER_PROTOCOL` rather than a header. An application that
allowlists `HTTP_VERSION` in `request_headers` reports a `version`
header that no client sent.

### [Describe the request's host, port and version](https://github.com/appsignal/appsignal-ruby/commit/1d614e1cfe96e3142b867bdf78815121065b29f4)

The Rack and Webmachine instrumentation describes an incoming request
with its method, path, scheme and query string. The semantic conventions
also ask for the host the client addressed the request to, the port, and
the HTTP version, and nothing sets those. Their values sit in the Rack
environment under `SERVER_NAME`, `SERVER_PORT` and `SERVER_PROTOCOL`,
which the OpenTelemetry backend drops rather than mislabel as request
headers, so a collector-mode request described none of them. The host is
read through `Rack::Request#hostname` instead of `SERVER_NAME`, because
the conventions want the host the client used and that reader tries
`Forwarded`, `X-Forwarded-Host` and `Host` before falling back to the
server's own name.

### [Report the environment in collector mode](https://github.com/appsignal/appsignal-ruby/commit/8bc76f5ac17510098d6f1f12f301ccc7b4e0e6c7)

The OpenTelemetry backend turns the transaction's environment sample
data into `http.request.header.*` attributes for the keys that are real
headers, and drops the rest. The `request_headers` option those keys
come from is an allowlist of Rack environment names, so the rest is
whatever the application asked for and got nothing back for, such as
`QUERY_STRING` or `REMOTE_ADDR`. Keep each one under its environment
name as `appsignal.environment.<key>`, which the trace views show as
the request's environment. `PATH_INFO`, `REQUEST_METHOD`,
`REQUEST_PATH` and the `SERVER_*` keys stay out of it, because the
instrumentation already describes those from the request itself, and
from better sources than this blob: `url.path` keeps the mount prefix
that `PATH_INFO` drops, and `server.address` follows the forwarded host
that `SERVER_NAME` ignores.

## Related pull requests

Four pull requests cover this, one per repository. They can be reviewed on their own,
but the server one has to merge before or together with the processor
one. Until it does, a trace from an agent-based integration shows neither panel,
because the processor stops emitting the prefix the views read and the views drop
a panel they have no entries for.

- [appsignal-processor-rs#2341](https://github.com/appsignal/appsignal-processor-rs/pull/2341) does the same thing for a sample from an agent-based integration, which is the path the customer who reported this is on. It cannot sort the entries the way this pull request does, so it sends all of them as `appsignal.environment.*`.
- [appsignal-server#17332](https://github.com/appsignal/appsignal-server/pull/17332) shows the two prefixes as two panels, "Request headers" and "Environment", which is what gives the attributes this sends somewhere to appear.
- [appsignal-docs#213](https://github.com/appsignal/appsignal-docs/pull/213) documents that some `request_headers` entries are not request headers, and what collector mode does with each kind.
