### PR TITLE
Pin public_suffix on Rubies below 3.2

### DIFF
--- a/appsignal.gemspec
+++ b/appsignal.gemspec
@@ -61,6 +61,13 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rack", ">= 2.0.0"
 
   gem.add_development_dependency "pry"
+  # Reached through webmock's addressable. Version 7 requires Ruby 3.2 and
+  # version 6 requires 3.0, so an older Ruby cannot resolve the development
+  # dependencies unless this is held back. The cop guards the requirements of
+  # the released gem, which a development dependency is not part of.
+  # rubocop:disable Gemspec/RubyVersionGlobalsUsage
+  gem.add_development_dependency "public_suffix", "< 6" if RUBY_VERSION < "3.2"
+  # rubocop:enable Gemspec/RubyVersionGlobalsUsage
   gem.add_development_dependency "rake", ">= 12"
   gem.add_development_dependency "rspec", "~> 3.8"
   gem.add_development_dependency "rubocop", "~> 1.87.0"


### PR DESCRIPTION
The same fix as #1604, on the 4.x line.

The gemspec asks for webmock without a version, and webmock reaches
public_suffix through addressable. public_suffix 7 requires Ruby 3.2, so
the Ruby 2.7 and 3.0 builds resolve a version they cannot install and
fail before running a spec. Version 6 requires Ruby 3.0, which the 2.7
build cannot take either, so this holds it below 6. No gemfile commits a
lockfile, so every gemset resolves afresh and any of them can hit this
once its dependency cache misses.

[skip changeset]
