### PR TITLE
Pin the grape gemset to grape 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -592,8 +592,8 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/faraday-2-collector.gemfile
-  ruby_4-0-0__grape_ubuntu-latest:
-    name: Ruby 4.0.0 - grape
+  ruby_4-0-0__grape-3_ubuntu-latest:
+    name: Ruby 4.0.0 - grape-3
     needs: ruby_4-0-0_ubuntu-latest
     runs-on: ubuntu-latest
     steps:
@@ -619,9 +619,9 @@ jobs:
       RAILS_ENV: test
       JRUBY_OPTS: ''
       COV: '1'
-      BUNDLE_GEMFILE: gemfiles/grape.gemfile
-  ruby_4-0-0__grape-collector_ubuntu-latest:
-    name: Ruby 4.0.0 - grape-collector
+      BUNDLE_GEMFILE: gemfiles/grape-3.gemfile
+  ruby_4-0-0__grape-3-collector_ubuntu-latest:
+    name: Ruby 4.0.0 - grape-3-collector
     needs: ruby_4-0-0_ubuntu-latest
     runs-on: ubuntu-latest
     steps:
@@ -645,7 +645,7 @@ jobs:
       RAILS_ENV: test
       JRUBY_OPTS: ''
       COV: '1'
-      BUNDLE_GEMFILE: gemfiles/grape-collector.gemfile
+      BUNDLE_GEMFILE: gemfiles/grape-3-collector.gemfile
   ruby_4-0-0__http5_ubuntu-latest:
     name: Ruby 4.0.0 - http5
     needs: ruby_4-0-0_ubuntu-latest
@@ -2405,8 +2405,8 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/faraday-2-collector.gemfile
-  ruby_3-4-1__grape_ubuntu-latest:
-    name: Ruby 3.4.1 - grape
+  ruby_3-4-1__grape-3_ubuntu-latest:
+    name: Ruby 3.4.1 - grape-3
     needs: ruby_3-4-1_ubuntu-latest
     runs-on: ubuntu-latest
     steps:
@@ -2432,9 +2432,9 @@ jobs:
       RAILS_ENV: test
       JRUBY_OPTS: ''
       COV: '1'
-      BUNDLE_GEMFILE: gemfiles/grape.gemfile
-  ruby_3-4-1__grape-collector_ubuntu-latest:
-    name: Ruby 3.4.1 - grape-collector
+      BUNDLE_GEMFILE: gemfiles/grape-3.gemfile
+  ruby_3-4-1__grape-3-collector_ubuntu-latest:
+    name: Ruby 3.4.1 - grape-3-collector
     needs: ruby_3-4-1_ubuntu-latest
     runs-on: ubuntu-latest
     steps:
@@ -2458,7 +2458,7 @@ jobs:
       RAILS_ENV: test
       JRUBY_OPTS: ''
       COV: '1'
-      BUNDLE_GEMFILE: gemfiles/grape-collector.gemfile
+      BUNDLE_GEMFILE: gemfiles/grape-3-collector.gemfile
   ruby_3-4-1__hanami-2-0_ubuntu-latest:
     name: Ruby 3.4.1 - hanami-2.0
     needs: ruby_3-4-1_ubuntu-latest
@@ -4488,8 +4488,8 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/faraday-2-collector.gemfile
-  ruby_3-3-4__grape_ubuntu-latest:
-    name: Ruby 3.3.4 - grape
+  ruby_3-3-4__grape-3_ubuntu-latest:
+    name: Ruby 3.3.4 - grape-3
     needs: ruby_3-3-4_ubuntu-latest
     runs-on: ubuntu-latest
     steps:
@@ -4515,9 +4515,9 @@ jobs:
       RAILS_ENV: test
       JRUBY_OPTS: ''
       COV: '1'
-      BUNDLE_GEMFILE: gemfiles/grape.gemfile
-  ruby_3-3-4__grape-collector_ubuntu-latest:
-    name: Ruby 3.3.4 - grape-collector
+      BUNDLE_GEMFILE: gemfiles/grape-3.gemfile
+  ruby_3-3-4__grape-3-collector_ubuntu-latest:
+    name: Ruby 3.3.4 - grape-3-collector
     needs: ruby_3-3-4_ubuntu-latest
     runs-on: ubuntu-latest
     steps:
@@ -4541,7 +4541,7 @@ jobs:
       RAILS_ENV: test
       JRUBY_OPTS: ''
       COV: '1'
-      BUNDLE_GEMFILE: gemfiles/grape-collector.gemfile
+      BUNDLE_GEMFILE: gemfiles/grape-3-collector.gemfile
   ruby_3-3-4__hanami-2-0_ubuntu-latest:
     name: Ruby 3.3.4 - hanami-2.0
     needs: ruby_3-3-4_ubuntu-latest
@@ -6463,8 +6463,8 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/faraday-2-collector.gemfile
-  ruby_3-2-5__grape_ubuntu-latest:
-    name: Ruby 3.2.5 - grape
+  ruby_3-2-5__grape-3_ubuntu-latest:
+    name: Ruby 3.2.5 - grape-3
     needs: ruby_3-2-5_ubuntu-latest
     runs-on: ubuntu-latest
     steps:
@@ -6490,9 +6490,9 @@ jobs:
       RAILS_ENV: test
       JRUBY_OPTS: ''
       COV: '1'
-      BUNDLE_GEMFILE: gemfiles/grape.gemfile
-  ruby_3-2-5__grape-collector_ubuntu-latest:
-    name: Ruby 3.2.5 - grape-collector
+      BUNDLE_GEMFILE: gemfiles/grape-3.gemfile
+  ruby_3-2-5__grape-3-collector_ubuntu-latest:
+    name: Ruby 3.2.5 - grape-3-collector
     needs: ruby_3-2-5_ubuntu-latest
     runs-on: ubuntu-latest
     steps:
@@ -6516,7 +6516,7 @@ jobs:
       RAILS_ENV: test
       JRUBY_OPTS: ''
       COV: '1'
-      BUNDLE_GEMFILE: gemfiles/grape-collector.gemfile
+      BUNDLE_GEMFILE: gemfiles/grape-3-collector.gemfile
   ruby_3-2-5__hanami-2-0_ubuntu-latest:
     name: Ruby 3.2.5 - hanami-2.0
     needs: ruby_3-2-5_ubuntu-latest
@@ -8438,8 +8438,8 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/faraday-2-collector.gemfile
-  ruby_3-1-6__grape_ubuntu-latest:
-    name: Ruby 3.1.6 - grape
+  ruby_3-1-6__grape-3_ubuntu-latest:
+    name: Ruby 3.1.6 - grape-3
     needs: ruby_3-1-6_ubuntu-latest
     runs-on: ubuntu-latest
     steps:
@@ -8465,9 +8465,9 @@ jobs:
       RAILS_ENV: test
       JRUBY_OPTS: ''
       COV: '1'
-      BUNDLE_GEMFILE: gemfiles/grape.gemfile
-  ruby_3-1-6__grape-collector_ubuntu-latest:
-    name: Ruby 3.1.6 - grape-collector
+      BUNDLE_GEMFILE: gemfiles/grape-3.gemfile
+  ruby_3-1-6__grape-3-collector_ubuntu-latest:
+    name: Ruby 3.1.6 - grape-3-collector
     needs: ruby_3-1-6_ubuntu-latest
     runs-on: ubuntu-latest
     steps:
@@ -8491,7 +8491,7 @@ jobs:
       RAILS_ENV: test
       JRUBY_OPTS: ''
       COV: '1'
-      BUNDLE_GEMFILE: gemfiles/grape-collector.gemfile
+      BUNDLE_GEMFILE: gemfiles/grape-3-collector.gemfile
   ruby_3-1-6__hanami-2-0_ubuntu-latest:
     name: Ruby 3.1.6 - hanami-2.0
     needs: ruby_3-1-6_ubuntu-latest
@@ -10035,8 +10035,8 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/faraday-2.gemfile
-  ruby_3-0-7__grape_ubuntu-latest:
-    name: Ruby 3.0.7 - grape
+  ruby_3-0-7__grape-3_ubuntu-latest:
+    name: Ruby 3.0.7 - grape-3
     needs: ruby_3-0-7_ubuntu-latest
     runs-on: ubuntu-latest
     steps:
@@ -10061,7 +10061,7 @@ jobs:
       RAILS_ENV: test
       JRUBY_OPTS: ''
       COV: '1'
-      BUNDLE_GEMFILE: gemfiles/grape.gemfile
+      BUNDLE_GEMFILE: gemfiles/grape-3.gemfile
   ruby_3-0-7__hanami-2-0_ubuntu-latest:
     name: Ruby 3.0.7 - hanami-2.0
     needs: ruby_3-0-7_ubuntu-latest
@@ -10876,8 +10876,8 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/faraday-1.gemfile
-  ruby_2-7-8__grape_ubuntu-latest:
-    name: Ruby 2.7.8 - grape
+  ruby_2-7-8__grape-3_ubuntu-latest:
+    name: Ruby 2.7.8 - grape-3
     needs: ruby_2-7-8_ubuntu-latest
     runs-on: ubuntu-latest
     steps:
@@ -10902,7 +10902,7 @@ jobs:
       RAILS_ENV: test
       JRUBY_OPTS: ''
       COV: '1'
-      BUNDLE_GEMFILE: gemfiles/grape.gemfile
+      BUNDLE_GEMFILE: gemfiles/grape-3.gemfile
   ruby_2-7-8__http5_ubuntu-latest:
     name: Ruby 2.7.8 - http5
     needs: ruby_2-7-8_ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ configurations you need to run the spec suite with a specific Gemfile.
 BUNDLE_GEMFILE=gemfiles/capistrano2.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/capistrano3.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/dry-monitor.gemfile bundle exec rspec
-BUNDLE_GEMFILE=gemfiles/grape.gemfile bundle exec rspec
+BUNDLE_GEMFILE=gemfiles/grape-3.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/hanami.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/http5.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/no_dependencies.gemfile bundle exec rspec

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -174,7 +174,7 @@ matrix:
           - "3.2.5"
           - "3.1.6"
           - "3.0.7"
-    - gem: "grape"
+    - gem: "grape-3"
     - gem: "hanami-2.0"
       only:
         ruby:

--- a/gemfiles/grape-3-collector.gemfile
+++ b/gemfiles/grape-3-collector.gemfile
@@ -1,0 +1,6 @@
+# DO NOT EDIT
+# This is a generated file by the `rake build_matrix:gemfiles:generate` task.
+# It layers the optional OpenTelemetry gems (gemfiles/collector.rb) on top of grape-3.gemfile.
+
+eval_gemfile File.expand_path("grape-3.gemfile", __dir__)
+eval_gemfile File.expand_path("collector.rb", __dir__)

--- a/gemfiles/grape-3.gemfile
+++ b/gemfiles/grape-3.gemfile
@@ -1,0 +1,13 @@
+source "https://rubygems.org"
+
+# Capped below grape 4 because the Grape middleware does not support it yet.
+# See https://github.com/appsignal/appsignal-ruby/issues/1606.
+#
+# No grape 3 supports Ruby 2.7, so that build resolves grape 2.4.0, the last
+# grape 2 release. Capping below 4 rather than requiring 3 is what keeps that
+# build working, so grape 2 stays covered. That coverage rides on Ruby 2.7
+# being in the matrix, and it goes away with it.
+gem "grape", "< 4"
+gem "ostruct"
+
+gemspec :path => "../"

--- a/gemfiles/grape-collector.gemfile
+++ b/gemfiles/grape-collector.gemfile
@@ -1,6 +1,0 @@
-# DO NOT EDIT
-# This is a generated file by the `rake build_matrix:gemfiles:generate` task.
-# It layers the optional OpenTelemetry gems (gemfiles/collector.rb) on top of grape.gemfile.
-
-eval_gemfile File.expand_path("grape.gemfile", __dir__)
-eval_gemfile File.expand_path("collector.rb", __dir__)

--- a/gemfiles/grape.gemfile
+++ b/gemfiles/grape.gemfile
@@ -1,6 +1,0 @@
-source "https://rubygems.org"
-
-gem "grape"
-gem "ostruct"
-
-gemspec :path => "../"


### PR DESCRIPTION
A workaround to bring CI back to green. It does not make the Grape middleware work with grape 4, which #1606 tracks.

The grape gemset installs grape without a version constraint. grape 4
moves the endpoint's HTTP method, path and API class off the public
`options` Hash, and `Appsignal::Rack::GrapeMiddleware` reads all three
from there to build the transaction action, so every example in the
Grape middleware spec raises `NoMethodError`. grape 4 requires Ruby
3.3, so only the three newest Rubies in the matrix resolve it and fail.
This caps the gemset below grape 4 and renames it to `grape-3`, so that
a `grape-4` gemset can sit beside it once the middleware supports both.

The cap is an upper bound rather than a requirement on grape 3 because
no grape 3 supports Ruby 2.7. That build resolves grape 2.4.0, the last
grape 2 release, and requiring grape 3 would leave it unable to resolve
the gemset at all. So grape 2 stays covered, on that one build, for as
long as Ruby 2.7 is in the matrix.

[skip changeset]
