### PR TITLE
Support Grape 4

### DIFF
--- a/.changesets/support-grape-4.md
+++ b/.changesets/support-grape-4.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+type: add
+---
+
+Add support for Grape 4. On Grape 4, every request through a Grape API raised a `NoMethodError`. Applications on Grape 3 and below were not affected.
+
+On Grape 4, the action name and the reported path now describe the endpoint's full route, so they include the API prefix, the path version and the mount point. They also no longer end in a trailing slash when the endpoint declares no path of its own, so an endpoint reported as `GET::My::Api#/users/:id/` is now reported as `GET::My::Api#/users/:id`. Action names on Grape 3 and below do not change.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 # This is a generated file by the `rake build_matrix:github:generate` task.
 # See `build_matrix.yml` for the build matrix.
 # Generate this file with `rake build_matrix:github:generate`.
-# Generated job count: 433
+# Generated job count: 439
 ---
 name: Ruby gem CI
 'on':
@@ -806,6 +806,76 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/grape-3-collector.gemfile
+  ruby_4-0-0__grape-4_ubuntu-latest:
+    name: Ruby 4.0.0 - grape-4
+    needs: ruby_4-0-0_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 4.0.0
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - &11
+      name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__grape-4_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/grape-4.gemfile
+  ruby_4-0-0__grape-4-collector_ubuntu-latest:
+    name: Ruby 4.0.0 - grape-4-collector
+    needs: ruby_4-0-0_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 4.0.0
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - *11
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_4-0-0__grape-4-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/grape-4-collector.gemfile
   ruby_4-0-0__http5_ubuntu-latest:
     name: Ruby 4.0.0 - http5
     needs: ruby_4-0-0_ubuntu-latest
@@ -826,7 +896,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &11
+    - &12
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -862,7 +932,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *11
+    - *12
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -896,7 +966,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &12
+    - &13
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -932,7 +1002,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *12
+    - *13
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -966,7 +1036,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &13
+    - &14
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -1002,7 +1072,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *13
+    - *14
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -1036,7 +1106,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &14
+    - &15
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -1072,7 +1142,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *14
+    - *15
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -1106,7 +1176,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &15
+    - &16
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -1142,7 +1212,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *15
+    - *16
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -1176,7 +1246,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &16
+    - &17
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -1212,7 +1282,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *16
+    - *17
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -1246,7 +1316,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &17
+    - &18
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -1282,7 +1352,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *17
+    - *18
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -1316,7 +1386,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &18
+    - &19
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -1352,7 +1422,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *18
+    - *19
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -1386,7 +1456,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &19
+    - &20
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -1422,7 +1492,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *19
+    - *20
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -1456,7 +1526,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &20
+    - &21
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -1492,7 +1562,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *20
+    - *21
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -1526,7 +1596,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &21
+    - &22
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -1562,7 +1632,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *21
+    - *22
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -1596,7 +1666,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &22
+    - &23
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -1632,7 +1702,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *22
+    - *23
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -1666,7 +1736,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &23
+    - &24
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -1702,7 +1772,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *23
+    - *24
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -1736,7 +1806,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &24
+    - &25
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -1772,7 +1842,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *24
+    - *25
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -1806,7 +1876,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &25
+    - &26
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -1842,7 +1912,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *25
+    - *26
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -1876,7 +1946,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &26
+    - &27
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -1912,7 +1982,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *26
+    - *27
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -1946,7 +2016,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &27
+    - &28
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -1982,7 +2052,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *27
+    - *28
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -2016,7 +2086,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &28
+    - &29
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -2052,7 +2122,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *28
+    - *29
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -2086,7 +2156,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &29
+    - &30
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -2122,7 +2192,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *29
+    - *30
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -2156,7 +2226,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &30
+    - &31
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -2192,7 +2262,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *30
+    - *31
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -2226,7 +2296,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &31
+    - &32
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -2262,7 +2332,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *31
+    - *32
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -2296,7 +2366,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &32
+    - &33
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -2332,7 +2402,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *32
+    - *33
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -2366,7 +2436,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &33
+    - &34
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -2402,7 +2472,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *33
+    - *34
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -2473,7 +2543,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &34
+    - &35
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Run tests without extension
@@ -2511,7 +2581,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *34
+    - *35
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -2545,7 +2615,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &35
+    - &36
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -2581,7 +2651,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *35
+    - *36
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -2615,7 +2685,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &36
+    - &37
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -2651,7 +2721,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *36
+    - *37
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -2685,7 +2755,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &37
+    - &38
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -2721,7 +2791,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *37
+    - *38
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -2755,7 +2825,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &38
+    - &39
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -2791,7 +2861,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *38
+    - *39
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -2825,7 +2895,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &39
+    - &40
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -2861,7 +2931,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *39
+    - *40
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -2895,7 +2965,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &40
+    - &41
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -2931,7 +3001,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *40
+    - *41
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -2965,7 +3035,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &41
+    - &42
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -3001,7 +3071,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *41
+    - *42
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -3035,7 +3105,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &42
+    - &43
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -3071,7 +3141,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *42
+    - *43
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -3105,7 +3175,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &43
+    - &44
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -3141,7 +3211,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *43
+    - *44
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -3155,6 +3225,76 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/grape-3-collector.gemfile
+  ruby_3-4-1__grape-4_ubuntu-latest:
+    name: Ruby 3.4.1 - grape-4
+    needs: ruby_3-4-1_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.1
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - &45
+      name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__grape-4_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/grape-4.gemfile
+  ruby_3-4-1__grape-4-collector_ubuntu-latest:
+    name: Ruby 3.4.1 - grape-4-collector
+    needs: ruby_3-4-1_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.1
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - *45
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-4-1__grape-4-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/grape-4-collector.gemfile
   ruby_3-4-1__hanami-2-0_ubuntu-latest:
     name: Ruby 3.4.1 - hanami-2.0
     needs: ruby_3-4-1_ubuntu-latest
@@ -3175,7 +3315,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &44
+    - &46
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -3211,7 +3351,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *44
+    - *46
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -3245,7 +3385,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &45
+    - &47
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -3281,7 +3421,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *45
+    - *47
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -3315,7 +3455,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &46
+    - &48
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -3351,7 +3491,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *46
+    - *48
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -3385,7 +3525,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &47
+    - &49
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -3421,7 +3561,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *47
+    - *49
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -3455,7 +3595,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &48
+    - &50
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -3491,7 +3631,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *48
+    - *50
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -3525,7 +3665,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &49
+    - &51
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -3561,7 +3701,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *49
+    - *51
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -3595,7 +3735,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &50
+    - &52
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -3631,7 +3771,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *50
+    - *52
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -3665,7 +3805,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &51
+    - &53
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -3701,7 +3841,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *51
+    - *53
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -3735,7 +3875,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &52
+    - &54
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -3771,7 +3911,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *52
+    - *54
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -3805,7 +3945,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &53
+    - &55
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -3841,7 +3981,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *53
+    - *55
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -3875,7 +4015,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &54
+    - &56
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -3911,7 +4051,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *54
+    - *56
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -3945,7 +4085,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &55
+    - &57
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -3981,7 +4121,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *55
+    - *57
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -4015,7 +4155,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &56
+    - &58
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -4051,7 +4191,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *56
+    - *58
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -4085,7 +4225,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &57
+    - &59
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -4121,7 +4261,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *57
+    - *59
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -4155,7 +4295,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &58
+    - &60
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -4191,7 +4331,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *58
+    - *60
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -4225,7 +4365,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &59
+    - &61
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -4261,7 +4401,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *59
+    - *61
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -4295,7 +4435,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &60
+    - &62
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -4331,7 +4471,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *60
+    - *62
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -4365,7 +4505,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &61
+    - &63
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -4401,7 +4541,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *61
+    - *63
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -4435,7 +4575,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &62
+    - &64
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -4471,7 +4611,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *62
+    - *64
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -4505,7 +4645,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &63
+    - &65
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -4541,7 +4681,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *63
+    - *65
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -4575,7 +4715,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &64
+    - &66
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -4611,7 +4751,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *64
+    - *66
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -4645,7 +4785,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &65
+    - &67
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -4681,7 +4821,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *65
+    - *67
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -4715,7 +4855,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &66
+    - &68
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -4751,7 +4891,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *66
+    - *68
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -4785,7 +4925,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &67
+    - &69
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -4821,7 +4961,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *67
+    - *69
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -4855,7 +4995,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &68
+    - &70
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -4891,7 +5031,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *68
+    - *70
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -4925,7 +5065,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &69
+    - &71
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -4961,7 +5101,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *69
+    - *71
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -4995,7 +5135,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &70
+    - &72
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -5031,7 +5171,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *70
+    - *72
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -5065,7 +5205,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &71
+    - &73
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -5101,7 +5241,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *71
+    - *73
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -5172,7 +5312,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &72
+    - &74
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Run tests without extension
@@ -5210,7 +5350,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *72
+    - *74
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -5244,7 +5384,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &73
+    - &75
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -5280,7 +5420,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *73
+    - *75
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -5314,7 +5454,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &74
+    - &76
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -5350,7 +5490,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *74
+    - *76
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -5384,7 +5524,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &75
+    - &77
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -5420,7 +5560,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *75
+    - *77
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -5454,7 +5594,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &76
+    - &78
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -5490,7 +5630,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *76
+    - *78
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -5524,7 +5664,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &77
+    - &79
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -5560,7 +5700,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *77
+    - *79
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -5594,7 +5734,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &78
+    - &80
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -5630,7 +5770,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *78
+    - *80
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -5664,7 +5804,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &79
+    - &81
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -5700,7 +5840,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *79
+    - *81
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -5734,7 +5874,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &80
+    - &82
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -5770,7 +5910,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *80
+    - *82
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -5804,7 +5944,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &81
+    - &83
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -5840,7 +5980,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *81
+    - *83
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -5854,6 +5994,76 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/grape-3-collector.gemfile
+  ruby_3-3-4__grape-4_ubuntu-latest:
+    name: Ruby 3.3.4 - grape-4
+    needs: ruby_3-3-4_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.3.4
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - &84
+      name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__grape-4_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/grape-4.gemfile
+  ruby_3-3-4__grape-4-collector_ubuntu-latest:
+    name: Ruby 3.3.4 - grape-4-collector
+    needs: ruby_3-3-4_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.3.4
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - *84
+    - name: Upload example list
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ruby_3-3-4__grape-4-collector_ubuntu-latest
+        path: tmp/examples-*.json
+        if-no-files-found: error
+        retention-days: 1
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/grape-4-collector.gemfile
   ruby_3-3-4__hanami-2-0_ubuntu-latest:
     name: Ruby 3.3.4 - hanami-2.0
     needs: ruby_3-3-4_ubuntu-latest
@@ -5874,7 +6084,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &82
+    - &85
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -5910,7 +6120,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *82
+    - *85
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -5944,7 +6154,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &83
+    - &86
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -5980,7 +6190,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *83
+    - *86
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -6014,7 +6224,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &84
+    - &87
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -6050,7 +6260,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *84
+    - *87
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -6084,7 +6294,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &85
+    - &88
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -6120,7 +6330,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *85
+    - *88
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -6154,7 +6364,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &86
+    - &89
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -6190,7 +6400,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *86
+    - *89
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -6224,7 +6434,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &87
+    - &90
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -6260,7 +6470,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *87
+    - *90
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -6294,7 +6504,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &88
+    - &91
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -6330,7 +6540,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *88
+    - *91
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -6364,7 +6574,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &89
+    - &92
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -6400,7 +6610,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *89
+    - *92
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -6434,7 +6644,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &90
+    - &93
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -6470,7 +6680,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *90
+    - *93
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -6504,7 +6714,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &91
+    - &94
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -6540,7 +6750,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *91
+    - *94
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -6574,7 +6784,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &92
+    - &95
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -6610,7 +6820,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *92
+    - *95
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -6644,7 +6854,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &93
+    - &96
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -6680,7 +6890,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *93
+    - *96
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -6714,7 +6924,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &94
+    - &97
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -6750,7 +6960,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *94
+    - *97
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -6784,7 +6994,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &95
+    - &98
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -6820,7 +7030,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *95
+    - *98
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -6854,7 +7064,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &96
+    - &99
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -6890,7 +7100,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *96
+    - *99
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -6924,7 +7134,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &97
+    - &100
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -6960,7 +7170,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *97
+    - *100
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -6994,7 +7204,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &98
+    - &101
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -7030,7 +7240,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *98
+    - *101
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -7064,7 +7274,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &99
+    - &102
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -7100,7 +7310,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *99
+    - *102
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -7134,7 +7344,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &100
+    - &103
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -7170,7 +7380,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *100
+    - *103
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -7204,7 +7414,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &101
+    - &104
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -7240,7 +7450,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *101
+    - *104
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -7274,7 +7484,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &102
+    - &105
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -7310,7 +7520,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *102
+    - *105
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -7344,7 +7554,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &103
+    - &106
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -7380,7 +7590,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *103
+    - *106
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -7414,7 +7624,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &104
+    - &107
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -7450,7 +7660,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *104
+    - *107
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -7484,7 +7694,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &105
+    - &108
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -7520,7 +7730,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *105
+    - *108
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -7554,7 +7764,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &106
+    - &109
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -7590,7 +7800,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *106
+    - *109
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -7624,7 +7834,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &107
+    - &110
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -7660,7 +7870,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *107
+    - *110
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -7694,7 +7904,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &108
+    - &111
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -7730,7 +7940,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *108
+    - *111
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -7801,7 +8011,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &109
+    - &112
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Run tests without extension
@@ -7839,7 +8049,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *109
+    - *112
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -7873,7 +8083,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &110
+    - &113
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -7909,7 +8119,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *110
+    - *113
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -7943,7 +8153,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &111
+    - &114
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -7979,7 +8189,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *111
+    - *114
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -8013,7 +8223,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &112
+    - &115
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -8049,7 +8259,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *112
+    - *115
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -8083,7 +8293,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &113
+    - &116
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -8119,7 +8329,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *113
+    - *116
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -8153,7 +8363,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &114
+    - &117
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -8189,7 +8399,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *114
+    - *117
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -8223,7 +8433,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &115
+    - &118
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -8259,7 +8469,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *115
+    - *118
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -8293,7 +8503,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &116
+    - &119
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -8329,7 +8539,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *116
+    - *119
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -8363,7 +8573,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &117
+    - &120
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -8399,7 +8609,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *117
+    - *120
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -8433,7 +8643,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &118
+    - &121
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -8469,7 +8679,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *118
+    - *121
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -8503,7 +8713,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &119
+    - &122
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -8539,7 +8749,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *119
+    - *122
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -8573,7 +8783,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &120
+    - &123
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -8609,7 +8819,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *120
+    - *123
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -8643,7 +8853,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &121
+    - &124
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -8679,7 +8889,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *121
+    - *124
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -8713,7 +8923,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &122
+    - &125
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -8749,7 +8959,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *122
+    - *125
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -8783,7 +8993,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &123
+    - &126
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -8819,7 +9029,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *123
+    - *126
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -8853,7 +9063,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &124
+    - &127
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -8889,7 +9099,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *124
+    - *127
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -8923,7 +9133,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &125
+    - &128
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -8959,7 +9169,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *125
+    - *128
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -8993,7 +9203,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &126
+    - &129
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -9029,7 +9239,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *126
+    - *129
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -9063,7 +9273,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &127
+    - &130
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -9099,7 +9309,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *127
+    - *130
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -9133,7 +9343,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &128
+    - &131
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -9169,7 +9379,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *128
+    - *131
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -9203,7 +9413,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &129
+    - &132
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -9239,7 +9449,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *129
+    - *132
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -9273,7 +9483,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &130
+    - &133
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -9309,7 +9519,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *130
+    - *133
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -9343,7 +9553,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &131
+    - &134
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -9379,7 +9589,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *131
+    - *134
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -9413,7 +9623,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &132
+    - &135
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -9449,7 +9659,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *132
+    - *135
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -9483,7 +9693,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &133
+    - &136
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -9519,7 +9729,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *133
+    - *136
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -9553,7 +9763,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &134
+    - &137
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -9589,7 +9799,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *134
+    - *137
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -9623,7 +9833,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &135
+    - &138
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -9659,7 +9869,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *135
+    - *138
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -9693,7 +9903,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &136
+    - &139
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -9729,7 +9939,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *136
+    - *139
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -9763,7 +9973,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &137
+    - &140
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -9799,7 +10009,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *137
+    - *140
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -9833,7 +10043,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &138
+    - &141
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -9869,7 +10079,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *138
+    - *141
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -9903,7 +10113,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &139
+    - &142
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -9939,7 +10149,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *139
+    - *142
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -9973,7 +10183,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &140
+    - &143
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -10009,7 +10219,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *140
+    - *143
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -10043,7 +10253,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &141
+    - &144
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -10079,7 +10289,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *141
+    - *144
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -10113,7 +10323,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &142
+    - &145
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -10149,7 +10359,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *142
+    - *145
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -10183,7 +10393,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &143
+    - &146
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -10219,7 +10429,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *143
+    - *146
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -10253,7 +10463,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &144
+    - &147
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -10289,7 +10499,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *144
+    - *147
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -10360,7 +10570,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &145
+    - &148
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Run tests without extension
@@ -10398,7 +10608,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *145
+    - *148
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -10432,7 +10642,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &146
+    - &149
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -10468,7 +10678,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *146
+    - *149
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -10502,7 +10712,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &147
+    - &150
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -10538,7 +10748,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *147
+    - *150
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -10572,7 +10782,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &148
+    - &151
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -10608,7 +10818,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *148
+    - *151
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -10642,7 +10852,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &149
+    - &152
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -10678,7 +10888,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *149
+    - *152
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -10712,7 +10922,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &150
+    - &153
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -10748,7 +10958,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *150
+    - *153
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -10782,7 +10992,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &151
+    - &154
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -10818,7 +11028,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *151
+    - *154
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -10852,7 +11062,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &152
+    - &155
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -10888,7 +11098,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *152
+    - *155
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -10922,7 +11132,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &153
+    - &156
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -10958,7 +11168,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *153
+    - *156
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -10992,7 +11202,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &154
+    - &157
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -11028,7 +11238,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *154
+    - *157
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -11062,7 +11272,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &155
+    - &158
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -11098,7 +11308,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *155
+    - *158
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -11132,7 +11342,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &156
+    - &159
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -11168,7 +11378,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *156
+    - *159
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -11202,7 +11412,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &157
+    - &160
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -11238,7 +11448,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *157
+    - *160
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -11272,7 +11482,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &158
+    - &161
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -11308,7 +11518,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *158
+    - *161
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -11342,7 +11552,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &159
+    - &162
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -11378,7 +11588,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *159
+    - *162
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -11412,7 +11622,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &160
+    - &163
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -11448,7 +11658,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *160
+    - *163
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -11482,7 +11692,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &161
+    - &164
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -11518,7 +11728,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *161
+    - *164
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -11552,7 +11762,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &162
+    - &165
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -11588,7 +11798,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *162
+    - *165
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -11622,7 +11832,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &163
+    - &166
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -11658,7 +11868,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *163
+    - *166
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -11692,7 +11902,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &164
+    - &167
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -11728,7 +11938,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *164
+    - *167
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -11762,7 +11972,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &165
+    - &168
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -11798,7 +12008,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *165
+    - *168
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -11832,7 +12042,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &166
+    - &169
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -11868,7 +12078,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *166
+    - *169
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -11902,7 +12112,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &167
+    - &170
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -11938,7 +12148,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *167
+    - *170
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -11972,7 +12182,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &168
+    - &171
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -12008,7 +12218,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *168
+    - *171
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -12042,7 +12252,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &169
+    - &172
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -12078,7 +12288,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *169
+    - *172
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -12112,7 +12322,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &170
+    - &173
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -12148,7 +12358,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *170
+    - *173
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -12182,7 +12392,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &171
+    - &174
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -12218,7 +12428,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *171
+    - *174
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -12252,7 +12462,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &172
+    - &175
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -12288,7 +12498,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *172
+    - *175
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -12322,7 +12532,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &173
+    - &176
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -12358,7 +12568,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *173
+    - *176
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -12392,7 +12602,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &174
+    - &177
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -12428,7 +12638,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *174
+    - *177
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -12462,7 +12672,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &175
+    - &178
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -12498,7 +12708,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *175
+    - *178
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -12532,7 +12742,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &176
+    - &179
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -12568,7 +12778,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *176
+    - *179
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4
@@ -12602,7 +12812,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - &177
+    - &180
       name: Run tests
       run: "./script/bundler_wrapper exec rake test"
     - name: Upload example list
@@ -12638,7 +12848,7 @@ jobs:
     - name: Print Makefile log file
       run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
         found'"
-    - *177
+    - *180
     - name: Upload example list
       if: always()
       uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ BUNDLE_GEMFILE=gemfiles/capistrano2.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/capistrano3.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/dry-monitor.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/grape-3.gemfile bundle exec rspec
+BUNDLE_GEMFILE=gemfiles/grape-4.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/hanami.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/http5.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/no_dependencies.gemfile bundle exec rspec

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -175,6 +175,12 @@ matrix:
           - "3.1.6"
           - "3.0.7"
     - gem: "grape-3"
+    - gem: "grape-4"
+      only:
+        ruby:
+          - "4.0.0"
+          - "3.4.1"
+          - "3.3.4"
     - gem: "hanami-2.0"
       only:
         ruby:

--- a/gemfiles/grape-3.gemfile
+++ b/gemfiles/grape-3.gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 
-# Capped below grape 4 because the Grape middleware does not support it yet.
-# See https://github.com/appsignal/appsignal-ruby/issues/1606.
+# Capped below grape 4, which the grape-4 gemset covers.
 #
 # No grape 3 supports Ruby 2.7, so that build resolves grape 2.4.0, the last
 # grape 2 release. Capping below 4 rather than requiring 3 is what keeps that

--- a/gemfiles/grape-4-collector.gemfile
+++ b/gemfiles/grape-4-collector.gemfile
@@ -1,0 +1,6 @@
+# DO NOT EDIT
+# This is a generated file by the `rake build_matrix:gemfiles:generate` task.
+# It layers the optional OpenTelemetry gems (gemfiles/collector.rb) on top of grape-4.gemfile.
+
+eval_gemfile File.expand_path("grape-4.gemfile", __dir__)
+eval_gemfile File.expand_path("collector.rb", __dir__)

--- a/gemfiles/grape-4.gemfile
+++ b/gemfiles/grape-4.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "grape", "~> 4.0"
+gem "ostruct"
+
+gemspec :path => "../"

--- a/lib/appsignal/rack/grape_middleware.rb
+++ b/lib/appsignal/rack/grape_middleware.rb
@@ -16,26 +16,56 @@ module Appsignal
 
       def add_transaction_metadata_after(transaction, request)
         endpoint = request.env["api.endpoint"]
-        unless endpoint&.options
+        request_method, klass, path = endpoint && endpoint_action(endpoint)
+        unless path
           super
           return
         end
-
-        options = endpoint.options
-        request_method = options[:method].first.to_s.upcase
-        klass = options[:for]
-        namespace = endpoint.namespace
-        namespace = "" if namespace == "/"
-
-        path = options[:path].first.to_s
-        path = "/#{path}" if path[0] != "/"
-        path = "#{namespace}#{path}"
 
         transaction.set_action_if_nil("#{request_method}::#{klass}##{path}")
 
         super
 
         transaction.set_metadata("path", path)
+      end
+
+      # Returns the HTTP method, API class and path that make up the action
+      # name, or nil when the endpoint does not describe a route.
+      def endpoint_action(endpoint)
+        options = endpoint.options
+        return unless options
+
+        if options.key?(:path)
+          # Only Grape 3 and older populate `options[:path]`. Their route is
+          # readable too, but its path is the full route template, so reading
+          # it would rename the actions these applications already report.
+          endpoint_action_from_options(endpoint, options)
+        else
+          # Grape 4 keeps these three in a value object behind a protected
+          # reader, leaving the route as the only public source.
+          endpoint_action_from_route(endpoint)
+        end
+      end
+
+      def endpoint_action_from_options(endpoint, options)
+        namespace = endpoint.namespace
+        namespace = "" if namespace == "/"
+
+        path = options[:path].first.to_s
+        path = "/#{path}" if path[0] != "/"
+
+        [
+          options[:method].first.to_s.upcase,
+          options[:for],
+          "#{namespace}#{path}"
+        ]
+      end
+
+      def endpoint_action_from_route(endpoint)
+        route = endpoint.routes.first
+        return unless route
+
+        [route.request_method.to_s.upcase, endpoint.api, route.origin]
       end
     end
   end

--- a/spec/lib/appsignal/rack/grape_middleware_spec.rb
+++ b/spec/lib/appsignal/rack/grape_middleware_spec.rb
@@ -26,6 +26,30 @@ if DependencyHelper.grape_present?
       end.to raise_error(exception_class, exception_message)
     end
 
+    let(:expected_method) { "GET" }
+
+    # Where the two Grape majors report a route differently, each gets its own
+    # "in Grape 3" and "in Grape 4" examples rather than one example with a
+    # version-dependent expectation. The spec coverage audit works per source
+    # line and asks only that some build matrix combination runs each one, so
+    # examples shared between the two majors would let a Grape 4 run stand in
+    # for a Grape 3 one that the matrix had stopped running. These helpers hold
+    # the assertions so that only the expected path is written out twice.
+    def expect_reported_route_in_agent_mode
+      expect(last_transaction).to have_action(expected_action)
+      expect(last_transaction).to include_metadata(
+        "path" => expected_path,
+        "method" => expected_method
+      )
+    end
+
+    def expect_reported_route_in_collector_mode
+      expect(root_span.name).to eq(expected_action)
+      expect(root_span.attributes["appsignal.action_name"]).to eq(expected_action)
+      expect(root_span.attributes["appsignal.tag.path"]).to eq(expected_path)
+      expect(root_span.attributes["appsignal.tag.method"]).to eq(expected_method)
+    end
+
     context "with error" do
       let(:app) do
         Class.new(::Grape::API) do
@@ -156,28 +180,48 @@ if DependencyHelper.grape_present?
         Rack::MockRequest.env_for("/users/123", :method => "GET")
       end
 
-      describe "sets non-unique route_param path" do
-        def perform
-          make_request(env)
-        end
+      let(:expected_action) { "GET::GrapeExample::Api##{expected_path}" }
 
-        it "in agent mode", :agent_mode do
+      def perform
+        make_request(env)
+      end
+
+      # The endpoint declares no path of its own, so the namespace is reported
+      # with the endpoint's default "/" path appended.
+      describe "in Grape 3", :if => !DependencyHelper.grape4_present? do
+        let(:expected_path) { "/users/:id/" }
+
+        it "sets non-unique route_param path in agent mode", :agent_mode do
           start_agent
           perform
 
-          expect(last_transaction).to have_action("GET::GrapeExample::Api#/users/:id/")
-          expect(last_transaction).to include_metadata("path" => "/users/:id/", "method" => "GET")
+          expect_reported_route_in_agent_mode
         end
 
-        it "in collector mode", :collector_mode do
+        it "sets non-unique route_param path in collector mode", :collector_mode do
           start_collector_agent
           perform
 
-          expect(root_span.name).to eq("GET::GrapeExample::Api#/users/:id/")
-          expect(root_span.attributes["appsignal.action_name"])
-            .to eq("GET::GrapeExample::Api#/users/:id/")
-          expect(root_span.attributes["appsignal.tag.path"]).to eq("/users/:id/")
-          expect(root_span.attributes["appsignal.tag.method"]).to eq("GET")
+          expect_reported_route_in_collector_mode
+        end
+      end
+
+      # The route's own template has no trailing slash.
+      describe "in Grape 4", :if => DependencyHelper.grape4_present? do
+        let(:expected_path) { "/users/:id" }
+
+        it "sets non-unique route_param path in agent mode", :agent_mode do
+          start_agent
+          perform
+
+          expect_reported_route_in_agent_mode
+        end
+
+        it "sets non-unique route_param path in collector mode", :collector_mode do
+          start_collector_agent
+          perform
+
+          expect_reported_route_in_collector_mode
         end
       end
     end
@@ -274,6 +318,137 @@ if DependencyHelper.grape_present?
           end
 
           include_examples "sets the namespaced path", "POST::GrapeExample::Api#/v1/beta/ping"
+        end
+      end
+    end
+
+    context "with a prefix and a path version" do
+      let(:app) do
+        Class.new(::Grape::API) do
+          use Appsignal::Rack::GrapeMiddleware
+          format :json
+          prefix "api"
+          version "v2", :using => :path
+          namespace :things do
+            get :list do
+              { :message => "Hello prefixed world!" }
+            end
+          end
+        end
+      end
+      let(:env) do
+        Rack::MockRequest.env_for("/api/v2/things/list", :method => "GET")
+      end
+      let(:expected_action) { "GET::GrapeExample::Api##{expected_path}" }
+
+      def perform
+        make_request(env)
+      end
+
+      # Only the endpoint's namespace and its own path are reported.
+      describe "in Grape 3", :if => !DependencyHelper.grape4_present? do
+        let(:expected_path) { "/things/list" }
+
+        it "sets the prefixed and versioned path in agent mode", :agent_mode do
+          start_agent
+          perform
+
+          expect_reported_route_in_agent_mode
+        end
+
+        it "sets the prefixed and versioned path in collector mode", :collector_mode do
+          start_collector_agent
+          perform
+
+          expect_reported_route_in_collector_mode
+        end
+      end
+
+      # The route's template also carries the API prefix and the path
+      # version.
+      describe "in Grape 4", :if => DependencyHelper.grape4_present? do
+        let(:expected_path) { "/api/:version/things/list" }
+
+        it "sets the prefixed and versioned path in agent mode", :agent_mode do
+          start_agent
+          perform
+
+          expect_reported_route_in_agent_mode
+        end
+
+        it "sets the prefixed and versioned path in collector mode", :collector_mode do
+          start_collector_agent
+          perform
+
+          expect_reported_route_in_collector_mode
+        end
+      end
+    end
+
+    context "with a mounted API" do
+      let(:mounted_app) do
+        Class.new(::Grape::API) do
+          namespace :inner do
+            get :thing do
+              { :message => "Hello mounted world!" }
+            end
+          end
+        end
+      end
+      let(:app) do
+        mounted = mounted_app
+        Class.new(::Grape::API) do
+          use Appsignal::Rack::GrapeMiddleware
+          format :json
+          mount mounted => "/mnt"
+        end
+      end
+      let(:env) do
+        Rack::MockRequest.env_for("/mnt/inner/thing", :method => "GET")
+      end
+      before { stub_const("GrapeExample::Mounted", mounted_app) }
+      # The action names the mounted API rather than the one it is mounted in.
+      let(:expected_action) { "GET::GrapeExample::Mounted##{expected_path}" }
+
+      def perform
+        make_request(env)
+      end
+
+      # Only the endpoint's namespace and its own path are reported.
+      describe "in Grape 3", :if => !DependencyHelper.grape4_present? do
+        let(:expected_path) { "/inner/thing" }
+
+        it "sets the mounted path in agent mode", :agent_mode do
+          start_agent
+          perform
+
+          expect_reported_route_in_agent_mode
+        end
+
+        it "sets the mounted path in collector mode", :collector_mode do
+          start_collector_agent
+          perform
+
+          expect_reported_route_in_collector_mode
+        end
+      end
+
+      # The route's template also carries the mount point.
+      describe "in Grape 4", :if => DependencyHelper.grape4_present? do
+        let(:expected_path) { "/mnt/inner/thing" }
+
+        it "sets the mounted path in agent mode", :agent_mode do
+          start_agent
+          perform
+
+          expect_reported_route_in_agent_mode
+        end
+
+        it "sets the mounted path in collector mode", :collector_mode do
+          start_collector_agent
+          perform
+
+          expect_reported_route_in_collector_mode
         end
       end
     end

--- a/spec/support/helpers/dependency_helper.rb
+++ b/spec/support/helpers/dependency_helper.rb
@@ -147,6 +147,10 @@ module DependencyHelper
     dependency_present? "grape"
   end
 
+  def grape4_present?
+    grape_present? && Gem.loaded_specs["grape"].version >= Gem::Version.new("4.0")
+  end
+
   def webmachine_present?
     dependency_present? "webmachine"
   end


### PR DESCRIPTION
Fixes https://github.com/appsignal/appsignal-ruby/issues/1606.

`Appsignal::Rack::GrapeMiddleware` builds the transaction action from
the HTTP method, path and API class on the Grape endpoint's `options`
Hash. Grape 4 keeps those three in a value object behind a protected
reader, so all three lookups return nil and every request through a
Grape API raises `NoMethodError`. The middleware now reads them from
the endpoint's route on Grape 4, and keeps reading `options` on Grape 3
and older, because the route spells the path as the full route template
and switching to it would rename their actions.
