### PR TITLE
Support Grape 4

### DIFF
--- a/.changesets/support-grape-4.md
+++ b/.changesets/support-grape-4.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+type: add
+---
+
+Add support for Grape 4. On Grape 4, every request through a Grape API raised a `NoMethodError`. Applications on Grape 3 and below were not affected.
+
+On Grape 4, the action name and the reported path now describe the endpoint's full route, so they include the API prefix, the path version and the mount point. They also no longer end in a trailing slash when the endpoint declares no path of its own, so an endpoint reported as `GET::My::Api#/users/:id/` is now reported as `GET::My::Api#/users/:id`. Action names on Grape 3 and below do not change.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 # This is a generated file by the `rake build_matrix:github:generate` task.
 # See `build_matrix.yml` for the build matrix.
 # Generate this file with `rake build_matrix:github:generate`.
-# Generated job count: 255
+# Generated job count: 258
 ---
 name: Ruby gem CI
 'on':
@@ -376,6 +376,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/grape-3.gemfile
+  ruby_4-0-0__grape-4_ubuntu-latest:
+    name: Ruby 4.0.0 - grape-4
+    needs: ruby_4-0-0_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 4.0.0
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/grape-4.gemfile
   ruby_4-0-0__http5_ubuntu-latest:
     name: Ruby 4.0.0 - http5
     needs: ruby_4-0-0_ubuntu-latest
@@ -1298,6 +1325,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/grape-3.gemfile
+  ruby_3-4-1__grape-4_ubuntu-latest:
+    name: Ruby 3.4.1 - grape-4
+    needs: ruby_3-4-1_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4.1
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/grape-4.gemfile
   ruby_3-4-1__hanami-2-0_ubuntu-latest:
     name: Ruby 3.4.1 - hanami-2.0
     needs: ruby_3-4-1_ubuntu-latest
@@ -2355,6 +2409,33 @@ jobs:
       JRUBY_OPTS: ''
       COV: '1'
       BUNDLE_GEMFILE: gemfiles/grape-3.gemfile
+  ruby_3-3-4__grape-4_ubuntu-latest:
+    name: Ruby 3.3.4 - grape-4
+    needs: ruby_3-3-4_ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.3.4
+        bundler-cache: true
+    - name: Install gem extension
+      run: "./script/bundler_wrapper exec rake extension:install"
+    - name: Print extension install report
+      run: "[ -e ext/install.report ] && cat ext/install.report || echo 'No ext/install.report
+        file found'"
+    - name: Print Makefile log file
+      run: "[ -f ext/mkmf.log ] && cat ext/mkmf.log || echo 'No ext/mkmf.log file
+        found'"
+    - name: Run tests
+      run: "./script/bundler_wrapper exec rake test"
+    env:
+      RAILS_ENV: test
+      JRUBY_OPTS: ''
+      COV: '1'
+      BUNDLE_GEMFILE: gemfiles/grape-4.gemfile
   ruby_3-3-4__hanami-2-0_ubuntu-latest:
     name: Ruby 3.3.4 - hanami-2.0
     needs: ruby_3-3-4_ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ BUNDLE_GEMFILE=gemfiles/capistrano2.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/capistrano3.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/dry-monitor.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/grape-3.gemfile bundle exec rspec
+BUNDLE_GEMFILE=gemfiles/grape-4.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/hanami.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/http5.gemfile bundle exec rspec
 BUNDLE_GEMFILE=gemfiles/no_dependencies.gemfile bundle exec rspec

--- a/build_matrix.yml
+++ b/build_matrix.yml
@@ -163,6 +163,12 @@ matrix:
           - "3.1.6"
           - "3.0.7"
     - gem: "grape-3"
+    - gem: "grape-4"
+      only:
+        ruby:
+          - "4.0.0"
+          - "3.4.1"
+          - "3.3.4"
     - gem: "hanami-2.0"
       only:
         ruby:

--- a/gemfiles/grape-3.gemfile
+++ b/gemfiles/grape-3.gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 
-# Capped below grape 4 because the Grape middleware does not support it yet.
-# See https://github.com/appsignal/appsignal-ruby/issues/1606.
+# Capped below grape 4, which the grape-4 gemset covers.
 #
 # No grape 3 supports Ruby 2.7, so that build resolves grape 2.4.0, the last
 # grape 2 release. Capping below 4 rather than requiring 3 is what keeps that

--- a/gemfiles/grape-4.gemfile
+++ b/gemfiles/grape-4.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "grape", "~> 4.0"
+gem "ostruct"
+
+gemspec :path => "../"

--- a/lib/appsignal/rack/grape_middleware.rb
+++ b/lib/appsignal/rack/grape_middleware.rb
@@ -15,26 +15,56 @@ module Appsignal
 
       def add_transaction_metadata_after(transaction, request)
         endpoint = request.env["api.endpoint"]
-        unless endpoint&.options
+        request_method, klass, path = endpoint && endpoint_action(endpoint)
+        unless path
           super
           return
         end
-
-        options = endpoint.options
-        request_method = options[:method].first.to_s.upcase
-        klass = options[:for]
-        namespace = endpoint.namespace
-        namespace = "" if namespace == "/"
-
-        path = options[:path].first.to_s
-        path = "/#{path}" if path[0] != "/"
-        path = "#{namespace}#{path}"
 
         transaction.set_action_if_nil("#{request_method}::#{klass}##{path}")
 
         super
 
         transaction.set_metadata("path", path)
+      end
+
+      # Returns the HTTP method, API class and path that make up the action
+      # name, or nil when the endpoint does not describe a route.
+      def endpoint_action(endpoint)
+        options = endpoint.options
+        return unless options
+
+        if options.key?(:path)
+          # Only Grape 3 and older populate `options[:path]`. Their route is
+          # readable too, but its path is the full route template, so reading
+          # it would rename the actions these applications already report.
+          endpoint_action_from_options(endpoint, options)
+        else
+          # Grape 4 keeps these three in a value object behind a protected
+          # reader, leaving the route as the only public source.
+          endpoint_action_from_route(endpoint)
+        end
+      end
+
+      def endpoint_action_from_options(endpoint, options)
+        namespace = endpoint.namespace
+        namespace = "" if namespace == "/"
+
+        path = options[:path].first.to_s
+        path = "/#{path}" if path[0] != "/"
+
+        [
+          options[:method].first.to_s.upcase,
+          options[:for],
+          "#{namespace}#{path}"
+        ]
+      end
+
+      def endpoint_action_from_route(endpoint)
+        route = endpoint.routes.first
+        return unless route
+
+        [route.request_method.to_s.upcase, endpoint.api, route.origin]
       end
     end
   end

--- a/spec/lib/appsignal/rack/grape_middleware_spec.rb
+++ b/spec/lib/appsignal/rack/grape_middleware_spec.rb
@@ -33,6 +33,21 @@ if DependencyHelper.grape_present?
       end.to raise_error(exception_class, exception_message)
     end
 
+    let(:expected_method) { "GET" }
+
+    # Where the two Grape majors report a route differently, each gets its own
+    # "in Grape 3" and "in Grape 4" examples rather than one example with a
+    # version-dependent expectation. That way a build matrix that stopped
+    # running one of the two majors leaves examples that nothing runs, instead
+    # of examples that quietly stop checking that major.
+    def expect_reported_route
+      expect(last_transaction).to have_action(expected_action)
+      expect(last_transaction).to include_metadata(
+        "path" => expected_path,
+        "method" => expected_method
+      )
+    end
+
     context "with error" do
       let(:app) do
         Class.new(::Grape::API) do
@@ -109,11 +124,33 @@ if DependencyHelper.grape_present?
         Rack::MockRequest.env_for("/users/123", :method => "GET")
       end
 
-      it "sets non-unique route_param path" do
-        make_request(env)
+      let(:expected_action) { "GET::GrapeExample::Api##{expected_path}" }
 
-        expect(last_transaction).to have_action("GET::GrapeExample::Api#/users/:id/")
-        expect(last_transaction).to include_metadata("path" => "/users/:id/", "method" => "GET")
+      def perform
+        make_request(env)
+      end
+
+      # The endpoint declares no path of its own, so the namespace is reported
+      # with the endpoint's default "/" path appended.
+      describe "in Grape 3", :if => !DependencyHelper.grape4_present? do
+        let(:expected_path) { "/users/:id/" }
+
+        it "sets non-unique route_param path" do
+          perform
+
+          expect_reported_route
+        end
+      end
+
+      # The route's own template has no trailing slash.
+      describe "in Grape 4", :if => DependencyHelper.grape4_present? do
+        let(:expected_path) { "/users/:id" }
+
+        it "sets non-unique route_param path" do
+          perform
+
+          expect_reported_route
+        end
       end
     end
 
@@ -200,6 +237,105 @@ if DependencyHelper.grape_present?
             expect(last_transaction).to include_metadata("path" => "/v1/beta/ping",
               "method" => "POST")
           end
+        end
+      end
+    end
+
+    context "with a prefix and a path version" do
+      let(:app) do
+        Class.new(::Grape::API) do
+          use Appsignal::Rack::GrapeMiddleware
+          format :json
+          prefix "api"
+          version "v2", :using => :path
+          namespace :things do
+            get :list do
+              { :message => "Hello prefixed world!" }
+            end
+          end
+        end
+      end
+      let(:env) do
+        Rack::MockRequest.env_for("/api/v2/things/list", :method => "GET")
+      end
+      let(:expected_action) { "GET::GrapeExample::Api##{expected_path}" }
+
+      def perform
+        make_request(env)
+      end
+
+      # Only the endpoint's namespace and its own path are reported.
+      describe "in Grape 3", :if => !DependencyHelper.grape4_present? do
+        let(:expected_path) { "/things/list" }
+
+        it "sets the prefixed and versioned path" do
+          perform
+
+          expect_reported_route
+        end
+      end
+
+      # The route's template also carries the API prefix and the path
+      # version.
+      describe "in Grape 4", :if => DependencyHelper.grape4_present? do
+        let(:expected_path) { "/api/:version/things/list" }
+
+        it "sets the prefixed and versioned path" do
+          perform
+
+          expect_reported_route
+        end
+      end
+    end
+
+    context "with a mounted API" do
+      let(:mounted_app) do
+        Class.new(::Grape::API) do
+          namespace :inner do
+            get :thing do
+              { :message => "Hello mounted world!" }
+            end
+          end
+        end
+      end
+      let(:app) do
+        mounted = mounted_app
+        Class.new(::Grape::API) do
+          use Appsignal::Rack::GrapeMiddleware
+          format :json
+          mount mounted => "/mnt"
+        end
+      end
+      let(:env) do
+        Rack::MockRequest.env_for("/mnt/inner/thing", :method => "GET")
+      end
+      before { stub_const("GrapeExample::Mounted", mounted_app) }
+      # The action names the mounted API rather than the one it is mounted in.
+      let(:expected_action) { "GET::GrapeExample::Mounted##{expected_path}" }
+
+      def perform
+        make_request(env)
+      end
+
+      # Only the endpoint's namespace and its own path are reported.
+      describe "in Grape 3", :if => !DependencyHelper.grape4_present? do
+        let(:expected_path) { "/inner/thing" }
+
+        it "sets the mounted path" do
+          perform
+
+          expect_reported_route
+        end
+      end
+
+      # The route's template also carries the mount point.
+      describe "in Grape 4", :if => DependencyHelper.grape4_present? do
+        let(:expected_path) { "/mnt/inner/thing" }
+
+        it "sets the mounted path" do
+          perform
+
+          expect_reported_route
         end
       end
     end

--- a/spec/support/helpers/dependency_helper.rb
+++ b/spec/support/helpers/dependency_helper.rb
@@ -117,6 +117,10 @@ module DependencyHelper
     dependency_present? "grape"
   end
 
+  def grape4_present?
+    grape_present? && Gem.loaded_specs["grape"].version >= Gem::Version.new("4.0")
+  end
+
   def webmachine_present?
     dependency_present? "webmachine"
   end


### PR DESCRIPTION
Backport of #1610 for the 4.x line. See https://github.com/appsignal/appsignal-ruby/issues/1606.

`Appsignal::Rack::GrapeMiddleware` builds the transaction action from
the HTTP method, path and API class on the Grape endpoint's `options`
Hash. Grape 4 keeps those three in a value object behind a protected
reader, so all three lookups return nil and every request through a
Grape API raises `NoMethodError`. The middleware now reads them from
the endpoint's route on Grape 4, and keeps reading `options` on Grape 3
and older, because the route spells the path as the full route template
and switching to it would rename their actions.

[skip review] (reviewed in #1610)
